### PR TITLE
[feat] Wire principle skills into reasoning agents and harden PR-template + cleanup-merged paths

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,12 @@
 
      If no issue applies, DELETE the "Closes #" line and replace it with
      a standalone line:
-         N/A
+         Issue: N/A
      Preferred (more useful for reviewers):
-         N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">
+         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">
 
      The following WILL fail CI:
        - leaving "Closes #" empty with no replacement
        - deleting the line entirely with nothing in its place
-       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "N/A" instead) -->
+       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
 Closes #

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,9 +39,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Allow ad-hoc PRs that explicitly opt out with "N/A" on its own line.
-          # Accepts: "N/A", "N/A - reason", "N/A — reason" (bare N/A and with reason are both valid).
-          if echo "$PR_BODY" | grep -iqE '^[[:space:]]*N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
+          # Allow ad-hoc PRs that explicitly opt out with "N/A" or "Issue: N/A" on its own line.
+          # Accepts: "N/A", "Issue: N/A", "Issue: N/A — reason", "N/A — reason".
+          if echo "$PR_BODY" | grep -iqE '^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
             echo "Issue reference opted out with N/A — skipping check"
             exit 0
           fi
@@ -57,7 +57,7 @@ jobs:
             echo "  Fixes #123"
             echo "  Resolves #123"
             echo ""
-            echo "For ad-hoc changes without an issue, add a standalone 'N/A' line."
+            echo "For ad-hoc changes without an issue, add a standalone 'N/A' or 'Issue: N/A' line."
             echo ""
             echo "See: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue"
             exit 1

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -2,7 +2,7 @@
 name: refactorer
 description: Refactoring specialist — applies Fowler's catalog in small, behavior-preserving steps. Invoke when cleaning up a messy function, module, or class before adding a feature.
 model: sonnet
-tools: Read, Edit, Grep, Glob, Bash
+tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 
 You are a refactoring specialist. You improve structure without changing observable behavior.
@@ -25,3 +25,11 @@ You are a refactoring specialist. You improve structure without changing observa
 - Target-state sketch.
 - Numbered, named step plan.
 - Post-execution verification report.
+
+## Principle consultation
+
+Invoke these skills via the Skill tool when the refactoring touches their domain:
+
+- `swe-workbench:principle-clean-code` — naming smells, DRY, function length
+- `swe-workbench:principle-solid` — responsibility splits, coupling
+- `swe-workbench:principle-design-patterns` — when a pattern fits the smell being removed

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Senior code reviewer — audits diffs for correctness, security, design, and missing tests. Invoke when reviewing a PR, a diff, or a completed feature.
 model: sonnet
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Skill
 ---
 
 You are a senior code reviewer. Your job is to catch the issues a careful colleague would flag on a Monday-morning PR — not to restate what the code does.
@@ -30,3 +30,12 @@ You are a senior code reviewer. Your job is to catch the issues a careful collea
 - Prefer one strong comment over five weak ones.
 - If something is well done, say so briefly — silence is not approval.
 - Missing tests are a finding, not an afterthought.
+
+## Principle consultation
+
+Invoke these skills via the Skill tool when the review surfaces a concern in their domain:
+
+- `swe-workbench:principle-clean-code` — naming, duplication, readability
+- `swe-workbench:principle-error-handling` — failure modes, error wrapping
+- `swe-workbench:principle-solid` — responsibility violations, coupling
+- `swe-workbench:principle-security` — auth, input validation, trust boundaries

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -2,7 +2,7 @@
 name: security-auditor
 description: Security audit specialist — depth-first review of a diff or file for OWASP Top 10, secret leakage, insecure-by-default APIs, and language-specific foot-guns. Invoke when you want a focused security report, not a holistic code review.
 model: sonnet
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Skill
 ---
 
 You audit code for security vulnerabilities. Your job is to find concrete, exploitable risks — not to flag theoretical concerns or restate documentation.
@@ -95,3 +95,10 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 - No finding without a concrete failure scenario.
 - Prefer one strong finding over five weak ones — false positives erode trust faster than missed findings.
 - If the diff is clean, say so explicitly: "No security issues found in this diff." Silence is not a passing grade.
+
+## Principle consultation
+
+Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
+
+- `swe-workbench:principle-security` — trust boundaries, OWASP, input validation
+- `swe-workbench:principle-error-handling` — information leakage in error messages

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -2,7 +2,7 @@
 name: senior-engineer
 description: Architectural advisor — thinks in boundaries, contracts, and change vectors. Invoke when choosing between approaches, scoping a new service, or evaluating an architecture.
 model: sonnet
-tools: Read, Grep, Glob, WebFetch
+tools: Read, Grep, Glob, WebFetch, Skill
 ---
 
 You are a senior software architect. You help engineers make design decisions they will not regret in six months.
@@ -34,3 +34,12 @@ You are a senior software architect. You help engineers make design decisions th
 - Layered architecture without enforced dependency direction.
 
 Be honest. If the existing code is fine, say so and stop.
+
+## Principle consultation
+
+Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
+
+- `swe-workbench:principle-clean-architecture` — boundaries, layering, dependency direction
+- `swe-workbench:principle-ddd` — bounded contexts, aggregates, ubiquitous language
+- `swe-workbench:principle-api-design` — contracts, versioning, idempotency
+- `swe-workbench:principle-solid` — responsibility, coupling, open-closed

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -20,7 +20,7 @@ Read at least one existing test file before writing — match the repo's style, 
 
 ## Principle consultation
 
-Invoke `swe-workbench:principle-tdd` via the Skill tool at the start of each session for the full red-green-refactor discipline and "What to test" checklist.
+Invoke `swe-workbench:principle-tdd` via the Skill tool before writing any test for the full red-green-refactor discipline and "What to test" checklist.
 
 ## What to test
 

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -2,7 +2,7 @@
 name: test-writer
 description: Test author — writes focused, behavioural tests in language-idiomatic style. One behaviour per test, AAA, no mocks at internal boundaries. Invoke when adding tests for a function, module, or change set the user points to.
 model: sonnet
-tools: Read, Edit, Grep, Glob, Bash
+tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 
 You are a test author. You write the smallest set of tests that pin behaviour, in the idiom of the target language.
@@ -18,9 +18,11 @@ Auto-detect by language and existing repo conventions before writing a single li
 
 Read at least one existing test file before writing — match the repo's style, not your defaults.
 
-## What to test
+## Principle consultation
 
-From `principle-tdd` — "What to test":
+Invoke `swe-workbench:principle-tdd` via the Skill tool at the start of each session for the full red-green-refactor discipline and "What to test" checklist.
+
+## What to test
 
 - **Behavior** — not implementation. "Returns total with tax" survives refactor; "calls foo then bar" does not.
 - **Boundaries** — empty, single, max, null, unicode.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -26,7 +26,7 @@ Run `superpowers:verification-before-completion` before claiming any phase done.
 Invoke `superpowers:requesting-code-review`, which delegates to the `reviewer` subagent. Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
-Invoke `superpowers:finishing-a-development-branch` to open the PR.
+Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder before invoking. Do not fall through to the heredoc in `templates/plan-workflow-section.md` unless no template was found. Then invoke `superpowers:finishing-a-development-branch` to complete the delivery.
 
 Absolute rules:
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -26,7 +26,7 @@ Run `superpowers:verification-before-completion` before claiming any phase done.
 Invoke `superpowers:requesting-code-review`, which delegates to the `reviewer` subagent. Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
-Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder before invoking. Do not fall through to the heredoc in `templates/plan-workflow-section.md` unless no template was found. Then invoke `superpowers:finishing-a-development-branch` to complete the delivery.
+Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `superpowers:finishing-a-development-branch` to complete the delivery.
 
 Absolute rules:
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,7 +26,7 @@
 
 ## Skills
 
-### Principles — auto-load when designing or writing code
+### Principles — consulted by reasoning agents (senior-engineer, reviewer, refactorer, test-writer, security-auditor) when relevant triggers apply
 
 | Skill | Triggers |
 |---|---|

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,7 +26,7 @@
 
 ## Skills
 
-### Principles — consulted by reasoning agents (senior-engineer, reviewer, refactorer, test-writer, security-auditor) when relevant triggers apply
+### Principles — consulted by reasoning agents when relevant triggers apply
 
 | Skill | Triggers |
 |---|---|

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -163,6 +163,21 @@ def check_commands():
             fail(cmd_md.relative_to(ROOT), "frontmatter missing required field: 'description'")
 
 
+def check_agent_skill_refs():
+    """Every `swe-workbench:<id>` in agents/*.md must resolve to skills/<id>/ on disk."""
+    agents_dir = ROOT / "agents"
+    skills_dir = ROOT / "skills"
+    pattern = re.compile(r'`swe-workbench:([\w-]+)`')
+    for agent_md in sorted(agents_dir.glob("*.md")):
+        text = agent_md.read_text(encoding="utf-8")
+        for skill_id in set(pattern.findall(text)):
+            if not (skills_dir / skill_id).is_dir():
+                fail(
+                    agent_md.relative_to(ROOT),
+                    f"references 'swe-workbench:{skill_id}' but skills/{skill_id}/ does not exist",
+                )
+
+
 # ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────
@@ -177,6 +192,7 @@ def main():
     check_skills()
     check_agents()
     check_commands()
+    check_agent_skill_refs()
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -143,13 +143,16 @@ def check_skills():
 def check_agents():
     agents_dir = ROOT / "agents"
     for agent_md in sorted(agents_dir.glob("*.md")):
-        fm = parse_frontmatter(agent_md)
+        text = agent_md.read_text(encoding="utf-8")
+        fm = parse_frontmatter(agent_md, text=text)
         if fm is None:
             fail(agent_md.relative_to(ROOT), "missing or malformed frontmatter")
             continue
         for field in ("name", "description"):
             if field not in fm:
                 fail(agent_md.relative_to(ROOT), f"frontmatter missing required field: {field!r}")
+        if re.search(r'`swe-workbench:[\w-]+`', text) and "Skill" not in fm.get("tools", ""):
+            fail(agent_md.relative_to(ROOT), "references swe-workbench: skills but 'Skill' is missing from tools: frontmatter")
 
 
 def check_commands():

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -44,74 +44,61 @@ Read `state == "MERGED"` **and** `mergedAt != null`. Abort with a clear message 
 
 **Never use `git branch --merged` as a merge check.** GitHub's default squash-merge strategy creates a new commit SHA on `main`; the original branch tip is not a merge ancestor of `main`, so `git branch --merged` silently lies. `gh` is the only oracle that does not lie.
 
-### Step 3 — Locate Worktree
+### Batch A — Locate Worktree + Safety Checks
 
+Combine the worktree locate and both git safety checks into one shell. Emit exactly three fields:
+
+```bash
+WORKTREE=$(git worktree list --porcelain \
+  | awk '/^worktree /{p=$2} /^branch refs\/heads\/<headRefName>$/{print p; exit}')
+DIRTY=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" status --porcelain | wc -l | tr -d ' ' || echo 0)
+UNPUSHED=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" log @{upstream}..HEAD --oneline | wc -l | tr -d ' ' || echo 0)
+printf 'WORKTREE=%s\nDIRTY=%s\nUNPUSHED=%s\n' "$WORKTREE" "$DIRTY" "$UNPUSHED"
 ```
-git worktree list --porcelain
-```
 
-Match by `branch refs/heads/<headRefName>`. Per `superpowers:using-git-worktrees` convention, the worktree directory name equals the branch name. If no worktree matches, skip Steps 4 and 5 — the PR was developed in the main repo checkout, which is fine.
+- `WORKTREE`: matching worktree path, or empty if none (skip Batch B when empty).
+- `DIRTY`: count of uncommitted-change lines. Must be 0; if not, abort — re-run `git -C "$WORKTREE" status --porcelain` to show files.
+- `UNPUSHED`: count of unpushed commits. Must be 0; if not, abort — re-run `git -C "$WORKTREE" log @{upstream}..HEAD` to list them.
 
-### Step 4 — Safety Checks (Abort on Any Failure)
+### [Optional] cwd-fix
 
-Run these checks **inside the worktree directory** (if a worktree was found):
-
-**Check 1 — No uncommitted changes:**
-```
-git -C "<worktree-path>" status --porcelain
-```
-Must return empty output. If not, print the diff summary and abort — never delete a worktree with uncommitted work.
-
-**Check 2 — No unpushed commits:**
-```
-git -C "<worktree-path>" log @{upstream}..HEAD
-```
-Must return empty output. If not, list the unpushed commits and abort.
-
-**Check 3 — Not standing inside the worktree:**
-If `cwd` is a subdirectory of `<worktree-path>`, `cd` to the main repo root first:
+If `cwd` is a subdirectory of `$WORKTREE`, cd to the main repo root before removal:
 ```
 cd "$(git rev-parse --show-toplevel)"
 ```
-Never attempt to delete the directory you're standing in.
 
-### Step 5 — Remove Worktree
+### Batch B — Remove Worktree + Delete Local Branch
 
-```
-git worktree remove "<worktree-path>"
-```
+Only run if `WORKTREE` is non-empty. Both commands share abort-on-fail semantics; `&&` preserves that:
 
-No `--force`. If this fails (unexpected state), abort and report the error — do not proceed to branch deletion.
-
-### Step 6 — Delete Local Branch
-
-```
-git branch -D <headRefName>
+```bash
+git worktree remove "$WORKTREE" && git branch -D <headRefName>
 ```
 
-Capital `-D` is required. Because squash-merge creates a new commit on `main` with a different SHA, the local branch is never a merge ancestor of `main`. Lowercase `-d` would refuse to delete it. This is expected and correct behavior, not a footgun — the `gh` oracle already confirmed the PR is merged.
+No `--force`. If `git worktree remove` fails, the `&&` prevents `git branch -D` from running — abort and report the error verbatim.
 
-### Step 7 — Delete Remote Branch
+Capital `-D` is required: squash-merged branches are not merge ancestors of `main`; lowercase `-d` would refuse.
+
+### Step 9 — Delete Remote Branch
 
 ```
 git push origin --delete <headRefName>
 ```
 
-Treat HTTP 404 or "remote ref does not exist" as success — GitHub's `auto-delete-head-branches` repo setting commonly removes the remote branch immediately on merge. If the error is anything else, report it.
+Treat HTTP 404 or "remote ref does not exist" as success — GitHub's `auto-delete-head-branches` repo setting commonly removes the remote branch on merge. Any other error: report it.
 
-### Step 8 — Sync Local Main (Best-Effort)
+### Batch C — Sync Local Main (Best-Effort)
 
-After all artifact deletions succeed, fast-forward local `main` to match `origin/main`:
+Both commands share best-effort semantics; `||` prevents abort while `&&` ensures pull runs only after a clean checkout:
+
+```bash
+(git checkout main && git pull --ff-only origin main) \
+  || echo "sync-main: best-effort failed — reconcile main manually"
 ```
-git checkout main
-git pull --ff-only origin main
-```
 
-The explicit `git checkout main` is safe because Step 6 guarantees the feature branch is already deleted. **Best-effort:** if either command fails (dirty working tree, divergence, network error), capture the error and warn in Step 9's report — do not abort, as artifact deletions already succeeded. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
+`--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
 
-### Step 9 — Report
-
-Print a clear summary of which artifacts were removed and which were already gone:
+### Step — Report
 
 ```
 Cleanup complete for PR #<number> (<headRefName>):
@@ -126,25 +113,23 @@ Cleanup complete for PR #<number> (<headRefName>):
 | Failure | Signal | Action |
 |---------|--------|--------|
 | PR not yet merged | `state != "MERGED"` or `mergedAt == null` | Abort. Print PR state and URL. Do not delete anything. |
-| Uncommitted changes in worktree | `git status --porcelain` non-empty | Abort. Print the dirty files. Tell user to stash or commit first. |
-| Unpushed commits in worktree | `git log @{upstream}..HEAD` non-empty | Abort. List the unpushed commits. Tell user to push or discard first. |
-| cwd is inside the worktree | Path comparison | `cd` to main repo root before removal, or abort with a clear message if `cd` is not possible. |
-| `git worktree remove` fails | Non-zero exit | Abort. Do not delete branches. Report the error verbatim. |
-| No matching worktree found | `git worktree list --porcelain` has no entry | Skip Steps 4–5. Proceed to Step 6 (local branch deletion). |
+| Uncommitted changes in worktree | `DIRTY > 0` | Abort. Re-run `git status --porcelain` to show files. Tell user to stash or commit first. |
+| Unpushed commits in worktree | `UNPUSHED > 0` | Abort. Re-run `git log @{upstream}..HEAD` to list commits. Tell user to push or discard first. |
+| cwd is inside the worktree | Path comparison | `cd` to main repo root before Batch B, or abort if not possible. |
+| `git worktree remove` fails | Batch B `&&` short-circuits | Abort. Do not delete branches. Report verbatim. |
+| No matching worktree found | `WORKTREE` empty | Skip Batch B. Proceed to Step 9 (local branch deletion). |
 | Remote branch already gone | HTTP 404 / "remote ref does not exist" | Treat as success. Report "already gone". |
-| `git checkout main` fails (dirty working tree) | Non-zero exit | Warn in Step 9 report. Do not abort — deletions already succeeded. |
-| `git pull --ff-only` fails (local main has diverged) | Non-fast-forward error | Warn in Step 9 report. Do not abort. Tell user to reconcile main manually. |
-| Network error during sync | Network-related stderr | Warn in Step 9 report. Do not abort. |
-| PR number not derivable from current branch | `gh pr view` fails on current branch | Ask the user for the PR number explicitly. |
+| Batch C fails | Non-zero exit from `git checkout` or `git pull` | Warn in report. Do not abort — deletions already succeeded. |
+| PR number not derivable from current branch | `gh pr view` fails | Ask the user for the PR number explicitly. |
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Use `git branch --merged` to check if a PR is merged | Never. It lies after squash-merges (GitHub's default). Use `gh pr view --json state,mergedAt`. |
-| Use lowercase `git branch -d` | Always use `git branch -D` (capital D). Squash-merged branches are not merge ancestors of `main`. |
-| Force-delete a worktree with dirty state | Never. The safety checks in Step 4 exist to prevent data loss. |
-| Run cleanup from inside the worktree being deleted | Always `cd` to the main repo root first (Step 4, Check 3). |
+| Use `git branch --merged` to check if a PR is merged | Never. Squash-merges lie. Use `gh pr view --json state,mergedAt`. |
+| Use lowercase `git branch -d` | Always use `-D`. Squash-merged branches are not merge ancestors of `main`. |
+| Force-delete a worktree with dirty state | Never. Batch A aborts before Batch B runs. |
+| Run cleanup from inside the worktree being deleted | Always cd to the main repo root first (cwd-fix step). |
 | Auto-trigger cleanup on merge | Never. Cleanup is user-initiated or explicitly orchestrated. No Stop hooks. |
 | Treat remote-404 as an error | It is success — `auto-delete-head-branches` already removed it. |
-| Use plain `git pull origin main` for the sync | Always `--ff-only`. Plain pull can synthesize a merge commit on divergence, violating the skill's "does not alter commit history" promise. |
+| Use plain `git pull origin main` for the sync | Always `--ff-only`. Plain pull can synthesize a merge commit. |

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -67,15 +67,21 @@ If `cwd` is a subdirectory of `$WORKTREE`, cd to the main repo root before remov
 cd "$(git rev-parse --show-toplevel)"
 ```
 
-### Batch B — Remove Worktree + Delete Local Branch
+### Batch B — Remove Worktree
 
-Only run if `WORKTREE` is non-empty. Both commands share abort-on-fail semantics; `&&` preserves that:
+Only run if `WORKTREE` is non-empty. If `git worktree remove` fails, abort and report the error verbatim — do not proceed to local branch deletion.
 
 ```bash
-git worktree remove "$WORKTREE" && git branch -D <headRefName>
+git worktree remove "$WORKTREE"
 ```
 
-No `--force`. If `git worktree remove` fails, the `&&` prevents `git branch -D` from running — abort and report the error verbatim.
+### Step 8 — Delete Local Branch (unconditional)
+
+Always runs, whether or not a worktree was found:
+
+```bash
+git branch -D <headRefName>
+```
 
 Capital `-D` is required: squash-merged branches are not merge ancestors of `main`; lowercase `-d` would refuse.
 
@@ -116,8 +122,8 @@ Cleanup complete for PR #<number> (<headRefName>):
 | Uncommitted changes in worktree | `DIRTY > 0` | Abort. Re-run `git status --porcelain` to show files. Tell user to stash or commit first. |
 | Unpushed commits in worktree | `UNPUSHED > 0` | Abort. Re-run `git log @{upstream}..HEAD` to list commits. Tell user to push or discard first. |
 | cwd is inside the worktree | Path comparison | `cd` to main repo root before Batch B, or abort if not possible. |
-| `git worktree remove` fails | Batch B `&&` short-circuits | Abort. Do not delete branches. Report verbatim. |
-| No matching worktree found | `WORKTREE` empty | Skip Batch B. Proceed to Step 9 (local branch deletion). |
+| `git worktree remove` fails | Non-zero exit | Abort. Do not delete branches. Report verbatim. |
+| No matching worktree found | `WORKTREE` empty | Skip Batch B. Proceed directly to Step 8 (local branch delete). |
 | Remote branch already gone | HTTP 404 / "remote ref does not exist" | Treat as success. Report "already gone". |
 | Batch C fails | Non-zero exit from `git checkout` or `git pull` | Warn in report. Do not abort — deletions already succeeded. |
 | PR number not derivable from current branch | `gh pr view` fails | Ask the user for the PR number explicitly. |

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -59,7 +59,7 @@ Also check CLAUDE.md for project-specific conventions.
 | `Cargo.toml` | `cargo fmt` | `cargo clippy` | `cargo test` |
 | `pyproject.toml` | `ruff format` or `black .` | `ruff check` | `pytest` |
 
-**PR template:** check `cat .github/pull_request_template.md 2>/dev/null` (and common variants). If it exists, **use it and fill every section**.
+**PR template:** check `cat .github/pull_request_template.md 2>/dev/null` (and common variants: `.github/PULL_REQUEST_TEMPLATE.md`, `docs/pull_request_template.md`). If found, record the **absolute path** — pass it to `gh pr create --body-file <path>` in Phase 5. Before invoking, replace the literal `Closes #` placeholder with the resolved issue (`Closes #123`) or remove it and write a standalone `N/A — <one-line reason>` line. Never leave `Closes #` empty.
 
 ## The 5 Phases
 
@@ -125,7 +125,7 @@ Act on feedback:
 
 Invoke `superpowers:finishing-a-development-branch`.
 
-**PR template rule:** if a template was detected in Project Detection, use it and fill every section. Skipping sections signals incomplete work to reviewers.
+**PR template rule:** if a template was detected in Project Detection, use `gh pr create --body-file <detected-path>` — fill every section and substitute the `Closes #` placeholder before invoking. Do **not** fall through to a heredoc body when a template exists. Only use the heredoc fallback if no template was found.
 
 ---
 

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -59,7 +59,7 @@ Also check CLAUDE.md for project-specific conventions.
 | `Cargo.toml` | `cargo fmt` | `cargo clippy` | `cargo test` |
 | `pyproject.toml` | `ruff format` or `black .` | `ruff check` | `pytest` |
 
-**PR template:** check `cat .github/pull_request_template.md 2>/dev/null` (and common variants: `.github/PULL_REQUEST_TEMPLATE.md`, `docs/pull_request_template.md`). If found, record the **absolute path** — pass it to `gh pr create --body-file <path>` in Phase 5. Before invoking, replace the literal `Closes #` placeholder with the resolved issue (`Closes #123`) or remove it and write a standalone `N/A — <one-line reason>` line. Never leave `Closes #` empty.
+**PR template:** check `cat .github/pull_request_template.md 2>/dev/null` (and common variants: `.github/PULL_REQUEST_TEMPLATE.md`, `docs/pull_request_template.md`). If found, record the **absolute path** — pass it to `gh pr create --body-file <path>` in Phase 5. Before invoking, replace the literal `Closes #` placeholder with the resolved issue (`Closes #123`) or remove it and write a standalone `Issue: N/A — <one-line reason>` line. Never leave `Closes #` empty.
 
 ## The 5 Phases
 

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -72,7 +72,7 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Test Plan
 - [ ] <verification steps>
 
-<!-- If your repo requires an issue reference, add it per CONTRIBUTING.md or PR template; if none, use a standalone "N/A — <reason>" line. -->
+<!-- If your repo requires an issue reference, add it per CONTRIBUTING.md or PR template; if none, use a standalone "Issue: N/A — <reason>" line. -->
 EOF
 )"
 ```

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -59,7 +59,7 @@ git push -u origin <branch-name>
 gh pr create --title "<title>" --body-file <detected-template-path>
 ```
 
-Before invoking, replace the `Closes #` placeholder with the resolved issue ref (`Closes #123`) or a standalone `N/A — <reason>` line. Never leave `Closes #` empty.
+Before invoking, replace the `Closes #` placeholder with the resolved issue ref (`Closes #123`) or a standalone `Issue: N/A — <reason>` line. Never leave `Closes #` empty.
 
 If **no** template was found, use the heredoc fallback:
 

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -52,7 +52,16 @@ Act on feedback:
 
 **PR template:** `<detected template path, or "none — use default format">`
 
-If a PR template exists, use it and fill in every section. Otherwise:
+If a PR template was detected (recorded in Project Detection), use it:
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<title>" --body-file <detected-template-path>
+```
+
+Before invoking, replace the `Closes #` placeholder with the resolved issue ref (`Closes #123`) or a standalone `N/A — <reason>` line. Never leave `Closes #` empty.
+
+If **no** template was found, use the heredoc fallback:
 
 ```bash
 git push -u origin <branch-name>
@@ -62,6 +71,8 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 
 ## Test Plan
 - [ ] <verification steps>
+
+<!-- If your repo requires an issue reference, add it per CONTRIBUTING.md or PR template; if none, use a standalone "N/A — <reason>" line. -->
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
- Wire `Skill` into all 5 reasoning agent `tools:` frontmatters and add "Principle consultation" sections mapping each agent to 2–4 principle skills with explicit trigger conditions; replace the prose `principle-tdd` citation in `test-writer` with an explicit invocation instruction
- Force `--body-file <detected-template>` as the primary PR creation path in workflow-development (gating heredoc fallback behind "no template found"), add `Closes #` / `Issue: N/A` substitution rule in all three relevant files, and update the CI regex to accept the new `Issue: N/A` format
- Batch the 11 git invocations in `workflow-cleanup-merged` into 6 grouped by failure semantics: Batch A (locate worktree + safety checks, emits WORKTREE/DIRTY/UNPUSHED), Batch B (worktree remove only), standalone Step 8 (local branch delete, unconditional), Step 9 (remote delete, 404=success preserved), Batch C (sync main, best-effort `||` wrapper)
- Add two drift guards to `scripts/validate.py`: `check_agent_skill_refs()` (every backtick `swe-workbench:<id>` in `agents/*.md` must resolve to `skills/<id>/`) and a `Skill` frontmatter check in `check_agents()` (agents referencing skills must declare `Skill` in `tools:`)

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` — clean
- [x] `python scripts/validate.py` — all checks passed; all skill refs in `agents/*.md` resolve
- [x] `git worktree remove` failure path: Batch B now only removes worktree; local branch deletion in standalone Step 8 runs regardless of whether a worktree was found
- [x] `Issue: N/A` format accepted by updated CI regex in `pr.yml`

Issue: N/A — three self-contained defect fixes identified during real-world use of the plugin