### PR TITLE
[docs] Add ISSUE_TEMPLATE/config.yml — disable blank issues, add install contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Setup & installation help
+    url: https://github.com/lugassawan/swe-workbench#install
+    about: Read the README's Install section for prerequisites and the one-line install command before opening an issue.


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` to remove the "Open a blank issue" escape hatch from the new-issue chooser.
- Adds a `contact_links` entry pointing contributors with setup questions to the README's `## Install` section (`#install` anchor confirmed at `README.md:9`).

## Acceptance criteria

- [x] `.github/ISSUE_TEMPLATE/config.yml` exists and is valid YAML.
- [ ] "Blank issue" option no longer appears on the new-issue page — **manual verification after merge**: visit `https://github.com/lugassawan/swe-workbench/issues/new/choose` and confirm no "Open a blank issue" link.
- [ ] Contact link resolves correctly — **manual verification after merge**: click the Install link from the new-issue chooser and confirm it lands on the Install section.

Closes #42