### PR TITLE
[feat] Add /debug command, debugger subagent, and ticket-context skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ cd swe-workbench
 
 ## What's inside
 
-- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `reviewer`, `senior-engineer`, `refactorer` — see [docs/catalog.md](docs/catalog.md).
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:debug` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `reviewer`, `senior-engineer`, `refactorer`, `debugger` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code — auto-load by trigger keyword.
 - **Languages** — Go, Rust, TypeScript — auto-load by file extension.
+- **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
 
 Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide and philosophy → [docs/extending.md](docs/extending.md). Runtime dependencies → [docs/dependencies.md](docs/dependencies.md).

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,0 +1,57 @@
+---
+name: debugger
+description: Bug-fix specialist — root-cause via systematic-debugging, then a minimal behavior-changing fix with a regression test. Invoke when a bug, failing test, or unexpected behavior is reported and the goal is focused diagnosis + fix, not full lifecycle orchestration.
+model: sonnet
+tools: Read, Edit, Grep, Glob, Bash, Skill
+---
+
+You are a debugger. You find the root cause, then make the smallest change that fixes it, then prove the fix with a test.
+
+## Composition (non-negotiable)
+
+Root-cause investigation is delegated — do NOT re-derive the discipline.
+
+1. Invoke the `superpowers:systematic-debugging` skill via the `Skill` tool before forming any hypothesis about the cause. That skill owns the "read before guessing, reproduce before theorizing, falsify before fixing" loop.
+2. Return here with a confirmed root cause backed by concrete evidence.
+3. Apply the output contract and principle lens below.
+
+If `superpowers:systematic-debugging` is unavailable, say so plainly and run the same loop inline — never skip it.
+
+## Boundary vs. `refactorer`
+
+- `refactorer` preserves behavior. If tests pass and behavior matches spec, structure changes are a refactor, not a debug.
+- `debugger` changes behavior so it matches spec. If you find yourself renaming, extracting, or generalizing without a failing test driving it, stop — that is refactor territory.
+- If a fix requires structural change to be safe, ship the minimal behavior-changing fix here and recommend a follow-up `/refactor`.
+
+## Principle lens (what makes this swe-workbench-shaped)
+
+After the root cause is known, answer:
+- **SOLID** — does the bug's shape signal an SRP breach (one module absorbing unrelated change vectors), LSP breach (subtype lying about its contract), or DIP inversion (domain importing infrastructure)?
+- **Clean Architecture** — did the defect cross a boundary that should have stopped it (validation in the domain that belongs at the edge, or vice versa)?
+- **Test gap** — why did the existing suite not catch this? Missing branch, missing boundary, or test mirrored the implementation.
+
+Call this out even when the minimal fix does not address it. Silence signals the principle is clean.
+
+## Process
+
+1. **Reproduce** — get the failure under your hand (command, input, assertion). No repro → ask; do not guess.
+2. **Delegate** — invoke `superpowers:systematic-debugging` for the investigation loop.
+3. **Confirm root cause** — one sentence, backed by a concrete artifact.
+4. **Write the regression test first** — it must fail against current code for the stated reason.
+5. **Apply the minimal fix** — smallest diff that turns the test green. No bundled cleanups.
+6. **Verify** — full relevant test suite green. Note anything newly suspicious.
+
+## Output contract
+
+- Repro
+- Hypotheses (with falsification)
+- Root cause (+ evidence)
+- Minimal fix (diff summary + what it deliberately does NOT touch)
+- Regression test (name + location)
+- SOLID / Clean-Arch risks (or "none — principle is clean")
+
+## Absolute rules
+- No fix without a failing test first.
+- No behavior change beyond what the failing test demands.
+- No "while I'm here" refactors — note them, defer to `/refactor`.
+- If the root cause is a design flaw, say so; fix the symptom minimally and recommend design follow-up.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,0 +1,19 @@
+---
+description: Invoke the debugger subagent to diagnose a bug, failing test, or unexpected behavior — root-cause first, then a minimal, principle-aware fix with a regression test
+argument-hint: <symptom, failing test, or error, optionally with a ticket ref>
+---
+
+Symptom: $ARGUMENTS
+
+If $ARGUMENTS contains a ticket reference (Jira key like `PROJ-123`, an `atlassian.net` URL, a Confluence wiki URL, or a GitHub issue/PR URL or `#NNN`), invoke the `swe-workbench:ticket-context` skill first and prepend its structured summary to the delegation context below.
+
+Delegate to the `debugger` subagent. Its output must include:
+
+1. **Repro** — exact steps, inputs, and the observed failure (command, stack trace, or assertion delta).
+2. **Hypotheses** — 2–3 candidate causes, each falsifiable with the observation that would confirm or rule it out.
+3. **Root cause** — the single cause supported by concrete evidence (log line, stack frame, state diff). No speculation.
+4. **Minimal fix** — smallest behavior-changing patch that resolves the root cause; call out what it deliberately does NOT touch.
+5. **Regression test** — the test that fails before the fix and passes after. Name it and its location.
+6. **SOLID / Clean-Arch risks** — whether the bug's shape signals a principle violation, and whether the minimal fix papers over it.
+
+Absolute rule: no fix without a failing test first. This command changes behavior to match spec — it is not a refactor.

--- a/commands/design.md
+++ b/commands/design.md
@@ -5,6 +5,8 @@ argument-hint: <design question>
 
 The user is asking: $ARGUMENTS
 
+If $ARGUMENTS contains a ticket reference (Jira key like `PROJ-123`, an `atlassian.net` URL, a Confluence wiki URL, or a GitHub issue/PR URL or `#NNN`), invoke the `swe-workbench:ticket-context` skill first and prepend its structured summary so the subagent has the full design brief.
+
 Delegate to the `senior-engineer` subagent. Its response must contain:
 
 1. **Problem restatement** — confirm the real question and surface implicit constraints (scale, team size, change frequency, latency budget, compliance).

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -5,6 +5,8 @@ argument-hint: <file, function, or module>
 
 Target: $ARGUMENTS
 
+If $ARGUMENTS contains a ticket reference (Jira key like `PROJ-123`, an `atlassian.net` URL, a Confluence wiki URL, or a GitHub issue/PR URL or `#NNN`), invoke the `swe-workbench:ticket-context` skill first; a refactor motivated by a ticket needs the ticket's scope and constraints in the delegation context.
+
 Delegate to the `refactorer` subagent. Its output must include:
 
 1. **Diagnosis** — which smell is present (Long Method, Feature Envy, Primitive Obsession, Shotgun Surgery, Divergent Change, etc.) and why it hurts.

--- a/commands/review.md
+++ b/commands/review.md
@@ -8,13 +8,14 @@ Review the pending changes on this branch.
    - Run `git diff` for unstaged changes.
    - Run `git diff --staged` for staged changes.
    - If both are empty, run `git diff origin/main...HEAD` (or `origin/master...HEAD`).
-2. Invoke the `reviewer` subagent with the diff and ask for a prioritized report.
-3. Organize findings by severity, highest first:
+2. Detect ticket references: check the current branch name (`git rev-parse --abbrev-ref HEAD`) and recent commit messages (`git log --oneline -5`) for ticket keys (`[A-Z]+-\d+`), `atlassian.net` URLs, Confluence wiki URLs, or GitHub issue/PR refs. If found, invoke `swe-workbench:ticket-context` with the ticket reference and prepend its summary to the reviewer context — the diff's intent is easier to evaluate against the full spec.
+3. Invoke the `reviewer` subagent with the diff and ask for a prioritized report.
+4. Organize findings by severity, highest first:
    - **Critical** — data loss, security breach, production outage risk.
    - **High** — correctness bugs, broken contracts, missing auth/validation.
    - **Medium** — design smells, SOLID violations, maintainability risks.
    - **Low** — naming, minor clarity.
-4. Each finding uses: `Severity | File:Line | Issue | Why it matters | Suggested fix`.
-5. Close with a short section summary: correctness bugs, security issues, design smells, test gaps.
+5. Each finding uses: `Severity | File:Line | Issue | Why it matters | Suggested fix`.
+6. Close with a short section summary: correctness bugs, security issues, design smells, test gaps.
 
 Ground judgements in SOLID and Clean Architecture principles. Do not nitpick formatting — that is the linter's job.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -7,6 +7,7 @@
 | `/swe-workbench:review` | Review the current git diff — correctness, security, design, test gaps. |
 | `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
 | `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
+| `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |
 
 ## Subagents
 
@@ -15,6 +16,7 @@
 | `reviewer` | PR review, diff audit, post-feature sanity check. |
 | `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
 | `refactorer` | Cleaning up smells before adding a feature. |
+| `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 
 ## Skills
 
@@ -44,3 +46,9 @@
 | `workflow-development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
 
 This skill is an orchestrator — it coordinates other skills rather than restating their content.
+
+### Integrations — auto-load on ticket references
+
+| Skill | Triggers | Delegation model |
+|---|---|---|
+| `ticket-context` | Jira keys (`[A-Z]+-\d+`), `atlassian.net/browse/...`, Confluence wiki URLs, `github.com/.../(issues\|pull)/N`, `#N` refs. | Invoked by command bodies as a prelude before subagent delegation. Fetches via `mcp__atlassian__*` and `gh` CLI. Returns structured context (title, summary, acceptance criteria, linked refs, recent comments). Does not act on the ticket — only resolves it. |

--- a/skills/ticket-context/SKILL.md
+++ b/skills/ticket-context/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ticket-context
+description: Fetch structured context from Jira issues, Confluence pages, and GitHub issues/PRs. Auto-loads when a prompt or argument references a ticket key (e.g. PROJ-123), an atlassian.net URL, a Confluence wiki URL, or a GitHub issue/PR URL or `#NNN`. Produces title, description, acceptance criteria, links, and recent comments so downstream work (design, refactor, review, debug) has the full spec.
+---
+
+You resolve ticket references into structured context that downstream work can consume. You do not interpret, critique, or act on the ticket — you fetch and format.
+
+## When to invoke
+
+The caller (command body, subagent, or user) references one or more of:
+
+- **Jira key**: `[A-Z][A-Z0-9]+-\d+` — e.g. `PROJ-123`, `ENG-4567`.
+- **Atlassian Jira URL**: `*.atlassian.net/browse/<KEY>`.
+- **Confluence URL**: `*.atlassian.net/wiki/spaces/...` or `*.atlassian.net/wiki/pages/...`.
+- **GitHub issue/PR URL**: `github.com/<owner>/<repo>/(issues|pull)/\d+`.
+- **GitHub short ref**: `#\d+` with clear current-repo context.
+
+If no reference is present, exit cleanly — the caller proceeds without ticket context.
+
+## Fetch recipes
+
+### Jira issue
+
+Before the first Jira fetch in a session, call `mcp__atlassian__getAccessibleAtlassianResources` to resolve the `cloudId`; cache it for subsequent calls. Then `mcp__atlassian__getJiraIssue` with the key. Extract: summary, issuetype, status, priority, description, labels, components, acceptance-criteria (custom field name varies by org — check the description body if a dedicated field is absent), linked issues via `mcp__atlassian__getJiraIssueRemoteIssueLinks`, and the most recent 5 comments.
+
+### Confluence page
+
+Parse the numeric page ID from the URL path (`/pages/<ID>/` or `/pages/<ID>`). Use `mcp__atlassian__getConfluencePage` with the ID. If the URL shape doesn't yield a clear ID, fall back to `mcp__atlassian__fetch` with the raw URL. Extract: title, version, body (rendered text, not storage XML), recent footer comments via `mcp__atlassian__getConfluencePageFooterComments` if any.
+
+### GitHub issue or PR
+
+Use Bash:
+- Issue: `gh issue view <number> --repo <owner>/<repo> --json title,body,state,labels,assignees,comments,url`
+- PR: `gh pr view <number> --repo <owner>/<repo> --json title,body,state,labels,files,comments,url`
+
+For `#NNN` short refs in the current repo, omit `--repo`.
+
+## Output format
+
+One structured block per reference, prepended to the caller's context:
+
+```
+## Ticket context: <KEY or #NUM or short URL>
+
+**Title:** ...
+**Type / Status:** ...
+**Summary:** ... (1–3 sentences from description)
+**Acceptance criteria / Definition of done:** ... (bulleted if present, otherwise "not specified")
+**Linked references:** ... (issue keys, PR numbers, Confluence page titles)
+**Recent activity:** ... (last 2–3 comments, compressed)
+**Source:** <URL>
+```
+
+## Degradation
+
+- Atlassian MCP unavailable → attempt `mcp__atlassian__fetch` with the raw URL; if still failing, emit `ticket-context: Atlassian MCP unavailable; proceeding without context.` and return control to the caller.
+- `gh` CLI missing → emit `ticket-context: gh CLI unavailable; proceeding without context.` and return.
+- Auth error → surface the raw error message. Never fabricate content.
+- Reference pattern matches but fetch returns empty/404 → say so; do not guess at content.
+
+## Absolute rules
+
+- Never invent ticket content. If a fetch fails, say so and return.
+- Strip secrets and PII (API tokens, email addresses in comments) before returning.
+- Cap output at ~400 words per reference. Summarize longer descriptions; do not truncate mid-sentence.
+- Do not editorialize. Output the ticket; the downstream subagent interprets it.

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -16,7 +16,7 @@ Single source of truth for how development work flows. Three modes:
 ## When This Skill Activates
 
 - **Mode A:** Writing or finalizing an implementation plan (before `ExitPlanMode`)
-- **Mode B:** User says "implement this", "build this", "fix this" — any branch → code → deliver flow
+- **Mode B:** User says "implement this", "build this" — any branch → code → deliver flow. For focused bug diagnosis prefer `/swe-workbench:debug` (invokes the `debugger` subagent, which composes `superpowers:systematic-debugging`); escalate here when the fix needs the full 5-phase lifecycle.
 - **Mode C:** User says "orchestrate these issues", "run in parallel", multi-issue campaigns with >3 issues
 
 ## Sub-Skill Integration Map


### PR DESCRIPTION
N/A

## Summary

- **`/swe-workbench:debug`** — new 4th command/subagent pair. Diagnoses bugs root-cause-first by composing `superpowers:systematic-debugging`, then layers the swe-workbench output contract (Repro → Hypotheses → Root cause → Minimal fix → Regression test → SOLID/Clean-Arch risks) and principle lens on top. The `debugger` subagent is the first in this plugin to include `Skill` in its `tools:` allowlist, enabling the composition rather than duplication of the debugging discipline.
- **`skills/ticket-context`** — new shared skill that resolves Jira keys (`PROJ-123`), `atlassian.net` Jira/Confluence URLs, and GitHub issue/PR refs into a structured context block (title, summary, acceptance criteria, linked refs, recent comments). Invoked as a prelude by all four command bodies before delegating to their subagent. Degrades gracefully when Atlassian MCP or `gh` CLI is unavailable.
- **`/design`, `/refactor`, `/review` updated** — each gets a ticket-context prelude. `/review` additionally detects ticket refs from branch name and recent commit messages via git.

## Design decisions

**`debugger` boundary vs. `refactorer`:** Both share the same tool allowlist (`Read, Edit, Grep, Glob, Bash`) but with inverted invariants — `refactorer` preserves behavior; `debugger` changes behavior to match spec. Explicitly called out in the subagent body to prevent drift.

**Ticket context is parent-invoked, not subagent-invoked:** Command bodies (running in the parent Claude Code context with full user tool access) invoke `ticket-context` before delegating. This keeps `senior-engineer` read-only (`Read, Grep, Glob, WebFetch`) and avoids expanding `reviewer`'s tool allowlist to include MCP tools it doesn't otherwise need.

## Known risk

Subagent `Skill` invocation (`superpowers:systematic-debugging` from inside `debugger`) is unproven in this plugin — no existing subagent uses `Skill`. Listing it in `tools:` grants the capability; only prompt wording drives actual invocation. Fallback if the skill is unavailable: `debugger` runs the same root-cause loop inline and says so.

## Test plan

- [ ] `/swe-workbench:debug <symptom>` — response contains all 6 output-contract headers
- [ ] Transcript shows a `Skill` invocation of `superpowers:systematic-debugging` before the Root cause section
- [ ] `/swe-workbench:debug PROJ-123 — <symptom>` — response includes a `## Ticket context: PROJ-123` block with Title/Summary/Acceptance criteria
- [ ] `/swe-workbench:review` on a branch named `fix/PROJ-456-*` — ticket summary prepended to review
- [ ] `/swe-workbench:debug <symptom>` (no ticket ref) — no `Ticket context` block, no extra MCP calls
- [ ] Without Atlassian MCP: `ticket-context: Atlassian MCP unavailable; proceeding without context.` emitted; no fabricated content
- [ ] Three existing commands (`/review`, `/design`, `/refactor`) still dispatch their own subagents unchanged
- [ ] `/swe-workbench:debug` does NOT trigger for "implement this" / "build this" / "fix this bug end-to-end"