### PR TITLE
[fix] dev-loop hardening: PR validation, pre-push pytest, cleanup-merged cwd anchor

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Pre-push hook: validate plugin files before pushing to remote.
+# Pre-push hook: validate plugin files and run tests before pushing to remote.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 bash "$REPO_ROOT/scripts/validate.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "pre-push: ERROR — python3 is required to run tests. Install Python 3.12+." >&2
+  exit 1
+fi
+if ! python3 -c 'import pytest' 2>/dev/null; then
+  echo "pre-push: ERROR — pytest not installed. Run: pip install -r tests/requirements.txt" >&2
+  exit 1
+fi
+python3 -m pytest "$REPO_ROOT/tests/" -q

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,9 +39,15 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
+          # Strip HTML comments first so example text inside <!-- ... --> blocks
+          # (e.g. "Issue: N/A" documentation in the PR template) does not
+          # accidentally match the opt-out or closing-keyword patterns.
+          PR_BODY_VISIBLE=$(echo "$PR_BODY" | python3 -c \
+            "import re,sys; print(re.sub(r'<!--.*?-->','',sys.stdin.read(),flags=re.DOTALL))")
+
           # Allow ad-hoc PRs that explicitly opt out with "N/A" or "Issue: N/A" on its own line.
           # Accepts: "N/A", "Issue: N/A", "Issue: N/A — reason", "N/A — reason".
-          if echo "$PR_BODY" | grep -iqE '^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
+          if echo "$PR_BODY_VISIBLE" | grep -iqE '^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
             echo "Issue reference opted out with N/A — skipping check"
             exit 0
           fi
@@ -49,7 +55,7 @@ jobs:
           # Require a GitHub closing keyword (case-insensitive).
           # "Closes N/A" or "Closes #N/A" will NOT match the N/A check above (not a standalone line)
           # and will NOT match this check — so they correctly fail CI.
-          if ! echo "$PR_BODY" | grep -iqE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+'; then
+          if ! echo "$PR_BODY_VISIBLE" | grep -iqE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+'; then
             echo "::error::PR body must reference an issue with a closing keyword"
             echo ""
             echo "Add one of these to your PR description:"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
           # (e.g. "Issue: N/A" documentation in the PR template) does not
           # accidentally match the opt-out or closing-keyword patterns.
           PR_BODY_VISIBLE=$(echo "$PR_BODY" | python3 -c \
-            "import re,sys; print(re.sub(r'<!--.*?-->','',sys.stdin.read(),flags=re.DOTALL))")
+            "import re,sys; print(re.sub(r'<!--.*?(?:-->|$)','',sys.stdin.read(),flags=re.DOTALL))")
 
           # Allow ad-hoc PRs that explicitly opt out with "N/A" or "Issue: N/A" on its own line.
           # Accepts: "N/A", "Issue: N/A", "Issue: N/A — reason", "N/A — reason".

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -51,6 +51,7 @@ First, derive `$MAIN_REPO` and anchor the shell to it. The rimba post-merge hook
 
 ```bash
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+[ -n "$MAIN_REPO" ] || { echo "sync-main: could not resolve main repo path — aborting" >&2; exit 1; }
 cd "$MAIN_REPO"
 ```
 

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -45,13 +45,19 @@ Read `state == "MERGED"` **and** `mergedAt != null`. Abort with a clear message 
 
 **Never use `git branch --merged` as a merge check.** GitHub's default squash-merge strategy creates a new commit SHA on `main`; the original branch tip is not a merge ancestor of `main`, so `git branch --merged` silently lies. `gh` is the only oracle that does not lie.
 
-### Step 3 — Sync Local Main
+### Step 3 — Anchor cwd + Sync Local Main
 
-Sync local main BEFORE destructive operations so the merge commit is visible on `main` and the next branch cut starts from a current tip.
+First, derive `$MAIN_REPO` and anchor the shell to it. The rimba post-merge hook fires during the pull below and deletes any merged worktree — including the one this skill may be running from. Anchoring before the pull keeps the cwd valid regardless:
 
 ```bash
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
-(git -C "$MAIN_REPO" checkout main && git -C "$MAIN_REPO" pull --ff-only origin main) \
+cd "$MAIN_REPO"
+```
+
+Then sync local main so the merge commit is visible on `main` and the next branch cut starts from a current tip:
+
+```bash
+(git checkout main && git pull --ff-only origin main) \
   || echo "sync-main: best-effort failed — reconcile main manually"
 ```
 
@@ -214,6 +220,7 @@ git worktree remove "$WORKTREE"
 | Step 3 (sync main) fails | Non-zero exit from `git checkout` or `git pull` | Warn in report. Do not abort — sync is best-effort; cleanup proceeds. |
 | PR number not derivable from current branch | `gh pr view` fails | Ask the user for the PR number explicitly. |
 | Hook ran but did not clean | `WORKTREE_GONE=0` after sync despite hook active | Fall through to rimba-binary or shell strategy. No abort. |
+| cwd deleted mid-flow by hook | `fatal: not a git repository` on next command | Step 3 cwd-anchor (`cd "$MAIN_REPO"` before pull) prevents this. If observed, re-run from the main repo root. |
 
 ## Common Mistakes
 
@@ -222,7 +229,7 @@ git worktree remove "$WORKTREE"
 | Use `git branch --merged` to check if a PR is merged | Never. Squash-merges lie. Use `gh pr view --json state,mergedAt`. |
 | Use lowercase `git branch -d` | Always use `-D`. Squash-merged branches are not merge ancestors of `main`. |
 | Force-delete a worktree with dirty state | Never. Batch A aborts before Batch B runs. |
-| Run cleanup from inside the worktree being deleted | Always cd to the main repo root first (cwd-fix step). |
+| Run cleanup from inside the worktree being deleted | Step 3 anchors cwd to $MAIN_REPO before the pull. If skipped, the rimba hook can delete the cwd mid-flight and strand subsequent commands with "fatal: not a git repository". |
 | Auto-trigger cleanup on merge | Never. Cleanup is user-initiated or explicitly orchestrated. No Stop hooks. |
 | Treat remote-404 as an error | It is success — `auto-delete-head-branches` already removed it. |
 | Use plain `git pull origin main` for the sync | Always `--ff-only`. Plain pull can synthesize a merge commit. |

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -166,6 +166,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Use `(scope):` in commit subject | This repo uses `[type] Subject` not `type(scope): Subject`. Quote the regex. |
 | Append `[no ci]` to a commit touching `commands/foo.md` | The exclusion of `commands/`, `skills/`, `agents/` is load-bearing. |
 | Use `gh pr create --fill` | Use `--body-file <PR template path>` so the `Closes #` line is filled correctly. |
+| Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); <fill template> > "$TMP"; gh pr create --body-file "$TMP"; rm "$TMP"` |
 | Auto-`gh pr create --draft` without asking | Always ask `draft` vs `ready`. Drafts hide the PR from `assignees` and reviewers. |
 
 ## Quick reference

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -166,7 +166,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Use `(scope):` in commit subject | This repo uses `[type] Subject` not `type(scope): Subject`. Quote the regex. |
 | Append `[no ci]` to a commit touching `commands/foo.md` | The exclusion of `commands/`, `skills/`, `agents/` is load-bearing. |
 | Use `gh pr create --fill` | Use `--body-file <PR template path>` so the `Closes #` line is filled correctly. |
-| Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); <fill template> > "$TMP"; gh pr create --body-file "$TMP"; rm "$TMP"` |
+| Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT; <fill template> > "$TMP"; gh pr create --body-file "$TMP"` (trap ensures cleanup on failure too). |
 | Auto-`gh pr create --draft` without asking | Always ask `draft` vs `ready`. Drafts hide the PR from `assignees` and reviewers. |
 
 ## Quick reference

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -135,3 +135,17 @@ class TestHardResetPatternMatch:
     ])
     def test_pattern_does_not_match(self, hook_patterns, cmd):
         assert not grep_matches(hook_patterns["hard_reset"], cmd), f"Expected no match for: {cmd!r}"
+
+
+class TestPrePushHook:
+    """Verify .githooks/pre-push contains the expected invocations."""
+
+    PRE_PUSH = Path(__file__).parent.parent / ".githooks" / "pre-push"
+
+    def test_pre_push_runs_validate(self):
+        content = self.PRE_PUSH.read_text(encoding="utf-8")
+        assert "validate.sh" in content, "pre-push hook must invoke validate.sh"
+
+    def test_pre_push_runs_pytest(self):
+        content = self.PRE_PUSH.read_text(encoding="utf-8")
+        assert "pytest" in content, "pre-push hook must invoke pytest"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -148,4 +148,6 @@ class TestPrePushHook:
 
     def test_pre_push_runs_pytest(self):
         content = self.PRE_PUSH.read_text(encoding="utf-8")
-        assert "pytest" in content, "pre-push hook must invoke pytest"
+        assert "pytest" in content and "tests/" in content, (
+            "pre-push hook must invoke pytest against the tests/ directory"
+        )

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -1,0 +1,141 @@
+"""
+Regression tests for the validate-pr CI issue-reference check.
+
+These tests replicate the strip-then-match pipeline from
+.github/workflows/pr.yml so the logic is verifiable without CI.
+"""
+import re
+
+
+def strip_html_comments(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def has_na_optout(visible: str) -> bool:
+    return bool(
+        re.search(
+            r"^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$",
+            visible,
+            re.IGNORECASE | re.MULTILINE,
+        )
+    )
+
+
+def _na_optout(visible: str) -> bool:
+    """Python-native equivalent of the bash grep -iqE pattern."""
+    return bool(
+        re.search(
+            r"^[ \t]*(Issue:[ \t]+)?N/A([ \t]+[—\-].+)?[ \t]*$",
+            visible,
+            re.IGNORECASE | re.MULTILINE,
+        )
+    )
+
+
+def has_closing_keyword(visible: str) -> bool:
+    return bool(
+        re.search(
+            r"(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+",
+            visible,
+            re.IGNORECASE,
+        )
+    )
+
+
+PR_127_BODY = """\
+## Summary
+<!-- Describe what changed and why. Use bullet points. -->
+-
+
+## Test Plan
+<!-- How did you verify this works? Check the boxes. -->
+- [ ] Changed skills/commands/agents load without errors
+- [ ] Examples in the diff were exercised manually
+- [ ]
+
+<!-- Link to the GitHub issue this PR addresses.
+     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>
+
+     If no issue applies, DELETE the "Closes #" line and replace it with
+     a standalone line:
+         Issue: N/A
+     Preferred (more useful for reviewers):
+         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">
+
+     The following WILL fail CI:
+       - leaving "Closes #" empty with no replacement
+       - deleting the line entirely with nothing in its place
+       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
+Closes #
+"""
+
+BODY_STANDALONE_NA = """\
+## Summary
+- Fixed the thing
+
+## Test Plan
+- [x] Tested manually
+
+Issue: N/A — internal tooling, no user-facing issue
+"""
+
+BODY_WITH_CLOSES = """\
+## Summary
+- Added new feature
+
+## Test Plan
+- [x] Tests pass
+
+Closes #42
+"""
+
+
+class TestStripHtmlComments:
+    def test_removes_single_line_comment(self):
+        assert strip_html_comments("<!-- foo -->bar") == "bar"
+
+    def test_removes_multiline_comment(self):
+        result = strip_html_comments("before\n<!-- \n  multi\n  line\n -->after")
+        assert "Issue: N/A" not in result
+        assert "after" in result
+
+    def test_preserves_text_outside_comments(self):
+        result = strip_html_comments("<!-- hidden -->visible")
+        assert result == "visible"
+
+
+class TestPr127Regression:
+    """PR #127 was merged with unfilled template — validate-pr CI passed incorrectly
+    because 'Issue: N/A' inside an HTML comment matched the opt-out regex."""
+
+    def test_na_inside_comment_does_not_trigger_optout(self):
+        visible = strip_html_comments(PR_127_BODY)
+        assert not _na_optout(visible), (
+            "Issue: N/A inside an HTML comment must NOT trigger the opt-out"
+        )
+
+    def test_na_inside_comment_does_not_match_closing_keyword(self):
+        visible = strip_html_comments(PR_127_BODY)
+        assert not has_closing_keyword(visible), (
+            "'Closes #' with no number must NOT match the closing-keyword pattern"
+        )
+
+
+class TestValidOptout:
+    def test_standalone_na_triggers_optout(self):
+        visible = strip_html_comments(BODY_STANDALONE_NA)
+        assert _na_optout(visible), "Standalone 'Issue: N/A' must trigger the opt-out"
+
+    def test_standalone_na_with_reason_triggers_optout(self):
+        body = "## Summary\n- x\n\nIssue: N/A — internal tooling\n"
+        visible = strip_html_comments(body)
+        assert _na_optout(visible)
+
+    def test_closes_with_number_matches(self):
+        visible = strip_html_comments(BODY_WITH_CLOSES)
+        assert has_closing_keyword(visible), "'Closes #42' must match the closing-keyword pattern"
+
+    def test_fixes_with_number_matches(self):
+        body = "## Summary\n- x\n\nFixes #99\n"
+        visible = strip_html_comments(body)
+        assert has_closing_keyword(visible)

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -8,21 +8,12 @@ import re
 
 
 def strip_html_comments(text: str) -> str:
-    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
-
-
-def has_na_optout(visible: str) -> bool:
-    return bool(
-        re.search(
-            r"^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$",
-            visible,
-            re.IGNORECASE | re.MULTILINE,
-        )
-    )
+    """Strip <!-- ... --> blocks. Unterminated comments are stripped to end-of-string."""
+    return re.sub(r"<!--.*?(?:-->|$)", "", text, flags=re.DOTALL)
 
 
 def _na_optout(visible: str) -> bool:
-    """Python-native equivalent of the bash grep -iqE pattern."""
+    """Python-native equivalent of the bash grep -iqE N/A opt-out pattern."""
     return bool(
         re.search(
             r"^[ \t]*(Issue:[ \t]+)?N/A([ \t]+[—\-].+)?[ \t]*$",
@@ -102,6 +93,18 @@ class TestStripHtmlComments:
     def test_preserves_text_outside_comments(self):
         result = strip_html_comments("<!-- hidden -->visible")
         assert result == "visible"
+
+    def test_unterminated_comment_stripped_to_end(self):
+        body = "## Summary\n- x\n\n<!-- Issue: N/A\n(no closing tag)"
+        result = strip_html_comments(body)
+        assert "Issue: N/A" not in result
+
+    def test_closing_keyword_inside_comment_not_visible(self):
+        body = "## Summary\n- x\n\n<!-- Closes #42 -->\n"
+        visible = strip_html_comments(body)
+        assert not has_closing_keyword(visible), (
+            "'Closes #42' inside an HTML comment must NOT match after stripping"
+        )
 
 
 class TestPr127Regression:


### PR DESCRIPTION
## Summary

- **Fix `validate-pr` CI false-positive**: strip HTML comments from PR body before running the N/A opt-out and closing-keyword regex checks. PR #127 was merged with an unfilled template because `Issue: N/A` inside the template's `<!-- -->` block matched the opt-out regex.
- **Warn against `--body` + `--body-file` in `workflow-commit-and-pr`**: `gh` silently discards `--body` when both flags are given. Documents the correct temp-file substitution pattern with `trap`-based cleanup.
- **Pre-push hook runs pytest**: local test failures are now caught before the network round-trip. Hard-requires python3 + pytest with actionable install hints.
- **`cleanup-merged` Step 3 cwd anchor**: derive `$MAIN_REPO` and `cd` to it before `git pull`, so the rimba post-merge hook deleting the worktree mid-pull cannot strand the shell. Guards against empty `$MAIN_REPO`.

## Test Plan

- [x] `bash scripts/validate.sh` — All checks passed
- [x] `python3 -m pytest tests/` — 212/212 passed (+13 new: 11 PR validation, 2 pre-push hook)
- [x] Local simulate of new `validate-pr` logic against PR #127 body: opt-out does NOT fire, closing-keyword fails as expected
- [x] `git log --oneline main..HEAD` — 5 commits (fix → docs → feat → refactor → fix review)
- [x] `git diff --stat main..HEAD` — 6 files changed

Issue: N/A — internal dev-loop hardening; fixes surfaced during PR #127 lifecycle
