### PR TITLE
[feat] Add agents/shared/skills.md as single-source skill discovery index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` �
 
 **Skill directory layout**: Skills must live at `skills/<skill-name>/SKILL.md` — exactly one level deep. Claude Code's auto-discovery does not recurse into nested category subdirectories. Use a hyphenated prefix to preserve categorical grouping while meeting this constraint: `principle-*`, `language-*`, `workflow-*`. The `name:` field in the `SKILL.md` frontmatter must match the directory name exactly.
 
+**Skill catalog**: `agents/shared/skills.md` is the single-source index of every skill in this plugin. When you add a new skill, add a corresponding entry there (format: `- \`swe-workbench:<name>\` — <one-line description>`). The validator's `check_catalog_completeness()` enforces that the catalog matches on-disk skills and that every agent file includes it via `@./shared/skills.md`. See `docs/extending.md` for the full recipe.
+
 ## Cutting a release
 
 Run the release script from a clean `main`:

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -50,6 +50,10 @@ Call this out even when the minimal fix does not address it. Silence signals the
 - Regression test (name + location)
 - SOLID / Clean-Arch risks (or "none — principle is clean")
 
+## Available skills
+
+See @./shared/skills.md for the full skill catalog.
+
 ## Absolute rules
 - No fix without a failing test first.
 - No behavior change beyond what the failing test demands.

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -80,6 +80,10 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
 - Does not manage a backlog, roadmap, or quarterly plan. Capture only.
 - Does not prioritize across multiple issues. One thought → one issue.
 
+## Available skills
+
+See @./shared/skills.md for the full skill catalog.
+
 ## Output format
 
 On the preview turn (step 8): one response containing, in order — repo detected, restatement, product framing (4 lenses), classification + reason (or "no templates → default"), dup-scan results, drafted title, drafted body (code-fenced), and the exact `gh issue create` command — followed by `Reply 'confirm' to file, or edit any of the above and I'll redraft.`

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -28,6 +28,8 @@ You are a refactoring specialist. You improve structure without changing observa
 
 ## Principle consultation
 
+> See @./shared/skills.md for the full skill catalog.
+
 Invoke these skills via the Skill tool when the refactoring touches their domain:
 
 - `swe-workbench:principle-clean-code` — naming smells, DRY, function length

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -33,6 +33,8 @@ You are a senior code reviewer. Your job is to catch the issues a careful collea
 
 ## Principle consultation
 
+> See @./shared/skills.md for the full skill catalog.
+
 Invoke these skills via the Skill tool when the review surfaces a concern in their domain:
 
 - `swe-workbench:principle-clean-code` — naming, duplication, readability

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -98,6 +98,8 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 
 ## Principle consultation
 
+> See @./shared/skills.md for the full skill catalog.
+
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 
 - `swe-workbench:principle-security` — trust boundaries, OWASP, input validation

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -37,6 +37,8 @@ Be honest. If the existing code is fine, say so and stop.
 
 ## Principle consultation
 
+> See @./shared/skills.md for the full skill catalog.
+
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 
 - `swe-workbench:principle-clean-architecture` — boundaries, layering, dependency direction

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -1,0 +1,33 @@
+# Skill catalog
+
+All `swe-workbench` skills available in this plugin. Use the `Skill` tool to invoke any of these.
+
+## Principles
+
+- `swe-workbench:principle-api-design` — API design: contract-first, versioning, idempotency, REST/RPC/event trade-offs.
+- `swe-workbench:principle-clean-architecture` — Clean Architecture: dependency rule, ports and adapters, domain-centric layering.
+- `swe-workbench:principle-clean-code` — Clean code: DRY, KISS, YAGNI, naming, function length, abstraction level.
+- `swe-workbench:principle-concurrency` — Concurrency: race conditions, deadlock, structured concurrency, cancellation, backpressure.
+- `swe-workbench:principle-ddd` — Domain-Driven Design: bounded contexts, aggregates, ubiquitous language, domain events.
+- `swe-workbench:principle-design-patterns` — Design patterns: GoF catalog — Strategy, Factory, Observer, Decorator, Adapter, and more.
+- `swe-workbench:principle-error-handling` — Error handling: errors as values, classification, wrapping, retry, circuit breakers.
+- `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
+- `swe-workbench:principle-security` — Security: trust boundaries, input validation, secrets handling, secure defaults, threat modeling.
+- `swe-workbench:principle-solid` — SOLID principles: SRP, OCP, LSP, ISP, DIP — responsibility, coupling, abstractions.
+- `swe-workbench:principle-tdd` — TDD: red-green-refactor, test-first, F.I.R.S.T., Arrange-Act-Assert.
+
+## Languages
+
+- `swe-workbench:language-go` — Go idioms: error handling, goroutines, channels, interfaces, context, standard library.
+- `swe-workbench:language-python` — Python idioms: PEP 8, type hints, dataclasses, asyncio, generators, pytest.
+- `swe-workbench:language-rust` — Rust idioms: ownership, borrowing, lifetimes, traits, iterators, error handling.
+- `swe-workbench:language-typescript` — TypeScript/JavaScript idioms: strict mode, discriminated unions, async patterns, Node.
+
+## Workflows
+
+- `swe-workbench:workflow-cleanup-merged` — Post-merge cleanup: remove worktree, delete local and remote branch, fast-forward main.
+- `swe-workbench:workflow-development` — Full development lifecycle: Branch → Implement → Verify → Review → Deliver.
+
+## Other
+
+- `swe-workbench:ticket-context` — Fetch structured context from Jira, Confluence, and GitHub issues/PRs before starting work.

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -20,6 +20,8 @@ Read at least one existing test file before writing — match the repo's style, 
 
 ## Principle consultation
 
+> See @./shared/skills.md for the full skill catalog.
+
 Invoke `swe-workbench:principle-tdd` via the Skill tool before writing any test for the full red-green-refactor discipline and "What to test" checklist.
 
 ## What to test

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -8,7 +8,8 @@ To add a new language skill (say, Ruby or another language not already shipped):
 2. Rewrite `SKILL.md` frontmatter: `name: language-<your-language>`, and a keyword-rich `description` listing the language's file types and ecosystem terms.
 3. Replace the body with the idioms that matter: error handling, typing, packaging, async, testing.
 4. Keep it under 150 lines.
-5. Commit; users who reinstall the plugin will pick it up.
+5. Add an entry to `agents/shared/skills.md` (the skill catalog) — see CONTRIBUTING.md for the required format and how the validator enforces it.
+6. Commit; users who reinstall the plugin will pick it up.
 
 ## Philosophy
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -181,6 +181,45 @@ def check_agent_skill_refs():
                 )
 
 
+def check_catalog_completeness():
+    """Catalog at agents/shared/skills.md must list every skill, and every agent must include it."""
+    catalog = ROOT / "agents" / "shared" / "skills.md"
+    skills_dir = ROOT / "skills"
+    agents_dir = ROOT / "agents"
+
+    if not catalog.is_file():
+        fail(catalog.relative_to(ROOT), "missing — required catalog file")
+        return  # remaining checks require the file; can't continue without it
+
+    if not skills_dir.is_dir():
+        fail(skills_dir.relative_to(ROOT), "missing — required skills directory")
+        return
+
+    text = catalog.read_text(encoding="utf-8")
+    # — = EM DASH; [^\r\n]* avoids capturing CRLF carriage returns in description
+    entry_re = re.compile(r'^-\s+`swe-workbench:([\w-]+)`\s+—\s+(\S[^\r\n]*)$', re.MULTILINE)
+    catalog_ids = {sid for sid, _ in entry_re.findall(text)}
+    on_disk = {p.name for p in skills_dir.iterdir() if (p / "SKILL.md").is_file()}
+
+    for sid in sorted(on_disk - catalog_ids):
+        fail(catalog.relative_to(ROOT),
+             f"missing entry for 'swe-workbench:{sid}' (skills/{sid}/SKILL.md exists)")
+    for sid in sorted(catalog_ids - on_disk):
+        fail(catalog.relative_to(ROOT),
+             f"stale entry 'swe-workbench:{sid}' has no skills/{sid}/ on disk")
+
+    for agent_md in sorted(agents_dir.glob("*.md")):
+        try:
+            agent_text = agent_md.read_text(encoding="utf-8")
+        except OSError as e:
+            fail(agent_md.relative_to(ROOT), f"could not read file: {e}")
+            continue
+        if "@./shared/skills.md" not in agent_text:
+            fail(agent_md.relative_to(ROOT),
+                 "missing required '@./shared/skills.md' include"
+                 " — add: '> See @./shared/skills.md for the full skill catalog.'")
+
+
 # ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────
@@ -196,6 +235,7 @@ def main():
     check_agents()
     check_commands()
     check_agent_skill_refs()
+    check_catalog_completeness()
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Introduces `agents/shared/skills.md` — a single catalog (18 entries, 4 sections: Principles, Languages, Workflows, Other) listing every `swe-workbench:*` skill with a one-line description
- Wires all 7 agent files to include it via `@./shared/skills.md` (Pattern A: prepended blockquote at top of `## Principle consultation`; Pattern B: new `## Available skills` section)
- Adds `check_catalog_completeness()` to `scripts/validate.py` enforcing: catalog exists, every on-disk skill has an entry (and vice versa), every `agents/*.md` includes `@./shared/skills.md`

## Test Plan

- [x] `bash scripts/validate.sh` → "All checks passed."
- [x] Negative case 1: renamed `skills/language-go/` → validator reports stale + missing entries and frontmatter mismatch
- [x] Negative case 2: removed one catalog entry → validator reports "missing entry for 'swe-workbench:principle-clean-code'"
- [x] Negative case 3: typo'd agent include (`skills-TYPO.md`) → validator reports "missing required '@./shared/skills.md' include"
- [x] All 7 agent files include `@./shared/skills.md` (confirmed by validator green)
- [x] CONTRIBUTING.md "Skill catalog" paragraph added; `docs/extending.md` step 5 cross-reference added

Closes #103