### PR TITLE
[feat] Add principle-performance skill and wire into reviewer + senior-engineer

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -75,3 +75,4 @@ Invoke these skills via the Skill tool when the review surfaces a concern in the
 - `swe-workbench:principle-error-handling` — failure modes, error wrapping
 - `swe-workbench:principle-solid` — responsibility violations, coupling
 - `swe-workbench:principle-security` — auth, input validation, trust boundaries
+- `swe-workbench:principle-performance` — hot-path allocations, N+1 queries, algorithmic complexity

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -45,3 +45,4 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-ddd` — bounded contexts, aggregates, ubiquitous language
 - `swe-workbench:principle-api-design` — contracts, versioning, idempotency
 - `swe-workbench:principle-solid` — responsibility, coupling, open-closed
+- `swe-workbench:principle-performance` — latency vs throughput, profile-first, scalability trade-offs

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -12,6 +12,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:principle-design-patterns` — Design patterns: GoF catalog — Strategy, Factory, Observer, Decorator, Adapter, and more.
 - `swe-workbench:principle-error-handling` — Error handling: errors as values, classification, wrapping, retry, circuit breakers.
 - `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
+- `swe-workbench:principle-performance` — Performance: latency vs throughput, profile-before-optimize, Big-O, allocation pressure, data locality, N+1 queries.
 - `swe-workbench:principle-security` — Security: trust boundaries, input validation, secrets handling, secure defaults, threat modeling.
 - `swe-workbench:principle-solid` — SOLID principles: SRP, OCP, LSP, ISP, DIP — responsibility, coupling, abstractions.
 - `swe-workbench:principle-tdd` — TDD: red-green-refactor, test-first, F.I.R.S.T., Arrange-Act-Assert.

--- a/skills/principle-performance/SKILL.md
+++ b/skills/principle-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-performance
-description: Performance engineering principles — latency vs throughput, profile-before-optimize discipline, Big-O instincts for common patterns, allocation and GC pressure, data locality and cache-friendliness, N+1 query detection. Auto-load when reviewing hot-path code, choosing data structures, designing batch or streaming pipelines, hunting allocations or GC pauses, weighing latency vs throughput trade-offs, considering caching, analyzing query patterns, or sizing capacity for scale.
+description: Performance engineering principles — latency vs throughput, profile-before-optimize discipline, Big-O instincts for common patterns, allocation and GC pressure, data locality and cache-friendliness, N+1 queries on a list endpoint. Auto-load when reviewing hot-path code, choosing data structures, designing batch or streaming pipelines, hunting allocations or GC pauses, weighing latency trade-offs, considering caching, detecting N+1 queries on list endpoint calls, or evaluating scalability.
 ---
 
 # Performance

--- a/skills/principle-performance/SKILL.md
+++ b/skills/principle-performance/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: principle-performance
+description: Performance engineering principles — latency vs throughput, profile-before-optimize discipline, Big-O instincts for common patterns, allocation and GC pressure, data locality and cache-friendliness, N+1 query detection. Auto-load when reviewing hot-path code, choosing data structures, designing batch or streaming pipelines, hunting allocations or GC pauses, weighing latency vs throughput trade-offs, considering caching, analyzing query patterns, or sizing capacity for scale.
+---
+
+# Performance
+
+Performance bugs are design bugs. They are cheapest to fix before the first line of code is written. This skill teaches design-time discipline — choosing the right algorithm, data structure, and access pattern — not runtime profiler operation.
+
+## Latency vs Throughput
+
+They pull in opposite directions; name the goal before optimizing.
+- Latency: time to serve one request. Throughput: requests served per unit time. Improving one often degrades the other.
+- Tail latency (p99, p999) is a separate budget from mean latency — do not let averages hide outliers.
+- Batching and buffering improve throughput at the cost of per-item latency; state this trade-off explicitly.
+- Choose the objective first: a real-time API and a batch pipeline have different success criteria.
+
+## Profile Before You Optimize
+
+Measurement beats intuition; no fix without a hot path identified by data.
+- Identify the bottleneck with a profiler before changing code — optimizing a path that accounts for 5% of runtime cannot yield more than a 5% total improvement, no matter how perfect the fix.
+- Benchmark before and after each change; a "feels faster" claim is not evidence.
+- Most code is cold; optimize only the identified hot path. Premature optimization is applied to the wrong place.
+- A profile that surprises you is information; a profile you skipped is a bug waiting to be filed.
+
+## Big-O Where It Bites
+
+Algorithmic complexity matters when N grows; the right abstraction is cheaper than any constant-factor tweak.
+- Nested loops over collections are O(n²) by default — verify that the outer N is bounded and small.
+- Membership tests on lists are O(n); use a hash set when the check is inside a loop.
+- String concatenation inside a loop builds O(n²) bytes; accumulate then join once outside the loop.
+- Sort once, query many times — precompute sorted order or indexes when access patterns allow.
+- Accidental quadratic is the most common performance regression; review any loop whose body touches a collection.
+
+## Allocation & GC Pressure
+
+Every allocation is work; allocation rate drives GC pause frequency and duration.
+- Allocations on the hot path accumulate — a tight loop that allocates per iteration can dominate GC time.
+- Reuse buffers, pools, or pre-allocated slices; avoid constructing intermediate objects that are immediately discarded.
+- Value types (stack-allocated structs, primitives) beat heap-allocated objects on hot paths.
+- Immutability is a correctness tool with a cost: copying for safety is fine in cold code, expensive in hot code.
+- Profile allocation rate, not just CPU — GC pauses show up as latency spikes, not CPU%.
+
+## Data Locality
+
+Access patterns that match memory layout are faster than clever but scattered code.
+- Arrays of values beat arrays of pointers on hot paths — the CPU prefetcher handles sequential access, not pointer chasing.
+- Structs-of-arrays (SoA) outperform arrays-of-structs (AoS) when only one field is accessed per loop iteration.
+- Sequential access patterns are predictable and prefetch-friendly; random access patterns are not.
+- Profile cache misses before restructuring data layouts — the gain varies widely by workload.
+
+## N+1 and the Database Boundary
+
+One query per iteration is the most common silent performance killer.
+- An ORM that lazy-loads relations inside a list handler issues N+1 queries by default; always verify the query count.
+- Batch, join, or preload: fetch all related records in one query, then associate in memory.
+- Eager-loading defaults beat lazy-loading defaults in most list and aggregate endpoints.
+- Measure query count at the boundary (query logs, explain plans) — not only wall-clock time.
+- "We'll cache it later" is not a query strategy; the cache miss path is still N+1.
+
+## When Pre-Write Performance Thinking is Overkill
+
+- Scripts that process fixed, small inputs and run rarely or once.
+- Throwaway prototypes where correctness is the only requirement.
+- Cold paths: initialization code, admin-only endpoints under negligible load.
+- One-time migrations on small, bounded datasets where row count is verified before run.
+- Internal tooling with known-small N (under a few hundred items, single-digit users).
+- Apply YAGNI: do not optimize for scale that does not yet exist and may never arrive.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| Optimization without a profile | Speedup applied to a path that may not be the bottleneck |
+| O(n²) loop over user-controlled input | N is unbounded; attacker can trigger quadratic blowup |
+| Allocation inside inner loop | High allocation rate causes GC pauses at the worst time |
+| Lazy ORM relation on list endpoint | Guarantees N+1 queries at runtime |
+| "We'll cache it later" | Cache masks a bad access pattern; the cache-miss path is still slow |
+| Tail latency ignored in SLOs | p99 outliers hit real users; mean metrics hide them |
+| String concat in loop | O(n²) byte copies; accumulate and join once outside the loop |

--- a/skills/principle-performance/triggers.txt
+++ b/skills/principle-performance/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-performance
+how do I weigh latency vs throughput trade-offs for this hot-path endpoint
+what should I profile before optimizing this slow request
+how do I avoid N+1 queries on this list endpoint
+what allocation patterns will hurt GC pause times in this service
+how do I think about Big-O complexity for this data-processing loop


### PR DESCRIPTION
## Summary
- Add `skills/principle-performance/SKILL.md` (~80 lines, 9 sections): latency vs throughput, profile-before-optimize, Big-O, allocation & GC pressure, data locality, N+1 queries, overkill carve-outs, Red Flags table — style matches `principle-security` exactly
- Add `skills/principle-performance/triggers.txt` with header comment and 5 representative trigger prompts
- Insert catalog entry in `agents/shared/skills.md` alphabetically between `principle-observability` and `principle-security`
- Append principle consultation bullets to `agents/reviewer.md` and `agents/senior-engineer.md`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python scripts/validate.py` passes clean

Closes #83
