### PR TITLE
[ci] Add shellcheck to PR validation workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,3 +66,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate plugin files
         run: bash scripts/validate.sh
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: error
+          additional_files: 'commit-msg pre-commit pre-push'
+          check_together: 'yes'


### PR DESCRIPTION
## Summary
- Adds a third parallel `shellcheck` job to `.github/workflows/pr.yml` alongside `validate-pr` and `validate-plugin-files`
- Runs `ludeeus/action-shellcheck@2.0.0` with `severity: error` — gates only on SC1xxx parse errors and SC2xxx code defects (e.g. SC2086 unquoted expansions); style nits intentionally excluded
- Covers `scripts/*.sh` via default `scandir: './'` and all three `.githooks/*` files (`commit-msg`, `pre-commit`, `pre-push`) via `additional_files` basenames; `check_together: yes` for aggregated output and single exit code

## Test Plan
- [ ] `shellcheck` job appears alongside the other two jobs in the PR Checks tab
- [ ] All three scripts and three hooks pass with zero SC-error violations (expected green on current main)
- [ ] Introducing a deliberate `$UNQUOTED` expansion in any script causes the job to fail (SC2086)

Closes #40