### PR TITLE
[docs] Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current minor release receives security fixes. Older minors are unsupported.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes       |
+| < 0.1   | No        |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security bugs.**
+
+Use GitHub's private vulnerability reporting instead:
+
+**Security tab → "Report a vulnerability"** — or go directly to:
+<https://github.com/lugassawan/swe-workbench/security/advisories/new>
+
+## Scope
+
+**In scope** — vulnerabilities in the plugin's own files:
+- Subagent and skill prompts (`agents/`, `skills/`)
+- Commands (`commands/`)
+- Hooks (`hooks/`)
+- Scripts (`scripts/`)
+- Plugin manifests (`.claude-plugin/`)
+
+**Out of scope** — security issues that originate entirely in the user's own codebase (not caused by the plugin). That code is the user's responsibility.
+
+## Response Time
+
+This is a personal-time project. Acknowledgement aim: 7 days. Patches for critical issues: best-effort, no formal SLA. Fixes are prioritised by severity.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` at the repo root so GitHub surfaces a "Security policy" tab
- Routes vulnerability reports through GitHub private advisories (not public issues)
- Covers: supported versions table, private reporting link, in/out-of-scope boundaries, response time expectations

## Test Plan

- [x] `wc -l SECURITY.md` → 34 lines (≤ 40 limit)
- [x] `scripts/validate.sh` → "All checks passed"
- [ ] After merge: verify `https://github.com/lugassawan/swe-workbench/security` shows "Security policy" tab resolving to this file

Closes #39