### PR TITLE
[chore] Replace core.hooksPath with per-file symlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ After cloning, run the setup script once:
 ./scripts/setup.sh
 ```
 
-This sets `core.hooksPath` to the absolute path of `.githooks/`, ensuring hooks fire from linked worktrees as well as the main checkout.
+This installs per-file symlinks in `.git/hooks/` pointing at `.githooks/`. The default git location is used (no `core.hooksPath` config), so the setup is resistant to tools that reset that key.
+
+> **Note:** If a new hook is added to `.githooks/`, re-run `./scripts/setup.sh` to install its symlink.
 
 ## Branch naming
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,16 @@
 #!/bin/sh
-git config core.hooksPath "$(git rev-parse --show-toplevel)/.githooks"
-echo "Git hooks enabled (.githooks/)"
+set -e
+ROOT="$(git rev-parse --show-toplevel)"
+GIT_DIR="$(git rev-parse --git-dir)"
+case "$GIT_DIR" in /*) ;; *) GIT_DIR="$ROOT/$GIT_DIR" ;; esac
+
+# Remove any stale core.hooksPath — symlinks in the default location handle it.
+git -C "$ROOT" config --unset core.hooksPath 2>/dev/null || true
+
+mkdir -p "$GIT_DIR/hooks"
+for src in "$ROOT"/.githooks/*; do
+  name=$(basename "$src")
+  ln -sfn "../../.githooks/$name" "$GIT_DIR/hooks/$name"
+done
+
+echo "Git hooks linked: .git/hooks/<name> -> ../../.githooks/<name>"


### PR DESCRIPTION
## Summary
- Replace `core.hooksPath` git config with per-file symlinks in `.git/hooks/` pointing at `.githooks/`
- `setup.sh` now unsets any stale `core.hooksPath` and runs `ln -sfn` for each hook — idempotent on re-runs
- Add note to `CONTRIBUTING.md`: re-run `setup.sh` when a new hook is added to `.githooks/`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Ran `./scripts/setup.sh` — confirmed `core.hooksPath` unset (exit=1), all four symlinks resolve to `.githooks/`
- [x] Committed on a feature branch — `pre-commit` and `commit-msg` hooks fired correctly

Issue: N/A — eliminates silent hook failure mode caused by tools resetting core.hooksPath
