### PR TITLE
[docs] Refresh README and manifests to reflect current surface area

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "swe-workbench",
-  "description": "Senior-engineer toolkit for Claude Code — principled design, language expertise, and pragmatic workflows",
+  "description": "Senior-engineer toolkit for Claude Code — principled design, security review, language expertise, and pragmatic workflows",
   "owner": {
     "name": "Lugas Septiawan",
     "email": "lugassawan@gmail.com"
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "swe-workbench",
-      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns), language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
       "version": "0.1.2",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swe-workbench",
   "version": "0.1.2",
-  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns), language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
     "email": "lugassawan@gmail.com",

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ cd swe-workbench
 
 ## What's inside
 
-- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:debug` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `reviewer`, `senior-engineer`, `refactorer`, `debugger` — see [docs/catalog.md](docs/catalog.md).
-- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code — auto-load by trigger keyword.
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:test`, `/swe-workbench:security-review` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `reviewer`, `senior-engineer`, `refactorer`, `debugger`, `security-auditor`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
+- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency — auto-load by trigger keyword.
 - **Languages** — Go, Rust, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
@@ -37,11 +37,7 @@ Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide an
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR, run the plugin validator locally:
-
-```sh
-bash scripts/validate.sh
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
N/A

## Summary

- **README "What's inside"**: counts corrected — Commands 4→7 (adds `/implement`, `/test`, `/security-review`), Subagents 4→6 (adds `security-auditor`, `test-writer`), Principles 6→9 (adds observability, API design, concurrency)
- **Contributing section**: collapsed to a single pointer to `CONTRIBUTING.md`; removed the duplicate `bash scripts/validate.sh` block that already lives with full context at `CONTRIBUTING.md:54-58`
- **`plugin.json` / `marketplace.json`**: description strings updated to mention security review, observability, and concurrency; `plugins[0].description` kept byte-identical across both files (validator confirmed passing)

## Test plan

- [x] `bash scripts/validate.sh` passes
- [x] `plugins[0].description` in `marketplace.json` matches `plugin.json` description exactly
- [x] README command/subagent/principle counts match actual files in `commands/`, `agents/`, `skills/`