### PR TITLE
[fix] setup.sh: use absolute hooksPath so pre-commit fires in linked worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ After cloning, run the setup script once:
 ./scripts/setup.sh
 ```
 
-This sets `core.hooksPath` to `.githooks/`, activating the two local git hooks described below.
+This sets `core.hooksPath` to the absolute path of `.githooks/`, ensuring hooks fire from linked worktrees as well as the main checkout.
 
 ## Branch naming
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-git config core.hooksPath .githooks
+git config core.hooksPath "$(git rev-parse --show-toplevel)/.githooks"
 echo "Git hooks enabled (.githooks/)"


### PR DESCRIPTION
## Summary
- `scripts/setup.sh` was setting `core.hooksPath .githooks` (relative path)
- Git resolves relative `hooksPath` from the worktree root — linked worktrees at paths like `.claude/worktrees/fix+72-...` have no `.githooks/` directory, so hooks silently don't exist and all hook checks (including the direct-commit-to-main guard) are bypassed
- Fix: use `$(git rev-parse --show-toplevel)/.githooks` — an absolute path that resolves correctly from any linked worktree
- Update `CONTRIBUTING.md` to reflect the change

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` — All checks passed
- [x] Confirmed: after running `setup.sh`, `git commit` from a linked worktree on `main` is correctly blocked by the pre-commit hook

Issue: N/A — hardening discovered during post-merge cleanup session