### PR TITLE
[fix] Update Contributing section to reference setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` â€
 
 ## Contributing
 
-After cloning, enable the project git hooks once:
+After cloning, run the setup script once:
 
 ```sh
-git config core.hooksPath .githooks
+./setup.sh
 ```
 
-The hooks enforce `[type] Subject` commit format and block accidental commits to `main`. CI (`.github/workflows/pr.yml`) runs the same checks on every pull request, so if you skip the local setup you'll just discover issues in CI instead.
+This sets `core.hooksPath` to activate the project git hooks. The hooks enforce `[type] Subject` commit format and block accidental commits to `main`. CI (`.github/workflows/pr.yml`) runs the same checks on every pull request, so if you skip the local setup you'll just discover issues in CI instead.
 
 Note: `.githooks/` (git hooks) is unrelated to `hooks/hooks.json` (Claude Code plugin runtime hooks) â€” same directory depth, different purpose.
 


### PR DESCRIPTION
## Summary

- The README Contributing section was committed with the original `git config core.hooksPath .githooks` wording before `setup.sh` was added in the same session. This corrects it to point to `./setup.sh`.

## Test Plan

- [ ] README Contributing section now shows `./setup.sh` as the setup command

Closes #2