### PR TITLE
[fix] Update skill name: fields and docs to match renamed directories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Then try:
 
 If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
 
+**Skill directory layout**: Skills must live at `skills/<skill-name>/SKILL.md` — exactly one level deep. Claude Code's auto-discovery does not recurse into nested category subdirectories. Use a hyphenated prefix to preserve categorical grouping while meeting this constraint: `principle-*`, `language-*`, `workflow-*`. The `name:` field in the `SKILL.md` frontmatter must match the directory name exactly.
+
 ## `.githooks/` vs `hooks/hooks.json`
 
 These two directories share the same depth but serve different runtimes:

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -22,25 +22,25 @@
 
 | Skill | Triggers |
 |---|---|
-| `clean-architecture` | "clean architecture", "hexagonal", "ports and adapters", "dependency rule", "layering". |
-| `ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
-| `solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
-| `tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
-| `design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
-| `clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
+| `principle-clean-architecture` | "clean architecture", "hexagonal", "ports and adapters", "dependency rule", "layering". |
+| `principle-ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
+| `principle-solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
+| `principle-tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
+| `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
+| `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
 
 ### Languages — auto-load by file type
 
 | Skill | Triggers |
 |---|---|
-| `go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
-| `rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
-| `typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
+| `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
+| `language-rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
+| `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
 
 ### Workflows — auto-load during implementation
 
 | Skill | Triggers | Delegation model |
 |---|---|---|
-| `development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
+| `workflow-development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
 
 This skill is an orchestrator — it coordinates other skills rather than restating their content.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -4,8 +4,8 @@
 
 To add a new language skill (say, Python):
 
-1. Copy `skills/languages/go/` to `skills/languages/python/`.
-2. Rewrite `SKILL.md` frontmatter: `name: python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
+1. Copy `skills/language-go/` to `skills/language-python/`.
+2. Rewrite `SKILL.md` frontmatter: `name: language-python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
 3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
 4. Keep it under 150 lines.
 5. Commit; users who reinstall the plugin will pick it up.

--- a/skills/language-go/SKILL.md
+++ b/skills/language-go/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: go
+name: language-go
 description: Go idioms, error handling, concurrency, and standard library usage. Auto-load when working with .go files, go.mod, go.sum, or when the user mentions Go, Golang, goroutines, channels, interfaces, context, or error wrapping.
 ---
 

--- a/skills/language-rust/SKILL.md
+++ b/skills/language-rust/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: rust
+name: language-rust
 description: Rust idioms — ownership, borrowing, lifetimes, error handling, traits, and iterators. Auto-load when working with .rs files, Cargo.toml, or when the user mentions Rust, cargo, ownership, borrow checker, trait, lifetime, or async Rust.
 ---
 

--- a/skills/language-typescript/SKILL.md
+++ b/skills/language-typescript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: typescript
+name: language-typescript
 description: TypeScript and JavaScript idioms — strict mode, type safety, discriminated unions, async patterns, and Node. Auto-load when working with .ts, .tsx, .js, .jsx files, package.json, or when the user mentions TypeScript, JavaScript, Node, type safety, or tsconfig.
 ---
 

--- a/skills/principle-clean-architecture/SKILL.md
+++ b/skills/principle-clean-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: clean-architecture
+name: principle-clean-architecture
 description: Clean Architecture, hexagonal architecture, ports and adapters, dependency rule, and domain-centric layering. Auto-load when designing architecture, choosing layers, discussing the dependency rule, ports, adapters, or keeping the domain free of framework code.
 ---
 

--- a/skills/principle-clean-code/SKILL.md
+++ b/skills/principle-clean-code/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: clean-code
+name: principle-clean-code
 description: Clean code, DRY, KISS, YAGNI, function length, naming, abstraction level, error handling. Auto-load when writing functions, naming variables, reviewing code clarity, discussing comments, or debating whether to abstract.
 ---
 

--- a/skills/principle-ddd/SKILL.md
+++ b/skills/principle-ddd/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ddd
+name: principle-ddd
 description: Domain-Driven Design — bounded contexts, aggregates, entities, value objects, ubiquitous language, and domain events. Auto-load when modeling a complex domain, splitting services, designing aggregates, or aligning code with business language.
 ---
 

--- a/skills/principle-design-patterns/SKILL.md
+++ b/skills/principle-design-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: design-patterns
+name: principle-design-patterns
 description: Design patterns — Gang of Four and beyond. Strategy, factory method, observer, decorator, adapter, facade, template method, command, repository, dependency injection. Auto-load when designing class structure, refactoring toward a pattern, or evaluating whether a pattern applies.
 ---
 

--- a/skills/principle-solid/SKILL.md
+++ b/skills/principle-solid/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: solid
+name: principle-solid
 description: SOLID principles — single responsibility, open-closed, Liskov substitution, interface segregation, dependency inversion. Auto-load when designing classes, refactoring, reviewing object-oriented code, or discussing coupling, cohesion, or abstractions.
 ---
 

--- a/skills/principle-tdd/SKILL.md
+++ b/skills/principle-tdd/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tdd
+name: principle-tdd
 description: Test-Driven Development — red, green, refactor; writing tests first; making tests fast and isolated. Auto-load when implementing a feature, fixing a bug with tests, discussing test strategy, or reviewing test quality.
 ---
 

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: development
+name: workflow-development
 description: Use when implementing features, fixing bugs, or executing plans — defines the full development lifecycle (Branch → Implement → Verify → Review → Deliver) and embeds workflow steps into plans
 ---
 


### PR DESCRIPTION
## Summary

- Follow-up to #16. The previous PR renamed the skill directories but the frontmatter `name:` field in each `SKILL.md` and the documentation were not committed (Edit tool changes weren't staged before the commit).
- Updates `name:` in all 10 `SKILL.md` files to match their directory names (e.g. `name: tdd` → `name: principle-tdd`) so the invocation key (`swe-workbench:principle-tdd`) is consistent with the directory.
- Updates `docs/catalog.md`, `docs/extending.md`, and `CONTRIBUTING.md` to reference the new prefixed skill names.

## Test plan

- [ ] Confirm `grep -r "^name: tdd\|^name: go\|^name: rust\|^name: typescript\|^name: solid\|^name: ddd\|^name: development\|^name: clean" skills/` returns no matches
- [ ] Verify each `SKILL.md` frontmatter `name:` matches its parent directory name

N/A