### PR TITLE
[feat] Add marketplace.json for plugin marketplace installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "swe-workbench",
+  "description": "Senior-engineer toolkit for Claude Code — principled design, language expertise, and pragmatic workflows",
+  "owner": {
+    "name": "Lugas Septiawan",
+    "email": "lugassawan@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "swe-workbench",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns), language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+      "version": "0.1.0",
+      "source": "./",
+      "author": {
+        "name": "Lugas Septiawan",
+        "email": "lugassawan@gmail.com"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` — required by the Claude Code plugin installer when running `/plugin marketplace add lugassawan/swe-workbench`
- The installer looks for `marketplace.json` (not `plugin.json`) at `.claude-plugin/marketplace.json`; without it the install fails with "Marketplace file not found"

## Test Plan

- [ ] `/plugin marketplace add lugassawan/swe-workbench` completes without error
- [ ] `/plugin install swe-workbench` installs successfully

N/A