### PR TITLE
[feat] Add /cleanup-merged command and workflow-cleanup-merged skill

### DIFF
--- a/commands/cleanup-merged.md
+++ b/commands/cleanup-merged.md
@@ -1,0 +1,12 @@
+---
+description: Clean up worktree and local + remote branch for a merged PR
+argument-hint: [PR number — optional, defaults to current branch]
+---
+
+Target: $ARGUMENTS (PR number if provided; otherwise derive from current branch)
+
+Invoke `swe-workbench:workflow-cleanup-merged` to perform the full cleanup.
+
+Pass the PR number from $ARGUMENTS to the skill if provided. If $ARGUMENTS is empty, the skill will derive the target branch from the current branch.
+
+When the skill completes, print a summary listing each artifact (worktree, local branch, remote branch) and whether it was removed or was already gone.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -11,6 +11,7 @@
 | `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |
 | `/swe-workbench:test <target>` | Write focused, behavioural tests in the target language's idiom. |
 | `/swe-workbench:implement <ticket or description>` | Drive a feature end-to-end — branch, plan, TDD build, verify, review, PR. Orchestrates the full 5-phase `workflow-development` lifecycle. |
+| `/swe-workbench:cleanup-merged [PR number]` | Remove the worktree, local branch, and remote branch for a merged PR. Defaults to the current branch. Squash-merge safe. |
 
 ## Subagents
 
@@ -54,6 +55,7 @@
 | Skill | Triggers | Delegation model |
 |---|---|---|
 | `workflow-development` | "implement this", "build this", "fix this bug", "execute plan", "orchestrate these issues". | Wraps the 5-phase lifecycle (Branch → Implement → Verify → Review → Deliver) around `superpowers:{using-git-worktrees, executing-plans, subagent-driven-development, test-driven-development, verification-before-completion, requesting-code-review, finishing-a-development-branch}`. Phase 4 dispatches both `superpowers:code-reviewer` (plan alignment) and the local `reviewer` subagent (diff correctness/security/design). Mode A plan template and Mode C orchestration live in companion files. |
+| `workflow-cleanup-merged` | "clean up merged branch", "remove worktree", "delete branch after merge", after a PR is merged. | Verifies merge via `gh pr view` (squash-merge safe), runs safety checks (dirty/unpushed/cwd-inside), removes the worktree, deletes the local branch with `git branch -D`, and deletes the remote branch. Invoked by `/swe-workbench:cleanup-merged` and by Mode C orchestration Step 7. |
 
 This skill is an orchestrator — it coordinates other skills rather than restating their content.
 

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: workflow-cleanup-merged
+description: Use after a PR has been merged on GitHub to remove the local worktree, delete the local branch, and delete the remote branch — safely, with squash-merge support.
+---
+
+# Workflow: Cleanup Merged Branch
+
+**Announce at start:** "I'm using the workflow-cleanup-merged skill to clean up after the merged PR."
+
+## When to Invoke
+
+- After the user has confirmed a PR is merged on GitHub.
+- Invoked by `/swe-workbench:cleanup-merged` (user-triggered, one-off cleanup).
+- Invoked by Mode C orchestration (`orchestration.md`) at Step 7, after each merge round.
+
+**Never auto-trigger.** Cleanup is user-initiated or orchestrator-initiated. Do not attach to a Stop hook.
+
+## What This Skill Does NOT Do
+
+- Does not merge PRs — that is the user's action.
+- Does not force-delete branches with uncommitted work — no `--force`, ever.
+- Does not squash, rebase, or alter commit history.
+- Does not bypass branch protection rules.
+- Does not verify CI status — CI verification happens in Phase 3/4 before the PR is created.
+
+## Cleanup Contract
+
+### Step 1 — Resolve Target PR
+
+- If the user passed a PR number → use it directly.
+- Else → derive from current branch:
+  ```
+  gh pr view --json number,state,mergedAt,headRefName,headRepository
+  ```
+  Extract `headRefName` as the branch name to clean up.
+
+### Step 2 — Verify Merged via `gh` (Sole Oracle)
+
+```
+gh pr view <number> --json state,mergedAt,headRefName
+```
+
+Read `state == "MERGED"` **and** `mergedAt != null`. Abort with a clear message if either condition fails.
+
+**Never use `git branch --merged` as a merge check.** GitHub's default squash-merge strategy creates a new commit SHA on `main`; the original branch tip is not a merge ancestor of `main`, so `git branch --merged` silently lies. `gh` is the only oracle that does not lie.
+
+### Step 3 — Locate Worktree
+
+```
+git worktree list --porcelain
+```
+
+Match by `branch refs/heads/<headRefName>`. Per `superpowers:using-git-worktrees` convention, the worktree directory name equals the branch name. If no worktree matches, skip Steps 4 and 5 — the PR was developed in the main repo checkout, which is fine.
+
+### Step 4 — Safety Checks (Abort on Any Failure)
+
+Run these checks **inside the worktree directory** (if a worktree was found):
+
+**Check 1 — No uncommitted changes:**
+```
+git -C "<worktree-path>" status --porcelain
+```
+Must return empty output. If not, print the diff summary and abort — never delete a worktree with uncommitted work.
+
+**Check 2 — No unpushed commits:**
+```
+git -C "<worktree-path>" log @{upstream}..HEAD
+```
+Must return empty output. If not, list the unpushed commits and abort.
+
+**Check 3 — Not standing inside the worktree:**
+If `cwd` is a subdirectory of `<worktree-path>`, `cd` to the main repo root first:
+```
+cd "$(git rev-parse --show-toplevel)"
+```
+Never attempt to delete the directory you're standing in.
+
+### Step 5 — Remove Worktree
+
+```
+git worktree remove "<worktree-path>"
+```
+
+No `--force`. If this fails (unexpected state), abort and report the error — do not proceed to branch deletion.
+
+### Step 6 — Delete Local Branch
+
+```
+git branch -D <headRefName>
+```
+
+Capital `-D` is required. Because squash-merge creates a new commit on `main` with a different SHA, the local branch is never a merge ancestor of `main`. Lowercase `-d` would refuse to delete it. This is expected and correct behavior, not a footgun — the `gh` oracle already confirmed the PR is merged.
+
+### Step 7 — Delete Remote Branch
+
+```
+git push origin --delete <headRefName>
+```
+
+Treat HTTP 404 or "remote ref does not exist" as success — GitHub's `auto-delete-head-branches` repo setting commonly removes the remote branch immediately on merge. If the error is anything else, report it.
+
+### Step 8 — Report
+
+Print a clear summary of which artifacts were removed and which were already gone:
+
+```
+Cleanup complete for PR #<number> (<headRefName>):
+  ✓ Worktree removed: <path>        (or: no worktree found — skipped)
+  ✓ Local branch deleted: <branch>  (or: already gone)
+  ✓ Remote branch deleted: <branch> (or: already gone)
+```
+
+## Failure Mode Table
+
+| Failure | Signal | Action |
+|---------|--------|--------|
+| PR not yet merged | `state != "MERGED"` or `mergedAt == null` | Abort. Print PR state and URL. Do not delete anything. |
+| Uncommitted changes in worktree | `git status --porcelain` non-empty | Abort. Print the dirty files. Tell user to stash or commit first. |
+| Unpushed commits in worktree | `git log @{upstream}..HEAD` non-empty | Abort. List the unpushed commits. Tell user to push or discard first. |
+| cwd is inside the worktree | Path comparison | `cd` to main repo root before removal, or abort with a clear message if `cd` is not possible. |
+| `git worktree remove` fails | Non-zero exit | Abort. Do not delete branches. Report the error verbatim. |
+| No matching worktree found | `git worktree list --porcelain` has no entry | Skip Steps 4–5. Proceed to Step 6 (local branch deletion). |
+| Remote branch already gone | HTTP 404 / "remote ref does not exist" | Treat as success. Report "already gone". |
+| PR number not derivable from current branch | `gh pr view` fails on current branch | Ask the user for the PR number explicitly. |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Use `git branch --merged` to check if a PR is merged | Never. It lies after squash-merges (GitHub's default). Use `gh pr view --json state,mergedAt`. |
+| Use lowercase `git branch -d` | Always use `git branch -D` (capital D). Squash-merged branches are not merge ancestors of `main`. |
+| Force-delete a worktree with dirty state | Never. The safety checks in Step 4 exist to prevent data loss. |
+| Run cleanup from inside the worktree being deleted | Always `cd` to the main repo root first (Step 4, Check 3). |
+| Auto-trigger cleanup on merge | Never. Cleanup is user-initiated or explicitly orchestrated. No Stop hooks. |
+| Treat remote-404 as an error | It is success — `auto-delete-head-branches` already removed it. |

--- a/skills/workflow-development/orchestration.md
+++ b/skills/workflow-development/orchestration.md
@@ -27,7 +27,8 @@ For dispatching individual agents and agent prompt structure, see `superpowers:d
 │   └─ gh pr view --json mergeable on remaining open PRs
 │   └─ Spawn fix agents for any conflicting PRs
 │
-├─ 7. CLEANUP: Remove merged worktrees → delete merged branches (local + remote)
+├─ 7. CLEANUP: For each merged PR → invoke `swe-workbench:workflow-cleanup-merged`
+│   └─ Skill handles: gh-verified merge check, worktree removal, local + remote branch deletion
 │
 └─ 8. NEXT ROUND: Back to step 1 — re-evaluate dependency graph
 ```
@@ -46,6 +47,6 @@ For dispatching individual agents and agent prompt structure, see `superpowers:d
 | Spawn only 3 agents when 8 are unblocked | Spawn all unblocked agents. Maximize throughput. |
 | Wait for batch 1 to merge before spawning remaining unblocked issues | If unblocked issues remain, spawn them immediately. |
 | Skip CI verification on PR | Always run `gh pr checks`. CI failures caught early prevent merge issues. |
-| Don't clean up worktrees after merge | Stale worktrees block branch deletion and clutter the repo. |
+| Don't clean up worktrees after merge | Invoke `swe-workbench:workflow-cleanup-merged` after each merge round — it handles gh-verified merge check, worktree removal, and local + remote branch deletion safely. |
 | Ignore merge conflicts on remaining PRs after a merge | Always check `gh pr view --json mergeable` after each merge round. |
 | Use heredocs for PR bodies with code | Use `--body-file` with temp files. |


### PR DESCRIPTION
## Summary
- Add `skills/workflow-cleanup-merged/SKILL.md` — full cleanup contract: gh-verified merge check (squash-merge safe via `gh pr view`, never `git branch --merged`), safety checks (dirty worktree, unpushed commits, cwd-inside-worktree), worktree removal, local `git branch -D`, remote branch deletion with HTTP-404-as-success
- Add `commands/cleanup-merged.md` — thin delegator passing the optional PR number to the skill, requiring a removal summary on exit
- Update `skills/workflow-development/orchestration.md` Step 7 and Common Mistakes to reference the skill instead of prose, so Mode C orchestrators delegate rather than re-implement
- Update `docs/catalog.md` with command and skill entries

## Test Plan
- [x] Changed skills/commands/agents load without errors (`bash scripts/validate.sh` — clean)
- [x] Examples in the diff were exercised manually (skill steps traced against a real squash-merge scenario; safety-check abort paths verified by inspection)
- [x] Three logical commits: skill → command → orchestration+catalog

N/A — no related issue; this fills the gap between Mode C Step 7 prose and the missing cleanup implementation