### PR TITLE
[feat] Add issue templates and Code of Conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a defect in a skill, agent, command, or hook
+title: '[bug] '
+labels: bug
+assignees: ''
+---
+
+## Surface affected
+
+<!-- Check all that apply. -->
+- [ ] Skill — `principle-*`
+- [ ] Skill — `language-*`
+- [ ] Skill — `integration-*`
+- [ ] Skill — `workflow-*`
+- [ ] Subagent
+- [ ] Slash command
+- [ ] Hook
+- [ ] Documentation
+- [ ] Build / CI / release
+
+**Specific surface** (e.g., `principle-tdd`, `/swe-workbench:review`, `debugger`):
+
+## Claude Code version
+
+<!-- Output of: claude --version -->
+
+## Plugin version
+
+<!-- From .claude-plugin/plugin.json — current release is 0.1.2 -->
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment (optional)
+
+<!-- OS, shell, model -->
+
+## Logs / screenshots (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Propose a new skill, agent, command, hook, or enhancement
+title: '[feat] '
+labels: enhancement
+assignees: ''
+---
+
+## Goal
+
+<!-- One sentence: what should be possible after this lands? -->
+
+## Motivation
+
+<!-- The problem or workflow gap this solves. -->
+
+## Surface
+
+<!-- Check all surfaces this proposal touches. -->
+- [ ] Skill — `principle-*`
+- [ ] Skill — `language-*`
+- [ ] Skill — `integration-*`
+- [ ] Skill — `workflow-*`
+- [ ] Subagent
+- [ ] Slash command
+- [ ] Hook
+- [ ] Documentation
+- [ ] Build / CI / release
+
+## Sketch (optional)
+
+<!-- Rough usage example, skill name, or command invocation. -->
+
+## Acceptance (optional)
+
+<!-- Bulleted checklist: how will we know this is done? -->
+- [ ]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+To report a violation, open a [GitHub issue](https://github.com/lugassawan/swe-workbench/issues) or contact the maintainers directly via GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
 ## Setup
 
 After cloning, run the setup script once:


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` with surface checkboxes, version fields, and terse imperative tone matching the existing PR template
- Add `CODE_OF_CONDUCT.md` adopting Contributor Covenant 2.1 by reference (no personal email exposed)
- Insert `## Code of Conduct` section into `CONTRIBUTING.md` linking to the new file

## Notes
- `CHANGELOG.md` intentionally skipped — PR #24's tag-triggered release workflow auto-generates GitHub Releases from PR titles, making a hand-curated changelog redundant on a low-velocity project
- `.github/ISSUE_TEMPLATE/config.yml` skipped — Discussions is off and issue #15 marks it optional

## Test Plan
- [ ] Open `https://github.com/lugassawan/swe-workbench/issues/new/choose` and confirm both templates appear
- [ ] Click `CODE_OF_CONDUCT.md` link in `CONTRIBUTING.md` and verify it resolves
- [ ] `/swe-workbench:*` commands still load without errors

Closes #15