### PR TITLE
[docs] Add /implement command to catalog

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -58,3 +58,4 @@ This skill is an orchestrator — it coordinates other skills rather than restat
 | Skill | Triggers | Delegation model |
 |---|---|---|
 | `ticket-context` | Jira keys (`[A-Z]+-\d+`), `atlassian.net/browse/...`, Confluence wiki URLs, `github.com/.../(issues\|pull)/N`, `#N` refs. | Invoked by command bodies as a prelude before subagent delegation. Fetches via `mcp__atlassian__*` and `gh` CLI. Returns structured context (title, summary, acceptance criteria, linked refs, recent comments). Does not act on the ticket — only resolves it. |
+

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -9,6 +9,7 @@
 | `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
 | `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |
 | `/swe-workbench:test <target>` | Write focused, behavioural tests in the target language's idiom. |
+| `/swe-workbench:implement <ticket or description>` | Drive a feature end-to-end — branch, plan, TDD build, verify, review, PR. Orchestrates the full 5-phase `workflow-development` lifecycle. |
 
 ## Subagents
 


### PR DESCRIPTION
## Summary

- Adds the missing `/swe-workbench:implement` row to the Commands table in `docs/catalog.md`

`/implement` is the full orchestrator — branch → TDD build → verify → review → PR — but was absent from the catalog while the four narrower commands (`/review`, `/design`, `/refactor`, `/debug`) were all listed.

## Test plan

- [x] `bash scripts/validate.sh` passes clean
- [x] `/swe-workbench:implement` appears in Commands table

N/A