### PR TITLE
[feat] Wire principle-concurrency & principle-observability into agents (closes #79)

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -52,8 +52,6 @@ Call this out even when the minimal fix does not address it. Silence signals the
 
 ## Principle consultation
 
-> See @./shared/skills.md for the full skill catalog.
-
 Invoke these skills via the Skill tool when the diagnosis surfaces a concern in their domain:
 
 - `swe-workbench:principle-solid` — responsibility, substitutability, dependency direction

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -58,6 +58,7 @@ Invoke these skills via the Skill tool when the diagnosis surfaces a concern in 
 
 - `swe-workbench:principle-solid` — responsibility, substitutability, dependency direction
 - `swe-workbench:principle-clean-architecture` — boundaries, layering, dependency rule
+- `swe-workbench:principle-concurrency` — race conditions, deadlock, missing cancellation propagation, ordering bugs, memory-model surprises
 
 ## Available skills
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -78,3 +78,5 @@ Invoke these skills via the Skill tool when the review surfaces a concern in the
 - `swe-workbench:principle-performance` — hot-path allocations, N+1 queries, algorithmic complexity
 - `swe-workbench:principle-resiliency` — partial failure, bulkheads, graceful degradation, health-check correctness
 - `swe-workbench:principle-accessibility` — semantic HTML, ARIA usage, keyboard navigation, focus management, contrast, screen-reader compatibility
+- `swe-workbench:principle-concurrency` — race conditions, deadlocks, missing synchronization, lost cancellation propagation
+- `swe-workbench:principle-observability` — log/metric/trace gaps, structured-logging hygiene, cardinality blowups, alerting on causes vs symptoms

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -47,3 +47,4 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-solid` — responsibility, coupling, open-closed
 - `swe-workbench:principle-performance` — latency vs throughput, profile-first, scalability trade-offs
 - `swe-workbench:principle-resiliency` — failure domains, fault isolation, degradation strategy, blast radius
+- `swe-workbench:principle-observability` — SLI/SLO selection, what to instrument at boundaries, alerting on symptoms vs causes

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -338,6 +338,7 @@ def main():
     check_command_skill_refs()
     check_catalog_completeness()
     check_template_placeholders()
+    check_unwired_principle_skills()
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -294,6 +294,31 @@ def check_catalog_completeness():
                  " — add: '> See @./shared/skills.md for the full skill catalog.'")
 
 
+def check_unwired_principle_skills():
+    """Every skills/principle-*/ must be referenced by at least one agent
+    (excluding agents/shared/skills.md which is the catalog and references all skills)."""
+    skills_dir = ROOT / "skills"
+    agents_dir = ROOT / "agents"
+
+    principle_skills = sorted(
+        p.name for p in skills_dir.glob("principle-*")
+        if (p / "SKILL.md").is_file()
+    )
+
+    agent_files = sorted(agents_dir.glob("*.md"))
+
+    for skill_id in principle_skills:
+        needle = f"`swe-workbench:{skill_id}`"
+        wired = any(needle in f.read_text(encoding="utf-8") for f in agent_files)
+        if not wired:
+            fail(
+                Path("agents") / "<unwired>",
+                f"principle skill 'swe-workbench:{skill_id}' is not referenced by any "
+                f"agent in agents/*.md — wire it into a relevant agent's "
+                f"'## Principle consultation' list",
+            )
+
+
 # ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -295,17 +295,21 @@ def check_catalog_completeness():
 
 
 def check_unwired_principle_skills():
-    """Every skills/principle-*/ must be referenced by at least one agent
-    (excluding agents/shared/skills.md which is the catalog and references all skills)."""
+    """Every skills/principle-*/ must be referenced by at least one agent.
+
+    agents/shared/skills.md (the catalog) is explicitly excluded — it lists
+    every skill by design and must not count as a wiring reference.
+    """
     skills_dir = ROOT / "skills"
     agents_dir = ROOT / "agents"
+    catalog = agents_dir / "shared" / "skills.md"
 
     principle_skills = sorted(
         p.name for p in skills_dir.glob("principle-*")
         if (p / "SKILL.md").is_file()
     )
 
-    agent_files = sorted(agents_dir.glob("*.md"))
+    agent_files = sorted(f for f in agents_dir.rglob("*.md") if f != catalog)
 
     for skill_id in principle_skills:
         needle = f"`swe-workbench:{skill_id}`"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -631,3 +631,22 @@ class TestCheckUnwiredPrincipleSkills:
         )
         validate.check_unwired_principle_skills()
         assert len(validate.FAILURES) == 0
+
+    def test_catalog_reference_alone_does_not_satisfy_wiring(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"principle-foo": "---\nname: principle-foo\ndescription: d\n---\n"},
+            # No agents written — the auto-generated catalog at agents/shared/skills.md
+            # will contain the skill id, but that must not count as a wiring reference.
+        )
+        validate.check_unwired_principle_skills()
+        assert any("principle-foo" in f for f in validate.FAILURES)
+
+    def test_principle_dir_without_skill_md_is_ignored(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        # principle-bare/ exists on disk but has no SKILL.md — must not register
+        (root / "skills" / "principle-bare").mkdir(parents=True, exist_ok=True)
+        validate.check_unwired_principle_skills()
+        assert len(validate.FAILURES) == 0

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -576,3 +576,58 @@ class TestCheckSkillTriggerFixtures:
         _skill_with_triggers(root, "my-skill", f"short prompt\n{long_line}\n")
         validate.check_skill_trigger_fixtures()
         assert any("line exceeds 200 chars" in f for f in validate.FAILURES)
+
+
+# ──────────────────────────────────────────────
+# check_unwired_principle_skills
+# ──────────────────────────────────────────────
+
+class TestCheckUnwiredPrincipleSkills:
+    def _agent_body(self, extra=""):
+        return (
+            "---\nname: my-agent\ndescription: d\ntools: Read, Skill\n---\n"
+            "\n> See @./shared/skills.md for the full skill catalog.\n"
+            + extra
+        )
+
+    def test_wired_principle_skill_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"principle-foo": "---\nname: principle-foo\ndescription: d\n---\n"},
+        )
+        agents_dir = root / "agents"
+        (agents_dir / "my-agent.md").write_text(
+            self._agent_body("\n- `swe-workbench:principle-foo` — rationale\n"),
+            encoding="utf-8",
+        )
+        validate.check_unwired_principle_skills()
+        assert len(validate.FAILURES) == 0
+
+    def test_unwired_principle_skill_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"principle-foo": "---\nname: principle-foo\ndescription: d\n---\n"},
+        )
+        agents_dir = root / "agents"
+        (agents_dir / "my-agent.md").write_text(
+            self._agent_body(),  # no reference to principle-foo
+            encoding="utf-8",
+        )
+        validate.check_unwired_principle_skills()
+        assert any("principle-foo" in f and "not referenced" in f for f in validate.FAILURES)
+
+    def test_non_principle_skill_unwired_does_not_fail(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"language-foo": "---\nname: language-foo\ndescription: d\n---\n"},
+        )
+        agents_dir = root / "agents"
+        (agents_dir / "my-agent.md").write_text(
+            self._agent_body(),  # no reference to language-foo — check should ignore it
+            encoding="utf-8",
+        )
+        validate.check_unwired_principle_skills()
+        assert len(validate.FAILURES) == 0


### PR DESCRIPTION
## Summary
- Add `check_unwired_principle_skills()` to `scripts/validate.py` — every `skills/principle-*/` must be referenced by ≥1 agent in `agents/*.md` (catalog `agents/shared/skills.md` explicitly excluded)
- Add `TestCheckUnwiredPrincipleSkills` (5 tests) to `tests/test_validate.py` covering wired/unwired/non-principle/catalog-exclusion/missing-SKILL.md cases
- Wire `principle-concurrency` into `agents/reviewer.md` and `agents/debugger.md`
- Wire `principle-observability` into `agents/reviewer.md` and `agents/senior-engineer.md`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` → 233 passed (5 new in `TestCheckUnwiredPrincipleSkills`)
- [x] `bash scripts/validate.sh` → "All checks passed."
- [x] Drift-guard sanity: removing all principle-concurrency bullets from agents → validator fails with exact skill id + "not referenced" message

Closes #79
