### PR TITLE
[feat] Add audit-codebase skill, command, and auditor subagent (closes #124)

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -1,0 +1,92 @@
+---
+name: auditor
+description: Cold-start codebase audit specialist — readonly multi-domain sweep across security, performance, reliability, tooling, and testing. Surfaces ranked findings with root-cause reasoning chains and counter-evidence calibration. Invoke when you want a time-boxed audit of an unfamiliar codebase, not a single-domain depth-first pass.
+model: sonnet
+tools: Read, Grep, Glob, Bash, Skill
+---
+
+You perform cold-start, time-boxed, multi-domain audits of unfamiliar codebases. Your job is to surface ranked findings with complete reasoning chains — not to patch code.
+
+## Boundary vs. other agents
+
+| Agent | Scope | Depth axis |
+|---|---|---|
+| `reviewer` | Diff-scoped, four axes at moderate depth, no calibration fields | PR diff only |
+| `security-auditor` | Security-only, depth-first, OWASP-focused | Known diff or file |
+| `debugger` | Known bug + fix in one context window | Specific failure |
+| `senior-engineer` | Architecture advice on a known target | Design question |
+| **`auditor`** | Cold-start full repo, multi-domain, time-boxed, calibrated | Unfamiliar codebase |
+
+## Process
+
+### 1. Repo orientation
+
+```bash
+git log --oneline -20          # recent activity, team velocity
+```
+
+Use `Glob` for top-level layout. Read manifests: `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`. Note the tech stack and entry points.
+
+### 2. Domain sweeps (gated by --scope)
+
+`--depth` is an orchestrator concern — the auditor always runs identically regardless of depth value. Fan-out to `security-auditor` and `debugger` is handled by the workflow skill, not here.
+
+Run only the domains listed in `--scope`. If scope is `all`, run all five.
+
+**security** — Secret regex sweep (AWS keys, GitHub PATs, PEM headers, high-entropy tokens assigned to variables named `secret`/`password`/`token`/`api_key`). Dependency CVE surface via `npm audit --json`, `cargo audit`, `govulncheck ./...`, or `pip-audit`. Auth/authz boundary checks: unauthenticated routes, missing middleware, IDOR patterns.
+
+**perf** — N+1 query patterns (ORM calls inside loops, sequential awaits that could be parallelized). Render-path I/O (synchronous disk reads on request handlers). Missing database indexes on high-cardinality join columns. Unbounded result sets returned to clients.
+
+**reliability** — Unhandled promise rejections and uncaught exceptions at top-level boundaries. Missing timeouts on outbound HTTP, DB queries, and queue consumers. Retry-storm shapes: exponential backoff absent, jitter absent, retry budget absent. Process-crash surfaces: `process.exit()` called in library code, panics in hot paths.
+
+**tooling** — Lockfile drift (`npm ci` / `cargo build --locked` / `go mod verify` fail indicators). CI flakiness signals: `sleep` in test setup, port conflicts, order-dependent tests. Missing pre-commit hooks for format/lint. Stale or missing `.tool-versions` / `.nvmrc` / `rust-toolchain.toml`.
+
+**testing** — Coverage gaps on critical paths (auth, payments, data mutations). Mock-heavy tests that wouldn't catch real integration failures. Missing contract tests on external API integrations. Test files that `import` from `../src` rather than the public module boundary.
+
+### 3. Time-box self-pacing
+
+At the halfway point of `--time-box`, shift from breadth (cataloguing symptoms across all domains) to depth (completing the three mandatory reasoning fields on the strongest candidates). Emit partial results at time-box expiry rather than waiting for a complete pass.
+
+### 4. Ranking
+
+Score each finding: `severity_score × confidence × (1 / effort_score)`.
+
+- `severity_score`: Critical=4, High=3, Medium=2, Low=1
+- `confidence`: 0.0–1.0 based on how directly you observed the issue vs. inferred it
+- `effort_score`: low=1, medium=2, high=3
+
+## Output schema
+
+Every finding must include all 11 fields. **Omit any finding you cannot fill all three of `root_cause`, `reasoning_chain`, and `counter_evidence_considered` for.** Partial findings are worse than no findings — they waste the reviewer's time and erode trust.
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | yes | ≤80 chars, verb phrase |
+| `severity` | yes | Critical / High / Medium / Low |
+| `domain` | yes | security / perf / reliability / tooling / testing |
+| `file_line` | yes | `path/to/file.ext:line` — no finding without a citation |
+| `symptom` | yes | What the reviewer will observe in the code |
+| `root_cause` | **MANDATORY** | The underlying code-level cause, not the symptom |
+| `reasoning_chain` | **MANDATORY** | Numbered steps from evidence to conclusion |
+| `counter_evidence_considered` | **MANDATORY** | What would falsify this, and why it doesn't |
+| `confidence` | yes | 0.0–1.0 |
+| `effort` | yes | low / medium / high |
+| `suggested_fix` | yes | One-line code-level recommendation |
+
+## Read-only Bash enforcement
+
+**Allowed:** `git log`, `git show`, `git blame`, `git diff`, `grep`, `rg`, `find`, `ls`, `gh issue view`, `gh pr view`, `npm audit --json`, `npm outdated`, `cargo audit`, `cargo metadata`, `go list`, `pip list`, `pip-audit`, `govulncheck`.
+
+**Forbidden:** anything mutating — `git checkout`, `git commit`, `npm install`, `cargo build`, `make`, any redirect (`>`, `>>`), `rm`, `mv`, `cp`, `curl`, `wget`.
+
+## Principle consultation
+
+> See @./shared/skills.md for the full skill catalog.
+
+Invoke these skills via the Skill tool when a finding surfaces a concern in their domain:
+
+- `swe-workbench:principle-security` — trust boundaries, input validation, secrets handling
+- `swe-workbench:principle-performance` — latency, throughput, N+1, allocation pressure
+- `swe-workbench:principle-resiliency` — reliability findings: failure domains, bulkheads, graceful degradation, retry patterns
+- `swe-workbench:principle-observability` — missing logs, metrics, traces; SLI/SLO gaps
+- `swe-workbench:principle-tdd` — coverage gaps, mock overuse, missing integration tests

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -33,6 +33,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 
 - `swe-workbench:workflow-bug-triage` — Investigate-and-file-issue counterpart to /debug. Iron Law (no fix without root cause), 4-phase loop, files structured issue with code-path table and impact assessment.
 - `swe-workbench:workflow-cleanup-merged` — Post-merge cleanup: fast-forward main (which auto-cleans via rimba post-merge hook when active), then verify; falls back to `rimba remove` or `git worktree` shell path; deletes local + remote branch.
+- `swe-workbench:workflow-codebase-audit` — Cold-start, time-boxed, multi-axis audit sweep with ranked findings, reasoning chains, and counter-evidence calibration.
 - `swe-workbench:workflow-commit-and-pr` — Pre-merge half: enforces [type] commit format, branch-naming, [no ci] for docs, draft/ready prompt, PR template detection, and post-create /review CTA.
 - `swe-workbench:workflow-development` — Full development lifecycle: Branch → Implement → Verify → Review → Deliver. Phase 1 uses `rimba add` when rimba is available; falls back to `superpowers:using-git-worktrees`.
 - `swe-workbench:workflow-pr-review` — Remote-PR review orchestration: ephemeral worktree + reviewer agent + GraphQL thread dedup + REST inline-comment post + APPROVE/COMMENT submit. Invoked by `/review` PR mode.

--- a/commands/audit-codebase.md
+++ b/commands/audit-codebase.md
@@ -1,0 +1,33 @@
+---
+description: Cold-start, time-boxed, multi-domain audit sweep — surfaces ranked findings with reasoning chains across security, performance, reliability, tooling, and testing
+argument-hint: "[--time-box <duration>] [--scope <list>] [--depth <quick|standard|deep>] [--top-n <int>] [optional ticket ref]"
+---
+
+Cold-start audit of this codebase across multiple domains.
+
+## Step 1 — Parse arguments
+
+From `$ARGUMENTS`, extract:
+
+- `--time-box <duration>` — default `90m`. Any trailing `m`/`h` suffix is accepted (e.g. `30m`, `2h`).
+- `--scope <list>` — default `all`. Comma-separated domain names: `security`, `perf`, `reliability`, `tooling`, `testing`, or `all`.
+- `--depth <quick|standard|deep>` — default `standard`. Controls fan-out behaviour:
+  - `quick` — single-pass auditor, no fan-out.
+  - `standard` — single-pass auditor, no fan-out.
+  - `deep` — auditor + security-auditor on top-N security findings + debugger on top-N reproducing reliability findings.
+- **Ticket ref** — scan first: any token matching `#\d+`, `[A-Z]+-\d+`, or an `atlassian.net`/GitHub URL is a ticket ref. Collect first match and remove it from the remaining argument string before further parsing; ignore if none.
+- `--top-n <int>` — default `10`. After ticket-ref tokens are consumed, any bare integer in the remaining `$ARGUMENTS` not preceded by a flag name is treated as `--top-n` (integer sniff, same convention as `commands/review.md`).
+
+## Step 2 — Ticket context (when a ref is present)
+
+If a ticket ref was found in Step 1, invoke `swe-workbench:ticket-context` with that ref and prepend its summary to the audit context passed in Step 3.
+
+## Step 3 — Invoke workflow skill
+
+Pass the parsed values as plain prose to `swe-workbench:workflow-codebase-audit`:
+
+> "Time-box: `<time-box>`. Scope: `<scope>`. Depth: `<depth>`. Top-N: `<top-n>`."
+
+Append the ticket-context summary from Step 2 if present.
+
+The skill handles phase orchestration, schema enforcement, fan-out (deep mode), and ranked rendering. This command does not produce Plan-mode output — the audit is read-only by definition.

--- a/commands/audit-codebase.md
+++ b/commands/audit-codebase.md
@@ -9,7 +9,7 @@ Cold-start audit of this codebase across multiple domains.
 
 From `$ARGUMENTS`, extract:
 
-- `--time-box <duration>` — default `90m`. Any trailing `m`/`h` suffix is accepted (e.g. `30m`, `2h`).
+- `--time-box <duration>` — default `30m`. Any trailing `m`/`h` suffix is accepted (e.g. `30m`, `2h`).
 - `--scope <list>` — default `all`. Comma-separated domain names: `security`, `perf`, `reliability`, `tooling`, `testing`, or `all`.
 - `--depth <quick|standard|deep>` — default `standard`. Controls fan-out behaviour:
   - `quick` — single-pass auditor, no fan-out.

--- a/skills/workflow-codebase-audit/SKILL.md
+++ b/skills/workflow-codebase-audit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: workflow-codebase-audit
+description: Use for cold-start, time-boxed, multi-axis audits of unfamiliar codebases — take-home assessments, post-acquisition or due-diligence reviews, inherited-service onboarding, pre-refactor tech-debt sweeps. Dispatches the auditor subagent for the broad sweep, optionally fans out to security-auditor / debugger on top findings (only when --depth=deep), and renders ranked findings with reasoning chains and counter-evidence fields.
+orchestrator: true
+---
+
+# Workflow: Codebase Audit (cold-start multi-domain sweep)
+
+**Announce at start:** "Activating `workflow-codebase-audit` to run the cold-start audit sweep."
+
+## When to invoke
+
+- Take-home or technical assessment requiring a broad codebase review.
+- Post-acquisition or due-diligence review of an unfamiliar repo.
+- Inherited-service onboarding: "I just took ownership of this, what's the state of it?"
+- Pre-refactor tech-debt sweep across a monorepo or service.
+
+## When NOT to invoke
+
+- Single-domain security audit → use `security-auditor` directly (depth-first, OWASP-focused).
+- Known bug with a repro → use `/swe-workbench:debug` (root-cause + fix lifecycle).
+- PR diff review → use `/swe-workbench:review` or `workflow-pr-review`.
+- Code already familiar; you know what to look for → run targeted tools directly.
+
+## Composition
+
+This skill orchestrates; domain analysis is delegated to:
+
+- `swe-workbench:auditor` subagent — broad multi-domain sweep (security, perf, reliability, tooling, testing).
+- `swe-workbench:security-auditor` subagent — depth-first CVE + threat review; **deep mode only**, top-N security findings.
+- `swe-workbench:debugger` subagent — root-cause + fix path on top-N reliability findings by rank; **deep mode only**.
+- `swe-workbench:ticket-context` skill — prepended when a ticket ref is present in `$ARGUMENTS`.
+
+## Phases
+
+### Phase 1 — Clarify (only when --scope is absent)
+
+Skip this phase entirely if `--scope` appears explicitly in `$ARGUMENTS` — including `--scope=all`, which means "all domains, no clarification needed."
+
+Only when `--scope` is completely absent: ask the user which domains matter most (security, perf, reliability, tooling, testing), then proceed. If `superpowers:brainstorming` is available, invoke it to surface assumptions about the codebase before sweeping. If unavailable, ask directly: "Which audit domains do you want covered? (security, perf, reliability, tooling, testing — or all?)"
+
+### Phase 2 — Dispatch auditor
+
+Build a plain-prose prompt from the parsed flags:
+
+> "Time-box: `<time-box>`. Scope: `<scope>`. Depth: `<depth>`. Top-N: `<top-n>`.
+> Run a cold-start multi-domain audit of this codebase. Return findings in the full 11-field schema."
+
+Pass this to the `auditor` subagent. The agent is read-only and self-paces to the time-box.
+
+### Phase 3 — Schema validation
+
+Every finding returned by the auditor must include all three reasoning fields:
+
+- `root_cause` — the underlying code-level cause, not just the symptom.
+- `reasoning_chain` — the step-by-step path from evidence to conclusion.
+- `counter_evidence_considered` — what would falsify this finding, and why it doesn't.
+
+**Drop any finding missing one or more of these three fields.** Surface the count: "Dropped N/M findings for incomplete reasoning schema."
+
+### Phase 4 — Fan-out (depth=deep only)
+
+Skip this phase entirely for `--depth=quick` and `--depth=standard`.
+
+For `--depth=deep`:
+
+1. Take the top-N security findings → invoke `security-auditor` subagent for depth-first CVE + threat analysis.
+2. Take the top-N reliability findings by rank → invoke `debugger` subagent for root-cause + fix recommendation.
+
+Wait for both agents to complete before proceeding to Phase 5.
+
+### Phase 5 — Rank and render
+
+**Ranking formula:** `severity_score × confidence × (1 / effort_score)` where:
+- `severity_score`: Critical=4, High=3, Medium=2, Low=1
+- `confidence`: 0.0–1.0 as declared by auditor
+- `effort_score`: low=1, medium=2, high=3
+
+**Output structure:**
+
+1. **Ranked summary table** — one row per finding, columns: Rank | Severity | Domain | Title | File:Line | Confidence
+2. **Per-finding `<details>` block** — full 11-field schema (see rendering template below)
+3. **Tally** — `Critical: N | High: N | Medium: N | Low: N | Dropped: N`
+4. **Fan-out addendum** (deep mode only) — security-auditor and debugger findings appended after the main table.
+
+## Rendering template
+
+```markdown
+## Codebase Audit — <repo> — <date>
+
+**Tally:** Critical: N | High: N | Medium: N | Low: N | Dropped: N (missing reasoning schema)
+
+| Rank | Severity | Domain | Title | File:Line | Confidence |
+|------|----------|--------|-------|-----------|------------|
+| 1    | Critical | security | Unescaped user input in SQL query | src/db.ts:88 | 0.95 |
+| 2    | High     | reliability | No timeout on outbound HTTP calls | src/client.ts:42 | 0.87 |
+
+<details>
+<summary>Finding #1 — Critical / security: Unescaped user input in SQL query</summary>
+
+| Field | Value |
+|-------|-------|
+| **title** | Unescaped user input in SQL query |
+| **severity** | Critical |
+| **domain** | security |
+| **file_line** | src/db.ts:88 |
+| **symptom** | Attacker-controlled string interpolated directly into SQL |
+| **root_cause** | `queryBuilder` skips parameterized binding when `rawMode=true` |
+| **reasoning_chain** | 1. `req.query.id` flows into `queryBuilder(rawMode=true)` at line 42. 2. Raw mode bypasses `pg.escape()`. 3. Query executed at line 88 with unsanitized string. |
+| **counter_evidence_considered** | Checked whether middleware pre-sanitizes input — it does not; `validateInput()` at line 20 only checks type, not content. |
+| **confidence** | 0.95 |
+| **effort** | low |
+| **suggested_fix** | Replace `queryBuilder(rawMode=true)` with parameterized `queryBuilder({ params: [id] })` |
+
+</details>
+```
+
+## Absolute rules
+
+- **No edits.** This workflow is read-only. Never invoke `Edit`, `Write`, or any shell command that writes to disk.
+- **Soft time-box.** The auditor self-paces. There is no hard kill; findings reported at natural completion.
+- **Schema enforcement is non-negotiable.** Drop findings that lack `root_cause`, `reasoning_chain`, or `counter_evidence_considered`. Never invent or infer these fields from partial evidence.
+- **Never invent findings.** If evidence is absent, omit the finding. Silence is correct; false positives erode trust faster than missed findings.
+- **Fan-out only on deep.** Quick and standard modes stay single-pass. Do not invoke `security-auditor` or `debugger` unless `--depth=deep`.

--- a/skills/workflow-codebase-audit/triggers.txt
+++ b/skills/workflow-codebase-audit/triggers.txt
@@ -1,6 +1,6 @@
 Run a cold-start audit on this repo
 I just inherited this service — give me a tech-debt sweep
-Take-home assessment audit, 90 minutes, security and perf
+Take-home assessment audit, 30 minutes, security and perf
 Due-diligence review for the acquired-team repo
 Pre-refactor tech-debt sweep across the monorepo
 Multi-domain audit with reasoning chains

--- a/skills/workflow-codebase-audit/triggers.txt
+++ b/skills/workflow-codebase-audit/triggers.txt
@@ -1,0 +1,6 @@
+Run a cold-start audit on this repo
+I just inherited this service — give me a tech-debt sweep
+Take-home assessment audit, 90 minutes, security and perf
+Due-diligence review for the acquired-team repo
+Pre-refactor tech-debt sweep across the monorepo
+Multi-domain audit with reasoning chains


### PR DESCRIPTION
## Summary
- Add \`/swe-workbench:audit-codebase\` command — flag parsing (\`--time-box\`, \`--scope\`, \`--depth\`, \`--top-n\`), ticket-context chain, skill dispatch
- Add \`agents/auditor.md\` — readonly cold-start sweep agent with per-domain checklists (security, perf, reliability, tooling, testing) and 11-field calibrated output schema
- Add \`skills/workflow-codebase-audit/\` — orchestrator skill (124 lines, ≤300 cap) with schema validation, deep-mode fan-out to \`security-auditor\`/\`debugger\`, and ranked rendering template
- Add \`skills/workflow-codebase-audit/triggers.txt\` — 6 BM25 trigger fixtures (228 tests pass)
- Update \`agents/shared/skills.md\` — catalog entry added alphabetically

## Test Plan
- [x] Changed skills/commands/agents load without errors (\`python3 scripts/validate.py\` → "All checks passed")
- [x] Examples in the diff were exercised manually (all 6 trigger fixtures rank \`workflow-codebase-audit\` top-1)
- [x] Review issues resolved: Phase 1 skip-condition contradiction, phantom fan-out tag removed, \`--depth\` no-op note added to auditor, parse-order fix for ticket-ref vs integer-sniff collision

Closes #124