### PR TITLE
[feat] scaffold swe-workbench Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "swe-workbench",
+  "version": "0.1.0",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns), language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+  "author": {
+    "name": "Lugas Septiawan",
+    "email": "lugassawan@gmail.com",
+    "url": "https://github.com/lugassawan"
+  },
+  "homepage": "https://github.com/lugassawan/swe-workbench",
+  "repository": "https://github.com/lugassawan/swe-workbench",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "plugin",
+    "software-engineering",
+    "clean-architecture",
+    "ddd",
+    "tdd",
+    "solid",
+    "golang",
+    "rust",
+    "typescript"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# swe-workbench
+
+A senior-engineer toolkit for Claude Code — principled design, language expertise, and pragmatic workflows, packaged as one installable plugin.
+
+## What it is
+
+`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Go, Rust, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
+
+## Install
+
+From the marketplace:
+
+```
+/plugin marketplace add lugassawan/swe-workbench
+/plugin install swe-workbench
+```
+
+For local development:
+
+```
+git clone https://github.com/lugassawan/swe-workbench
+cd swe-workbench
+/plugin marketplace add $(pwd)
+/plugin install swe-workbench
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/swe-workbench:review` | Review the current git diff — correctness, security, design, test gaps. |
+| `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
+| `/swe-workbench:tdd <feature>` | Run a strict red-green-refactor loop. |
+| `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
+
+## Subagents
+
+| Agent | When to invoke |
+|---|---|
+| `reviewer` | PR review, diff audit, post-feature sanity check. |
+| `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
+| `refactorer` | Cleaning up smells before adding a feature. |
+
+## Skills
+
+### Principles — auto-load when designing or writing code
+
+| Skill | Triggers |
+|---|---|
+| `clean-architecture` | "clean architecture", "hexagonal", "ports and adapters", "dependency rule", "layering". |
+| `ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
+| `solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
+| `tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
+| `design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
+
+### Languages — auto-load by file type
+
+| Skill | Triggers |
+|---|---|
+| `go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
+| `rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
+| `typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
+
+## Philosophy
+
+Skills are intentionally small — each under 150 lines. A sharp, well-triggered skill teaches Claude the right thing at the right moment. A giant skill burns context on material the current task does not need. If a skill grows past 150 lines, split it.
+
+## Extending
+
+To add a new language skill (say, Python):
+
+1. Copy `skills/languages/go/` to `skills/languages/python/`.
+2. Rewrite `SKILL.md` frontmatter: `name: python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
+3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
+4. Keep it under 150 lines.
+5. Commit; users who reinstall the plugin will pick it up.
+
+## Testing locally
+
+```bash
+cd swe-workbench
+/plugin marketplace add $(pwd)
+/plugin install swe-workbench
+```
+
+Then try:
+
+```
+/swe-workbench:design "Should I use microservices for a 3-engineer team?"
+/swe-workbench:review
+```
+
+If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
+
+## License
+
+MIT.

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -1,0 +1,27 @@
+---
+name: refactorer
+description: Refactoring specialist — applies Fowler's catalog in small, behavior-preserving steps. Invoke when cleaning up a messy function, module, or class before adding a feature.
+model: sonnet
+tools: Read, Edit, Grep, Glob, Bash
+---
+
+You are a refactoring specialist. You improve structure without changing observable behavior.
+
+## Absolute rules
+- **Every step preserves behavior.** Tests (or characterization tests you add first) must pass before and after each step.
+- **No feature changes during refactoring.** If you find a bug, note it; do not fix it in the same commit.
+- **Small steps.** Each step is reviewable alone and revertable in isolation.
+- **Green between steps.** Run tests between steps. If red, revert immediately.
+
+## Process
+1. **Diagnose.** Name the smell: Long Method, Large Class, Feature Envy, Data Clumps, Primitive Obsession, Shotgun Surgery, Divergent Change, Speculative Generality.
+2. **Coverage audit.** If the target has no tests, write characterization tests that pin current behavior before touching production code.
+3. **Plan.** Emit an ordered list of moves named from Fowler's catalog (Extract Function, Inline Variable, Move Function, Replace Conditional with Polymorphism, Introduce Parameter Object…).
+4. **Execute.** One step at a time. Run tests after each. Commit per step when practical.
+5. **Verify.** Run the full suite at the end. Diff the public API to confirm nothing external changed.
+
+## Outputs
+- Diagnosis paragraph.
+- Target-state sketch.
+- Numbered, named step plan.
+- Post-execution verification report.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,0 +1,32 @@
+---
+name: reviewer
+description: Senior code reviewer — audits diffs for correctness, security, design, and missing tests. Invoke when reviewing a PR, a diff, or a completed feature.
+model: sonnet
+tools: Read, Grep, Glob, Bash
+---
+
+You are a senior code reviewer. Your job is to catch the issues a careful colleague would flag on a Monday-morning PR — not to restate what the code does.
+
+## Focus
+- **Correctness** — off-by-ones, null paths, concurrency races, lost errors, unhandled edge cases.
+- **Security** — injection, auth/authz gaps, secrets in code, unsafe deserialization, SSRF, missing input validation at trust boundaries.
+- **Design integrity** — SOLID violations, leaky abstractions, tight coupling, circular deps, domain logic bleeding into infrastructure.
+- **Tests** — missing coverage on new branches, brittle tests, tests that mirror implementation rather than behavior.
+
+## Explicitly ignore
+- Formatting, import order, quote style — that is the linter.
+- Stylistic preferences with no behavioral impact.
+- Speculative "could be" comments without a concrete failure mode.
+
+## Process
+1. Read the diff end-to-end before commenting.
+2. Use `Grep`/`Glob` to understand callers and blast radius.
+3. For non-trivial changes, read the modified files in full, not just the hunks.
+4. Group findings by severity: Critical, High, Medium, Low.
+5. Emit each finding as exactly: `Severity | File:Line | Issue | Why it matters | Suggested fix`.
+
+## Judgement rules
+- No finding without a concrete failure scenario.
+- Prefer one strong comment over five weak ones.
+- If something is well done, say so briefly — silence is not approval.
+- Missing tests are a finding, not an afterthought.

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -1,0 +1,36 @@
+---
+name: senior-engineer
+description: Architectural advisor — thinks in boundaries, contracts, and change vectors. Invoke when choosing between approaches, scoping a new service, or evaluating an architecture.
+model: sonnet
+tools: Read, Grep, Glob, WebFetch
+---
+
+You are a senior software architect. You help engineers make design decisions they will not regret in six months.
+
+## Mental model
+- Code is optimized for change, not cleverness. Ask: "what is likely to change, and does this design isolate it?"
+- Boundaries over layers. A bounded context with a narrow contract beats clever code inside a tangled one.
+- Dependencies point inward (Clean Architecture). Domain logic never imports infrastructure.
+- YAGNI is first-class. Abstraction without a second caller is usually premature.
+
+## Process for any design question
+1. **Clarify** — surface implicit constraints before recommending:
+   - Team size and experience.
+   - Scale (RPS, data volume, geo).
+   - Domain change frequency.
+   - Latency and availability budgets.
+   - Compliance or data-residency rules.
+   If unknown, ask. Do not guess.
+2. **Frame** — restate in the user's domain language. Fuzzy language is the first finding.
+3. **Options** — 2–3 candidates, each with sketch, strengths, weaknesses, operational cost, reversibility.
+4. **Recommend** — pick one, justify against the dependency rule and DDD boundaries where relevant.
+5. **Risks** — what would make this wrong, and which signals to watch.
+
+## Anti-patterns you call out loudly
+- Microservices for small teams.
+- Generic frameworks built ahead of the second caller.
+- Shared databases across bounded contexts.
+- "Event-driven" as a euphemism for hidden coupling.
+- Layered architecture without enforced dependency direction.
+
+Be honest. If the existing code is fine, say so and stop.

--- a/commands/design.md
+++ b/commands/design.md
@@ -1,0 +1,15 @@
+---
+description: Consult the senior-engineer subagent for an architectural decision
+argument-hint: <design question>
+---
+
+The user is asking: $ARGUMENTS
+
+Delegate to the `senior-engineer` subagent. Its response must contain:
+
+1. **Problem restatement** — confirm the real question and surface implicit constraints (scale, team size, change frequency, latency budget, compliance).
+2. **Options** — 2–3 candidate approaches, each with sketch, strengths, weaknesses, and reversibility.
+3. **Recommendation** — one option chosen, reasoned against Clean Architecture's dependency rule and DDD boundaries where relevant.
+4. **Risks** — what could make this choice wrong, and which signals to watch.
+
+If the question is under-specified, the subagent asks clarifying questions before recommending. Call out YAGNI explicitly when the design is premature.

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -1,0 +1,15 @@
+---
+description: Invoke the refactorer subagent for a behavior-preserving refactor
+argument-hint: <file, function, or module>
+---
+
+Target: $ARGUMENTS
+
+Delegate to the `refactorer` subagent. Its output must include:
+
+1. **Diagnosis** — which smell is present (Long Method, Feature Envy, Primitive Obsession, Shotgun Surgery, Divergent Change, etc.) and why it hurts.
+2. **Target state** — the shape of the code after refactoring, referenced to Fowler's catalog.
+3. **Step plan** — ordered steps, each behavior-preserving and independently testable, each named from the catalog (Extract Function, Move Function, Replace Conditional with Polymorphism, Introduce Parameter Object…).
+4. **Verification** — which tests protect each step; write characterization tests first if coverage is missing.
+
+Absolute rule: no feature changes during refactoring.

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,20 @@
+---
+description: Review the current git diff with senior-engineer depth — correctness, security, design, and test gaps
+---
+
+Review the pending changes on this branch.
+
+1. Gather the diff:
+   - Run `git diff` for unstaged changes.
+   - Run `git diff --staged` for staged changes.
+   - If both are empty, run `git diff origin/main...HEAD` (or `origin/master...HEAD`).
+2. Invoke the `reviewer` subagent with the diff and ask for a prioritized report.
+3. Organize findings by severity, highest first:
+   - **Critical** — data loss, security breach, production outage risk.
+   - **High** — correctness bugs, broken contracts, missing auth/validation.
+   - **Medium** — design smells, SOLID violations, maintainability risks.
+   - **Low** — naming, minor clarity.
+4. Each finding uses: `Severity | File:Line | Issue | Why it matters | Suggested fix`.
+5. Close with a short section summary: correctness bugs, security issues, design smells, test gaps.
+
+Ground judgements in SOLID and Clean Architecture principles. Do not nitpick formatting — that is the linter's job.

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,0 +1,20 @@
+---
+description: Run a strict red-green-refactor loop for a feature
+argument-hint: <feature description>
+---
+
+Feature: $ARGUMENTS
+
+Run a disciplined TDD loop.
+
+1. **Red** — write ONE failing test that describes the next slice of behavior. Run it and confirm it fails for the expected reason.
+2. **Green** — write the minimum production code to pass that test. No speculative code, no extra features.
+3. **Refactor** — only with all tests green, improve structure (rename, extract, dedupe). Re-run tests after each change.
+4. Repeat until the feature is complete.
+
+Hard rules:
+- No production code without a failing test driving it.
+- Never refactor on red.
+- Tests must be fast, isolated, repeatable, self-validating, timely (F.I.R.S.T.).
+
+Surface every step explicitly: `RED: …`, `GREEN: …`, `REFACTOR: …`.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]])(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/languages/go/SKILL.md
+++ b/skills/languages/go/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: go
+description: Go idioms, error handling, concurrency, and standard library usage. Auto-load when working with .go files, go.mod, go.sum, or when the user mentions Go, Golang, goroutines, channels, interfaces, context, or error wrapping.
+---
+
+# Go
+
+## Errors are values
+- Return `error`; do not `panic` across package boundaries.
+- Wrap with `fmt.Errorf("doing X: %w", err)` to preserve the chain.
+- Inspect with `errors.Is` and `errors.As`. Never string-match messages.
+- Sentinel errors (`var ErrNotFound = errors.New(...)`) for expected cases; typed errors when callers need structured data.
+
+```go
+if err != nil {
+    return fmt.Errorf("load user %s: %w", id, err)
+}
+```
+
+## Interfaces — small, defined by the consumer
+- Define interfaces in the package that *uses* them, not where concrete types live.
+- Single-method interfaces are normal (`io.Reader`, `io.Closer`).
+- Accept interfaces, return concrete types.
+
+## Concurrency
+- A goroutine without a known termination path is a leak. Always know who stops it.
+- `context.Context` plumbs cancellation and deadlines — first parameter, named `ctx`.
+- Channels for ownership transfer; mutexes for protecting state. A `sync.Mutex` is often simpler than a goroutine.
+- `errgroup.Group` for structured concurrency with error propagation.
+
+```go
+g, ctx := errgroup.WithContext(ctx)
+for _, job := range jobs {
+    job := job
+    g.Go(func() error { return process(ctx, job) })
+}
+if err := g.Wait(); err != nil { return err }
+```
+
+## Context rules
+- `ctx` is the first parameter of any blocking or IO function.
+- Never store `context.Context` in a struct field.
+- Don't use `context.Value` for required parameters — only cross-cutting concerns like request IDs.
+
+## Tests
+- Table-driven tests are the default.
+- `t.Run(name, ...)` for subtests.
+- `t.Cleanup` beats `defer` for shared fixtures.
+- `httptest.Server` for HTTP; `testing/iotest` for edge IO.
+
+```go
+for _, c := range cases {
+    t.Run(c.name, func(t *testing.T) {
+        if got := Add(c.a, c.b); got != c.want {
+            t.Errorf("Add(%d,%d) = %d, want %d", c.a, c.b, got, c.want)
+        }
+    })
+}
+```
+
+## Package design
+- Package name = its purpose, lower-case, no underscores.
+- Avoid `util`, `common`, `helpers`. Name by the domain thing it owns.
+- Cyclic imports are a design smell — break with an interface in the consuming package.
+
+## Idioms cheat sheet
+- `if err := do(); err != nil { ... }` — keep errors close to their cause.
+- Zero values are useful — design types so zero works.
+- `defer` for cleanup; `defer` in a loop accumulates.
+- Exported fields beat getters/setters unless behavior needs them.
+- `any` over `interface{}` in new code.
+- Prefer `slices`, `maps`, `cmp` from stdlib over hand-rolled helpers.
+
+## Avoid
+- Naked returns outside tiny functions.
+- `panic` as flow control.
+- Empty interfaces in public APIs without a strong reason.
+- Over-generics — use them only when they clearly reduce duplication.

--- a/skills/languages/rust/SKILL.md
+++ b/skills/languages/rust/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: rust
+description: Rust idioms — ownership, borrowing, lifetimes, error handling, traits, and iterators. Auto-load when working with .rs files, Cargo.toml, or when the user mentions Rust, cargo, ownership, borrow checker, trait, lifetime, or async Rust.
+---
+
+# Rust
+
+## Ownership in one paragraph
+Every value has one owner. Passing by value moves; borrow with `&` (shared, many) or `&mut` (exclusive, one). Shared and mutable references cannot coexist. Most "fights with the borrow checker" are a design smell — the data model mixed ownership and sharing.
+
+## Borrowing rules of thumb
+- `&T` when you only read.
+- `&mut T` when you mutate in place.
+- `T` (by value) when you consume — builders, transforming constructors.
+- Return owned types unless the caller clearly benefits from a borrow tied to a parameter's lifetime.
+
+## Lifetimes
+- Start without annotations; add them when the compiler asks.
+- `'static` does not mean "lives forever" — it means "no non-static references inside". Prefer owned types over `'static` juggling.
+- If a struct needs many lifetimes, consider owned data or `Arc` instead.
+
+## Error handling
+- Return `Result<T, E>`; use `?` to propagate.
+- **Library code:** custom enum with `thiserror`.
+- **Application code:** `anyhow::Error` for ergonomics; add context with `.with_context(|| "doing X")`.
+- Reserve `panic!` for invariant violations the caller cannot recover from.
+
+```rust
+#[derive(thiserror::Error, Debug)]
+pub enum LoadError {
+    #[error("io: {0}")] Io(#[from] std::io::Error),
+    #[error("bad format: {0}")] Format(String),
+}
+```
+
+## Traits
+- Design around capability, not identity (`Read`, not `IsFile`).
+- Default methods let traits evolve without breaking implementors.
+- `impl Trait` in arguments → static dispatch, monomorphized, fast.
+- `dyn Trait` behind `Box`/`&` → dynamic dispatch, smaller binary, one code path.
+- Choose `dyn` for open-ended type sets or heterogeneous collections.
+
+## Iterators
+Prefer iterator chains over indexed loops — usually faster, always clearer.
+
+```rust
+let total: u32 = orders.iter()
+    .filter(|o| o.is_paid())
+    .map(|o| o.total)
+    .sum();
+```
+
+- `collect::<Vec<_>>()` only when you need to materialize.
+- `iter()` borrows; `into_iter()` consumes; `iter_mut()` mutates in place.
+
+## Avoiding unnecessary clones
+- `.clone()` in a hot path is a red flag — can you borrow instead?
+- `Cow<'a, str>` for "maybe owned, maybe borrowed" in APIs.
+- `Arc<T>` for cheap shared ownership across threads; `Rc<T>` single-threaded.
+
+## Option and Result ergonomics
+- `?` propagates.
+- `ok_or_else`, `map_err`, `and_then`, `unwrap_or_else` — chain, don't match.
+- Reserve `unwrap`/`expect` for truly unreachable cases; always prefer `expect("why")` over `unwrap` in production.
+
+## Testing
+- `#[cfg(test)] mod tests { ... }` at the bottom of each file for unit tests.
+- Integration tests in `tests/`.
+- `#[should_panic(expected = "...")]` for panic paths.
+- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` in CI.
+
+## Async
+- Pick one runtime (usually `tokio`) and stay there.
+- `async fn` in traits — `async-trait` or the stable equivalent.
+- `Send + 'static` bounds propagate; design for them from the start.
+- Do not block in async — `spawn_blocking` for CPU or sync IO.
+
+## Avoid
+- `unsafe` without a `// SAFETY:` comment explaining the invariant.
+- Reimplementing iterators imperatively.
+- `String` where `&str` would do for read-only input.
+- Deep trait hierarchies — traits compose, they do not inherit.

--- a/skills/languages/typescript/SKILL.md
+++ b/skills/languages/typescript/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: typescript
+description: TypeScript and JavaScript idioms — strict mode, type safety, discriminated unions, async patterns, and Node. Auto-load when working with .ts, .tsx, .js, .jsx files, package.json, or when the user mentions TypeScript, JavaScript, Node, type safety, or tsconfig.
+---
+
+# TypeScript / JavaScript
+
+## Strict mode or nothing
+Enable in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true
+  }
+}
+```
+
+Without these, types lie.
+
+## Prefer `unknown` over `any`
+`any` turns off the type system. `unknown` forces narrowing.
+
+```ts
+function parse(input: unknown): User {
+  if (!isUser(input)) throw new Error("invalid user");
+  return input;
+}
+```
+
+## Discriminated unions over enums
+Enums have runtime quirks and poor exhaustiveness. Use string-literal unions with a discriminant.
+
+```ts
+type Event =
+  | { kind: "click"; x: number; y: number }
+  | { kind: "submit"; form: FormData };
+
+function handle(e: Event) {
+  switch (e.kind) {
+    case "click":  return trackClick(e.x, e.y);
+    case "submit": return submit(e.form);
+    default: {
+      const _exhaustive: never = e; return _exhaustive;
+    }
+  }
+}
+```
+
+## Branded types for domain primitives
+Stop `UserId` from being passed where an `OrderId` is expected.
+
+```ts
+type Brand<K, T> = K & { readonly __brand: T };
+type UserId = Brand<string, "UserId">;
+type OrderId = Brand<string, "OrderId">;
+const makeUserId = (s: string): UserId => s as UserId;
+```
+
+## Async patterns
+- `await` everything that returns a promise. Floating promises silently swallow errors.
+- Enable `@typescript-eslint/no-floating-promises`.
+- `Promise.all` for all-or-fail; `Promise.allSettled` when partial failure is acceptable.
+- Don't mix `.then()` chains with `await` in the same function.
+- Timeouts belong on every external call. `AbortController` is the standard.
+
+```ts
+const ac = new AbortController();
+const t = setTimeout(() => ac.abort(), 5_000);
+try {
+  const r = await fetch(url, { signal: ac.signal });
+  return await r.json();
+} finally {
+  clearTimeout(t);
+}
+```
+
+## Structural typing gotchas
+TypeScript types are shapes, not identities. Two unrelated types with the same fields are interchangeable. Brand when you need nominal behavior.
+
+## Error handling
+- Throw `Error` subclasses, not strings.
+- Catch `unknown` at boundaries; narrow before use.
+- For domain code, consider `Result<T, E>`-style unions over throwing — explicit, typed, exhaustively handled.
+
+## Modules and imports
+- ESM (`"type": "module"`) in new projects.
+- Absolute imports via `paths` in `tsconfig`; don't ship `../../../` ladders.
+- Keep barrels (`index.ts`) shallow — deep barrels slow cold-start and break tree-shaking.
+
+## React / TSX notes
+- `ReactNode` for children props. `JSX.Element` is narrower than you usually want.
+- Avoid `FC<Props>` — it adds implicit `children` and breaks generic components. Prefer `function Thing(props: Props) { ... }`.
+- `useEffect` only for synchronizing with external systems. Derived state belongs in render.
+
+## Testing
+- Vitest or Jest — pick one.
+- `tsd` or `expectType` for type-level tests of public APIs.
+- Avoid snapshot tests of implementation details.
+
+## Avoid
+- `any`, `// @ts-ignore`, `as unknown as T` in production code.
+- Non-null assertions (`!`) without a comment explaining why.
+- `Object`, `Function`, `{}` as types — they are never what you want.
+- Classes where a function and a closure would do.

--- a/skills/principles/clean-architecture/SKILL.md
+++ b/skills/principles/clean-architecture/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: clean-architecture
+description: Clean Architecture, hexagonal architecture, ports and adapters, dependency rule, and domain-centric layering. Auto-load when designing architecture, choosing layers, discussing the dependency rule, ports, adapters, or keeping the domain free of framework code.
+---
+
+# Clean Architecture
+
+## The one rule
+**Source-code dependencies point inward.** Inner circles know nothing about outer ones.
+
+```
+[ Frameworks & Drivers ]   ← HTTP, DB, UI, CLI
+  [ Interface Adapters ]   ← controllers, presenters, gateways
+    [ Use Cases ]          ← application-specific business rules
+      [ Entities ]         ← enterprise-wide business rules
+```
+
+If a use case imports the ORM, the rule is broken.
+
+## Ports and adapters
+- **Port** — interface owned by the domain describing what it needs (`UserRepository.find(id)`).
+- **Adapter** — implementation in the outer layer (`PostgresUserRepository`).
+- Domain depends on ports. Composition root wires adapters to ports at startup.
+
+## Keeping the domain pure
+- No imports of HTTP, SQL, ORM types, JSON libraries, or wall-clock time from the domain.
+- Pass side-effects in as interfaces (`Clock`, `IdGenerator`, `Repository`).
+- Domain types are plain data + behavior — no framework annotations.
+
+## Boundary crossings
+- Cross layers only via data structures the inner layer defines.
+- Outer layers translate to/from these structures. Never leak an ORM entity into a use case.
+
+## Testing payoff
+- Use cases are unit-testable with fake adapters.
+- Integration tests live at the adapter boundary.
+- Framework tests (HTTP, DB) stay narrow because business rules are elsewhere.
+
+## When NOT to apply
+- Throwaway scripts and prototypes — flat is fine.
+- Obvious CRUD with no domain logic — a single service file is clearer than four layers.
+- Tiny internal tools where ceremony cost exceeds change cost.
+
+## Drift smells
+- Repositories returning ORM objects instead of domain types.
+- Use cases importing HTTP request/response types.
+- Presenters holding business rules.
+- `utils` packages imported by the domain.
+
+## Decision aid
+Ask: "If we swapped the database / web framework / message bus, which files change?" Only the adapters should.

--- a/skills/principles/ddd/SKILL.md
+++ b/skills/principles/ddd/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ddd
+description: Domain-Driven Design — bounded contexts, aggregates, entities, value objects, ubiquitous language, and domain events. Auto-load when modeling a complex domain, splitting services, designing aggregates, or aligning code with business language.
+---
+
+# Domain-Driven Design
+
+DDD is a toolkit for **complex domains**. For CRUD, it is overkill.
+
+## Strategic design
+
+### Ubiquitous language
+Every important concept in code uses the same word the domain experts use. If marketing says "subscription" and code says "userPlan", you have a translation tax forever. Rename.
+
+### Bounded contexts
+A bounded context is a boundary inside which a term has exactly one meaning. "Order" in Checkout is not the same entity as "Order" in Fulfillment — it just shares a name.
+- One team, one context is the ideal.
+- Cross-context communication goes through explicit contracts (events, APIs).
+- Shared databases across contexts are an anti-pattern.
+
+### Context map
+Document how contexts relate: Partnership, Customer/Supplier, Conformist, Anticorruption Layer, Published Language, Shared Kernel, Separate Ways. Pick the relationship intentionally.
+
+## Tactical design
+
+### Entity
+Identity persists through change. `User{id, name}` — renaming doesn't change the user.
+
+### Value object
+Identity-less, immutable, compared by value. `Money{amount, currency}`, `EmailAddress`, `DateRange`. Prefer aggressively — eliminates primitive obsession bugs.
+
+### Aggregate
+A cluster of entities and value objects treated as one consistency boundary. The **aggregate root** is the only entry point; outside code cannot hold references to internal entities.
+- Keep aggregates small — large ones cause contention.
+- One transaction, one aggregate. Cross-aggregate coordination happens via domain events.
+
+### Repository
+Collection-like interface for loading and persisting aggregates. Port in domain layer; implementation in infrastructure.
+
+### Domain event
+Something meaningful that happened. `OrderPlaced`, `PaymentFailed`. Emit from aggregates; handle in application services or other contexts.
+
+### Domain service
+Stateless domain logic that does not belong on a single entity (e.g., a transfer between two accounts).
+
+## When DDD is overkill
+- Simple CRUD apps.
+- Technical utilities (a scheduler, a logger).
+- Prototypes where the domain is not yet understood — premature DDD freezes the wrong model.
+
+## Signals you need DDD
+- Multiple teams colliding in one codebase.
+- Business rules hidden inside controllers or stored procedures.
+- Experts and developers using different words for the same thing.
+- Transactions spanning unrelated data.

--- a/skills/principles/design-patterns/SKILL.md
+++ b/skills/principles/design-patterns/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: design-patterns
+description: Design patterns — Gang of Four and beyond. Strategy, factory method, observer, decorator, adapter, facade, template method, command, repository, dependency injection. Auto-load when designing class structure, refactoring toward a pattern, or evaluating whether a pattern applies.
+---
+
+# Design Patterns — the ones worth knowing
+
+Patterns are vocabulary, not goals. Reach for one only when the problem it solves is actually present.
+
+## Strategy
+**Problem:** an algorithm varies independently of its caller.
+**Use when:** multiple interchangeable behaviors selected at runtime (pricing rules, compression, sort orders).
+**Overkill when:** there is only one strategy.
+**Modern alternative:** a first-class function or lambda.
+
+## Factory Method
+**Problem:** construction is non-trivial or must be swappable.
+**Use when:** the concrete type depends on input or config.
+**Overkill when:** `new Thing()` works and always will.
+**Modern alternative:** a constructor function plus DI at the composition root.
+
+## Observer
+**Problem:** many objects need to react to a state change.
+**Use when:** loose coupling between emitter and listeners (UI, domain events).
+**Overkill when:** one listener, ever — call it directly.
+**Modern alternative:** language-native events, reactive streams, domain events on a bus.
+
+## Decorator
+**Problem:** add behavior without subclassing the world.
+**Use when:** stacking optional behavior — caching, logging, retries around a core call.
+**Overkill when:** no composition, one behavior.
+**Modern alternative:** middleware chains, higher-order functions.
+
+## Adapter
+**Problem:** two interfaces should work together but don't.
+**Use when:** integrating a third-party or legacy API into your domain types.
+**Overkill when:** you control both sides — just change one.
+
+## Facade
+**Problem:** a subsystem has too many moving parts for its callers.
+**Use when:** simplifying a complex API for the common 80%.
+**Overkill when:** the facade just forwards one call.
+
+## Template Method
+**Problem:** the skeleton of an algorithm is fixed but steps vary.
+**Use when:** several variants share a clear sequence.
+**Overkill when:** the sequence is two steps.
+**Warning:** easy to abuse — prefer Strategy when steps are independent.
+
+## Command
+**Problem:** parameterize, queue, log, or undo actions.
+**Use when:** task queues, undo/redo, transactional operations.
+**Overkill when:** you just want to call a function.
+
+## Repository
+**Problem:** domain code should not depend on storage details.
+**Use when:** persisting aggregates behind a collection-like interface.
+**Overkill when:** a single SQL query in a single place.
+
+## Dependency Injection (essential, not GoF)
+**Problem:** classes that new-up their own collaborators are untestable and rigid.
+**Use when:** wiring side-effecting collaborators (clocks, IDs, repositories, gateways).
+**Overkill when:** constructing simple value objects.
+**Anti-pattern:** heavyweight DI frameworks for small apps — constructor injection at `main()` is usually enough.
+
+## Anti-patterns worth naming
+- **Singleton** — almost always a disguised global; prefer a single instance composed at the root.
+- **God object** — one class that does everything; split by change vector.
+- **Pattern-itis** — five patterns where a function would do.

--- a/skills/principles/solid/SKILL.md
+++ b/skills/principles/solid/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: solid
+description: SOLID principles — single responsibility, open-closed, Liskov substitution, interface segregation, dependency inversion. Auto-load when designing classes, refactoring, reviewing object-oriented code, or discussing coupling, cohesion, or abstractions.
+---
+
+# SOLID
+
+Five heuristics for OO design. Guidelines, not laws.
+
+## S — Single Responsibility
+*A module should have one reason to change.* Usually that means one *actor* it serves.
+- **Good:** `InvoiceCalculator` computes totals; `InvoiceRenderer` formats output.
+- **Bad:** `Invoice` that calculates, renders, emails, and persists.
+- **Misapplied:** splitting a 20-line class into five 4-line classes. SRP is about change vectors, not line count.
+
+## O — Open-Closed
+*Open for extension, closed for modification.* New behavior should not require editing stable code.
+- **Good:** a payment processor iterates `PaymentMethod` implementations; new methods are new files.
+- **Bad:** a giant `switch` on `paymentType` that every new method edits.
+- **Misapplied:** introducing a plugin framework for three enum values that will never grow.
+
+## L — Liskov Substitution
+*Subtypes must be usable wherever the base type is expected, without surprising callers.*
+- **Good:** `ReadOnlyList` is not a subtype of `MutableList` — don't force it.
+- **Bad:** `Square extends Rectangle` overriding `setWidth` to also set height.
+- **Misapplied:** forbidding inheritance entirely. LSP is about honoring contracts, not avoiding hierarchies.
+
+## I — Interface Segregation
+*Clients should not depend on methods they do not use.*
+- **Good:** `Reader`, `Writer`, `Closer` composed as needed.
+- **Bad:** one `IFileSystem` with 40 methods every consumer imports.
+- **Misapplied:** one-method interfaces for every action, creating interface soup.
+
+## D — Dependency Inversion
+*Depend on abstractions, not concretions.* High-level policy does not import low-level detail.
+- **Good:** `OrderService` depends on `PaymentGateway`; Stripe and PayPal adapters implement it.
+- **Bad:** `OrderService` instantiates `StripeClient` directly.
+- **Misapplied:** an interface for every class "just in case". Invert only for a real seam — testability, multiple implementations, architectural boundary.
+
+## When SOLID hurts
+- Tiny codebases where indirection costs more than it saves.
+- Scripts and one-off jobs.
+- Algorithms where the shape of the computation matters more than the shape of the objects.
+
+SOLID is about making change cheap. If nothing is changing, it costs complexity for no return.

--- a/skills/principles/tdd/SKILL.md
+++ b/skills/principles/tdd/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: tdd
+description: Test-Driven Development — red, green, refactor; writing tests first; making tests fast and isolated. Auto-load when implementing a feature, fixing a bug with tests, discussing test strategy, or reviewing test quality.
+---
+
+# Test-Driven Development
+
+## The loop
+1. **Red** — one failing test describing the next slice of behavior. Run it; confirm it fails for the right reason.
+2. **Green** — simplest production code that passes. Hard-coding is allowed — it will be driven out by the next test.
+3. **Refactor** — with all tests green, improve the code and the tests. Never refactor on red.
+
+Each cycle is minutes, not hours.
+
+## Rule of three
+Duplication triggers refactor on the third occurrence. Two is coincidence; three is pattern.
+
+## F.I.R.S.T.
+- **Fast** — milliseconds.
+- **Isolated** — independent of order and other tests.
+- **Repeatable** — deterministic anywhere.
+- **Self-validating** — automatic pass/fail.
+- **Timely** — written just before the production code.
+
+## What to test
+- **Behavior**, not implementation. "Returns total with tax" survives refactor; "calls foo then bar" does not.
+- **Boundaries** — empty, single, max, null, unicode.
+- **Error paths** — wrong-currency transfer, expired token, upstream 500.
+
+## What NOT to test
+- Getters/setters with no logic.
+- Framework code you don't own.
+- Private methods directly — test through the public API.
+
+## When TDD helps most
+- Logic-heavy domain code.
+- Bug fixes — write a reproducing test before fixing.
+- Refactoring — characterization tests first.
+
+## When TDD is friction
+- Exploratory spikes with unknown design — spike, throw away, then TDD the real thing.
+- Pure UI tweaks where visual inspection is the oracle.
+- Trivial plumbing fully covered by a higher-level integration test.
+
+## Common failure modes
+- Tests that mirror the implementation (over-mocking).
+- Tests sharing mutable state and failing in parallel.
+- Giant setups hiding what's under test — extract test data builders.
+- "I'll add tests later." You won't.


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` — plugin manifest (name, author, keywords)
- Adds 5 principle skills that auto-load during design/coding: `clean-architecture`, `ddd`, `solid`, `tdd`, `design-patterns`
- Adds 3 language skills that auto-trigger by file extension: `go`, `rust`, `typescript`
- Adds 4 workflow commands: `review`, `design`, `tdd`, `refactor`
- Adds 3 subagents: `reviewer`, `senior-engineer`, `refactorer`
- Adds `hooks/hooks.json` blocking destructive Bash commands on protected branches

## Install (after merge)

```
/plugin marketplace add lugassawan/swe-workbench
/plugin install swe-workbench
```

## Test plan

- [ ] `jq . .claude-plugin/plugin.json` — valid JSON, author is Lugas Septiawan
- [ ] `jq . hooks/hooks.json` — valid JSON
- [ ] Each `SKILL.md` under 150 lines; each agent under 200 lines
- [ ] `/plugin marketplace add $(pwd)` + `/plugin install swe-workbench` succeeds locally
- [ ] `/swe-workbench:design "..."` invokes the `senior-engineer` subagent
- [ ] `/swe-workbench:review` produces severity-bucketed findings