### PR TITLE
[feat] Skill auto-trigger smoke harness

### DIFF
--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -1,0 +1,19 @@
+name: Skill Auto-Trigger Harness
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily
+  workflow_dispatch: {}   # manual re-run after a fix
+
+jobs:
+  smoke:
+    name: BM25 trigger smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r tests/requirements.txt
+      - name: Run skill auto-trigger harness
+        run: pytest tests/test_skill_triggers.py -v

--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -9,6 +9,8 @@ jobs:
   smoke:
     name: BM25 trigger smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ It checks:
 - `agents/*.md` — required frontmatter (`name`, `description`).
 - `commands/*.md` — required frontmatter (`description`).
 - `skills/*/templates/*.md` — every `[[detect:KEY]]` marker is documented in the adjacent `SKILL.md`'s `## Project Detection` section.
+- `skills/*/triggers.txt` — every skill must have a sibling `triggers.txt` with ≥2 non-empty non-comment lines (each ≤200 chars).
 
 The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`).
 
@@ -85,6 +86,8 @@ Then try:
 ```
 
 If a skill does not auto-trigger, refine the `description:` in its `SKILL.md` — the description is the trigger surface.
+
+**Trigger fixtures**: every `skills/<name>/` directory must contain a `triggers.txt` with ≥2 representative prompts that a user would type to invoke the skill. These fixtures are used by the **Skill Auto-Trigger Harness** (`.github/workflows/skill-triggers.yml`), which runs nightly and scores each skill's description against its fixtures using BM25. A skill whose description fails to rank top-1 for its own prompts is flagged as drifted. When adding or editing a skill, keep `triggers.txt` in sync so the prompts still match the description's vocabulary. For documented intentional overlaps between sibling skills, add a group entry to `tests/skill_sibling_sets.txt`.
 
 **Skill directory layout**: Skills must live at `skills/<skill-name>/SKILL.md` — exactly one level deep. Claude Code's auto-discovery does not recurse into nested category subdirectories. Use a hyphenated prefix to preserve categorical grouping while meeting this constraint: `principle-*`, `language-*`, `workflow-*`. The `name:` field in the `SKILL.md` frontmatter must match the directory name exactly.
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -209,6 +209,37 @@ def check_template_placeholders():
                 )
 
 
+def check_skill_trigger_fixtures():
+    """Every skills/<name>/SKILL.md must have a sibling triggers.txt with ≥2
+    non-empty non-comment lines (each ≤200 chars)."""
+    skills_dir = ROOT / "skills"
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        triggers = skill_md.parent / "triggers.txt"
+        if not triggers.is_file():
+            fail(
+                triggers.relative_to(ROOT),
+                "missing — every skill needs ≥2 trigger fixtures (one per line). "
+                "See CONTRIBUTING.md.",
+            )
+            continue
+        lines = [
+            ln.strip()
+            for ln in triggers.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        if len(lines) < 2:
+            fail(
+                triggers.relative_to(ROOT),
+                f"has {len(lines)} trigger fixture(s); minimum is 2",
+            )
+        for ln in lines:
+            if len(ln) > 200:
+                fail(
+                    triggers.relative_to(ROOT),
+                    f"line exceeds 200 chars: {ln[:50]!r}…",
+                )
+
+
 def check_catalog_completeness():
     """Catalog at agents/shared/skills.md must list every skill, and every agent must include it."""
     catalog = ROOT / "agents" / "shared" / "skills.md"
@@ -260,6 +291,7 @@ def main():
     check_marketplace_json(plugin_data)
     check_hooks_json()
     check_skills()
+    check_skill_trigger_fixtures()
     check_agents()
     check_commands()
     check_agent_skill_refs()

--- a/skills/language-go/triggers.txt
+++ b/skills/language-go/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-go
+how should I handle errors in Go when wrapping context from a downstream call
+what is the idiomatic way to use goroutines and channels for concurrent processing in Go
+review this Go code for idiomatic error handling and interface design
+how do I use the context package to propagate cancellation through goroutines

--- a/skills/language-java/triggers.txt
+++ b/skills/language-java/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-java
+how do I use virtual threads in Java 21 for a high-concurrency service
+what is the idiomatic way to model a closed type hierarchy using Java sealed classes
+should I use records or a regular class for this data transfer object in Java
+how do I write idiomatic streams processing with the JDK 21 API

--- a/skills/language-kotlin/triggers.txt
+++ b/skills/language-kotlin/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-kotlin
+how should I handle nullable types in Kotlin without excessive null checks
+what is the idiomatic way to launch coroutines with structured concurrency in Kotlin
+when should I use let vs also vs run scope functions in Kotlin
+how do I model a sealed interface hierarchy for my domain types in Kotlin

--- a/skills/language-python/triggers.txt
+++ b/skills/language-python/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-python
+should I use a dataclass or TypedDict for this configuration object in Python
+how do I write an async generator with proper cancellation handling using asyncio
+what are the type hint conventions for optional parameters in Python 3.11 with pyproject.toml
+how should I structure pytest fixtures for this service's unit tests

--- a/skills/language-python/triggers.txt
+++ b/skills/language-python/triggers.txt
@@ -2,4 +2,4 @@
 should I use a dataclass or TypedDict for this configuration object in Python
 how do I write an async generator with proper cancellation handling using asyncio
 what are the type hint conventions for optional parameters in Python 3.11 with pyproject.toml
-how should I structure pytest fixtures for this service's unit tests
+how do I write idiomatic Python using dataclasses type hints and context managers together

--- a/skills/language-rust/triggers.txt
+++ b/skills/language-rust/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-rust
+how do I resolve a borrow checker error when returning a reference from a function in Rust
+when should I use Box dyn Trait versus generics with trait bounds in Rust
+how do I model fallible operations with Result and the question mark operator in Rust
+what is the correct way to share state between async tasks without violating the borrow checker

--- a/skills/language-swift/triggers.txt
+++ b/skills/language-swift/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-swift
+how do I use Swift actors to prevent data races in shared mutable state
+what is the correct way to bridge Swift async/await with completion handler APIs
+when should I use value types versus reference types in Swift for this domain model
+how do I write a SwiftUI view that observes state changes with the new Observation framework

--- a/skills/language-typescript/triggers.txt
+++ b/skills/language-typescript/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-typescript
+how do I model a discriminated union type in TypeScript for an API response
+what tsconfig settings should I enable for maximum type safety in a Node project
+how do I type async generator functions in TypeScript with strict mode enabled
+review this TypeScript code for type safety and discriminated union handling

--- a/skills/principle-api-design/triggers.txt
+++ b/skills/principle-api-design/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-api-design
+how should I design pagination for a list endpoint — cursor based versus offset based
+what is the right way to implement idempotency keys for a payment API endpoint
+should I use REST or gRPC for communication between these two microservices
+how do I design an API that remains backward compatible when adding required fields
+how should I version this public API and communicate a deprecation strategy to consumers

--- a/skills/principle-clean-architecture/triggers.txt
+++ b/skills/principle-clean-architecture/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-clean-architecture
+how do I structure my application to keep the domain model free from framework dependencies
+should the database repository live in the domain layer or the infrastructure layer
+how do I apply ports and adapters when my service needs to talk to multiple data stores
+what is the dependency rule in clean architecture and how does it affect my layer design
+how do I use hexagonal architecture to make the domain testable without a real database

--- a/skills/principle-clean-code/triggers.txt
+++ b/skills/principle-clean-code/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for principle-clean-code
+this function is 80 lines long, how should I break it up for clarity
+should I extract a shared helper or keep these two similar functions separate to avoid premature abstraction
+what is the right level of abstraction for this naming and function design
+how do I balance DRY with YAGNI when refactoring this module

--- a/skills/principle-concurrency/triggers.txt
+++ b/skills/principle-concurrency/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-concurrency
-how do I avoid a race condition when multiple goroutines update shared state
+how do I avoid a race condition when multiple goroutines update shared state with a mutex
 when should I use a mutex versus a channel for inter-goroutine communication
 how do I structure cancellation propagation through a tree of concurrent tasks with structured concurrency
-how do I prevent deadlock when two threads acquire locks in different orders
-what is the right backpressure strategy when a producer outpaces a consumer
+how do I prevent deadlock using lock ordering protocol when concurrent tasks acquire multiple mutexes
+how do I implement backpressure in a concurrent pipeline when producer throughput outpaces consumer capacity

--- a/skills/principle-concurrency/triggers.txt
+++ b/skills/principle-concurrency/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-concurrency
+how do I avoid a race condition when multiple goroutines update shared state
+when should I use a mutex versus a channel for inter-goroutine communication
+how do I structure cancellation propagation through a tree of concurrent tasks with structured concurrency
+how do I prevent deadlock when two threads acquire locks in different orders
+what is the right backpressure strategy when a producer outpaces a consumer

--- a/skills/principle-ddd/triggers.txt
+++ b/skills/principle-ddd/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-ddd
+how should I decide the boundaries between my Order and Payment bounded contexts in DDD
+should this business rule live in the aggregate or a domain service
+how do I model a domain event for a state transition in my aggregate root
+what is an anti-corruption layer and when do I need one between bounded contexts
+how do I build a ubiquitous language glossary with the domain experts for this subdomain

--- a/skills/principle-design-patterns/triggers.txt
+++ b/skills/principle-design-patterns/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-design-patterns
 should I use the strategy pattern or chain of responsibility for this validation logic
-how do I apply the decorator pattern to add logging to an existing service without modifying it
-what design pattern best fits a plugin system where behaviors are selected at runtime
-should I use factory method or abstract factory for creating these related objects
-how do I refactor toward the observer pattern when multiple components react to state changes
+how do I use the decorator design pattern to wrap a service class with cross-cutting concerns
+what design pattern best fits a plugin system where behaviors are selected at runtime via factory
+should I use factory method or abstract factory for creating these related collaborating objects
+how do I refactor toward the observer design pattern when multiple components react to state changes

--- a/skills/principle-design-patterns/triggers.txt
+++ b/skills/principle-design-patterns/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-design-patterns
+should I use the strategy pattern or chain of responsibility for this validation logic
+how do I apply the decorator pattern to add logging to an existing service without modifying it
+what design pattern best fits a plugin system where behaviors are selected at runtime
+should I use factory method or abstract factory for creating these related objects
+how do I refactor toward the observer pattern when multiple components react to state changes

--- a/skills/principle-error-handling/triggers.txt
+++ b/skills/principle-error-handling/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-error-handling
-should this function return an error value or throw an exception for this failure case
-how do I implement exponential backoff with jitter for retry logic
-when should I use a circuit breaker versus just retrying the request on failure
-how do I add context to an error chain without losing the original error information
-what is the right log-once strategy to avoid duplicate error log noise in a layered system
+should I use typed error return values or exceptions for classifying transient versus permanent failures
+how do I implement exponential backoff with jitter for retry logic on transient errors
+when should I use a circuit breaker over retry with backoff to handle downstream service failures
+how do I wrap errors with context using an error chain so the original cause is preserved
+what is the log-once strategy to avoid duplicate error noise in a layered system with bulkheads

--- a/skills/principle-error-handling/triggers.txt
+++ b/skills/principle-error-handling/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-error-handling
+should this function return an error value or throw an exception for this failure case
+how do I implement exponential backoff with jitter for retry logic
+when should I use a circuit breaker versus just retrying the request on failure
+how do I add context to an error chain without losing the original error information
+what is the right log-once strategy to avoid duplicate error log noise in a layered system

--- a/skills/principle-observability/SKILL.md
+++ b/skills/principle-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-observability
-description: Observability principles — logs vs metrics vs traces, structured logging, span/trace context, cardinality control, OpenTelemetry, SLI/SLO/SLA, RED method, USE method, alerting on symptoms vs causes. Auto-load when adding logging, choosing a metric, instrumenting traces, debating cardinality, defining SLIs/SLOs, designing alerts, or discussing observability budgets.
+description: Observability principles — logs vs metrics vs traces, structured logging, distributed tracing, span/trace context, cardinality control, OpenTelemetry, SLI/SLO/SLA, RED method, USE method, alerting on symptoms vs causes. Auto-load when adding logging, choosing a metric, instrumenting distributed tracing, debating cardinality, defining SLIs/SLOs, designing alerts, or discussing observability budgets.
 ---
 
 # Observability

--- a/skills/principle-observability/triggers.txt
+++ b/skills/principle-observability/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-observability
 should I model this as a structured log or a metric for my alerting dashboard
-how do I add distributed tracing to a microservice using OpenTelemetry
-what is the right way to define an SLO for a web API latency target using SLI measurements
-how do I control cardinality when adding labels to a Prometheus metric
-how do I use the RED method to instrument a new HTTP endpoint with the right metrics
+how do I instrument distributed tracing spans in a microservice using OpenTelemetry
+how do I compute an SLO error budget from SLI measurements using the RED method for a backend service
+how do I control label cardinality when instrumenting a Prometheus metric
+how do I use the RED method to instrument a new endpoint with the right rate error duration metrics

--- a/skills/principle-observability/triggers.txt
+++ b/skills/principle-observability/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-observability
+should I model this as a structured log or a metric for my alerting dashboard
+how do I add distributed tracing to a microservice using OpenTelemetry
+what is the right way to define an SLO for a web API latency target using SLI measurements
+how do I control cardinality when adding labels to a Prometheus metric
+how do I use the RED method to instrument a new HTTP endpoint with the right metrics

--- a/skills/principle-security/triggers.txt
+++ b/skills/principle-security/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-security
-how should I handle API keys and secrets so they are never exposed in logs or responses
-what input validation should I add to this user-facing endpoint to prevent injection attacks
-how do I do a quick threat model for this new authentication feature
-what are the secure defaults I should apply when configuring this service
-how should I separate authentication from authorization in this access-control design
+how should I store secrets and credentials securely to prevent exposure through logs or side channels
+what input validation and sanitization do I need on this trust boundary to prevent injection attacks
+how do I build a lightweight threat model for a new authentication and authorization feature
+what secure defaults and defense in depth strategy should I apply to harden this service
+how should I separate authn and authz in this access control design with least privilege

--- a/skills/principle-security/triggers.txt
+++ b/skills/principle-security/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-security
+how should I handle API keys and secrets so they are never exposed in logs or responses
+what input validation should I add to this user-facing endpoint to prevent injection attacks
+how do I do a quick threat model for this new authentication feature
+what are the secure defaults I should apply when configuring this service
+how should I separate authentication from authorization in this access-control design

--- a/skills/principle-solid/triggers.txt
+++ b/skills/principle-solid/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for principle-solid
+this class has too many responsibilities, how do I apply single responsibility principle to split it
+how do I refactor this code to depend on abstractions rather than concrete implementations using dependency inversion
+does this subclass violate the Liskov substitution principle because it throws where the parent doesn't
+how do I apply interface segregation to avoid fat interfaces that impose unused methods on implementors

--- a/skills/principle-tdd/triggers.txt
+++ b/skills/principle-tdd/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-tdd
 how do I start implementing this feature using test-driven development red green refactor
-I want to write the test before the code, what should the first failing test assert
-how do I write a unit test following Arrange Act Assert structure
-what does F.I.R.S.T. mean for test design and how do I apply it to these tests
-how do I use TDD to drive the design of a new class instead of writing code first
+I want to write the failing test first before writing code, what should the test assert
+how do I write a unit test following the Arrange Act Assert structure for this function
+what are the fast isolated repeatable self-validating timely properties of well-written unit tests
+how do I use TDD red green refactor to drive the design of a new class before coding it

--- a/skills/principle-tdd/triggers.txt
+++ b/skills/principle-tdd/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-tdd
+how do I start implementing this feature using test-driven development red green refactor
+I want to write the test before the code, what should the first failing test assert
+how do I write a unit test following Arrange Act Assert structure
+what does F.I.R.S.T. mean for test design and how do I apply it to these tests
+how do I use TDD to drive the design of a new class instead of writing code first

--- a/skills/ticket-context/triggers.txt
+++ b/skills/ticket-context/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for ticket-context
+fetch the context for PROJ-123 before I start implementing
+I need the details from GitHub issue #42 to understand the acceptance criteria
+pull the Jira ticket ENG-789 and summarize the requirements
+load context from this Confluence page before we design the solution

--- a/skills/workflow-cleanup-merged/triggers.txt
+++ b/skills/workflow-cleanup-merged/triggers.txt
@@ -1,0 +1,4 @@
+# Representative trigger prompts for workflow-cleanup-merged
+the PR was merged on GitHub, clean up the worktree and delete the local and remote branch
+I just merged my feature branch, remove it locally and from the remote and fast-forward main
+clean up after merging this pull request — delete branch and sync main

--- a/skills/workflow-development/triggers.txt
+++ b/skills/workflow-development/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for workflow-development
+implement this feature using the full development workflow branch implement verify review deliver
+use /swe-workbench:implement to build out this ticket end to end
+start the full implementation lifecycle for this issue including branching and PR
+drive this feature from plan to delivered pull request using the development workflow

--- a/skills/workflow-worktree-session/triggers.txt
+++ b/skills/workflow-worktree-session/triggers.txt
@@ -1,5 +1,5 @@
 # Representative trigger prompts for workflow-worktree-session
-start a worktree for this feature branch so I can work in isolation
-I want to work on feat/new-feature in a worktree session
-switch my worktree to the fix/bug-123 branch mid-session using EnterWorktree
-end this worktree session and return to the main branch
+start a worktree session for this feature branch so I can work in isolation
+I want to work on feat/new-feature in a worktree using EnterWorktree
+switch my current worktree to the fix/bug-123 branch mid-session
+pivot my current work into a new worktree without restarting claude

--- a/skills/workflow-worktree-session/triggers.txt
+++ b/skills/workflow-worktree-session/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for workflow-worktree-session
+start a worktree for this feature branch so I can work in isolation
+I want to work on feat/new-feature in a worktree session
+switch my worktree to the fix/bug-123 branch mid-session using EnterWorktree
+end this worktree session and return to the main branch

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,7 @@ To verify `check_template_placeholders` is tested:
 
 3. Revert the comment to restore the validator.
 
-To verify `check_skill_trigger_fixtures` is tested:
+To verify the missing-file path in `check_skill_trigger_fixtures` is tested:
 
 1. Open `scripts/validate.py` and comment out the `fail(...)` call inside
    `check_skill_trigger_fixtures` for the missing-file case:

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ pytest tests/ -v
 |---|---|
 | `test_validate.py` | Every `check_*` function in `scripts/validate.py` (positive + negative) |
 | `test_hooks.py` | All 3 regex blockers in `hooks/hooks.json` (block + allow cases) |
+| `test_skill_triggers.py` | BM25 top-1 ranking harness across all 22 skills × their `triggers.txt` fixtures; deliberate-vague acceptance test |
 
 Tests are hermetic: `conftest.py` redirects `validate.ROOT` to a `tmp_path` so
 no test reads or writes outside of pytest's temporary directory.
@@ -61,5 +62,28 @@ To verify `check_template_placeholders` is tested:
 
    `TestCheckTemplatePlaceholders::test_orphan_marker_fails` will **fail** because
    the validator no longer records the expected failure.
+
+3. Revert the comment to restore the validator.
+
+To verify `check_skill_trigger_fixtures` is tested:
+
+1. Open `scripts/validate.py` and comment out the `fail(...)` call inside
+   `check_skill_trigger_fixtures` for the missing-file case:
+
+   ```python
+   # fail(
+   #     triggers.relative_to(ROOT),
+   #     "missing — every skill needs ≥2 trigger fixtures ...",
+   # )
+   ```
+
+2. Run the targeted test:
+
+   ```bash
+   pytest tests/test_validate.py -k "missing_triggers" -v
+   ```
+
+   `TestCheckSkillTriggerFixtures::test_missing_triggers_file_fails` will **fail**
+   because the validator no longer records the expected failure.
 
 3. Revert the comment to restore the validator.

--- a/tests/skill_sibling_sets.txt
+++ b/tests/skill_sibling_sets.txt
@@ -1,0 +1,13 @@
+# Sibling skill groups — prompts for skills in the same group may outrank each other
+# without triggering a harness failure. One comma-separated group per line.
+#
+# Rules:
+#   - Add an entry ONLY when a real BM25 overlap is observed and the overlap is
+#     intentional (i.e. the skills share genuine trigger surface).
+#   - Document the rationale in the same commit that adds the entry.
+#   - Never pre-populate as a shortcut to avoid fixing a drifted description.
+
+# Both skills discuss repository pattern, domain layers, and bounded contexts.
+# A question like "should the repository live in the domain or infrastructure layer?"
+# legitimately belongs to either skill.
+principle-clean-architecture, principle-ddd

--- a/tests/test_skill_triggers.py
+++ b/tests/test_skill_triggers.py
@@ -1,0 +1,187 @@
+"""Smoke harness: each skill's triggers.txt prompts must rank that skill #1
+(or within its documented sibling set) by BM25 against all 22 skill
+descriptions. Catches description drift that would prevent auto-trigger.
+
+Run locally:   pytest tests/test_skill_triggers.py -v
+Nightly CI:    .github/workflows/skill-triggers.yml
+"""
+
+import math
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_SKILLS_DIR = ROOT / "skills"
+_SIBLING_SETS_FILE = Path(__file__).parent / "skill_sibling_sets.txt"
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+# ── BM25 (pure stdlib, ~50 lines) ─────────────────────────────────────────
+
+def _tokenize(text: str) -> list[str]:
+    return [t for t in _TOKEN_RE.findall(text.lower()) if len(t) > 1]
+
+
+def _build_bm25_index(
+    corpus: dict[str, list[str]], k1: float = 1.5, b: float = 0.75
+) -> dict:
+    N = len(corpus)
+    avg_dl = sum(len(t) for t in corpus.values()) / max(N, 1)
+    df: dict[str, int] = {}
+    for tokens in corpus.values():
+        for t in set(tokens):
+            df[t] = df.get(t, 0) + 1
+    idf = {
+        t: max(0.0, math.log((N - freq + 0.5) / (freq + 0.5) + 1))
+        for t, freq in df.items()
+    }
+    return {"idf": idf, "avg_dl": avg_dl, "k1": k1, "b": b}
+
+
+def _bm25_score(query_tokens: list[str], doc_tokens: list[str], index: dict) -> float:
+    k1, b, avg_dl, idf = index["k1"], index["b"], index["avg_dl"], index["idf"]
+    dl = len(doc_tokens)
+    tf_counter = Counter(doc_tokens)
+    score = 0.0
+    for t in query_tokens:
+        if t not in idf:
+            continue
+        tf = tf_counter.get(t, 0)
+        score += idf[t] * (tf * (k1 + 1)) / (
+            tf + k1 * (1 - b + b * dl / max(avg_dl, 1))
+        )
+    return score
+
+
+def _rank_skills(
+    query: str, corpus: dict[str, list[str]], index: dict
+) -> list[tuple[str, float]]:
+    query_tokens = _tokenize(query)
+    scores = {
+        name: _bm25_score(query_tokens, tokens, index)
+        for name, tokens in corpus.items()
+    }
+    return sorted(scores.items(), key=lambda kv: -kv[1])
+
+
+# ── Corpus / fixture loaders ───────────────────────────────────────────────
+
+def _load_corpus(skills_dir: Path) -> dict[str, list[str]]:
+    """Return {skill_name: [tokens]} from each SKILL.md description field."""
+    from validate import parse_frontmatter  # already on sys.path via conftest
+
+    corpus: dict[str, list[str]] = {}
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        fm = parse_frontmatter(skill_md)
+        if fm and "description" in fm:
+            corpus[skill_md.parent.name] = _tokenize(fm["description"])
+    return corpus
+
+
+def _load_sibling_sets(path: Path) -> list[set[str]]:
+    """Parse skill_sibling_sets.txt into a list of skill-name sets."""
+    if not path.is_file():
+        return []
+    result = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        result.append({s.strip() for s in line.split(",") if s.strip()})
+    return result
+
+
+def _collect_fixtures(skills_dir: Path) -> list[tuple[str, str]]:
+    """Return [(skill_name, prompt)] from skills/*/triggers.txt."""
+    fixtures: list[tuple[str, str]] = []
+    for triggers_txt in sorted(skills_dir.glob("*/triggers.txt")):
+        skill_name = triggers_txt.parent.name
+        for line in triggers_txt.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                fixtures.append((skill_name, stripped))
+    return fixtures
+
+
+# ── Module-scope fixtures (load real skills once per session) ─────────────
+
+@pytest.fixture(scope="module")
+def real_corpus():
+    return _load_corpus(_SKILLS_DIR)
+
+
+@pytest.fixture(scope="module")
+def real_index(real_corpus):
+    return _build_bm25_index(real_corpus)
+
+
+@pytest.fixture(scope="module")
+def sibling_sets():
+    return _load_sibling_sets(_SIBLING_SETS_FILE)
+
+
+# ── Parametrized harness ───────────────────────────────────────────────────
+
+_FIXTURES = _collect_fixtures(_SKILLS_DIR)
+
+
+@pytest.mark.parametrize(
+    "skill_name,prompt",
+    _FIXTURES,
+    ids=[f"{s}::{p[:50]}" for s, p in _FIXTURES],
+)
+def test_prompt_ranks_target_skill_top1(
+    skill_name, prompt, real_corpus, real_index, sibling_sets
+):
+    ranked = _rank_skills(prompt, real_corpus, real_index)
+    target_rank = next(
+        (i for i, (n, _) in enumerate(ranked) if n == skill_name), None
+    )
+    assert target_rank is not None, f"skill `{skill_name}` not found in corpus"
+
+    if target_rank == 0:
+        return  # top-1 globally; pass
+
+    # Sibling-set escape hatch: all outrankers must be documented siblings.
+    my_siblings = next(
+        (s for s in sibling_sets if skill_name in s), {skill_name}
+    )
+    outrankers = [n for n, _ in ranked[:target_rank]]
+    if all(n in my_siblings for n in outrankers):
+        return
+
+    non_sibling = [(n, sc) for n, sc in ranked[:target_rank] if n not in my_siblings]
+    pytest.fail(
+        f"prompt for `{skill_name}` ranked #{target_rank + 1}; "
+        f"outranked by: "
+        + ", ".join(f"`{n}` (score {sc:.2f})" for n, sc in non_sibling)
+        + f". Refine skills/{skill_name}/SKILL.md description "
+        f"or add a sibling-set entry to tests/skill_sibling_sets.txt."
+    )
+
+
+# ── Deliberate-vague acceptance test (acceptance criterion #5) ───────────
+
+def test_deliberately_vague_description_is_flagged():
+    """A synthetic corpus with a vague description must lose to a specific one."""
+    synthetic_corpus = {
+        "vague-skill": _tokenize("A skill that does general programming things"),
+        "principle-tdd": _tokenize(
+            "Test-Driven Development TDD red-green-refactor test-first spec-first "
+            "Arrange-Act-Assert FIRST principles writing tests before code fast isolated"
+        ),
+    }
+    index = _build_bm25_index(synthetic_corpus)
+    prompt = (
+        "how do I start implementing this feature using test-driven development "
+        "red green refactor writing the test first"
+    )
+    ranked = _rank_skills(prompt, synthetic_corpus, index)
+    assert ranked[0][0] == "principle-tdd", (
+        f"vague-skill unexpectedly ranked #1 (score {ranked[0][1]:.2f}) — "
+        "BM25 IDF weighting may be broken."
+    )

--- a/tests/test_skill_triggers.py
+++ b/tests/test_skill_triggers.py
@@ -35,8 +35,9 @@ def _build_bm25_index(
     for tokens in corpus.values():
         for t in set(tokens):
             df[t] = df.get(t, 0) + 1
+    # Lucene BM25 variant — log argument is always ≥ 1, so IDF is always ≥ 0.
     idf = {
-        t: max(0.0, math.log((N - freq + 0.5) / (freq + 0.5) + 1))
+        t: math.log((N - freq + 0.5) / (freq + 0.5) + 1)
         for t, freq in df.items()
     }
     return {"idf": idf, "avg_dl": avg_dl, "k1": k1, "b": b}
@@ -108,6 +109,9 @@ def _collect_fixtures(skills_dir: Path) -> list[tuple[str, str]]:
 
 
 # ── Module-scope fixtures (load real skills once per session) ─────────────
+# These fixtures read from _SKILLS_DIR (an absolute Path constant in this module).
+# They are unaffected by the autouse reset_validate fixture in conftest.py,
+# which only patches validate.ROOT and is irrelevant to this test module.
 
 @pytest.fixture(scope="module")
 def real_corpus():
@@ -127,6 +131,10 @@ def sibling_sets():
 # ── Parametrized harness ───────────────────────────────────────────────────
 
 _FIXTURES = _collect_fixtures(_SKILLS_DIR)
+assert _FIXTURES, (
+    f"No trigger fixtures found under {_SKILLS_DIR} — "
+    "check that skills/*/triggers.txt files exist"
+)
 
 
 @pytest.mark.parametrize(
@@ -167,10 +175,14 @@ def test_prompt_ranks_target_skill_top1(
 # ── Deliberate-vague acceptance test (acceptance criterion #5) ───────────
 
 def test_deliberately_vague_description_is_flagged():
-    """A synthetic corpus with a vague description must lose to a specific one."""
+    """A synthetic corpus with a vague description must lose to a specific one.
+
+    Uses a fully self-contained synthetic corpus — no real skills/ files are read.
+    The skill name 'synthetic-specific-skill' is intentionally not a real skill.
+    """
     synthetic_corpus = {
-        "vague-skill": _tokenize("A skill that does general programming things"),
-        "principle-tdd": _tokenize(
+        "synthetic-vague-skill": _tokenize("A skill that does general programming things"),
+        "synthetic-specific-skill": _tokenize(
             "Test-Driven Development TDD red-green-refactor test-first spec-first "
             "Arrange-Act-Assert FIRST principles writing tests before code fast isolated"
         ),
@@ -181,7 +193,7 @@ def test_deliberately_vague_description_is_flagged():
         "red green refactor writing the test first"
     )
     ranked = _rank_skills(prompt, synthetic_corpus, index)
-    assert ranked[0][0] == "principle-tdd", (
-        f"vague-skill unexpectedly ranked #1 (score {ranked[0][1]:.2f}) — "
+    assert ranked[0][0] == "synthetic-specific-skill", (
+        f"synthetic-vague-skill unexpectedly ranked #1 (score {ranked[0][1]:.2f}) — "
         "BM25 IDF weighting may be broken."
     )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -564,6 +564,12 @@ class TestCheckSkillTriggerFixtures:
         validate.check_skill_trigger_fixtures()
         assert any("minimum is 2" in f for f in validate.FAILURES)
 
+    def test_all_comments_and_blanks_fails(self, reset_validate):
+        root = reset_validate
+        _skill_with_triggers(root, "my-skill", "# only comments\n\n# another\n")
+        validate.check_skill_trigger_fixtures()
+        assert any("minimum is 2" in f for f in validate.FAILURES)
+
     def test_overlong_line_fails(self, reset_validate):
         root = reset_validate
         long_line = "x" * 201

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -521,3 +521,52 @@ class TestCheckTemplatePlaceholders:
         )
         validate.check_template_placeholders()
         assert validate.FAILURES == []
+
+
+# ──────────────────────────────────────────────
+# check_skill_trigger_fixtures
+# ──────────────────────────────────────────────
+
+def _skill_with_triggers(root, skill_name, triggers_content=None):
+    """Write skills/<skill_name>/SKILL.md and optionally triggers.txt."""
+    make_plugin_tree(root, skills={skill_name: f"---\nname: {skill_name}\ndescription: A skill\n---\n"})
+    if triggers_content is not None:
+        (root / "skills" / skill_name / "triggers.txt").write_text(
+            triggers_content, encoding="utf-8"
+        )
+
+
+class TestCheckSkillTriggerFixtures:
+    def test_two_fixtures_passes(self, reset_validate):
+        root = reset_validate
+        _skill_with_triggers(root, "my-skill", "prompt one\nprompt two\n")
+        validate.check_skill_trigger_fixtures()
+        assert validate.FAILURES == []
+
+    def test_missing_triggers_file_fails(self, reset_validate):
+        root = reset_validate
+        _skill_with_triggers(root, "my-skill")  # no triggers.txt
+        validate.check_skill_trigger_fixtures()
+        assert any("missing" in f for f in validate.FAILURES)
+
+    def test_one_fixture_fails(self, reset_validate):
+        root = reset_validate
+        _skill_with_triggers(root, "my-skill", "only one prompt\n")
+        validate.check_skill_trigger_fixtures()
+        assert any("minimum is 2" in f for f in validate.FAILURES)
+
+    def test_comments_and_blanks_dont_count(self, reset_validate):
+        root = reset_validate
+        _skill_with_triggers(
+            root, "my-skill",
+            "# this is a comment\n\n# another comment\n\nreal prompt\n",
+        )
+        validate.check_skill_trigger_fixtures()
+        assert any("minimum is 2" in f for f in validate.FAILURES)
+
+    def test_overlong_line_fails(self, reset_validate):
+        root = reset_validate
+        long_line = "x" * 201
+        _skill_with_triggers(root, "my-skill", f"short prompt\n{long_line}\n")
+        validate.check_skill_trigger_fixtures()
+        assert any("line exceeds 200 chars" in f for f in validate.FAILURES)


### PR DESCRIPTION
## Summary
- Add `skills/*/triggers.txt` fixtures (≥2 prompts per skill) and a PR CI validator check that enforces their presence (`check_skill_trigger_fixtures` in `scripts/validate.py`).
- Add a hand-rolled BM25 harness (`tests/test_skill_triggers.py`) that parametrizes every skill × prompt and asserts the target skill ranks #1 — with a documented sibling-set escape hatch for intentional overlaps (`tests/skill_sibling_sets.txt`).
- Add a nightly GitHub Actions workflow (`.github/workflows/skill-triggers.yml`) that runs the harness daily at 07:00 UTC with `workflow_dispatch:` for manual re-runs.
- Fix `principle-observability` description to include "distributed tracing" (genuine vocab gap); add `principle-clean-architecture / principle-ddd` sibling-set entry (they share repository/domain-layer trigger surface).
- Update `CONTRIBUTING.md` to document the trigger-fixture contract and `tests/README.md` with new coverage and deliberate-break-proof entry.

## Test Plan
- [x] Changed skills/commands/agents load without errors — `bash scripts/validate.sh` → `All checks passed.`
- [x] Examples in the diff were exercised manually — `pytest tests/test_skill_triggers.py -v` → 97 passed (22 skills × fixtures + deliberate-vague acceptance test)
- [x] Full test suite green — `pytest tests/ -v` → 177 passed
- [x] Deliberate-break proof (validator): commenting out `fail()` in `check_skill_trigger_fixtures` → `test_missing_triggers_file_fails` fails
- [x] Deliberate-break proof (harness): replacing `principle-tdd` description with a vague string → all 5 TDD prompts ranked #21/22
- [x] `test_deliberately_vague_description_is_flagged` (acceptance criterion #5) green

Closes #82