### PR TITLE
[feat] New skill: principle-testing (closes #92)

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -89,4 +89,5 @@ Invoke these skills via the Skill tool when a finding surfaces a concern in thei
 - `swe-workbench:principle-performance` — latency, throughput, N+1, allocation pressure
 - `swe-workbench:principle-resiliency` — reliability findings: failure domains, bulkheads, graceful degradation, retry patterns
 - `swe-workbench:principle-observability` — missing logs, metrics, traces; SLI/SLO gaps
-- `swe-workbench:principle-tdd` — coverage gaps, mock overuse, missing integration tests
+- `swe-workbench:principle-tdd` — test-first discipline, red-green-refactor violations, F.I.R.S.T. failures
+- `swe-workbench:principle-testing` — coverage gaps, mock overuse, missing integration tests, flaky tests, test pyramid imbalance

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -35,3 +35,4 @@ Invoke these skills via the Skill tool when the refactoring touches their domain
 - `swe-workbench:principle-clean-code` — naming smells, DRY, function length
 - `swe-workbench:principle-solid` — responsibility splits, coupling
 - `swe-workbench:principle-design-patterns` — when a pattern fits the smell being removed
+- `swe-workbench:principle-testing` — characterization tests before touching legacy code, coverage audit, test data builders

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -81,3 +81,4 @@ Invoke these skills via the Skill tool when the review surfaces a concern in the
 - `swe-workbench:principle-concurrency` — race conditions, deadlocks, missing synchronization, lost cancellation propagation
 - `swe-workbench:principle-observability` — log/metric/trace gaps, structured-logging hygiene, cardinality blowups, alerting on causes vs symptoms
 - `swe-workbench:principle-i18n` — locale-aware formatting, time zones, plural rules, translatable string composition, RTL layout
+- `swe-workbench:principle-testing` — missing coverage on new branches, brittle tests, tests that mirror implementation rather than behavior, flaky tests, mock overuse

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -21,6 +21,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:principle-security` — Security: trust boundaries, input validation, secrets handling, secure defaults, threat modeling.
 - `swe-workbench:principle-solid` — SOLID principles: SRP, OCP, LSP, ISP, DIP — responsibility, coupling, abstractions.
 - `swe-workbench:principle-tdd` — TDD: red-green-refactor, test-first, F.I.R.S.T., Arrange-Act-Assert.
+- `swe-workbench:principle-testing` — Testing strategy: test pyramid, doubles taxonomy, coverage-vs-confidence, mutation testing, flaky-test triage, contract testing, fixtures and builders, property-based tests.
 
 ## Languages
 

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -24,6 +24,8 @@ Read at least one existing test file before writing — match the repo's style, 
 
 Invoke `swe-workbench:principle-tdd` via the Skill tool before writing any test for the full red-green-refactor discipline and "What to test" checklist.
 
+Invoke `swe-workbench:principle-testing` for test pyramid balance, doubles taxonomy, coverage-vs-confidence, flaky-test triage, and contract testing.
+
 ## What to test
 
 - **Behavior** — not implementation. "Returns total with tax" survives refactor; "calls foo then bar" does not.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -36,6 +36,7 @@
 | `principle-ddd` | "DDD", "domain-driven", "bounded context", "aggregate", "value object", "ubiquitous language". |
 | `principle-solid` | "SOLID", "single responsibility", "open-closed", "Liskov", "interface segregation", "dependency inversion". |
 | `principle-tdd` | "TDD", "test-driven", "red green refactor", "unit test", "test first". |
+| `principle-testing` | "test pyramid", "test double", "mock", "stub", "fake", "fixture", "coverage", "mutation testing", "flaky", "contract test", "property-based test", "characterization test". |
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |

--- a/skills/principle-testing/SKILL.md
+++ b/skills/principle-testing/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: principle-testing
+description: Testing strategy and architecture — test pyramid (unit / integration / e2e), test doubles taxonomy (stub / mock / spy / fake), coverage-vs-confidence, mutation testing, flaky-test triage, contract testing, property-based and characterization tests, fixtures and test data builders. Distinct from principle-tdd which covers the red-green-refactor micro-cycle. Auto-load when discussing test strategy, mock vs real dependency, coverage adequacy, test pyramid balance, flaky test diagnosis, contract testing, or test architecture.
+---
+
+# Testing Strategy and Architecture
+
+Strategy and architecture, not the red-green-refactor discipline. For that, see `principle-tdd`.
+
+## The pyramid
+
+Three tiers, wide base up: **unit → integration → e2e**. Baseline ratio: ~70% unit, ~20% integration, ~10% e2e — adjust toward more integration for infrastructure-heavy systems, more e2e for UI-heavy products.
+
+Inverting the pyramid (heavy e2e, thin unit) produces a slow, brittle suite — e2e tests amplify flakiness and punish every external dependency.
+
+- **Unit** — one class or function, no I/O, milliseconds.
+- **Integration** — two or more collaborators, real infrastructure (DB, message bus), seconds.
+- **e2e** — full stack through the UI or API gateway; minutes.
+
+Prefer more granular tests. One integration test that exercises a migration is worth more than five e2e tests covering the same path.
+
+## Test doubles
+
+Five kinds (Meszaros's xUnit Patterns taxonomy). State-based: Stub, Fake. Behavior-verification: Spy, Mock. Dummy is a degenerate no-op.
+
+| Double | What it does | When to use |
+|--------|-------------|-------------|
+| Dummy | Passed but never called | Satisfying required params |
+| Stub | Returns canned responses | Isolating the path under test |
+| Fake | Working implementation (e.g. in-memory DB) | Fast integration tests |
+| Spy | Records calls for post-hoc assertion | Verifying interactions |
+| Mock | Pre-programmed expectations; fails on violation | Strict boundary contracts |
+
+**Mock only at trust boundaries**: network, clock, filesystem, random, external services. The seam is domain ↔ infrastructure (Clean Architecture's dependency rule). Everything inside the domain is instantiated for real.
+
+If a collaborator is hard to instantiate, that is a design signal — recommend a refactor, not a mock.
+
+## Coverage vs confidence
+
+Line coverage is a metric, not a quality signal. 90% coverage with assertions only on getters is worthless; 60% coverage with well-targeted branch assertions is not.
+
+**Mutation testing** measures kill rate — surviving mutants reveal assertions that don't bind to observable behavior. Tools: Stryker (JS/TS), mutmut (Python), cargo-mutants (Rust), PIT (Java).
+
+Aim to kill 80%+ mutants in business-critical paths. Don't chase line count; chase surviving mutants.
+
+## Flaky tests
+
+Three root causes:
+
+1. **Shared mutable state** — tests leave rows, cache entries, or global flags for later tests.
+2. **Time / order dependence** — assertions on wall clock, ordering assumptions, race conditions.
+3. **Undeclared external dependency** — network calls, filesystem paths, env vars not controlled.
+
+Quarantine without root-cause is debt. A `@retry` annotation hides the diagnosis. Fix the cause; delete the annotation.
+
+## Contract testing
+
+Consumer-driven contracts let a consumer codify the shape of the responses it needs; the provider verifies it on every build. Tools: Pact, Spring Cloud Contract. Pact supports both HTTP and message (async/event-driven) contracts — the latter matters when services communicate via queues or event buses.
+
+When to use: microservices where a fast unit suite still leaves an integration crater. Not a substitute for integration tests — a complement that shifts verification left.
+
+## Fixtures and builders
+
+Magic values defeat readability. A fluent builder makes intent explicit:
+
+- `createUser(30, "active")` — what does 30 mean?
+- `UserBuilder().with_age(30).with_status("active").build()` — obvious.
+
+One builder per aggregate root. Keep factories close to tests, not scattered across setUp methods.
+
+## Property-based and characterization tests
+
+**Property-based** — generate hundreds of inputs and assert invariants hold for all. Finds edge cases example-based tests miss. Tools: Hypothesis (Python), fast-check (JS), proptest (Rust), jqwik (Java).
+
+**Characterization tests** — lock in existing behavior of legacy code before refactoring. Write them first; use them as a safety net.
+
+## When testing hurts
+
+- One-off scripts and CLI wrappers — integration cost exceeds value.
+- Exploratory spikes — spike, discard, then TDD the real thing.
+- Testing the framework rather than your use of it (asserting that `express()` routes middleware).
+- Prototypes you're prepared to throw away.
+
+## Common Excuses — and Why They're Wrong
+
+| Excuse | Reality |
+|--------|---------|
+| "90% coverage means we're well tested" | Coverage measures execution, not correctness. Surviving mutants reveal the gaps coverage hides. |
+| "Mocking the DB is faster to write" | A mock proves the code compiles, not that it works with a real store. Use a fake or a real DB. |
+| "e2e tests prove the system works end-to-end" | They prove the happy path when green. They obscure which layer failed when red. |
+| "This flaky test is just CI noise" | Noise is a symptom. The root cause is untested state or an undeclared dependency. |
+
+## Red Flags — Stop and Reassess
+
+- Mock-heavy unit suite with zero integration tests — no evidence the parts work together.
+- Tests that bind to private methods or internal call sequences.
+- 90%+ line coverage with production bugs that slipped through critical paths.
+- `@retry` / `--flaky` annotations with no linked root-cause ticket.
+- Contract changes caught only in staging or production.
+- Test setup longer than the test itself — extract builders.
+
+## If You Catch Yourself Thinking…
+
+| Thought | What to Do Instead |
+|---------|-------------------|
+| "I'll just mock the whole database" | Use a fake (in-memory) or a real DB in a container. Mocks prove nothing about SQL. |
+| "Retry will fix the flakiness" | Quarantine to a separate CI job and open a ticket. Then fix the root cause. Retries and skips both hide the bug. |
+| "More e2e tests = more confidence" | Invert: more integration tests = faster feedback. Reserve e2e for critical user journeys. |
+| "We have great coverage, we're safe" | Run mutation tests on the critical path. Kill rate tells the truth. |

--- a/skills/principle-testing/triggers.txt
+++ b/skills/principle-testing/triggers.txt
@@ -1,0 +1,8 @@
+# Trigger fixtures for principle-testing
+# These emphasize strategy, pyramid, mock-vs-real, coverage, flakiness, and contract testing
+# — intentionally distinct from principle-tdd triggers (red-green-refactor, AAA, F.I.R.S.T.)
+How do I decide the right shape for my test pyramid and measure whether my coverage actually catches bugs using mutation testing
+Should I mock the database in this integration test or stand up a real one for confidence on the migration
+We have ninety percent line coverage but production bugs still slip through how do I diagnose missing branch coverage
+How do I identify a flaky test that fails randomly due to shared mutable state or timing in my test suite
+How do I decide when to use a stub versus a fake versus a real dependency and where contract testing fits in my test pyramid


### PR DESCRIPTION
## Summary
- New principle skill `principle-testing` covering test pyramid, test doubles taxonomy, coverage-vs-confidence, mutation testing, flaky-test triage, contract testing, fixtures/builders, and property-based tests
- Distinct from `principle-tdd` (red-green-refactor micro-cycle) — scope boundary enforced in frontmatter description and skill body
- Wired into `test-writer`, `auditor`, `reviewer`, and `refactorer` agents; catalog entry added to `agents/shared/skills.md` and `docs/catalog.md`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` → All checks passed
- [x] `pytest tests/` → 238/238 passed (includes BM25 trigger ranking for all 5 fixtures)

Closes #92
