### PR TITLE
[chore] rimba: copy .claude dir and set claude as open agent

### DIFF
--- a/.rimba/settings.toml
+++ b/.rimba/settings.toml
@@ -1,1 +1,4 @@
-copy_files = ['.env', '.env.local', '.envrc', '.tool-versions']
+copy_files = ['.env', '.env.local', '.envrc', '.claude']
+
+[open]
+agent = 'claude'


### PR DESCRIPTION
## Summary
- Replace `.tool-versions` with `.claude` in `copy_files` so new worktrees inherit the Claude Code config directory
- Add `[open]` section with `agent = 'claude'` to set Claude as the default agent when opening a worktree

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] Verified `.rimba/settings.toml` parses correctly

Issue: N/A — config-only update to rimba worktree settings