### PR TITLE
[docs] Update language skill addition instructions for clarity

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -2,10 +2,10 @@
 
 ## Adding a language skill
 
-To add a new language skill (say, Python):
+To add a new language skill (say, Ruby or another language not already shipped):
 
-1. Copy `skills/language-go/` to `skills/language-python/`.
-2. Rewrite `SKILL.md` frontmatter: `name: language-python`, and a keyword-rich `description` listing `.py` files, `pyproject.toml`, and common Python terms.
+1. Copy `skills/language-go/` to `skills/language-<your-language>/`.
+2. Rewrite `SKILL.md` frontmatter: `name: language-<your-language>`, and a keyword-rich `description` listing the language's file types and ecosystem terms.
 3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
 4. Keep it under 150 lines.
 5. Commit; users who reinstall the plugin will pick it up.


### PR DESCRIPTION
## Summary
Updated `extending.md` to remove the stale example that copied language-go into an already-existing language-python.
Made the language-skill example generic by using skills/language-<your-language>/ and name: language-<your-language>.

## Test Plan
 Confirmed the updated docs no longer reference language-python as the copy target
 Verified the example is generic and consistent with existing skill directory layout

<!-- Link to the GitHub issue this PR addresses.
     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>

     If no issue applies, DELETE the "Closes #" line and replace it with
     a standalone line:
         Issue: N/A
     Preferred (more useful for reviewers):
         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">

     The following WILL fail CI:
       - leaving "Closes #" empty with no replacement
       - deleting the line entirely with nothing in its place
       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
Closes #70 
