### PR TITLE
[feat] Sync local main after cleanup-merged

### DIFF
--- a/commands/cleanup-merged.md
+++ b/commands/cleanup-merged.md
@@ -9,4 +9,4 @@ Invoke `swe-workbench:workflow-cleanup-merged` to perform the full cleanup.
 
 Pass the PR number from $ARGUMENTS to the skill if provided. If $ARGUMENTS is empty, the skill will derive the target branch from the current branch.
 
-When the skill completes, print a summary listing each artifact (worktree, local branch, remote branch) and whether it was removed or was already gone.
+When the skill completes, print a summary listing each artifact (worktree, local branch, remote branch) and whether it was removed or was already gone, plus whether local main was synced to origin/main.

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-cleanup-merged
-description: Use after a PR has been merged on GitHub to remove the local worktree, delete the local branch, and delete the remote branch — safely, with squash-merge support.
+description: Use after a PR has been merged on GitHub to remove the local worktree, delete the local branch, delete the remote branch, and fast-forward local main — safely, with squash-merge support.
 ---
 
 # Workflow: Cleanup Merged Branch
@@ -99,7 +99,17 @@ git push origin --delete <headRefName>
 
 Treat HTTP 404 or "remote ref does not exist" as success — GitHub's `auto-delete-head-branches` repo setting commonly removes the remote branch immediately on merge. If the error is anything else, report it.
 
-### Step 8 — Report
+### Step 8 — Sync Local Main (Best-Effort)
+
+After all artifact deletions succeed, fast-forward local `main` to match `origin/main`:
+```
+git checkout main
+git pull --ff-only origin main
+```
+
+The explicit `git checkout main` is safe because Step 6 guarantees the feature branch is already deleted. **Best-effort:** if either command fails (dirty working tree, divergence, network error), capture the error and warn in Step 9's report — do not abort, as artifact deletions already succeeded. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
+
+### Step 9 — Report
 
 Print a clear summary of which artifacts were removed and which were already gone:
 
@@ -108,6 +118,7 @@ Cleanup complete for PR #<number> (<headRefName>):
   ✓ Worktree removed: <path>        (or: no worktree found — skipped)
   ✓ Local branch deleted: <branch>  (or: already gone)
   ✓ Remote branch deleted: <branch> (or: already gone)
+  ✓ Local main synced to origin/main (or: ⚠ sync skipped — <reason>)
 ```
 
 ## Failure Mode Table
@@ -121,6 +132,9 @@ Cleanup complete for PR #<number> (<headRefName>):
 | `git worktree remove` fails | Non-zero exit | Abort. Do not delete branches. Report the error verbatim. |
 | No matching worktree found | `git worktree list --porcelain` has no entry | Skip Steps 4–5. Proceed to Step 6 (local branch deletion). |
 | Remote branch already gone | HTTP 404 / "remote ref does not exist" | Treat as success. Report "already gone". |
+| `git checkout main` fails (dirty working tree) | Non-zero exit | Warn in Step 9 report. Do not abort — deletions already succeeded. |
+| `git pull --ff-only` fails (local main has diverged) | Non-fast-forward error | Warn in Step 9 report. Do not abort. Tell user to reconcile main manually. |
+| Network error during sync | Network-related stderr | Warn in Step 9 report. Do not abort. |
 | PR number not derivable from current branch | `gh pr view` fails on current branch | Ask the user for the PR number explicitly. |
 
 ## Common Mistakes
@@ -133,3 +147,4 @@ Cleanup complete for PR #<number> (<headRefName>):
 | Run cleanup from inside the worktree being deleted | Always `cd` to the main repo root first (Step 4, Check 3). |
 | Auto-trigger cleanup on merge | Never. Cleanup is user-initiated or explicitly orchestrated. No Stop hooks. |
 | Treat remote-404 as an error | It is success — `auto-delete-head-branches` already removed it. |
+| Use plain `git pull origin main` for the sync | Always `--ff-only`. Plain pull can synthesize a merge commit on divergence, violating the skill's "does not alter commit history" promise. |


### PR DESCRIPTION
N/A

## Summary

- Adds **Step 8 — Sync Local Main (Best-Effort)** to `workflow-cleanup-merged`: runs `git checkout main && git pull --ff-only origin main` after artifact deletions succeed, so the next branch cut starts from the correct base.
- `--ff-only` is enforced — plain `git pull` was rejected because it can synthesize a merge commit on divergence, violating the skill's "does not alter commit history" promise.
- Failure is warn-not-abort: if the sync fails (dirty tree, divergence, network), it surfaces as a `⚠` line in Step 9's report rather than rolling back the cleanup.
- Extends the Failure Mode Table (3 new rows) and Common Mistakes table (1 new row).
- Updates `commands/cleanup-merged.md` summary contract to mention the sync.

## Test plan

- [x] Dry run on a recently merged PR — Steps 1–7 unchanged, Step 8 fast-forwards main, Step 9 reports sync line
- [x] `git rev-parse main == git rev-parse origin/main` after run
- [x] Already-on-main invocation: `git checkout main` no-ops, `pull` says "Already up to date."
- [x] Skill file stays at or below the 150-line cap (currently: 150 lines)