### PR TITLE
[feat] Add release script and tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate JSON well-formedness
+        run: |
+          jq empty .claude-plugin/plugin.json
+          jq empty .claude-plugin/marketplace.json
+
+      - name: Verify tag matches manifest versions
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PLUGIN_VER=$(jq -r .version .claude-plugin/plugin.json)
+          MKT_VER=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          if [ "$TAG" != "$PLUGIN_VER" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=$TAG) does not match plugin.json version ($PLUGIN_VER)"
+            exit 1
+          fi
+          if [ "$TAG" != "$MKT_VER" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} (=$TAG) does not match marketplace.json version ($MKT_VER)"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.log
 .idea/
 .vscode/
+.worktrees/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,16 @@ If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` â€
 
 **Skill directory layout**: Skills must live at `skills/<skill-name>/SKILL.md` â€” exactly one level deep. Claude Code's auto-discovery does not recurse into nested category subdirectories. Use a hyphenated prefix to preserve categorical grouping while meeting this constraint: `principle-*`, `language-*`, `workflow-*`. The `name:` field in the `SKILL.md` frontmatter must match the directory name exactly.
 
+## Cutting a release
+
+Run the release script from a clean `main`:
+
+```sh
+./scripts/release.sh patch   # or minor / major
+```
+
+It bumps both manifests, opens a PR, waits for CI to pass, auto-merges, then pushes a `v*.*.*` tag. The tag push triggers `.github/workflows/release.yml`, which validates the manifests and publishes a GitHub Release with auto-generated notes.
+
 ## `.githooks/` vs `hooks/hooks.json`
 
 These two directories share the same depth but serve different runtimes:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────
+# Preflight
+# ──────────────────────────────────────────────
+
+BUMP="${1:-}"
+if [[ ! "$BUMP" =~ ^(patch|minor|major)$ ]]; then
+  echo "Usage: $0 <patch|minor|major>" >&2
+  exit 1
+fi
+
+if ! gh auth status &>/dev/null; then
+  echo "Error: gh CLI is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+if ! jq --version &>/dev/null; then
+  echo "Error: jq is required. Install with: brew install jq" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree is dirty. Commit or stash your changes first." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "Error: must run from main, currently on '${CURRENT_BRANCH}'." >&2
+  exit 1
+fi
+
+git fetch origin
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [[ "$LOCAL" != "$REMOTE" ]]; then
+  echo "Error: local main is not up to date with origin/main. Run: git pull --ff-only" >&2
+  exit 1
+fi
+
+# ──────────────────────────────────────────────
+# Compute next version
+# ──────────────────────────────────────────────
+
+CURRENT=$(jq -r .version .claude-plugin/plugin.json)
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+NEXT="${MAJOR}.${MINOR}.${PATCH}"
+TAG="v${NEXT}"
+BRANCH="chore/bump-${TAG}"
+
+echo "Bumping ${CURRENT} → ${NEXT} (${TAG})"
+
+# ──────────────────────────────────────────────
+# Branch + edit + commit
+# ──────────────────────────────────────────────
+
+git checkout -b "$BRANCH"
+
+# Atomic writes via temp + mv to avoid half-written state on crash
+PLUGIN_JSON=".claude-plugin/plugin.json"
+MKT_JSON=".claude-plugin/marketplace.json"
+
+TMP_PLUGIN=$(mktemp)
+TMP_MKT=$(mktemp)
+
+jq --arg v "$NEXT" '.version = $v' "$PLUGIN_JSON" > "$TMP_PLUGIN" && mv "$TMP_PLUGIN" "$PLUGIN_JSON"
+jq --arg v "$NEXT" '.plugins[0].version = $v' "$MKT_JSON" > "$TMP_MKT" && mv "$TMP_MKT" "$MKT_JSON"
+
+git add "$PLUGIN_JSON" "$MKT_JSON"
+git commit -m "[chore] Bump version to ${NEXT}"
+
+# ──────────────────────────────────────────────
+# Push + PR
+# ──────────────────────────────────────────────
+
+git push -u origin "$BRANCH"
+
+PR_URL=$(gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "[chore] Bump version to ${NEXT}" \
+  --body "$(cat <<PREOF
+## Summary
+- Bump version: \`${CURRENT}\` → \`${NEXT}\`
+- Tag \`${TAG}\` will be pushed automatically once this merges, triggering \`.github/workflows/release.yml\` to publish a GitHub Release.
+
+## Test Plan
+- [x] CI (pr.yml) passes
+- [x] Tag-triggered release workflow publishes \`${TAG}\`
+
+N/A
+PREOF
+)")
+
+echo "PR created: ${PR_URL}"
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+# ──────────────────────────────────────────────
+# Auto-merge
+# ──────────────────────────────────────────────
+
+gh pr merge --auto --squash --delete-branch "$PR_URL"
+echo "Auto-merge enabled. Waiting for CI and merge..."
+
+# ──────────────────────────────────────────────
+# Wait for merge (max 20 min, heartbeat every 60s)
+# ──────────────────────────────────────────────
+
+TIMEOUT=1200
+ELAPSED=0
+HEARTBEAT=60
+LAST_HEARTBEAT=0
+
+while true; do
+  STATE=$(gh pr view "$PR_NUM" --json state -q '.state')
+  if [[ "$STATE" == "MERGED" ]]; then
+    echo "PR #${PR_NUM} merged."
+    break
+  fi
+
+  # Check for failed/closed state
+  if [[ "$STATE" == "CLOSED" ]]; then
+    echo "Error: PR #${PR_NUM} was closed without merging." >&2
+    echo "Check CI failures at: ${PR_URL}" >&2
+    echo "Once resolved, manually tag with:" >&2
+    echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+    exit 1
+  fi
+
+  if [[ $ELAPSED -ge $TIMEOUT ]]; then
+    echo "Error: timed out waiting for PR #${PR_NUM} to merge after $((TIMEOUT / 60)) minutes." >&2
+    echo "Check status at: ${PR_URL}" >&2
+    echo "Once merged, manually tag with:" >&2
+    echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+    exit 1
+  fi
+
+  if [[ $((ELAPSED - LAST_HEARTBEAT)) -ge $HEARTBEAT ]]; then
+    echo "[$(date '+%H:%M:%S')] Still waiting... (${ELAPSED}s elapsed, state=${STATE})"
+    LAST_HEARTBEAT=$ELAPSED
+  fi
+
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+done
+
+# ──────────────────────────────────────────────
+# Tag and push
+# ──────────────────────────────────────────────
+
+git checkout main
+git pull --ff-only origin main
+
+MERGE_SHA=$(gh pr view "$PR_NUM" --json mergeCommit -q '.mergeCommit.oid')
+LOCAL_SHA=$(git rev-parse HEAD)
+
+if [[ "$LOCAL_SHA" != "$MERGE_SHA" ]]; then
+  echo "Error: local main HEAD (${LOCAL_SHA}) does not match merge commit (${MERGE_SHA})." >&2
+  echo "Something unexpected was pushed to main. Aborting tag to avoid tagging wrong commit." >&2
+  exit 1
+fi
+
+git tag -a "$TAG" -m "Release ${TAG}"
+git push origin "$TAG"
+
+echo ""
+echo "Done!"
+echo "  PR:       ${PR_URL}"
+echo "  Tag:      ${TAG}"
+echo "  Release:  https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/tag/${TAG}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,15 +106,10 @@ echo "PR created: ${PR_URL}"
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
 # ──────────────────────────────────────────────
-# Auto-merge
+# Wait for CI checks, then merge explicitly
 # ──────────────────────────────────────────────
 
-gh pr merge --auto --squash --delete-branch "$PR_URL"
-echo "Auto-merge enabled. Waiting for CI and merge..."
-
-# ──────────────────────────────────────────────
-# Wait for merge (max 20 min, heartbeat every 60s)
-# ──────────────────────────────────────────────
+echo "Waiting for CI checks on PR #${PR_NUM}..."
 
 TIMEOUT=1200
 ELAPSED=0
@@ -122,31 +117,41 @@ HEARTBEAT=60
 LAST_HEARTBEAT=0
 
 while true; do
-  STATE=$(gh pr view "$PR_NUM" --json state -q '.state')
-  if [[ "$STATE" == "MERGED" ]]; then
+  if [[ $ELAPSED -ge $TIMEOUT ]]; then
+    echo "Error: timed out waiting for CI on PR #${PR_NUM} after $((TIMEOUT / 60)) minutes." >&2
+    echo "Check status at: ${PR_URL}" >&2
+    echo "Once CI passes, manually merge and tag with:" >&2
+    echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
+    echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+    exit 1
+  fi
+
+  # Count checks still running
+  PENDING=$(gh pr checks "$PR_NUM" --json state \
+    --jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED" or .state == "WAITING")] | length' 2>/dev/null || echo "0")
+
+  if [[ "$PENDING" -eq 0 ]]; then
+    # All checks finished — look for failures
+    FAILED=$(gh pr checks "$PR_NUM" --json conclusion \
+      --jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT")] | length' 2>/dev/null || echo "0")
+
+    if [[ "$FAILED" -gt 0 ]]; then
+      echo "Error: ${FAILED} CI check(s) failed on PR #${PR_NUM}." >&2
+      echo "Fix the failures at: ${PR_URL}" >&2
+      echo "Once CI passes, manually merge and tag with:" >&2
+      echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
+      echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+      exit 1
+    fi
+
+    echo "All CI checks passed. Merging PR #${PR_NUM}..."
+    gh pr merge --squash --delete-branch "$PR_NUM"
     echo "PR #${PR_NUM} merged."
     break
   fi
 
-  # Check for failed/closed state
-  if [[ "$STATE" == "CLOSED" ]]; then
-    echo "Error: PR #${PR_NUM} was closed without merging." >&2
-    echo "Check CI failures at: ${PR_URL}" >&2
-    echo "Once resolved, manually tag with:" >&2
-    echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
-    exit 1
-  fi
-
-  if [[ $ELAPSED -ge $TIMEOUT ]]; then
-    echo "Error: timed out waiting for PR #${PR_NUM} to merge after $((TIMEOUT / 60)) minutes." >&2
-    echo "Check status at: ${PR_URL}" >&2
-    echo "Once merged, manually tag with:" >&2
-    echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
-    exit 1
-  fi
-
   if [[ $((ELAPSED - LAST_HEARTBEAT)) -ge $HEARTBEAT ]]; then
-    echo "[$(date '+%H:%M:%S')] Still waiting... (${ELAPSED}s elapsed, state=${STATE})"
+    echo "[$(date '+%H:%M:%S')] CI still running... (${ELAPSED}s elapsed, ${PENDING} check(s) pending)"
     LAST_HEARTBEAT=$ELAPSED
   fi
 
@@ -172,6 +177,9 @@ fi
 
 git tag -a "$TAG" -m "Release ${TAG}"
 git push origin "$TAG"
+
+# Clean up local release branch (remote already deleted by --delete-branch)
+git branch -d "$BRANCH" 2>/dev/null || true
 
 echo ""
 echo "Done!"


### PR DESCRIPTION
## Summary
- Add \`scripts/release.sh\`: one command to bump both manifests, open a PR, wait for CI, auto-merge, then push a \`v*.*.*\` tag
- Add \`.github/workflows/release.yml\`: on tag push, validates JSON well-formedness + version match, then publishes a GitHub Release with auto-generated notes
- Add \`CONTRIBUTING.md\` "Cutting a release" section pointing at the script

## Test Plan
- [ ] Run \`./scripts/release.sh foo\` — expect usage error, exit 1
- [ ] Run from dirty tree — expect preflight refusal, no side effects
- [ ] Run \`./scripts/release.sh patch\` from clean \`main\` — new PR opens, CI passes, auto-merge fires, tag \`v0.1.3\` appears, release workflow publishes GitHub Release
- [ ] Manually push a mismatched tag — confirm release workflow version-match step fails loudly

N/A