### PR TITLE
[ci] Enable Dependabot for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[chore]"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with `version: 2` Dependabot config for the `github-actions` ecosystem
- Schedules weekly scans of `.github/workflows/` (the two tracked workflows: `pr.yml`, `release.yml`)
- Sets `commit-message.prefix: "[chore]"` so Dependabot PR titles (e.g. `[chore] bump actions/checkout from 4 to 5`) satisfy the existing `^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+` regex enforced by `pr.yml` — no changes to that workflow needed

## Test Plan

- [x] YAML parses without error (`python3 yaml.safe_load`)
- [x] Schema assertions pass (`version`, `package-ecosystem`, `directory`, `schedule.interval`, `commit-message.prefix` all verified)
- [x] `[chore]` prefix satisfies PR-title regex (verified with `grep -qE`)
- [ ] Post-merge: within ~7 days GitHub should open at least one Dependabot PR or show a "no updates needed" entry under Insights → Dependency graph → Dependabot (acceptance criterion #2 — observable post-merge only)

Closes #41