### PR TITLE
[docs] Add chore/maintenance issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/chore_maintenance.md
@@ -1,0 +1,29 @@
+---
+name: Chore / maintenance
+about: Documentation update, CI tweak, dependency bump, config change — no new behaviour
+title: '[chore] '
+labels: documentation
+assignees: ''
+---
+
+## Type
+
+<!-- Check all that apply. -->
+- [ ] Documentation (README, catalog, SECURITY, etc.)
+- [ ] CI / workflow (`.github/workflows/`, actions)
+- [ ] Dependency / tooling bump
+- [ ] Repository config (templates, Dependabot, labels)
+- [ ] Release / packaging (`.claude-plugin/`, `scripts/`)
+
+## Surface
+
+**Files to change** (list paths or globs):
+
+## Description
+
+<!-- What needs to change and why. Include the current state and desired state. -->
+
+## Acceptance
+
+<!-- How will we know this is done? -->
+- [ ]


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/chore_maintenance.md` for issues that don't fit `bug_report` or `feature_request` — docs updates, CI tweaks, dependency bumps, and repo config changes.
- Template has a **Type** checklist (Documentation / CI / Dependency / Repo config / Release) and a **Surface** free-text field for file paths, keeping it lean.
- `labels: documentation` pre-applied via frontmatter; title prefix defaults to `[chore]` to match the PR-title regex.

## Test plan

- [ ] Open a new issue on GitHub and confirm the "Chore / maintenance" template appears in the picker.
- [ ] Selecting it pre-fills the title with `[chore] ` and applies the `documentation` label.
- [ ] Template renders correctly with all checkboxes and sections.