### PR TITLE
[feat] Fill remaining gaps from senior-engineer and development-workflow port

### DIFF
--- a/skills/principles/clean-architecture/SKILL.md
+++ b/skills/principles/clean-architecture/SKILL.md
@@ -47,6 +47,17 @@ If a use case imports the ORM, the rule is broken.
 - Presenters holding business rules.
 - `utils` packages imported by the domain.
 
+## Layer import rules
+
+| Layer | Can import | Must NOT import |
+|-------|-----------|----------------|
+| Domain | Standard library only | Application, Infrastructure, Framework |
+| Application | Domain | Infrastructure, Framework |
+| Infrastructure | Domain, Application | Framework (except its own SDK) |
+| Framework/UI | All layers | — |
+
+Layers don't require separate modules. A directory per layer suffices: `domain/`, `app/` (or `usecase/`), `infra/`, `ui/`.
+
 ## Decision aid
 Ask: "If we swapped the database / web framework / message bus, which files change?" Only the adapters should.
 

--- a/skills/principles/ddd/SKILL.md
+++ b/skills/principles/ddd/SKILL.md
@@ -54,6 +54,11 @@ Stateless domain logic that does not belong on a single entity (e.g., a transfer
 - Experts and developers using different words for the same thing.
 - Transactions spanning unrelated data.
 
+## Signs you specifically need Full DDD
+- Multiple entities must change atomically (→ aggregates + unit of work).
+- Business events trigger cascading actions across the domain (→ domain events).
+- Different teams own different parts of the domain (→ bounded contexts + context map).
+
 ## Pattern Selection Quick Reference
 
 | Complexity | Domain patterns | Repository pattern | Example |

--- a/skills/principles/solid/SKILL.md
+++ b/skills/principles/solid/SKILL.md
@@ -37,6 +37,8 @@ Five heuristics for OO design. Guidelines, not laws.
 - **Bad:** `OrderService` instantiates `StripeClient` directly.
 - **Misapplied:** an interface for every class "just in case". Invert only for a real seam — testability, multiple implementations, architectural boundary.
 
+**Every cross-boundary dependency MUST be an abstraction — no exceptions.** If Component A depends on Component B in a different architectural layer, A defines the interface in its own layer and B implements it. Same-layer dependencies may be direct.
+
 ## When SOLID hurts
 - Tiny codebases where indirection costs more than it saves.
 - Scripts and one-off jobs.

--- a/skills/workflows/development/SKILL.md
+++ b/skills/workflows/development/SKILL.md
@@ -81,7 +81,14 @@ Choose execution strategy:
 - **Independent tasks, same session** → invoke `superpowers:subagent-driven-development`
 - **No plan / ad-hoc** → implement directly with `superpowers:test-driven-development` per unit
 
-Commit logically grouped changes as you go — infrastructure, core logic, tests, and wiring as separate commits. Never bundle unrelated changes.
+Commit logically grouped changes as you go. Never bundle unrelated changes.
+
+| Commit type | Contains |
+|---|---|
+| Infrastructure | Config, dependencies, build changes |
+| Core logic | Main feature/fix implementation |
+| Tests | Test files and test utilities |
+| Wiring | Integration, routing, CLI registration |
 
 ---
 


### PR DESCRIPTION
## Summary

Completes the content port from the two personal skills (`senior-engineer`, `development-workflow`) into the plugin. Fills gaps missed during the initial PR #4:

- **`clean-architecture`** — layer import rules table (Domain/Application/Infrastructure/Framework × can/must-not import) + mapping-to-packages note
- **`ddd`** — "Signs you specifically need Full DDD" bullets (atomic entity changes, cascading domain events, multi-team bounded contexts)
- **`solid`** — strengthens D section with "Every cross-boundary dependency MUST be an abstraction — no exceptions" + same-layer exception rule
- **`development`** — adds commit-grouping table to Phase 2 (Infrastructure / Core logic / Tests / Wiring)

## Test Plan

- [ ] "What can the Application layer import?" → `clean-architecture` surfaces the layer import rules table
- [ ] "When do I need Full DDD vs just Light DDD?" → `ddd` surfaces "Signs you specifically need Full DDD"
- [ ] "Does DIP apply to small components?" → `solid` D section surfaces the "no exceptions" absolute rule
- [ ] "How should I split my commits?" → `development` Phase 2 shows the commit-grouping table

N/A