### PR TITLE
[feat] Add plugin self-validator and CI gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Pre-push hook: validate plugin files before pushing to remote.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+bash "$REPO_ROOT/scripts/validate.sh"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,3 +59,10 @@ jobs:
             echo "See: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue"
             exit 1
           fi
+
+  validate-plugin-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate plugin files
+        run: bash scripts/validate.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,5 +103,5 @@ These two directories share the same depth but serve different runtimes:
 
 | Path | Purpose |
 |---|---|
-| `.githooks/` | Git hooks (`commit-msg`, `pre-commit`) — invoked by git. |
+| `.githooks/` | Git hooks (`commit-msg`, `pre-commit`, `pre-push`) — invoked by git. |
 | `hooks/hooks.json` | Claude Code plugin runtime hooks — invoked by the Claude Code plugin system. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,25 @@ Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). It requires:
 
 `.github/workflows/pr.yml` runs the same commit-format and issue-reference checks on every PR. Skipping local setup does not skip CI — it just shifts the failure to after you push.
 
+## Validator
+
+Run the plugin self-validator locally before pushing:
+
+```sh
+bash scripts/validate.sh
+```
+
+It checks:
+
+- `.claude-plugin/plugin.json` — JSON well-formedness, required fields (`name`, `version`, `description`).
+- `.claude-plugin/marketplace.json` — JSON well-formedness, `plugins[0].name` and `plugins[0].version` match `plugin.json`.
+- `hooks/hooks.json` — JSON well-formedness and structural shape.
+- `skills/*/SKILL.md` — flat layout (no nesting), required frontmatter (`name`, `description`), `name` matches directory name, ≤150-line cap (≤300 for skills with `orchestrator: true`).
+- `agents/*.md` — required frontmatter (`name`, `description`).
+- `commands/*.md` — required frontmatter (`description`).
+
+The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`).
+
 ## Testing locally
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide an
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR, run the plugin validator locally:
+
+```sh
+bash scripts/validate.sh
+```
 
 ## License
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Plugin self-validator. Zero dependencies beyond python3 stdlib."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+FAILURES = []
+
+
+def fail(path, reason):
+    FAILURES.append(f"  {path}: {reason}")
+
+
+def parse_frontmatter(path, text=None):
+    """Return dict of key:value from YAML frontmatter (single-line scalars only), or None.
+
+    Keys are lowercased for case-insensitive lookup. Caller may pass pre-read `text`
+    to avoid a second file read.
+    """
+    if text is None:
+        text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    # Match closing --- on its own line; prefer \n---\n to avoid body horizontal rules.
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    block = text[3:end].strip()
+    result = {}
+    for line in block.splitlines():
+        m = re.match(r'^([\w][\w-]*):\s*(.*)$', line.strip())
+        if m:
+            result[m.group(1).lower()] = m.group(2).strip()
+    return result
+
+
+# ──────────────────────────────────────────────
+# Validators
+# ──────────────────────────────────────────────
+
+def check_plugin_json():
+    path = ROOT / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        fail(path.relative_to(ROOT), f"JSON parse error: {e}")
+        return None
+    for field in ("name", "version", "description"):
+        if field not in data:
+            fail(path.relative_to(ROOT), f"missing required field: {field!r}")
+    return data
+
+
+def check_marketplace_json(plugin_data):
+    path = ROOT / ".claude-plugin" / "marketplace.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        fail(path.relative_to(ROOT), f"JSON parse error: {e}")
+        return
+    try:
+        entry = data["plugins"][0]
+    except (KeyError, IndexError, TypeError):
+        fail(path.relative_to(ROOT), "expected plugins[0] to exist")
+        return
+    if plugin_data:
+        if entry.get("name") != plugin_data.get("name"):
+            fail(
+                path.relative_to(ROOT),
+                f"plugins[0].name {entry.get('name')!r} != plugin.json name {plugin_data.get('name')!r}",
+            )
+        if entry.get("version") != plugin_data.get("version"):
+            fail(
+                path.relative_to(ROOT),
+                f"plugins[0].version {entry.get('version')!r} != plugin.json version {plugin_data.get('version')!r}",
+            )
+
+
+def check_hooks_json():
+    path = ROOT / "hooks" / "hooks.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        fail(path.relative_to(ROOT), f"JSON parse error: {e}")
+        return
+    hooks_root = data.get("hooks")
+    if not isinstance(hooks_root, dict):
+        fail(path.relative_to(ROOT), "top-level 'hooks' must be an object")
+        return
+    for event, matchers in hooks_root.items():
+        if not isinstance(matchers, list):
+            fail(path.relative_to(ROOT), f"hooks.{event} must be a list")
+            continue
+        for i, entry in enumerate(matchers):
+            if not isinstance(entry.get("matcher"), str):
+                fail(path.relative_to(ROOT), f"hooks.{event}[{i}].matcher must be a string")
+            sub_hooks = entry.get("hooks")
+            if not isinstance(sub_hooks, list):
+                fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks must be a list")
+                continue
+            for j, hook in enumerate(sub_hooks):
+                if not isinstance(hook.get("type"), str):
+                    fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].type must be a string")
+                if not isinstance(hook.get("command"), str):
+                    fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].command must be a string")
+
+
+def check_skills():
+    skills_dir = ROOT / "skills"
+    # glob("*/SKILL.md") matches exactly depth-2 paths; no need for a post-hoc depth guard.
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        skill_dir_name = skill_md.parent.name
+        text = skill_md.read_text(encoding="utf-8")
+        line_count = len(text.splitlines())  # total file length including frontmatter
+        fm = parse_frontmatter(skill_md, text=text)
+        if fm is None:
+            fail(skill_md.relative_to(ROOT), "missing or malformed frontmatter")
+            continue
+        if "name" not in fm:
+            fail(skill_md.relative_to(ROOT), "frontmatter missing required field: 'name'")
+        if "description" not in fm:
+            fail(skill_md.relative_to(ROOT), "frontmatter missing required field: 'description'")
+        if fm.get("name") != skill_dir_name:
+            fail(
+                skill_md.relative_to(ROOT),
+                f"frontmatter name {fm.get('name')!r} does not match directory name {skill_dir_name!r}",
+            )
+        is_orchestrator = fm.get("orchestrator", "").lower() == "true"
+        cap = 300 if is_orchestrator else 150
+        if line_count > cap:
+            fail(
+                skill_md.relative_to(ROOT),
+                f"exceeds {cap}-line cap ({line_count} lines)"
+                + ("" if is_orchestrator else "; add 'orchestrator: true' to frontmatter if intentional"),
+            )
+
+
+def check_agents():
+    agents_dir = ROOT / "agents"
+    for agent_md in sorted(agents_dir.glob("*.md")):
+        fm = parse_frontmatter(agent_md)
+        if fm is None:
+            fail(agent_md.relative_to(ROOT), "missing or malformed frontmatter")
+            continue
+        for field in ("name", "description"):
+            if field not in fm:
+                fail(agent_md.relative_to(ROOT), f"frontmatter missing required field: {field!r}")
+
+
+def check_commands():
+    commands_dir = ROOT / "commands"
+    for cmd_md in sorted(commands_dir.glob("*.md")):
+        fm = parse_frontmatter(cmd_md)
+        if fm is None:
+            fail(cmd_md.relative_to(ROOT), "missing or malformed frontmatter")
+            continue
+        if "description" not in fm:
+            fail(cmd_md.relative_to(ROOT), "frontmatter missing required field: 'description'")
+
+
+# ──────────────────────────────────────────────
+# Entry point
+# ──────────────────────────────────────────────
+
+def main():
+    print("Validating swe-workbench plugin files...")
+    print()
+
+    plugin_data = check_plugin_json()
+    check_marketplace_json(plugin_data)
+    check_hooks_json()
+    check_skills()
+    check_agents()
+    check_commands()
+
+    if FAILURES:
+        print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)
+        for f in FAILURES:
+            print(f, file=sys.stderr)
+        sys.exit(1)
+
+    print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/validate.py" "$@"

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: workflow-development
 description: Development workflow — full lifecycle from Branch → Implement → Verify → Review → Deliver. Auto-load when writing an implementation plan, creating a plan, finalizing a plan before ExitPlanMode, starting a feature branch, opening a PR, shipping a change, asking about branch naming or commit format, handing off work, or beginning any structured development task.
+orchestrator: true
 ---
 
 # Development Workflow


### PR DESCRIPTION
## Summary

- Add `scripts/validate.py` (zero-dep Python 3 stdlib) and `scripts/validate.sh` shim that validate all plugin files: `plugin.json`/`marketplace.json` version parity, `hooks/hooks.json` structural shape, skill flat-layout + 150/300-line caps, agent and command frontmatter required fields.
- Add `validate-plugin-files` job to `.github/workflows/pr.yml` so every PR is gated — broken manifests, malformed SKILL.md frontmatter, and nested skills now fail CI before merge.
- Add `orchestrator: true` to `skills/workflow-development/SKILL.md` frontmatter, opting it into the 300-line cap (it's 182 lines — a legitimate orchestrator with companion files in its dir).
- Document `bash scripts/validate.sh` in `CONTRIBUTING.md` (new Validator section) and `README.md` Contributing section.

## Test Plan

- [x] `bash scripts/validate.sh` exits 0 on clean checkout
- [x] Removing `description:` from a skill frontmatter → exits 1, names the file
- [x] Creating `skills/foo/bar/SKILL.md` (depth 3) → exits 1, flat-layout violation
- [x] Setting `plugin.json.version = "9.9.9"` → exits 1, version drift detected
- [x] `scripts/validate.sh` resolves correctly when called from a subdirectory (uses `BASH_SOURCE[0]`)
- [x] CI job appears in PR checks and passes on this branch

Closes #10