### PR TITLE
[docs] Restructure README, add CONTRIBUTING.md and docs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+## Setup
+
+After cloning, run the setup script once:
+
+```sh
+./setup.sh
+```
+
+This sets `core.hooksPath` to `.githooks/`, activating the two local git hooks described below.
+
+## Branch naming
+
+The `pre-commit` hook blocks direct commits to `main` and `master`. Always work on a feature branch:
+
+```sh
+git checkout -b feat/<topic>
+```
+
+## Commit message format
+
+The `commit-msg` hook enforces a `[type] Subject` prefix on every commit:
+
+```
+[feat] Add Python language skill
+[fix] Resolve trigger keyword collision in DDD skill
+[docs] Clarify F.I.R.S.T. principle in TDD skill
+```
+
+Allowed types: `feat`, `fix`, `refactor`, `test`, `ci`, `docs`, `perf`, `chore`, `polish`, `breaking`.
+
+Merge commits and reverts are exempt. The same pattern is validated by CI (see `.github/workflows/pr.yml`).
+
+## Pull requests
+
+Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). It requires:
+
+- A summary of what changed and why.
+- A test plan with checkboxes.
+- An issue reference: `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>`. For ad-hoc changes without an issue, put a standalone `N/A` line (with an optional reason) — `Closes N/A` and `Closes #N/A` are malformed and will fail CI.
+- PR title must match the same `[type] Subject` format as commit messages.
+
+## CI mirror
+
+`.github/workflows/pr.yml` runs the same commit-format and issue-reference checks on every PR. Skipping local setup does not skip CI — it just shifts the failure to after you push.
+
+## Testing locally
+
+```sh
+cd swe-workbench
+/plugin marketplace add $(pwd)
+/plugin install swe-workbench
+```
+
+Then try:
+
+```
+/swe-workbench:design "Should I use microservices for a 3-engineer team?"
+/swe-workbench:review
+```
+
+If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
+
+## `.githooks/` vs `hooks/hooks.json`
+
+These two directories share the same depth but serve different runtimes:
+
+| Path | Purpose |
+|---|---|
+| `.githooks/` | Git hooks (`commit-msg`, `pre-commit`) — invoked by git. |
+| `hooks/hooks.json` | Claude Code plugin runtime hooks — invoked by the Claude Code plugin system. |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# swe-workbench
+# SWE Workbench
 
-A senior-engineer toolkit for Claude Code — principled design, language expertise, and pragmatic workflows, packaged as one installable plugin.
+*A senior engineer's toolkit for Claude Code — principled design, language expertise, pragmatic workflows.*
 
 ## What it is
 
@@ -24,106 +24,19 @@ cd swe-workbench
 /plugin install swe-workbench
 ```
 
-## Commands
+## What's inside
 
-| Command | Purpose |
-|---|---|
-| `/swe-workbench:review` | Review the current git diff — correctness, security, design, test gaps. |
-| `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
-| `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `reviewer`, `senior-engineer`, `refactorer` — see [docs/catalog.md](docs/catalog.md).
+- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code — auto-load by trigger keyword.
+- **Languages** — Go, Rust, TypeScript — auto-load by file extension.
+- **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
 
-## Subagents
-
-| Agent | When to invoke |
-|---|---|
-| `reviewer` | PR review, diff audit, post-feature sanity check. |
-| `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
-| `refactorer` | Cleaning up smells before adding a feature. |
-
-## Skills
-
-### Principles — auto-load when designing or writing code
-
-| Skill | Triggers |
-|---|---|
-| `clean-architecture` | "clean architecture", "hexagonal", "ports and adapters", "dependency rule", "layering". |
-| `ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
-| `solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
-| `tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
-| `design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
-| `clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
-
-### Languages — auto-load by file type
-
-| Skill | Triggers |
-|---|---|
-| `go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
-| `rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
-| `typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
-
-### Workflows — auto-load during implementation
-
-| Skill | Triggers | Delegation model |
-|---|---|---|
-| `development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
-
-This skill is an orchestrator — it coordinates other skills rather than restating their content.
-
-## Philosophy
-
-Skills are intentionally small — each under 150 lines. A sharp, well-triggered skill teaches Claude the right thing at the right moment. A giant skill burns context on material the current task does not need. If a skill grows past 150 lines, split it.
-
-Orchestrator skills that compose many sub-skills (see Workflows) may exceed 150 lines. When they do, extract conditional content (mode templates, rarely-loaded sub-flows) into companion files inside the skill's directory rather than padding the always-loaded `SKILL.md`.
-
-## Extending
-
-To add a new language skill (say, Python):
-
-1. Copy `skills/languages/go/` to `skills/languages/python/`.
-2. Rewrite `SKILL.md` frontmatter: `name: python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
-3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
-4. Keep it under 150 lines.
-5. Commit; users who reinstall the plugin will pick it up.
-
-## Testing locally
-
-```bash
-cd swe-workbench
-/plugin marketplace add $(pwd)
-/plugin install swe-workbench
-```
-
-Then try:
-
-```
-/swe-workbench:design "Should I use microservices for a 3-engineer team?"
-/swe-workbench:review
-```
-
-If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
+Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide and philosophy → [docs/extending.md](docs/extending.md). Runtime dependencies → [docs/dependencies.md](docs/dependencies.md).
 
 ## Contributing
 
-After cloning, run the setup script once:
-
-```sh
-./setup.sh
-```
-
-This sets `core.hooksPath` to activate the project git hooks. The hooks enforce `[type] Subject` commit format and block accidental commits to `main`. CI (`.github/workflows/pr.yml`) runs the same checks on every pull request, so if you skip the local setup you'll just discover issues in CI instead.
-
-Note: `.githooks/` (git hooks) is unrelated to `hooks/hooks.json` (Claude Code plugin runtime hooks) — same directory depth, different purpose.
-
-## Dependencies
-
-`swe-workbench` composes with other Claude Code plugins at runtime:
-
-| Plugin | Source | Used for | Required? |
-|---|---|---|---|
-| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | Process skills invoked by `development` (`using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`). | Required for the `development` skill to function end-to-end. |
-| `claude-plugins-official` | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Official Anthropic plugin collection — install if you need any of its bundled tools. | Optional. |
-
-Install them via `/plugin marketplace add …` + `/plugin install …` before using the `development` skill.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Reference docs
+
+- [catalog.md](catalog.md) — commands, subagents, and skills (full tables).
+- [extending.md](extending.md) — how to add new skills; philosophy behind the design.
+- [dependencies.md](dependencies.md) — runtime plugin dependencies.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -1,0 +1,46 @@
+# Catalog
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/swe-workbench:review` | Review the current git diff — correctness, security, design, test gaps. |
+| `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
+| `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
+
+## Subagents
+
+| Agent | When to invoke |
+|---|---|
+| `reviewer` | PR review, diff audit, post-feature sanity check. |
+| `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
+| `refactorer` | Cleaning up smells before adding a feature. |
+
+## Skills
+
+### Principles — auto-load when designing or writing code
+
+| Skill | Triggers |
+|---|---|
+| `clean-architecture` | "clean architecture", "hexagonal", "ports and adapters", "dependency rule", "layering". |
+| `ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
+| `solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
+| `tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
+| `design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
+| `clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
+
+### Languages — auto-load by file type
+
+| Skill | Triggers |
+|---|---|
+| `go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
+| `rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
+| `typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
+
+### Workflows — auto-load during implementation
+
+| Skill | Triggers | Delegation model |
+|---|---|---|
+| `development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
+
+This skill is an orchestrator — it coordinates other skills rather than restating their content.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,10 @@
+# Runtime dependencies
+
+`swe-workbench` composes with other Claude Code plugins at runtime:
+
+| Plugin | Source | Used for | Required? |
+|---|---|---|---|
+| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | Process skills invoked by `development` (`using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`). | Required for the `development` skill to function end-to-end. |
+| `claude-plugins-official` | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Official Anthropic plugin collection — install if you need any of its bundled tools. | Optional. |
+
+Install them via `/plugin marketplace add …` + `/plugin install …` before using the `development` skill.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,17 @@
+# Extending
+
+## Adding a language skill
+
+To add a new language skill (say, Python):
+
+1. Copy `skills/languages/go/` to `skills/languages/python/`.
+2. Rewrite `SKILL.md` frontmatter: `name: python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
+3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
+4. Keep it under 150 lines.
+5. Commit; users who reinstall the plugin will pick it up.
+
+## Philosophy
+
+Skills are intentionally small — each under 150 lines. A sharp, well-triggered skill teaches Claude the right thing at the right moment. A giant skill burns context on material the current task does not need. If a skill grows past 150 lines, split it.
+
+Orchestrator skills that compose many sub-skills (see the `development` workflow) may exceed 150 lines. When they do, extract conditional content (mode templates, rarely-loaded sub-flows) into companion files inside the skill's directory rather than padding the always-loaded `SKILL.md`.


### PR DESCRIPTION
## Summary

- Slim `README.md` to a scannable landing page (~43 lines); rename title to `# SWE Workbench` with an italic tagline subtitle
- Add `CONTRIBUTING.md` at repo root — GitHub auto-surfaces this in the PR/issue sidebar; covers setup, branch rules, commit format, PR contract, CI mirror, local testing, and the `.githooks/` vs `hooks/hooks.json` disambiguation
- Add `docs/` with four files: `README.md` (index), `catalog.md` (commands/subagents/skills tables), `extending.md` (extending guide + philosophy), `dependencies.md` (runtime plugin deps)

No content lost — every section from the old README has a new home.

## Test Plan

- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] All links in README resolve (`CONTRIBUTING.md`, `docs/catalog.md`, `docs/extending.md`, `docs/dependencies.md`)
- [ ] All links in `docs/README.md` resolve
- [ ] `CONTRIBUTING.md` is self-contained — a new contributor can make a valid PR using only it + the PR template

N/A — docs-only restructure, no issue