### PR TITLE
[fix] Capture gh pr create URL directly instead of invalid --head flag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -131,7 +131,7 @@ if [[ -n "$EXISTING_PR" && "$EXISTING_PR" != "null" ]]; then
   PR_URL=$(echo "$EXISTING_PR" | jq -r .url)
   echo "Reusing existing PR #${PR_NUM}: ${PR_URL}"
 else
-  gh pr create \
+  PR_URL=$(gh pr create \
     --base main \
     --head "$BRANCH" \
     --title "[chore] Bump version to ${NEXT}" \
@@ -146,9 +146,9 @@ else
 
 N/A
 PREOF
-)"
-  PR_NUM=$(gh pr view --head "$BRANCH" --json number -q .number)
-  PR_URL=$(gh pr view --head "$BRANCH" --json url -q .url)
+)" | tail -1)
+  PR_NUM="${PR_URL##*/}"
+  [[ "$PR_NUM" =~ ^[0-9]+$ ]] || { echo "Error: could not derive PR number from '${PR_URL}'" >&2; exit 1; }
   echo "PR created: ${PR_URL}"
 fi
 


### PR DESCRIPTION
## Summary
- `gh pr view` has no `--head` flag; the two calls on lines 150–151 caused `release.sh` to abort after PR creation with `unknown flag: --head`
- Capture the PR URL directly from `gh pr create` stdout (`| tail -1` for robustness against future extra output lines)
- Derive `PR_NUM` via `${PR_URL##*/}` (strip path prefix) and guard with a numeric regex — prevents silent downstream failures if the URL is malformed or empty

## Test Plan
- [x] `bash -n scripts/release.sh` passes (syntax ok)
- [x] `! grep -nE 'gh pr view[^|]*--head' scripts/release.sh` passes (anti-regression)
- [x] In-progress 0.1.4 release (#57) can resume via the `EXISTING_PR` reuse path, short-circuiting the fixed block entirely

N/A — hotfix for broken release script; no issue filed