### PR TITLE
[feat] Add principle-observability, principle-api-design, principle-concurrency skills

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -30,6 +30,9 @@
 | `principle-tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
+| `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |
+| `principle-api-design` | "api versioning", "idempotency", "idempotency key", "pagination", "cursor pagination", "error shape", "REST vs RPC", "event-driven", "API deprecation", "API contract". |
+| `principle-concurrency` | "race condition", "deadlock", "livelock", "structured concurrency", "cancellation", "backpressure", "mutex vs channel", "actor model", "atomics", "memory model". |
 
 ### Languages — auto-load by file type
 

--- a/skills/principle-api-design/SKILL.md
+++ b/skills/principle-api-design/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: principle-api-design
+description: API design principles — contract-first thinking, semantic versioning, idempotency keys, pagination (offset vs cursor), error shape consistency, evolvability and backward compatibility, REST vs RPC vs event-driven trade-offs, hypermedia, resource modeling, deprecation strategy. Auto-load when designing an API, choosing REST or RPC or events, adding api versioning, designing idempotent endpoints, adding pagination, shaping error responses, deprecating an endpoint, or evolving a public contract.
+---
+
+# API Design
+
+An API is a contract. Breaking it breaks callers. Design for evolvability from day one.
+
+## Contract-First
+
+Design the interface before the implementation. Write the schema or proto before any code.
+- Contracts force clarity on resource modeling, field names, and error cases early.
+- If the design is painful to describe, the implementation will be painful to use.
+- API review at design time is cheap; API review after clients exist is very expensive.
+
+## Versioning
+
+Every breaking change requires a new version. Communicate it, window it, enforce the schedule.
+- **Breaking:** removing a field, changing a field type, changing semantics of a status code, renaming a resource.
+- **Additive (non-breaking):** new optional fields, new endpoints, new enum values in response.
+- **URL-path versioning** (`/v1/orders`) — visible, cacheable, easy to route; good for major versions.
+- **Header versioning** (`API-Version: 2024-01-01`) — cleaner URLs; common for date-based schemes.
+- Set a deprecation window (minimum 6 months for external APIs) and enforce it; sunset headers signal the date.
+
+## Idempotency
+
+Operations must be safe to retry. Network failures happen; callers will retry.
+- **Safe** (GET, HEAD, OPTIONS) — no side effects.
+- **Idempotent** (PUT, DELETE) — repeating produces the same result.
+- **Non-idempotent** (POST) — accept an idempotency key header; server deduplicates by key.
+- Key scope: client-generated UUID, tied to the logical operation, expires after a defined window.
+- Return the same response for a duplicate key — do not create twice, do not error.
+
+## Pagination
+
+Never return unbounded collections. Choose the model based on query patterns.
+- **Offset pagination** — simple; breaks when records insert or delete during traversal; fine for small, stable sets.
+- **Cursor pagination** — stable under concurrent writes; opaque cursor encodes position; cannot jump to page N.
+- Always cap page size server-side; document the default and maximum.
+- Return a `next_cursor` or `next_page` token — do not expose the underlying query offset or row ID.
+
+## Error Shapes
+
+Consistent error envelopes let callers handle errors generically.
+- Every error response: `code` (machine-readable), `message` (human-readable), `details` (optional array), `request_id`.
+- HTTP status discipline: 400 bad input, 401 unauthenticated, 403 unauthorized, 404 not found, 409 conflict, 422 semantic error, 429 rate limited, 500 server fault.
+- Problem+JSON (RFC 7807) as a standard envelope for REST APIs.
+- Never return 200 OK with `"error": true` in the body — callers cannot detect errors without body parsing.
+
+## Evolvability
+
+Design for forward and backward compatibility from the start.
+- **Additive only** — add fields, never remove or rename in-place.
+- **Tolerate unknown fields** — clients must ignore keys they do not recognize (Postel's law on reading).
+- **Default-on-omit** — if a field is absent, apply a safe default; do not error.
+- Never reuse a retired field name with a different type or semantic.
+- Serialize enums as strings, not integers — new values are additive; integer reordering is breaking.
+
+## REST vs RPC vs Event-Driven
+
+**REST**
+- **Use when:** resource-oriented CRUD, public APIs, cache-friendly reads, diverse client ecosystem.
+- **Costs:** round trips for complex operations; HTTP overhead; no native streaming.
+- **Don't use when:** low-latency internal services, server-push streaming, or highly procedural workflows.
+
+**RPC (gRPC / Thrift / Twirp)**
+- **Use when:** internal service-to-service, schema-first contracts, strong typing required, streaming needed.
+- **Costs:** less human-readable; requires code generation; harder to debug with standard HTTP tools.
+- **Don't use when:** public APIs consumed by browsers or third parties that lack generated client support.
+
+**Event-Driven**
+- **Use when:** decoupled producers and consumers, eventual consistency acceptable, audit log or replay required.
+- **Costs:** ordering guarantees complex; debugging harder; silent consumer drift possible.
+- **Don't use when:** synchronous response is required, or consumer must confirm processing before producer continues.
+
+## When Strict API Discipline is Overkill
+
+- Internal-only APIs with a single consumer owned by the same team.
+- Short-lived prototypes (under two weeks) with no external consumers.
+- Scripts or migrations that call an API once and are immediately discarded.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| `/v1/`, `/v1.1/`, `/v2/`, `/v2-new/` in one codebase | Version creep — no deprecation discipline enforced |
+| Breaking field removed in a patch release | Breaking change shipped without a version bump |
+| Response fields map directly to DB column names | Schema leak — any migration breaks clients |
+| `200 OK` with `{"error": true}` in body | Generic error handling impossible for callers |
+| GET endpoint that creates or modifies state | Violates HTTP safety; CDNs and browsers will cache the write |
+| No `request_id` in error responses | Cannot correlate support reports to server logs |

--- a/skills/principle-concurrency/SKILL.md
+++ b/skills/principle-concurrency/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: principle-concurrency
+description: Concurrency principles — race conditions, deadlock, livelock, starvation, structured concurrency, cancellation propagation, backpressure, lock-free primitives, atomics, memory models, choosing between mutex vs channel vs actor vs semaphore vs CAS. Auto-load when designing concurrent code, debugging a race condition, fixing a deadlock, propagating cancellation, choosing a synchronization primitive, designing worker pools, or reasoning about goroutine/thread/task lifetimes.
+---
+
+# Concurrency
+
+Concurrency is a correctness hazard first, a performance tool second. Prove correctness before optimizing.
+
+## Failure Modes
+
+**Race condition** — two goroutines/threads read and write shared state without synchronization; result is non-deterministic. **Fix:** mutex, channel, or atomic.
+
+**Deadlock** — two or more tasks each hold a lock the other needs; all block forever. **Fix:** consistent lock-acquisition ordering; prefer higher-level primitives.
+
+**Livelock** — tasks keep changing state in response to each other but make no progress; common in retry loops that back off identically. **Fix:** add jitter; use backpressure signals.
+
+**Starvation** — a low-priority task never gets scheduled because high-priority tasks monopolize a resource. **Fix:** fair queues; priority inheritance; rate limits.
+
+**Lost wakeup** — a condition-variable signal fires before the waiter starts waiting; waiter sleeps forever. **Fix:** always check the predicate in a loop; use atomic flags.
+
+**ABA problem** — a CAS succeeds because a value returned to A, masking an intervening change. **Fix:** use version tags or hazard pointers; prefer higher-level data structures.
+
+## Structured Concurrency
+
+Child task lifetimes must nest inside the parent's lifetime. No orphan goroutines or threads.
+- When the parent exits, all children are cancelled first.
+- Errors propagate up — a child error surfaces to the parent, not to a background log line.
+- Never fire-and-forget unless the lifetime is explicitly managed (e.g., a top-level worker pool with a shutdown hook).
+- For language-specific structured concurrency APIs, see `language-go` (errgroup, context) and your platform's task group primitives.
+
+## Cancellation
+
+Concurrency requires cooperative cancellation — you cannot safely kill a thread mid-operation.
+- Pass a context or cancellation token down the call stack; never rely on thread interruption.
+- Check for cancellation at every I/O boundary and between long computation steps.
+- Release resources (locks, file handles, connections) before acknowledging cancellation.
+- Do not swallow cancellation signals — propagate them or translate them into a clean shutdown signal.
+
+## Backpressure
+
+Unbounded queues hide a broken producer/consumer balance until memory is exhausted.
+- Use bounded queues with explicit drop or block policies.
+- Ask "what happens when downstream is slower than upstream?" before writing any queue.
+- **Drop oldest** — acceptable for telemetry and non-critical real-time data.
+- **Block producer** — correct for ordered pipelines where data loss is unacceptable.
+- **Error/circuit-break** — correct for RPC fan-out where partial failure is worse than full failure.
+
+## Primitive Selection
+
+**Mutex** — shared mutable state with exclusive access; short critical sections only.
+**Use when:** multiple writers share an in-memory structure; critical section is O(1) or near.
+**Costs:** lock contention serializes all callers; holding a lock across I/O causes convoy problems.
+
+**Channel** — ownership transfer, pipeline staging, fan-out/fan-in.
+**Use when:** passing a value from one goroutine/task to another; buffered for throughput, unbuffered for synchronization.
+**Costs:** overhead vs mutex for simple counters; wrong buffer size silently causes deadlock.
+
+**Actor** — state encapsulated behind a single mailbox; all access serialized through message passing.
+**Use when:** complex mutable state is accessed by many concurrent callers; prefer isolation over sharing.
+**Costs:** message copying overhead; harder to express synchronous request-response.
+
+**Atomic / CAS** — lock-free fast path for counters, flags, and pointer swaps.
+**Use when:** a single variable needs concurrent update; profiling shows mutex is the bottleneck.
+**Costs:** memory-ordering semantics are subtle; composing multiple atomics is not itself atomic.
+
+**Semaphore** — bounded resource pool (connection pool, worker pool, API rate limit).
+**Use when:** limit concurrent access to a resource to N callers.
+**Costs:** starvation possible without fair queueing.
+
+> For Go-specific idioms (goroutine lifecycles, channel patterns, `sync` package): see `language-go`.
+
+## When Concurrency is Overkill
+
+- Sequential is correct until a profiler identifies a throughput or latency bottleneck.
+- Single-core environments or scripts where parallelism is unavailable.
+- Synchronization complexity outweighs the speedup — measure first.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| `sleep` used to synchronize goroutines or threads | Sleep-based sync is a race condition with a timing window; use channels or barriers |
+| Double-checked locking without atomics or memory fences | Compilers and CPUs reorder; the outer check is not safe without proper memory ordering |
+| Unbounded channel or queue | Hides backpressure; exhausts memory under sustained load |
+| Lock held across a network call or database query | Serializes all callers for the full I/O duration; severe performance cliff |
+| Race "fixed" by adding more locks | Deadlock risk grows with lock count; redesign ownership instead |

--- a/skills/principle-observability/SKILL.md
+++ b/skills/principle-observability/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: principle-observability
+description: Observability principles — logs vs metrics vs traces, structured logging, span/trace context, cardinality control, OpenTelemetry, SLI/SLO/SLA, RED method, USE method, alerting on symptoms vs causes. Auto-load when adding logging, choosing a metric, instrumenting traces, debating cardinality, defining SLIs/SLOs, designing alerts, or discussing observability budgets.
+---
+
+# Observability
+
+Three signals, each with a distinct job. Use the right one for the right question.
+
+## The Three Pillars
+
+**Logs** — discrete events with context. Right for: debugging specific incidents, audit trails, free-text search.
+- Emit at decision points and error boundaries, not in loops.
+- Use structured key-value format; never interpolate variables into free-form strings.
+- Include a correlation ID on every line — trace parent ID if a trace exists.
+
+**Metrics** — numeric aggregations over time. Right for: dashboards, SLOs, alerting thresholds.
+- Pre-aggregate; do not stream raw events into a metrics backend.
+- Label only stable, low-cardinality dimensions (region, status_code, service) — never user ID, request ID, or email.
+
+**Traces** — causal chain of operations across services. Right for: latency attribution, dependency mapping.
+- A span represents one unit of work; parent/child links form the trace.
+- Propagate context headers at every service boundary — OpenTelemetry W3C trace context.
+- Put high-cardinality attributes (user ID, document ID) in span attributes, not metric labels.
+
+## Structured Logging
+
+Emit events as key-value pairs. The log processor should never parse a free-form string.
+- Correlation ID ties log lines to a trace and to a business operation.
+- Log level discipline: DEBUG (local dev), INFO (normal flow), WARN (recoverable anomaly), ERROR (action required).
+- No `log.debug("entering function X")` in hot paths — cost without signal.
+
+## Cardinality
+
+High-cardinality labels explode time-series count and kill metrics backends.
+- **Safe:** `status_code`, `method`, `region`, `environment` — bounded sets.
+- **Unsafe:** `user_id`, `request_id`, `session_token` — unbounded.
+- Move high-cardinality context to span attributes or structured log fields.
+- Rule of thumb: if a label's value count exceeds 1 000, it does not belong in a metric.
+
+## SLI / SLO / Error Budget
+
+Define SLIs around user-visible behavior, not internal mechanics.
+- **SLI** — the measurement: request success rate, p99 latency, data freshness.
+- **SLO** — the target: 99.9% success rate over a rolling 28-day window.
+- **Error budget** — 1 − SLO; spend it on risk, protect it by slowing releases.
+- Track error budgets as a team policy, not as an on-call metric.
+- Never use CPU utilization or memory as SLIs — users do not feel CPU.
+
+## RED Method (request-driven services)
+
+Three questions for every service:
+- **Rate** — how many requests per second?
+- **Errors** — what fraction are failing?
+- **Duration** — how long are they taking? (histogram, not average)
+
+## USE Method (resource-driven services)
+
+Three questions per resource (CPU, memory, disk, network):
+- **Utilization** — how busy is the resource?
+- **Saturation** — how much demand is queued?
+- **Errors** — is the resource reporting errors?
+
+## Alert on Symptoms, Not Causes
+
+Page humans for user-visible pain. Let dashboards explain why.
+- **Page-worthy:** error rate exceeds SLO budget burn rate; p99 latency exceeds user threshold.
+- **Not page-worthy:** CPU > 80%, heap > 70% — correlate these in post-mortems.
+- Symptom alerts reduce alert fatigue; cause alerts create it.
+
+## When Observability is Overkill
+
+- Internal scripts, batch jobs, one-off migrations — structured logs suffice.
+- Single-process services owned by one developer — standard library logging, no tracing.
+- Prototypes: instrument later; premature instrumentation shapes API decisions before the design is stable.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| Alerts fire on CPU or memory thresholds | Cause alert — pages without confirmed user impact |
+| `log.debug("value: " + obj.toString())` | String interpolation breaks log parsing; expensive in hot paths |
+| Metric labels include user ID or request ID | High-cardinality explosion; will saturate the metrics backend |
+| Dashboard added for every new feature | Dashboards-as-product; nobody reads them; builds false confidence |
+| On-call only reacts when paged | No error-budget tracking; SLO erosion invisible until breach |


### PR DESCRIPTION
## Summary
- Add `principle-observability` — three pillars (logs/metrics/traces), structured logging, cardinality control, SLI/SLO/error budget, RED method, USE method, alert on symptoms
- Add `principle-api-design` — contract-first, versioning (breaking vs additive), idempotency keys, pagination (offset vs cursor), error shapes (RFC 7807), evolvability rules, REST vs RPC vs event-driven comparison
- Add `principle-concurrency` — six failure modes (race/deadlock/livelock/starvation/lost-wakeup/ABA), structured concurrency, cancellation, backpressure, primitive selection (mutex/channel/actor/atomic/semaphore)
- Update `docs/catalog.md` with trigger phrases for all three new skills

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `python3 scripts/validate.py` passes — all checks passed, line counts 85/92/87 (cap: 150)
- [x] Frontmatter `name:` matches directory name in all three files
- [x] Trigger phrases in catalog are multi-word specifics (no bare common words)

Closes #13