### PR TITLE
[feat] Add git hooks, PR template, and CI validation

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Commit-msg hook: enforce [type] prefix convention.
+
+SUBJECT=$(head -1 "$1")
+
+# Allow merge commits and reverts
+case "$SUBJECT" in
+    Merge*|Revert*) exit 0 ;;
+esac
+
+# Keep in sync with .github/workflows/pr.yml
+PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+'
+
+if ! echo "$SUBJECT" | grep -qE "$PATTERN"; then
+    echo ""
+    echo "ERROR: Invalid commit message:"
+    echo "  $SUBJECT"
+    echo ""
+    echo "Expected format:"
+    echo "  [type] Description"
+    echo ""
+    echo "Allowed types:"
+    echo "  feat, fix, refactor, test, ci, docs, perf, chore, polish, breaking"
+    echo ""
+    echo "Examples:"
+    echo "  [feat] Add worktree sync command"
+    echo "  [fix] Resolve branch detection on Windows"
+    echo "  [ci] Add coverage gate to CI pipeline"
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Pre-commit hook: prevent direct commits to protected branches.
+
+_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$_branch" = "main" ] || [ "$_branch" = "master" ]; then
+    echo "ERROR: Direct commits to '$_branch' are not allowed."
+    echo "       Create a feature branch first:  git checkout -b feat/<topic>"
+    exit 1
+fi

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+<!-- Describe what changed and why. Use bullet points. -->
+-
+
+## Test Plan
+<!-- How did you verify this works? Check the boxes. -->
+- [ ] Changed skills/commands/agents load without errors
+- [ ] Examples in the diff were exercised manually
+- [ ]
+
+<!-- Link to the GitHub issue this PR addresses.
+     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>
+
+     If no issue applies, DELETE the "Closes #" line and replace it with
+     a standalone line:
+         N/A
+     Preferred (more useful for reviewers):
+         N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">
+
+     The following WILL fail CI:
+       - leaving "Closes #" empty with no replacement
+       - deleting the line entirely with nothing in its place
+       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "N/A" instead) -->
+Closes #

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,61 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main]
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Keep in sync with .githooks/commit-msg
+          PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+'
+          if ! echo "$PR_TITLE" | grep -qE "$PATTERN"; then
+            echo "::error::PR title must match format: [type] Description (e.g. [feat] Add new feature)"
+            echo ""
+            echo "Allowed types: feat, fix, refactor, test, ci, docs, perf, chore, polish, breaking"
+            exit 1
+          fi
+
+      - name: Validate PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          TRIMMED=$(echo "$PR_BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [ -z "$TRIMMED" ]; then
+            echo "::error::PR description must not be empty"
+            exit 1
+          fi
+
+      - name: Validate issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Allow ad-hoc PRs that explicitly opt out with "N/A" on its own line.
+          # Accepts: "N/A", "N/A - reason", "N/A — reason" (bare N/A and with reason are both valid).
+          if echo "$PR_BODY" | grep -iqE '^[[:space:]]*N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
+            echo "Issue reference opted out with N/A — skipping check"
+            exit 0
+          fi
+
+          # Require a GitHub closing keyword (case-insensitive).
+          # "Closes N/A" or "Closes #N/A" will NOT match the N/A check above (not a standalone line)
+          # and will NOT match this check — so they correctly fail CI.
+          if ! echo "$PR_BODY" | grep -iqE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+'; then
+            echo "::error::PR body must reference an issue with a closing keyword"
+            echo ""
+            echo "Add one of these to your PR description:"
+            echo "  Closes #123"
+            echo "  Fixes #123"
+            echo "  Resolves #123"
+            echo ""
+            echo "For ad-hoc changes without an issue, add a standalone 'N/A' line."
+            echo ""
+            echo "See: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Then try:
 
 If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
 
+## Contributing
+
+After cloning, enable the project git hooks once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+The hooks enforce `[type] Subject` commit format and block accidental commits to `main`. CI (`.github/workflows/pr.yml`) runs the same checks on every pull request, so if you skip the local setup you'll just discover issues in CI instead.
+
+Note: `.githooks/` (git hooks) is unrelated to `hooks/hooks.json` (Claude Code plugin runtime hooks) — same directory depth, different purpose.
+
 ## License
 
 MIT.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+git config core.hooksPath .githooks
+echo "Git hooks enabled (.githooks/)"


### PR DESCRIPTION
## Summary

- Adds `.githooks/commit-msg` — enforces `[type] Subject` commit format (ported from rimba, verbatim)
- Adds `.githooks/pre-commit` — blocks direct commits to `main`/`master` (stripped down from rimba; no Go/rimba-specific logic)
- Adds `.github/PULL_REQUEST_TEMPLATE.md` — structured PR description with an explicit N/A instruction: bare `N/A` is a valid opt-out, but `Closes N/A` / empty `Closes #` / deleted line will fail CI
- Adds `.github/workflows/pr.yml` — CI enforces PR title format and issue reference on every PR; acts as the enforcement backstop for contributors who skip the local hook setup
- Adds `setup.sh` — one-shot bootstrap (`./setup.sh`) that runs `git config core.hooksPath .githooks` after clone
- Updates `README.md` — Contributing section explaining the setup and the `.githooks/` vs `hooks/hooks.json` distinction

## Test Plan

- [ ] `./setup.sh` activates hooks locally
- [ ] A commit with a bad message (no `[type]` prefix) is rejected by `commit-msg`
- [ ] A direct commit to `main` is rejected by `pre-commit`
- [ ] CI `validate-pr` job passes with a valid title + `Closes #<num>` or standalone `N/A`
- [ ] CI rejects `Closes N/A`, empty `Closes #`, and bad PR title format

N/A