### PR TITLE
[feat] Wire workflow-development Mode A into all plan-producing commands

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -17,3 +17,5 @@ Delegate to the `debugger` subagent. Its output must include:
 6. **SOLID / Clean-Arch risks** — whether the bug's shape signals a principle violation, and whether the minimal fix papers over it.
 
 Absolute rule: no fix without a failing test first. This command changes behavior to match spec — it is not a refactor.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `<detected …>`. Since `/debug` always produces a fix (file edits), Mode A always applies here.

--- a/commands/design.md
+++ b/commands/design.md
@@ -15,3 +15,5 @@ Delegate to the `senior-engineer` subagent. Its response must contain:
 4. **Risks** — what could make this choice wrong, and which signals to watch.
 
 If the question is under-specified, the subagent asks clarifying questions before recommending. Call out YAGNI explicitly when the design is premature.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `<detected …>`. Skip Mode A if the plan is pure analysis, design recommendation, or any output that does not introduce file edits — the Workflow section's phases (Branch / Verify / Deliver) do not apply.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -14,7 +14,7 @@ Invoke `superpowers:using-git-worktrees` to isolate this work when the scope war
 
 **Phase 2 — Implement**
 - **Architectural consult (conditional):** If the ticket implies a new service, a boundary or contract change, a technology choice, or any non-trivial design fork — invoke the `senior-engineer` subagent *before* plan-writing for a boundary/trade-off read. Fold its output into the plan.
-- If no written plan exists, draft one via `superpowers:writing-plans`.
+- If no written plan exists, draft one via `superpowers:writing-plans`. Before finalizing the plan, activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so placeholders are substituted from this repo, not left as `<detected …>`. Since `/implement` always modifies the codebase, Mode A always applies here.
 - Execute via `superpowers:executing-plans` for sequential work, or `superpowers:subagent-driven-development` for parallelizable units.
 - Apply `superpowers:test-driven-development` per implementation unit: red → green → refactor.
 - **Mid-implementation forks:** If an architectural decision emerges that was not anticipated in the plan, pause and consult `senior-engineer` rather than guessing. Update the plan before continuing.

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -15,3 +15,5 @@ Delegate to the `refactorer` subagent. Its output must include:
 4. **Verification** — which tests protect each step; write characterization tests first if coverage is missing.
 
 Absolute rule: no feature changes during refactoring.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `<detected …>`. Skip Mode A if the plan is pure analysis, design recommendation, or any output that does not introduce file edits — the Workflow section's phases (Branch / Verify / Deliver) do not apply.

--- a/commands/test.md
+++ b/commands/test.md
@@ -16,3 +16,5 @@ Delegate to the `test-writer` subagent. Its output must include:
 5. **Untested behaviours and why** — e.g., "covered by integration test", "trivial getter".
 
 Absolute rule: no mocks for internal collaborators. If the code under test is hard to test as written, the agent must say so and recommend `/refactor` rather than mock around the design.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `<detected …>`. Since `/test` always adds test files to the codebase, Mode A always applies here.

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-development
-description: Development workflow — full lifecycle from Branch → Implement → Verify → Review → Deliver. Auto-load when writing an implementation plan, creating a plan, finalizing a plan before ExitPlanMode, starting a feature branch, opening a PR, shipping a change, asking about branch naming or commit format, handing off work, or beginning any structured development task.
+description: Development workflow — full lifecycle from Branch → Implement → Verify → Review → Deliver. Activated by /swe-workbench:implement, /swe-workbench:design, /swe-workbench:refactor, /swe-workbench:debug, and /swe-workbench:test when the plan being authored modifies the codebase (Mode A) or when driving an implementation (Mode B). Skip for pure design / analysis output. Can also be invoked directly to author a Workflow section, run the 5-phase implementation flow, or orchestrate parallel agents (Mode C).
 orchestrator: true
 ---
 
@@ -131,6 +131,8 @@ Invoke `superpowers:finishing-a-development-branch`.
 
 ## Plan-Time Behavior (Mode A)
 
+**Gate:** Before rendering the Workflow section, confirm the plan introduces file edits (fix / make / implement). If the plan is a pure design recommendation or analysis with no codebase changes, return without modifying the plan.
+
 When writing or finalizing a plan, add a `## Workflow` section using the template at `templates/plan-workflow-section.md`. Substitute detected commands before saving.
 
 ## Implementation-Time Behavior (Mode B)
@@ -158,7 +160,7 @@ When writing or finalizing a plan, add a `## Workflow` section using the templat
 | Run only tests (skip format/lint) | Run all three, in order |
 | Single giant commit | Group by logical change |
 | Guess at branch/commit conventions | Detect from `git branch -a` and `git log` first |
-| Plan without Workflow section | Always add the Workflow section (Mode A) |
+| Plan that introduces file edits without Workflow section | Always add the Workflow section (Mode A) — skip only for pure design / analysis output |
 | Jump straight to coding | Always start at Phase 1 |
 | Ignore PR template, use generic format | Check for PR template first; fill every section |
 
@@ -179,4 +181,4 @@ When writing or finalizing a plan, add a `## Workflow` section using the templat
 | "I'll just commit everything together" | Split into logical commits |
 | "Phase 2 sub-skill did everything" | Verify it provided evidence for Phases 3-4 |
 | "This is a small fix, no need for the full lifecycle" | Small fixes still need verify + review |
-| "The plan doesn't need a Workflow section" | It always does. Add one (Mode A). |
+| "The plan doesn't need a Workflow section" | If the plan introduces file edits, it does. Add one (Mode A). Skip only for pure design / analysis output. |


### PR DESCRIPTION
## Summary

- Hard-wires `swe-workbench:workflow-development` Mode A activation at the command boundary for all 5 plan-producing commands (`implement`, `design`, `refactor`, `debug`, `test`), replacing unreliable probabilistic auto-load from the skill description
- Each command's prelude is **conditional**: Mode A fires only when the plan introduces file edits; pure design/analysis output skips it (the Workflow section's Branch → Verify → Deliver phases don't apply to non-code outputs)
- `implement`, `debug`, `test` use unconditional wording (their outputs always touch files); `design` and `refactor` include an explicit skip clause
- Updates `SKILL.md` frontmatter description to name the 5 owning commands and drop the auto-load promise; adds a Mode A gate; tightens the guardrail table rows to reflect the conditional

N/A

## Test plan

- [ ] Static: `grep -l 'workflow-development.*Mode A\|Mode A.*workflow-development' commands/{implement,design,refactor,debug,test}.md` — all 5 files returned, no MISSING lines
- [ ] Static: `grep -El 'modifies the codebase|introduces file edits|fix / make / implement' commands/{implement,design,refactor,debug,test}.md` — all 5 files returned, no MISSING lines
- [ ] End-to-end (positive): `/swe-workbench:implement <small feature>` in plan mode → plan contains `## Workflow` with substituted values; Mode B proceeds through all 5 phases
- [ ] End-to-end (positive): `/swe-workbench:debug <real bug>` → plan contains `## Workflow` section
- [ ] End-to-end (negative): `/swe-workbench:design <pure architectural question>` → output is a recommendation with **no** `## Workflow` section
- [ ] Negative: `/swe-workbench:review` and `/swe-workbench:security-review` outputs unchanged (no Workflow section)