### PR TITLE
[feat] Add principle-security skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd swe-workbench
 
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:test`, `/swe-workbench:security-review` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `reviewer`, `senior-engineer`, `refactorer`, `debugger`, `security-auditor`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
-- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency — auto-load by trigger keyword.
+- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, error handling, security — auto-load by trigger keyword.
 - **Languages** — Go, Rust, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -39,6 +39,7 @@
 | `principle-api-design` | "api versioning", "idempotency", "idempotency key", "pagination", "cursor pagination", "error shape", "REST vs RPC", "event-driven", "API deprecation", "API contract". |
 | `principle-error-handling` | "errors as values", "Result type", "exception handling", "retry", "exponential backoff", "jitter", "circuit breaker", "fail fast", "fail soft", "idempotent retry", "error wrapping", "timeouts", "deadlines". |
 | `principle-concurrency` | "race condition", "deadlock", "livelock", "structured concurrency", "cancellation", "backpressure", "mutex vs channel", "actor model", "atomics", "memory model". |
+| `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
 ### Languages — auto-load by file type
 

--- a/skills/principle-security/SKILL.md
+++ b/skills/principle-security/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: principle-security
+description: Security design principles — trust boundaries and input validation, authentication vs authorization, secrets handling, secure defaults and defense in depth, lightweight threat modeling, cryptography hygiene, attack-surface minimization. Auto-load when designing auth, discussing authn or authz, handling secrets, defining trust boundaries, validating untrusted input, considering SSRF or CSRF, choosing session or JWT mechanics, configuring TLS, picking an encryption primitive, or weighing least-privilege trade-offs.
+---
+
+# Security
+
+Security bugs are design bugs. They are cheapest to fix before the first line of code is written. This skill teaches the principles that prevent security bugs at design time; the `security-auditor` subagent audits the resulting diff against vulnerability categories, secret patterns, and language foot-guns post-implementation.
+
+## Trust Boundaries
+
+Name every boundary where data crosses trust levels. Validate at the boundary, not inside it.
+- Name the boundary explicitly: user-to-service, service-to-service, internal-to-DB, public-to-admin.
+- Validate at the boundary once — do not scatter input checks throughout internal code.
+- Allowlist what is known-good; denylist silently grows as attackers find gaps.
+- Structural validity (is it an integer?) is not semantic validity (is it *your* integer?).
+- Re-validate whenever data crosses a boundary again — even "internal" calls.
+
+## Authentication is Not Authorization
+
+AuthN proves identity. AuthZ enforces policy. Confusing them produces exploitable gaps.
+- Authentication answers "who are you?"; authorization answers "can you do this to that?".
+- Enforce authorization on the resource, not the route — routes change; resources don't.
+- Default-deny: if no explicit grant exists, the answer is no.
+- Guard against confused deputy: a service acting on behalf of a user must not exceed that user's privileges.
+- Token revocation and session invalidation are Day-1 design concerns, not afterthoughts.
+
+## Secrets Belong in Secret Stores
+
+A secret in source is a secret that belongs to everyone who ever had read access.
+- Never store secrets in source, env files committed to git, URLs, or log output.
+- Prefer a secret store (Vault, AWS Secrets Manager, GCP Secret Manager) over env vars for sensitive values.
+- Design secret rotation from Day 1 — rotation that requires a deployment is already too slow.
+- Scrub sensitive values at every logging boundary; structured logging makes this tractable.
+- `.env.example` contains placeholder values only — never real tokens, passwords, or keys.
+
+## Secure Defaults & Defense in Depth
+
+A system should be secure without any extra configuration.
+- Fail closed: if a security check cannot complete, deny access — never assume permission.
+- Complete mediation: verify every access, every time — no auth caching that skips the check.
+- Layer controls — network, service, data — so that one breach does not mean full compromise.
+- Use conservative framework defaults; never disable security features for "dev convenience" that ships.
+- Defense in depth: assume the outer layer will be breached; inner layers must hold independently.
+
+## Cryptography: Use, Don't Build
+
+The algorithm is the easy part; key management and misuse-resistance are where production systems fail.
+- Pick a construction, not an algorithm: use `nacl/box`, `AES-GCM`, `Argon2id` — not raw AES.
+- Key management is where cryptography fails in production: rotation, storage, access, derivation.
+- Red flags: nonce reuse, `==` for MAC comparison, a custom HMAC scheme, PRNG instead of CSPRNG.
+- Symmetric comparison of secrets must use constant-time comparison to prevent timing attacks.
+- Pin one cipher suite for new services; do not negotiate downward.
+
+## Least Privilege & Smallest Surface
+
+Every capability that exists is a capability that can be abused.
+- Issue the smallest token: tightest scope, narrowest audience, shortest viable lifetime.
+- Expose the smallest API: every endpoint is an attack surface; delete what is not needed.
+- Grant the smallest privilege: DB read-only for read paths; row-level isolation where possible.
+- Prefer short-lived credentials with fast expiry over long-lived tokens with revocation lists.
+- Audit what is reachable from the network vs what the config intends to expose.
+
+## When Pre-Write Security Thinking is Overkill
+
+- Local-only scripts with no network access and no secrets.
+- Throwaway prototypes that will never leave a developer's machine.
+- Internal tooling behind fully trusted, non-internet-routable networks.
+- Single-file analysis scripts that read immutable data and produce no output artifacts.
+- Gated PoC code behind a feature flag with no user-facing surface.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| Custom authentication scheme | Hand-rolled auth misses decades of hardened library work |
+| Denylist input filter | New bypass vectors emerge; allowlist is the only durable approach |
+| Permission check at the route/controller layer | Moves as routes change; resource-level enforcement is the invariant |
+| Real value in `.env.example` | Anyone who clones the repo has the credential |
+| JWT with no revocation strategy | Compromised token is valid until expiry with no recourse |
+| Long-lived all-scope access tokens | Maximum blast radius on compromise; scope to the operation |
+| Verbose error responses to untrusted callers | Leaks internals; production errors should be opaque reference IDs |
+| Encryption scheme chosen by algorithm name only | Algorithm ≠ construction; misuse is the rule, not the exception |


### PR DESCRIPTION
## Summary

- Adds `skills/principle-security/SKILL.md` — a pre-write, design-time security skill (~83 lines) that auto-loads on auth/authz/trust-boundary/secrets/input-validation/SSRF/CSRF/JWT/TLS/encrypt keywords, complementing the post-write `security-auditor` subagent.
- Appends `principle-security` row to the Principles table in `docs/catalog.md`.
- Fixes `README.md` Principles prose list to include both `error handling` (shipped in #52 but prose never updated) and `security`.

Closes #44.

## Test Plan

- [x] `python scripts/validate.py` exits 0 (all checks pass)
- [x] `wc -l skills/principle-security/SKILL.md` = 83 (< 150 cap, ≥ 60 floor)
- [x] `grep -Fc 'principle-security' docs/catalog.md` = 1
- [x] README line 31 contains `error handling, security`
- [x] No forbidden content (OWASP, Top 10, A0x, secret regex, language foot-guns) in skill body
- [x] Code review passed (superpowers:code-reviewer) — no critical/important issues