### PR TITLE
[fix] cleanup-merged: use grep -c . instead of wc -l to avoid trailing-newline false positive

### DIFF
--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -82,8 +82,8 @@ Combine the worktree locate and both git safety checks into one shell. Emit exac
 ```bash
 WORKTREE=$(git worktree list --porcelain \
   | awk '/^worktree /{p=$2} /^branch refs\/heads\/<headRefName>$/{print p; exit}')
-DIRTY=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" status --porcelain | wc -l | tr -d ' ' || echo 0)
-UNPUSHED=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" log @{upstream}..HEAD --oneline | wc -l | tr -d ' ' || echo 0)
+DIRTY=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" status --porcelain | grep -c . || echo 0)
+UNPUSHED=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" log @{upstream}..HEAD --oneline 2>/dev/null | grep -c . || echo 0)
 printf 'WORKTREE=%s\nDIRTY=%s\nUNPUSHED=%s\n' "$WORKTREE" "$DIRTY" "$UNPUSHED"
 ```
 


### PR DESCRIPTION
## Summary
- Replace `wc -l | tr -d ' '` with `grep -c .` for both `DIRTY` and `UNPUSHED` counts in Batch A of `workflow-cleanup-merged`
- Add `2>/dev/null` to the `@{upstream}` log command to silence "no upstream" errors when the remote branch is already deleted (e.g. GitHub auto-delete-head-branches on merge)

`wc -l` returns `1` for a trailing newline in git output, causing a false positive `UNPUSHED=1` that aborts cleanup on an already-merged PR. `grep -c .` counts only non-empty lines and returns `0` for empty input.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` — All checks passed
- [x] Reproducer: cleanup after a merged PR with remote branch auto-deleted → `UNPUSHED` now correctly reports `0`

Issue: N/A — hotfix for false positive observed during post-merge cleanup