### PR TITLE
[feat] Symmetric drift guard: validate commands/*.md skill references

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -23,7 +23,7 @@ Isolate this work in a worktree when the scope warrants it (non-trivial changes,
 Run `superpowers:verification-before-completion` before claiming any phase done. Do not advance to Phase 4 until this passes clean.
 
 **Phase 4 — Review**
-Dispatch both reviewers: `superpowers:code-reviewer` (plan-alignment) and the `swe-workbench:reviewer` subagent (diff correctness/security/design). Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
+Dispatch both reviewers: `superpowers:code-reviewer` (plan-alignment) and the `reviewer` subagent (diff correctness/security/design). Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
 Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -181,6 +181,21 @@ def check_agent_skill_refs():
                 )
 
 
+def check_command_skill_refs():
+    """Every `swe-workbench:<id>` in commands/*.md must resolve to skills/<id>/ on disk."""
+    commands_dir = ROOT / "commands"
+    skills_dir = ROOT / "skills"
+    pattern = re.compile(r'`swe-workbench:([\w-]+)`')
+    for cmd_md in sorted(commands_dir.glob("*.md")):
+        text = cmd_md.read_text(encoding="utf-8")
+        for skill_id in set(pattern.findall(text)):
+            if not (skills_dir / skill_id).is_dir():
+                fail(
+                    cmd_md.relative_to(ROOT),
+                    f"references 'swe-workbench:{skill_id}' but skills/{skill_id}/ does not exist",
+                )
+
+
 TEMPLATE_MARKER_RE = re.compile(r'\[\[detect:([a-z][a-z0-9-]*)\]\]')
 
 
@@ -295,6 +310,7 @@ def main():
     check_agents()
     check_commands()
     check_agent_skill_refs()
+    check_command_skill_refs()
     check_catalog_completeness()
     check_template_placeholders()
 


### PR DESCRIPTION
## Summary
- Add `check_command_skill_refs()` to `scripts/validate.py`, mirroring the existing `check_agent_skill_refs()` — same regex, same dedup, same failure-message contract — but targeting `commands/*.md` instead of `agents/*.md`.
- Wire the new check into `main()` immediately after `check_agent_skill_refs()` so CI catches drift on every PR.
- Fix pre-existing notation bug in `commands/implement.md`: `swe-workbench:reviewer` was written in skill backtick notation but is an agent, not a skill — the new check correctly surfaces this; removing the backticks resolves it.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] TDD cycle verified: renamed `skills/ticket-context` → validator did **not** flag commands before the new function; **did** flag all 8 referencing commands after; restored → `All checks passed.`

Closes #73
