### PR TITLE
[ci] Add markdown link checker to PR CI (closes #75)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,3 +96,14 @@ jobs:
           python-version: '3.12'
       - run: pip install -r tests/requirements.txt
       - run: pytest tests/ -v
+
+  markdown-links:
+    name: Markdown link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check markdown links (lychee)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .lychee.toml './**/*.md'
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,16 @@
+# Markdown link checker config — used by .github/workflows/pr.yml
+# and runnable locally as `lychee .` from the repo root.
+
+# Skip all HTTP/HTTPS resolution; only validate filesystem paths and
+# relative links. Issue #75 scoped external URL checking out to avoid
+# CI flakiness from rate limits and transient failures.
+offline = true
+
+# Don't print per-link progress; CI logs are noisy enough.
+no_progress = true
+
+# Paths to skip when discovering markdown.
+exclude_path = [
+  "node_modules",
+  ".git",
+]


### PR DESCRIPTION
## Summary
- Add `lycheeverse/lychee-action@v2` as a new parallel `markdown-links` job in `.github/workflows/pr.yml`
- Add `.lychee.toml` at repo root with `offline = true` — validates only filesystem paths, no external URL checks (avoids rate-limit flakiness per #75)
- Relative markdown links now fail the build before merge; `.git` and `node_modules` are excluded from discovery

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `lychee --config .lychee.toml './**/*.md'` runs clean (exit 0) on current repo — 16 links, 0 errors
- [x] Negative test: broken link exits non-zero and reports `[ERROR] File not found`
- [x] YAML syntax validated via `python3 -c "import yaml; yaml.safe_load(...)"`

Closes #75
