### PR TITLE
[chore] Replace personal email with GitHub no-reply in plugin manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Senior-engineer toolkit for Claude Code — principled design, security review, language expertise, and pragmatic workflows",
   "owner": {
     "name": "Lugas Septiawan",
-    "email": "lugassawan@gmail.com"
+    "email": "11341007+lugassawan@users.noreply.github.com"
   },
   "plugins": [
     {
@@ -13,7 +13,7 @@
       "source": "./",
       "author": {
         "name": "Lugas Septiawan",
-        "email": "lugassawan@gmail.com"
+        "email": "11341007+lugassawan@users.noreply.github.com"
       }
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
-    "email": "lugassawan@gmail.com",
+    "email": "11341007+lugassawan@users.noreply.github.com",
     "url": "https://github.com/lugassawan"
   },
   "homepage": "https://github.com/lugassawan/swe-workbench",


### PR DESCRIPTION
N/A

## Summary

- Replaces the personal email address with the GitHub no-reply alias (`11341007+lugassawan@users.noreply.github.com`) in all 3 `email` fields across `.claude-plugin/marketplace.json` (lines 6 and 16) and `.claude-plugin/plugin.json` (line 7)
- The no-reply alias satisfies the manifest schema's email string requirement while routing nowhere, preventing spam harvesting on the public repo
- No functional change — these are author-metadata fields not used by any code path

## Test plan

- [ ] No personal email address remains in the working tree (`grep -rn "@gmail.com" . --exclude-dir=.git` returns no output)
- [ ] `grep -rn "noreply" .claude-plugin/` shows 3 hits (marketplace.json:6, marketplace.json:16, plugin.json:7)
- [ ] Both JSON files parse cleanly: `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json')); json.load(open('.claude-plugin/plugin.json'))"`