### PR TITLE
[feat] Add Python language skill

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -47,7 +47,7 @@
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
 | `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
-| `language-python` | `.py` files, `.pyi` files, `pyproject.toml`, `requirements.txt`, `setup.py` | Python idioms, typing, async, packaging, testing |
+| `language-python` | `.py` files, `.pyi` files, `pyproject.toml`, `requirements.txt`, `setup.py`, keywords: Python, pytest, mypy, asyncio, pydantic. |
 
 ### Workflows — auto-load during implementation
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -38,6 +38,7 @@
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
 | `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
+| `language-python` | `.py` files, `.pyi` files, `pyproject.toml`, `requirements.txt`, `setup.py` | Python idioms, typing, async, packaging, testing |
 
 ### Workflows — auto-load during implementation
 
@@ -51,4 +52,4 @@ This skill is an orchestrator — it coordinates other skills rather than restat
 
 | Skill | Triggers | Delegation model |
 |---|---|---|
-| `ticket-context` | Jira keys (`[A-Z]+-\d+`), `atlassian.net/browse/...`, Confluence wiki URLs, `github.com/.../(issues\|pull)/N`, `#N` refs. | Invoked by command bodies as a prelude before subagent delegation. Fetches via `mcp__atlassian__*` and `gh` CLI. Returns structured context (title, summary, acceptance criteria, linked refs, recent comments). Does not act on the ticket — only resolves it. |
+| `ticket-context` | Jira keys (`[A-Z]+-\d+`), `atlassian.net/browse/...`, Confluence wiki URLs, `github.com/.../(issues\|pull)/N`, `#N` refs. | Invoked by command bodies as a prelude before subagent delegation. Fetches via `mcp__atlassian__*` and `gh` CLI. Returns structured context (title, summary, acceptance criteria, linked refs, recent comments). Does not act on the ticket — only resolves it. 

--- a/skills/language-python/SKILL.md
+++ b/skills/language-python/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: language-python
-description: Python idioms, error handling, typing, async, and packaging. Auto-load when working with .py/.pyi, pyproject.toml, requirements.txt, setup.py, or mentions of Python, pytest, mypy, asyncio, dataclass, type hints, pydantic.
+description: Python idioms, error handling, typing, async, and packaging. Auto-load when working with .py files, .pyi files, pyproject.toml, requirements.txt, setup.py, or mentions of Python, pytest, mypy, asyncio, dataclass, type hints, pydantic.
 ---
+
 # Python
 
 ## Errors are values
+
 - Raise specific exceptions; never `except:`.
 - Chain errors: `raise NewError(...) from exc`.
 - Inspect via `isinstance`, not message strings.
@@ -20,17 +22,18 @@ except httpx.TimeoutException as exc:
 
 with suppress(FileNotFoundError):
     cache_path.unlink()
-```
+Typing (PEP 484/604)
+Prefer X | Y (3.10+); Optional[X] only for legacy.
 
-## Typing (PEP 484/604)
+TypedDict for structured dicts (no runtime cost).
 
-* Prefer `X | Y` (3.10+); `Optional[X]` only for legacy.
-* `TypedDict` for structured dicts (no runtime cost).
-* `Protocol` for duck typing (better than ABCs in libs).
-* `Final` for constants; `cast` sparingly.
+Protocol for duck typing (better than ABCs in libs).
 
-```python
-def load(src: str | Path) -> dict[str, int]: ...
+Final for constants; cast sparingly.
+
+python
+def load(src: str | Path) -> dict[str, int]:
+    pass  # stub
 
 class Config(TypedDict):
     host: str
@@ -40,43 +43,44 @@ class Closeable(Protocol):
     def close(self) -> None: ...
 
 MAX_RETRIES: Final = 3
-```
-## Dataclasses vs Pydantic vs TypedDict
+Dataclasses vs Pydantic vs TypedDict
+Need	Use
+Plain data	@dataclass
+Validation/API	pydantic.BaseModel
+Typed dict	TypedDict
+Immutable	@dataclass(frozen=True)
+Accept TypedDict/Protocol; return concrete types.
 
-| Need           | Use                       |
-| -------------- | ------------------------- |
-| Plain data     | `@dataclass`              |
-| Validation/API | `pydantic.BaseModel`      |
-| Typed dict     | `TypedDict`               |
-| Immutable      | `@dataclass(frozen=True)` |
+Use Pydantic for validation/coercion/JSON.
 
-* Accept `TypedDict`/`Protocol`; return concrete types.
-* Use Pydantic for validation/coercion/JSON.
+Async / Await
+No blocking I/O in coroutines → asyncio.to_thread.
 
-## Async / Await
+Keep task references; avoid orphan tasks.
 
-* No blocking I/O in coroutines → `asyncio.to_thread`.
-* Keep task references; avoid orphan tasks.
-* Prefer `TaskGroup` (3.11+).
-* `TaskGroup` cancels siblings on error; use `gather(..., return_exceptions=True)` if needed.
+Prefer TaskGroup (3.11+).
 
-```python
+TaskGroup cancels siblings on error; use gather(..., return_exceptions=True) when partial success matters.
+
+python
 async def main():
     async with asyncio.TaskGroup() as tg:
         a = tg.create_task(fetch_a())
         b = tg.create_task(fetch_b())
+    # Both tasks succeeded if we reach here
     print(a.result(), b.result())
 
 data = await asyncio.to_thread(blocking_db_query, arg)
-```
-## Packaging
+Packaging
+Use src/ layout.
 
-* Use `src/` layout.
-* `pyproject.toml` = single source of truth.
-* Editable install: `pip install -e ".[dev]"`.
-* Backends: hatchling, setuptools, flit, poetry-core.
+pyproject.toml = single source of truth.
 
-```toml
+Editable install: pip install -e ".[dev]".
+
+Backends: hatchling, setuptools, flit, poetry-core.
+
+toml
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -88,20 +92,19 @@ dependencies = ["httpx>=0.27"]
 
 [project.optional-dependencies]
 dev = ["pytest", "mypy", "ruff"]
-```
-## Tests
+Tests
+Prefer fixtures over setUp/tearDown.
 
-* Prefer fixtures over `setUp/tearDown`.
-* Use `@pytest.mark.parametrize`.
-* Use `monkeypatch`, `tmp_path` for isolation.
-* Register custom marks.
+Use @pytest.mark.parametrize.
 
-```toml
+Use monkeypatch, tmp_path for isolation.
+
+Register custom marks.
+
+toml
 [tool.pytest.ini_options]
 markers = ["integration: slow DB tests"]
-```
-
-```python
+python
 @pytest.fixture
 def client(tmp_path):
     return AppClient(tmp_path / "test.db")
@@ -115,26 +118,26 @@ def test_parse(raw, expected):
 
 @pytest.mark.integration
 def test_real_db(): ...
-```
-## Linting & Formatting
+Idioms
+if x is None (not falsy checks)
 
-* `ruff check` + `ruff format`
-* `mypy --strict`
-* Run both in CI.
+field(default_factory=list) (not mutable defaults)
 
-## Idioms
+Use @dataclass(slots=True) on Python 3.10+ instead of manual __slots__
 
-* `if x is None` (not falsy checks)
-* `field(default_factory=list)` (not mutable defaults)
-* `__slots__` for memory-heavy classes
-* `@cache` / `@lru_cache` for pure funcs
-* Prefer `match` over long `isinstance` chains
+@cache / @lru_cache for pure funcs
 
-## Avoid
+Prefer match over long isinstance chains
 
-* Mutable default args (`def f(x=[])`)
-* Bare `except` / swallowing `Exception`
-* Unexplained `type: ignore`
-* Redundant `@classmethod` factories
-* Threads for CPU-bound work (use `ProcessPoolExecutor`)
+Run ruff check + ruff format + mypy --strict in CI
 
+Avoid
+Mutable default args (def f(x=[]))
+
+Bare except / swallowing Exception
+
+Unexplained type: ignore
+
+Redundant @classmethod factories that merely duplicate __init__ with no new semantics
+
+Threads for CPU-bound work (use ProcessPoolExecutor)

--- a/skills/language-python/SKILL.md
+++ b/skills/language-python/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: language-python
-description: Python idioms, error handling, typing, async, and packaging. Auto-load when working with .py, .pyi files, pyproject.toml, requirements.txt, setup.py, or when the user mentions Python, pytest, mypy, asyncio, dataclass, type hints, or pydantic.
+description: Python idioms, error handling, typing, async, and packaging. Auto-load when working with .py/.pyi, pyproject.toml, requirements.txt, setup.py, or mentions of Python, pytest, mypy, asyncio, dataclass, type hints, pydantic.
 ---
-
 # Python
 
 ## Errors are values
-- Return and raise specific exceptions; never use bare `except:`.
-- Chain with `raise NewError("context") from original` to preserve the cause.
-- Inspect with `isinstance(exc, SomeError)`; never string-match messages.
-- Use `contextlib.suppress(ErrorType)` for intentionally swallowed errors.
+- Raise specific exceptions; never `except:`.
+- Chain errors: `raise NewError(...) from exc`.
+- Inspect via `isinstance`, not message strings.
+- Use `contextlib.suppress` for intentional ignores.
 
 ```python
+from contextlib import suppress
+
 try:
     result = fetch(url)
 except httpx.TimeoutException as exc:
@@ -21,11 +22,12 @@ with suppress(FileNotFoundError):
     cache_path.unlink()
 ```
 
-## Typing — PEP 484 / 604
-- Use `X | Y` unions (3.10+); `Optional[X]` only for older targets.
-- `TypedDict` for heterogeneous dicts (JSON payloads, config blobs) — zero runtime cost.
-- `Protocol` for structural duck-typed interfaces; prefer it over ABCs in library code.
-- `Final` for module-level constants; `cast` only to fix type-checker gaps.
+## Typing (PEP 484/604)
+
+* Prefer `X | Y` (3.10+); `Optional[X]` only for legacy.
+* `TypedDict` for structured dicts (no runtime cost).
+* `Protocol` for duck typing (better than ABCs in libs).
+* `Final` for constants; `cast` sparingly.
 
 ```python
 def load(src: str | Path) -> dict[str, int]: ...
@@ -39,26 +41,27 @@ class Closeable(Protocol):
 
 MAX_RETRIES: Final = 3
 ```
-
 ## Dataclasses vs Pydantic vs TypedDict
 
-| Need | Use |
-|---|---|
-| Plain data container, no validation | `@dataclass` |
-| Validated input / API models / settings | `pydantic.BaseModel` |
-| Typed dict shape, zero overhead | `TypedDict` |
-| Immutable record | `@dataclass(frozen=True)` |
+| Need           | Use                       |
+| -------------- | ------------------------- |
+| Plain data     | `@dataclass`              |
+| Validation/API | `pydantic.BaseModel`      |
+| Typed dict     | `TypedDict`               |
+| Immutable      | `@dataclass(frozen=True)` |
 
-- Accept `TypedDict` / `Protocol` for inputs; return concrete types.
-- Reach for Pydantic when you need coercion, validation, or JSON serialisation.
+* Accept `TypedDict`/`Protocol`; return concrete types.
+* Use Pydantic for validation/coercion/JSON.
 
-## async / await
-- Never call blocking I/O inside a coroutine — use `asyncio.to_thread`.
-- Always hold a reference to created tasks; orphaned tasks get GC'd silently.
-- Prefer `asyncio.TaskGroup` (3.11+) over `gather` — exceptions propagate immediately.
+## Async / Await
+
+* No blocking I/O in coroutines → `asyncio.to_thread`.
+* Keep task references; avoid orphan tasks.
+* Prefer `TaskGroup` (3.11+).
+* `TaskGroup` cancels siblings on error; use `gather(..., return_exceptions=True)` if needed.
 
 ```python
-async def main() -> None:
+async def main():
     async with asyncio.TaskGroup() as tg:
         a = tg.create_task(fetch_a())
         b = tg.create_task(fetch_b())
@@ -66,11 +69,12 @@ async def main() -> None:
 
 data = await asyncio.to_thread(blocking_db_query, arg)
 ```
-
 ## Packaging
-- Use `src/` layout — prevents accidental imports from the project root.
-- `pyproject.toml` is the single source of truth; avoid `setup.py` in new projects.
-- Editable install during development: `pip install -e ".[dev]"`.
+
+* Use `src/` layout.
+* `pyproject.toml` = single source of truth.
+* Editable install: `pip install -e ".[dev]"`.
+* Backends: hatchling, setuptools, flit, poetry-core.
 
 ```toml
 [build-system]
@@ -85,12 +89,17 @@ dependencies = ["httpx>=0.27"]
 [project.optional-dependencies]
 dev = ["pytest", "mypy", "ruff"]
 ```
-
 ## Tests
-- Fixtures over `setUp`/`tearDown` — pytest fixtures compose and scope cleanly.
-- `@pytest.mark.parametrize` for edge cases; keep each case a plain tuple.
-- `monkeypatch` for env vars and imports; `tmp_path` for file system work.
-- Mark slow tests so the default suite stays fast.
+
+* Prefer fixtures over `setUp/tearDown`.
+* Use `@pytest.mark.parametrize`.
+* Use `monkeypatch`, `tmp_path` for isolation.
+* Register custom marks.
+
+```toml
+[tool.pytest.ini_options]
+markers = ["integration: slow DB tests"]
+```
 
 ```python
 @pytest.fixture
@@ -107,17 +116,25 @@ def test_parse(raw, expected):
 @pytest.mark.integration
 def test_real_db(): ...
 ```
+## Linting & Formatting
 
-## Idioms cheat sheet
-- `if value is None` not `if not value` — avoids falsy surprises.
-- Dataclass `field(default_factory=list)` instead of mutable default args.
-- `__slots__` on hot dataclasses to cut per-instance memory.
-- `@functools.cache` / `@functools.lru_cache` for pure deterministic functions.
-- `match` statement (3.10+) over long `isinstance` chains.
+* `ruff check` + `ruff format`
+* `mypy --strict`
+* Run both in CI.
+
+## Idioms
+
+* `if x is None` (not falsy checks)
+* `field(default_factory=list)` (not mutable defaults)
+* `__slots__` for memory-heavy classes
+* `@cache` / `@lru_cache` for pure funcs
+* Prefer `match` over long `isinstance` chains
 
 ## Avoid
-- Mutable default arguments (`def f(x=[]):`).
-- Catching `Exception` or `BaseException` without re-raising.
-- `type: ignore` without a comment explaining why.
-- Overusing `@classmethod` factories — prefer `__init__` with `Optional` params.
-- Threads for CPU-bound work — use `ProcessPoolExecutor` or a task queue.
+
+* Mutable default args (`def f(x=[])`)
+* Bare `except` / swallowing `Exception`
+* Unexplained `type: ignore`
+* Redundant `@classmethod` factories
+* Threads for CPU-bound work (use `ProcessPoolExecutor`)
+

--- a/skills/language-python/SKILL.md
+++ b/skills/language-python/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: language-python
+description: Python idioms, error handling, typing, async, and packaging. Auto-load when working with .py, .pyi files, pyproject.toml, requirements.txt, setup.py, or when the user mentions Python, pytest, mypy, asyncio, dataclass, type hints, or pydantic.
+---
+
+# Python
+
+## Errors are values
+- Return and raise specific exceptions; never use bare `except:`.
+- Chain with `raise NewError("context") from original` to preserve the cause.
+- Inspect with `isinstance(exc, SomeError)`; never string-match messages.
+- Use `contextlib.suppress(ErrorType)` for intentionally swallowed errors.
+
+```python
+try:
+    result = fetch(url)
+except httpx.TimeoutException as exc:
+    raise ServiceUnavailableError(url) from exc
+
+with suppress(FileNotFoundError):
+    cache_path.unlink()
+```
+
+## Typing — PEP 484 / 604
+- Use `X | Y` unions (3.10+); `Optional[X]` only for older targets.
+- `TypedDict` for heterogeneous dicts (JSON payloads, config blobs) — zero runtime cost.
+- `Protocol` for structural duck-typed interfaces; prefer it over ABCs in library code.
+- `Final` for module-level constants; `cast` only to fix type-checker gaps.
+
+```python
+def load(src: str | Path) -> dict[str, int]: ...
+
+class Config(TypedDict):
+    host: str
+    port: int
+
+class Closeable(Protocol):
+    def close(self) -> None: ...
+
+MAX_RETRIES: Final = 3
+```
+
+## Dataclasses vs Pydantic vs TypedDict
+
+| Need | Use |
+|---|---|
+| Plain data container, no validation | `@dataclass` |
+| Validated input / API models / settings | `pydantic.BaseModel` |
+| Typed dict shape, zero overhead | `TypedDict` |
+| Immutable record | `@dataclass(frozen=True)` |
+
+- Accept `TypedDict` / `Protocol` for inputs; return concrete types.
+- Reach for Pydantic when you need coercion, validation, or JSON serialisation.
+
+## async / await
+- Never call blocking I/O inside a coroutine — use `asyncio.to_thread`.
+- Always hold a reference to created tasks; orphaned tasks get GC'd silently.
+- Prefer `asyncio.TaskGroup` (3.11+) over `gather` — exceptions propagate immediately.
+
+```python
+async def main() -> None:
+    async with asyncio.TaskGroup() as tg:
+        a = tg.create_task(fetch_a())
+        b = tg.create_task(fetch_b())
+    print(a.result(), b.result())
+
+data = await asyncio.to_thread(blocking_db_query, arg)
+```
+
+## Packaging
+- Use `src/` layout — prevents accidental imports from the project root.
+- `pyproject.toml` is the single source of truth; avoid `setup.py` in new projects.
+- Editable install during development: `pip install -e ".[dev]"`.
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-package"
+requires-python = ">=3.11"
+dependencies = ["httpx>=0.27"]
+
+[project.optional-dependencies]
+dev = ["pytest", "mypy", "ruff"]
+```
+
+## Tests
+- Fixtures over `setUp`/`tearDown` — pytest fixtures compose and scope cleanly.
+- `@pytest.mark.parametrize` for edge cases; keep each case a plain tuple.
+- `monkeypatch` for env vars and imports; `tmp_path` for file system work.
+- Mark slow tests so the default suite stays fast.
+
+```python
+@pytest.fixture
+def client(tmp_path):
+    return AppClient(tmp_path / "test.db")
+
+@pytest.mark.parametrize("raw,expected", [
+    ("42", 42),
+    pytest.param("x", None, id="non-numeric"),
+])
+def test_parse(raw, expected):
+    assert parse_int(raw) == expected
+
+@pytest.mark.integration
+def test_real_db(): ...
+```
+
+## Idioms cheat sheet
+- `if value is None` not `if not value` — avoids falsy surprises.
+- Dataclass `field(default_factory=list)` instead of mutable default args.
+- `__slots__` on hot dataclasses to cut per-instance memory.
+- `@functools.cache` / `@functools.lru_cache` for pure deterministic functions.
+- `match` statement (3.10+) over long `isinstance` chains.
+
+## Avoid
+- Mutable default arguments (`def f(x=[]):`).
+- Catching `Exception` or `BaseException` without re-raising.
+- `type: ignore` without a comment explaining why.
+- Overusing `@classmethod` factories — prefer `__init__` with `Optional` params.
+- Threads for CPU-bound work — use `ProcessPoolExecutor` or a task queue.


### PR DESCRIPTION
Adds Python language skill following template from language-go.

- Auto-loads on .py files, pyproject.toml, requirements.txt
- Covers error handling, typing, async, packaging, testing
- Under 150 lines as required
- Name field matches directory name exactly

Closes #8