### PR TITLE
[docs] Add chore/maintenance issue template and fix stale version in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ assignees: ''
 
 ## Plugin version
 
-<!-- From .claude-plugin/plugin.json — current release is 0.1.2 -->
+<!-- From .claude-plugin/plugin.json -->
 
 ## Reproduction steps
 

--- a/.github/ISSUE_TEMPLATE/chore_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/chore_maintenance.md
@@ -1,0 +1,29 @@
+---
+name: Chore / maintenance
+about: Documentation update, CI tweak, dependency bump, config change — no new behaviour
+title: '[chore] '
+labels: documentation
+assignees: ''
+---
+
+## Type
+
+<!-- Check all that apply. -->
+- [ ] Documentation (README, catalog, SECURITY, etc.)
+- [ ] CI / workflow (`.github/workflows/`, actions)
+- [ ] Dependency / tooling bump
+- [ ] Repository config (templates, Dependabot, labels)
+- [ ] Release / packaging (`.claude-plugin/`, `scripts/`)
+
+## Surface
+
+**Files to change** (list paths or globs):
+
+## Description
+
+<!-- What needs to change and why. Include the current state and desired state. -->
+
+## Acceptance
+
+<!-- How will we know this is done? -->
+- [ ]


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/chore_maintenance.md` for issues that don't fit `bug_report` or `feature_request` — docs updates, CI tweaks, dependency bumps, and repo config changes.
- Fixes stale hard-coded version (`0.1.2`) in `bug_report.md` line 30; replaces with a version-agnostic comment so it never drifts again.

## Test plan

- [ ] Open a new issue on GitHub and confirm the "Chore / maintenance" template appears in the picker alongside Bug report and Feature request.
- [ ] Selecting it pre-fills the title with `[chore] ` and applies the `documentation` label.
- [ ] `bug_report.md` plugin version comment no longer references a specific release number.

Closes #38