### PR TITLE
[fix] Sharpen trigger keywords in 4 skill descriptions

### DIFF
--- a/skills/principle-ddd/SKILL.md
+++ b/skills/principle-ddd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-ddd
-description: Domain-Driven Design — bounded contexts, aggregates, entities, value objects, ubiquitous language, and domain events. Auto-load when modeling a complex domain, splitting services, designing aggregates, or aligning code with business language.
+description: Domain-Driven Design (DDD) — bounded contexts, aggregates, entities, value objects, ubiquitous language, domain events, context map, anti-corruption layer, and repository pattern. Auto-load when modeling a complex domain, splitting services, deciding service boundaries, microservice splits, designing aggregates, or aligning code with business language.
 ---
 
 # Domain-Driven Design

--- a/skills/principle-solid/SKILL.md
+++ b/skills/principle-solid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-solid
-description: SOLID principles — single responsibility, open-closed, Liskov substitution, interface segregation, dependency inversion. Auto-load when designing classes, refactoring, reviewing object-oriented code, or discussing coupling, cohesion, or abstractions.
+description: SOLID principles — SRP, OCP, LSP, ISP, DIP (single responsibility, open-closed, Liskov substitution, interface segregation, dependency inversion). Auto-load when designing classes, refactoring, reviewing object-oriented code, or discussing coupling, cohesion, abstractions, or any SOLID violation.
 ---
 
 # SOLID

--- a/skills/principle-tdd/SKILL.md
+++ b/skills/principle-tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-tdd
-description: Test-Driven Development — red, green, refactor; writing tests first; making tests fast and isolated. Auto-load when implementing a feature, fixing a bug with tests, discussing test strategy, or reviewing test quality.
+description: Test-Driven Development (TDD) — red-green-refactor, test-first, spec first, Arrange-Act-Assert, F.I.R.S.T. principles; writing tests before code; making tests fast and isolated. Auto-load when implementing a feature TDD-style, fixing a bug with tests, discussing test strategy, reviewing test quality, or writing the test before the implementation.
 ---
 
 # Test-Driven Development

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-development
-description: Use when implementing features, fixing bugs, or executing plans — defines the full development lifecycle (Branch → Implement → Verify → Review → Deliver) and embeds workflow steps into plans
+description: Development workflow — full lifecycle from Branch → Implement → Verify → Review → Deliver. Auto-load when writing an implementation plan, creating a plan, finalizing a plan before ExitPlanMode, starting a feature branch, opening a PR, shipping a change, asking about branch naming or commit format, handing off work, or beginning any structured development task.
 ---
 
 # Development Workflow


### PR DESCRIPTION
## Summary
- Added missing acronym tokens (SRP, OCP, LSP, ISP, DIP; DDD; TDD) to `principle-solid`, `principle-ddd`, and `principle-tdd` descriptions so skills fire on the short forms users actually type
- Added Mode A (plan-writing) triggers to `workflow-development` — "writing an implementation plan", "creating a plan", "finalizing a plan before ExitPlanMode" — so the skill auto-loads during plan sessions and injects the `## Workflow` section
- Added DDD entry-point phrasing to `principle-ddd` — "service boundaries", "microservice splits", "context map", "anti-corruption layer", "repository pattern"
- All edits are additive only; no existing trigger text was removed

## Test Plan
- [x] Changed skills load without errors (frontmatter-only edits, no body changes)
- [x] Verified description changes are additive — no regression to existing trigger surface
- [ ] Manual trigger check in a fresh session: "Let's do this TDD-style" → `principle-tdd`; "SRP violation" → `principle-solid`; "writing an implementation plan" → `workflow-development`

N/A — no open issue; follow-up to skill description audit conversation