### PR TITLE
[chore] Add rimba git hooks, project config, and gitignore local settings

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# BEGIN RIMBA HOOK
+# Installed by rimba — do not edit this block manually
+if command -v rimba >/dev/null 2>&1; then
+  _rimba_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$_rimba_branch" = "main" ]; then
+    rimba clean --merged --force 2>/dev/null || true
+  fi
+fi
+# END RIMBA HOOK

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,3 +7,13 @@ if [ "$_branch" = "main" ] || [ "$_branch" = "master" ]; then
     echo "       Create a feature branch first:  git checkout -b feat/<topic>"
     exit 1
 fi
+
+# BEGIN RIMBA HOOK
+# Installed by rimba — do not edit this block manually
+_rimba_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$_rimba_branch" = "main" ] || [ "$_rimba_branch" = "master" ]; then
+  echo "rimba: direct commits to $_rimba_branch are not allowed."
+  echo "       Use 'rimba add <task>' to create a worktree branch."
+  exit 1
+fi
+# END RIMBA HOOK

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 scripts/__pycache__/
 *.pyc
 .venv/
+.rimba/settings.local.toml

--- a/.rimba/settings.toml
+++ b/.rimba/settings.toml
@@ -1,0 +1,1 @@
+copy_files = ['.env', '.env.local', '.envrc', '.tool-versions']


### PR DESCRIPTION
## Summary

- Add `.rimba/settings.toml` — project-level rimba configuration
- Update `.githooks/pre-commit` — rimba block that blocks direct commits to `main`/`master`
- Add `.githooks/post-merge` — rimba hook that auto-cleans merged worktree branches
- Add `.rimba/settings.local.toml` to `.gitignore` to prevent machine-specific config from being committed

## Test plan

- [ ] Confirm direct commit to `main` is blocked by pre-commit hook
- [ ] Confirm merged worktrees are cleaned up after `git merge` via post-merge hook
- [ ] Confirm `.rimba/settings.local.toml` does not appear as untracked in `git status`

N/A