### PR TITLE
[docs] dependencies: add missing superpowers references

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -4,7 +4,7 @@
 
 | Plugin | Source | Used for | Required? |
 |---|---|---|---|
-| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | Process skills invoked by `development` (`using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`). | Required for the `development` skill to function end-to-end. |
+| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | **Skills** (invoked via Skill tool from `skills/workflow-development/`, `commands/implement.md`, `agents/debugger.md`): `using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`, `systematic-debugging`, `writing-plans`.<br>**Subagent** (dispatched via `subagent_type` from `skills/workflow-development/`): `code-reviewer`. | Required for the `workflow-development` skill to function end-to-end. |
 | `claude-plugins-official` | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Official Anthropic plugin collection — install if you need any of its bundled tools. | Optional. |
 
-Install them via `/plugin marketplace add …` + `/plugin install …` before using the `development` skill.
+Install them via `/plugin marketplace add …` + `/plugin install …` before using the `workflow-development` skill.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -4,7 +4,7 @@
 
 | Plugin | Source | Used for | Required? |
 |---|---|---|---|
-| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | **Skills** (invoked via Skill tool from `skills/workflow-development/`, `commands/implement.md`, `agents/debugger.md`): `using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`, `systematic-debugging`, `writing-plans`.<br>**Subagent** (dispatched via `subagent_type` from `skills/workflow-development/`): `code-reviewer`. | Required for the `workflow-development` skill to function end-to-end. |
+| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | Skills invoked via Skill tool (from `skills/workflow-development/`, `commands/implement.md`, `agents/debugger.md`): `using-git-worktrees`, `executing-plans`, `subagent-driven-development`, `test-driven-development`, `verification-before-completion`, `requesting-code-review`, `finishing-a-development-branch`, `dispatching-parallel-agents`, `systematic-debugging`, `writing-plans`, `code-reviewer`. | Required for the `workflow-development` skill to function end-to-end. |
 | `claude-plugins-official` | [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) | Official Anthropic plugin collection — install if you need any of its bundled tools. | Optional. |
 
 Install them via `/plugin marketplace add …` + `/plugin install …` before using the `workflow-development` skill.


### PR DESCRIPTION
## Summary
- Add 3 missing `superpowers:*` identifiers (`systematic-debugging`, `writing-plans`, `code-reviewer`) that are referenced in `agents/`, `commands/`, and `skills/` but were absent from the doc
- Split the single comma list into an 11-item Skills enumeration with source attribution (`skills/workflow-development/`, `commands/implement.md`, `agents/debugger.md`) so readers can audit with grep
- Fix stale `` `development` `` → `` `workflow-development` `` in both the table cell and the trailing install instruction

## Test Plan
- [x] Changed skills/commands/agents load without errors — N/A, no executable code changed
- [x] Examples in the diff were exercised manually — grep cross-check run: `comm -23 <(grep -rohE 'superpowers:[a-z-]+' agents/ commands/ skills/ | sort -u) <(grep -ohE 'superpowers:[a-z-]+|\`[a-z-]+\`' docs/dependencies.md | sed -E 's/\`([a-z-]+)\`/superpowers:\1/' | sort -u)` returned empty (clean)

Closes #71