### PR TITLE
[ci] Allow optional colon in PR title and exempt Dependabot from issue ref

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,15 +14,16 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Keep in sync with .githooks/commit-msg
-          PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+'
+          PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\]:? .+'
           if ! echo "$PR_TITLE" | grep -qE "$PATTERN"; then
-            echo "::error::PR title must match format: [type] Description (e.g. [feat] Add new feature)"
+            echo "::error::PR title must match format: [type] Description or [type]: Description (e.g. [feat] Add new feature or [chore]: Bump dep)"
             echo ""
             echo "Allowed types: feat, fix, refactor, test, ci, docs, perf, chore, polish, breaking"
             exit 1
           fi
 
       - name: Validate PR description
+        # Intentionally runs for dependabot[bot] too — Dependabot bodies always contain release notes.
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -33,6 +34,8 @@ jobs:
           fi
 
       - name: Validate issue reference
+        # Dependabot cannot inject closing keywords; dependency bumps have no linked issue.
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |


### PR DESCRIPTION
N/A — automated CI rule adjustment, no issue

## Summary

- Relaxes the PR title regex from `[type] .+` to `[type]:? .+` so Dependabot's hardcoded `: ` separator is accepted alongside the human `[type] ` format
- Adds `if: github.actor != 'dependabot[bot]'` to the issue-reference validation step so automated dependency bumps aren't blocked by a check they can never satisfy
- Mirrors the regex change in `.githooks/commit-msg` to keep local and CI rules in sync (as noted in the file's own header comment)

## Test plan

- [ ] CI on this PR itself passes with the human `[type]` format (no regression)
- [ ] After merge, trigger `@dependabot rebase` on PR #60 (or any future Dependabot PR) — `validate-pr` goes green without manual edits
- [ ] Local: `echo "[chore]: Bump foo" | grep -qE '^\[(feat|fix|…)\]:? .+' && echo OK` → `OK`