### PR TITLE
[feat] Add principle-event-driven skill (closes #88)

### DIFF
--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -45,6 +45,7 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-data-modeling` — storage paradigm selection, normalization, schema evolution, query-first design
 - `swe-workbench:principle-ddd` — bounded contexts, aggregates, ubiquitous language
 - `swe-workbench:principle-api-design` — contracts, versioning, idempotency
+- `swe-workbench:principle-event-driven` — event sourcing, CQRS, sagas, schema evolution, idempotent consumers, DLQ
 - `swe-workbench:principle-solid` — responsibility, coupling, open-closed
 - `swe-workbench:principle-performance` — latency vs throughput, profile-first, scalability trade-offs
 - `swe-workbench:principle-resiliency` — failure domains, fault isolation, degradation strategy, blast radius

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -13,6 +13,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:principle-ddd` — Domain-Driven Design: bounded contexts, aggregates, ubiquitous language, domain events.
 - `swe-workbench:principle-design-patterns` — Design patterns: GoF catalog — Strategy, Factory, Observer, Decorator, Adapter, and more.
 - `swe-workbench:principle-error-handling` — Error handling: errors as values, classification, wrapping, retry, circuit breakers.
+- `swe-workbench:principle-event-driven` — Event-driven architecture: event sourcing, CQRS, sagas, schema evolution, consumer groups, DLQ, idempotent handlers.
 - `swe-workbench:principle-i18n` — Internationalization & localization: locale-aware formatting, time zones, plural rules, message catalogs, RTL layout, ISO 8601, currency.
 - `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
 - `swe-workbench:principle-performance` — Performance: latency vs throughput, profile-before-optimize, Big-O, allocation pressure, data locality, N+1 queries.

--- a/skills/principle-event-driven/SKILL.md
+++ b/skills/principle-event-driven/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: principle-event-driven
+description: Event-driven architecture — event sourcing, CQRS, sagas, choreography vs orchestration, schema evolution, consumer groups, partitions, ordering, idempotent handlers, outbox pattern, dead letter queues. Auto-load when designing event-driven systems, evaluating event sourcing or CQRS, planning saga workflows, evolving event schemas across consumers, configuring consumer groups or partitions, implementing idempotent consumers or the outbox pattern, managing dead letter queues, or assessing whether event-driven architecture fits the problem.
+---
+
+# Event-Driven Architecture
+
+The log is the source of truth: producers emit immutable events; consumers react asynchronously. This decouples services at deployment and operational boundaries and lets new consumers replay history — at the cost of eventual consistency and significantly more failure surface area than synchronous calls.
+
+## Event Sourcing
+
+Store every state change as an immutable event; derive current state by replaying the log. The aggregate's current state is a projection, not the record of truth.
+
+- Snapshots cap replay cost: persist a projected state checkpoint every N events and replay only from the latest snapshot.
+- Projections are disposable — design them to be rebuilt by replaying; avoid hand-rolled caches that drift from the log.
+- Event store must be append-only; mutating or deleting events destroys the audit trail and breaks replaying consumers.
+- GDPR erasure: store PII in a side-table and tombstone the key rather than mutating event history.
+
+## CQRS (Command Query Responsibility Segregation)
+
+Separate the write model (commands that mutate state) from the read model (queries over projections). Often paired with event sourcing but independent of it.
+
+- Read replicas can be denormalized and tuned for specific query shapes without polluting the write model.
+- Consistency lag between write and read models is a feature contract, not a bug — document the SLA.
+- Avoid CQRS in simple CRUD services; indirection cost exceeds benefit until query and write shapes diverge significantly.
+
+## Sagas — Choreography vs Orchestration
+
+Long-running transactions spanning services must be modeled as sagas with explicit compensation steps.
+
+**Choreography** — each service emits events and reacts to others; no central coordinator.
+- Low coupling; hard to trace and debug as the workflow grows beyond two or three participants.
+
+**Orchestration** — a central saga orchestrator drives the workflow and issues commands to participants.
+- Easier observability and rollback reasoning; introduces a single point of coordination and coupling.
+- Prefer orchestration when compensation logic is non-trivial or the workflow has more than three participants.
+
+Compensation steps must be idempotent — the orchestrator may retry them on failure.
+
+## Event Schema Evolution
+
+Consumers and producers deploy independently; schema drift causes silent deserialization failures.
+
+- **Backward-compatible changes** (add optional field): safe to deploy producer first.
+- **Conditionally breaking** (add enum value): safe only if all consumers tolerate unknown values (e.g., JSON Schema with a catch-all default); for Avro or Protobuf under BACKWARD compatibility, treat as breaking — require a versioned event type and a dual-publish period.
+- **Breaking changes** (rename field, remove field, change type): require a versioned event type and a dual-publish period.
+- Prefer a schema registry (Confluent Schema Registry, AWS Glue) over ad-hoc JSON to enforce compatibility rules at publish time.
+- Never rely on field ordering; always deserialize by name.
+
+## Consumer Groups, Partitions, and Ordering
+
+- Ordering is guaranteed only within a partition; partition by a key that co-locates events that must be ordered (e.g., all events for a given `entity_id` on the same partition).
+- Consumer group parallelism is bounded by partition count — you cannot have more active consumers than partitions.
+- Rebalance storms on group membership changes cause in-flight delays; use static group membership where supported.
+- Cross-partition ordering requires application-level sequencing (vector clocks or monotonic sequence numbers).
+
+## Idempotent Handlers and the Outbox Pattern
+
+At-least-once delivery is the broker default; consumers must handle duplicate events without producing duplicate side effects.
+
+- Use a stable event ID as the deduplication key; see `principle-api-design#Idempotency` for the storage pattern.
+- The **outbox pattern** ensures atomicity between a database write and event publication: write the event to an `outbox` table in the same transaction as the domain change; a relay process publishes it to the broker. Eliminates the dual-write problem.
+- For idempotency key design see `principle-api-design#Idempotency`; for retry budgets before DLQ routing see `principle-error-handling#Retries and Backoff`.
+
+## Dead Letter Queues and Poison Messages
+
+A dead letter queue (DLQ) is the fail-soft path for unprocessable messages — see `principle-resiliency#Fail-Fast vs Fail-Soft`.
+
+- Always configure a DLQ; without one a poison message halts the entire partition indefinitely.
+- Emit a structured alert on every DLQ write — silent DLQs hide data loss.
+- Preserve the original payload, headers, and metadata so messages are replayable after the root cause is fixed.
+- Define a replay SLA: stale DLQ messages replayed into a later system state may apply out-of-order effects.
+
+## When Event-Driven Architecture is Overkill
+
+- Simple CRUD with a single service and database; REST or RPC is cheaper and easier to reason about.
+- Strong consistency required across the operation — sagas with compensation add complexity without benefit.
+- Team has no operational experience with brokers; the operational burden exceeds the decoupling gain.
+- Low event volume (fewer than hundreds per day); a message broker adds infrastructure cost for no throughput benefit.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| No partition key strategy | Events for the same entity land on different partitions; ordering lost |
+| Dual-write without outbox | Crash between DB write and broker publish causes silent data loss |
+| No DLQ configured | Poison message halts the partition; data backs up without alerting |
+| Schema changes without versioning | Consumers fail silently on unexpected field shapes |
+| Choreography saga with no compensating events | Partial failures leave distributed state permanently inconsistent |
+| Idempotency check absent on consumer | At-least-once delivery produces duplicate side effects |
+| Cross-partition ordering assumed without sequencing | Ordering guarantee breaks silently across partitions or brokers |

--- a/skills/principle-event-driven/triggers.txt
+++ b/skills/principle-event-driven/triggers.txt
@@ -1,6 +1,6 @@
 # Representative trigger prompts for principle-event-driven
-how do I use the outbox pattern to avoid dual-write data loss when publishing events after a database transaction
-should I use choreography or orchestration for a saga that spans three services and needs compensation on partial failure
+how does the outbox pattern prevent event sourcing failures when consumers and producers need exactly-once effective delivery
+should sagas use choreography or orchestration when coordinating event-driven workflows across consumers that require compensation
 my consumers are receiving duplicate events — how do I design idempotent handlers to avoid double-processing side effects
-how should I version event schemas so adding new fields does not break existing consumers that were deployed earlier
-when does event-driven architecture add more complexity than it solves compared to synchronous REST or RPC calls
+how do schema evolution strategies help when evolving event schemas across consumer groups without breaking existing consumers
+what signals indicate that event-driven architecture is overkill when sagas and dead letter queues add more complexity than they solve

--- a/skills/principle-event-driven/triggers.txt
+++ b/skills/principle-event-driven/triggers.txt
@@ -1,0 +1,6 @@
+# Representative trigger prompts for principle-event-driven
+how do I use the outbox pattern to avoid dual-write data loss when publishing events after a database transaction
+should I use choreography or orchestration for a saga that spans three services and needs compensation on partial failure
+my consumers are receiving duplicate events — how do I design idempotent handlers to avoid double-processing side effects
+how should I version event schemas so adding new fields does not break existing consumers that were deployed earlier
+when does event-driven architecture add more complexity than it solves compared to synchronous REST or RPC calls

--- a/tests/skill_sibling_sets.txt
+++ b/tests/skill_sibling_sets.txt
@@ -7,7 +7,9 @@
 #   - Document the rationale in the same commit that adds the entry.
 #   - Never pre-populate as a shortcut to avoid fixing a drifted description.
 
-# Both skills discuss repository pattern, domain layers, and bounded contexts.
-# A question like "should the repository live in the domain or infrastructure layer?"
-# legitimately belongs to either skill.
-principle-clean-architecture, principle-ddd
+# principle-clean-architecture and principle-ddd share repository pattern, domain
+# layers, and bounded contexts. principle-event-driven joins the group because domain
+# events are a DDD tactical pattern AND the core primitive of event-driven systems —
+# a prompt like "how do I model a domain event for a state transition?" legitimately
+# belongs to any of these three skills.
+principle-clean-architecture, principle-ddd, principle-event-driven


### PR DESCRIPTION
## Summary
- Add `skills/principle-event-driven/SKILL.md` — 91-line rubric covering event sourcing, CQRS, sagas (choreography vs orchestration), schema evolution, consumer groups, idempotent handlers, outbox pattern, and DLQs
- Add `skills/principle-event-driven/triggers.txt` — 5 BM25 trigger prompts tuned to description vocabulary
- Register `swe-workbench:principle-event-driven` in `agents/shared/skills.md` catalog (alphabetically after `principle-error-handling`)
- Wire into `agents/senior-engineer.md` `## Principle consultation` list (required by validator)
- Add `principle-event-driven` to sibling set with `principle-ddd` in `tests/skill_sibling_sets.txt` (domain-event overlap is intentional)
- Fix enum-value schema evolution claim to be accurate for Avro/Protobuf BACKWARD compatibility mode

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python scripts/validate.py` exits 0, all checks passed
- [x] `pytest tests/test_validate.py` — 59/59 passed
- [x] `pytest tests/test_skill_triggers.py` — 135/135 passed (including 5 new principle-event-driven trigger cases)
- [x] SKILL.md is 91 lines (target ≤95, hard cap 150)
- [x] Cross-links verified: `principle-api-design#Idempotency`, `principle-error-handling#Retries and Backoff`, `principle-resiliency#Fail-Fast vs Fail-Soft`

Closes #88
