### PR TITLE
[refactor] cleanup-merged: extract bash blocks into shell scripts

### DIFF
--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -191,14 +191,11 @@ If `$RIMBA remove` exits non-zero, run a filesystem probe as the canonical signa
 
 *Batch A — Locate Worktree + Safety Checks*
 
-Combine the worktree locate and both git safety checks into one shell. Emit exactly three fields:
+Run the companion script and eval its `KEY=VALUE` output:
 
 ```bash
-WORKTREE=$(git worktree list --porcelain \
-  | awk '/^worktree /{p=$2} /^branch refs\/heads\/<headRefName>$/{print p; exit}')
-DIRTY=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" status --porcelain | grep -c . || echo 0)
-UNPUSHED=$([ -n "$WORKTREE" ] && git -C "$WORKTREE" log @{upstream}..HEAD --oneline 2>/dev/null | grep -c . || echo 0)
-printf 'WORKTREE=%s\nDIRTY=%s\nUNPUSHED=%s\n' "$WORKTREE" "$DIRTY" "$UNPUSHED"
+_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+eval "$("$_SCRIPTS/probe-worktree.sh" "<headRefName>")"
 ```
 
 - `WORKTREE`: matching worktree path, or empty if none (skip Batch B when empty).

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -56,44 +56,20 @@ If the session is currently inside a worktree (e.g. entered via `EnterWorktree p
 
 If `EnterWorktree` was never called this session (or the `ExitWorktree` tool is unavailable), this step is a no-op — proceed to 3b without aborting.
 
-**3b. Derive `$MAIN_REPO` and anchor the shell.** The rimba post-merge hook fires during the pull below and deletes any merged worktree — including the one this skill may be running from. Anchoring before the pull keeps the cwd valid regardless:
+**3b+3c. Anchor cwd, sync local main, and verify hook cleanup** with the companion script:
 
 ```bash
-MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
-[ -n "$MAIN_REPO" ] || { echo "sync-main: could not resolve main repo path — aborting" >&2; exit 1; }
-cd "$MAIN_REPO"
+_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>")"
 ```
 
-**3c. Sync local main** so the merge commit is visible on `main` and the next branch cut starts from a current tip:
-
-```bash
-(git checkout main && git pull --ff-only origin main) \
-  || echo "sync-main: best-effort failed — reconcile main manually"
-```
-
-`--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
+The script: anchors the shell to the main repo root (so the rimba hook cannot strand a deleted cwd), runs `git checkout main && git pull --ff-only origin main` (best-effort — sync failure warns to stderr but does not abort), then checks whether the hook already removed the worktree and local branch. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
 
 When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast path)`), `git pull` fires the hook as a side-effect, which removes the merged worktree and local branch automatically. A sync failure on the fast path forces fall-through to the rimba-binary or shell strategy — it does NOT abort cleanup.
 
-For all other paths, sync failure is best-effort: a warning is recorded in the report and cleanup proceeds.
-
 ### Step 4 — Remove Worktree
 
-After Step 3 sync, run the verification gate to check whether the rimba post-merge hook already cleaned up the worktree and local branch. `$MAIN_REPO` is set during Step 3 and must be in scope here — run this gate in the **same bash invocation** as Step 3b so the variable remains defined:
-
-```bash
-WORKTREE_FOUND=$(git worktree list --porcelain \
-  | awk '/^branch refs\/heads\/<headRefName>$/{print 1; exit}')
-if git -C "$MAIN_REPO" rev-parse --verify "refs/heads/<headRefName>" 2>/dev/null; then
-  BRANCH_FOUND=1
-else
-  BRANCH_FOUND=
-fi
-WORKTREE_GONE=0
-[ -z "$WORKTREE_FOUND" ] && [ -z "$BRANCH_FOUND" ] && WORKTREE_GONE=1
-```
-
-(`WORKTREE_FOUND` is `1` when the worktree is present, empty when absent. Same for `BRANCH_FOUND`. The gate fires when both are empty — i.e., both are already gone. `refs/heads/` prefix prevents a same-named tag or remote ref from being mistaken for a live local branch.)
+`sync-and-verify.sh` (Step 3) emits `WORKTREE_GONE=0|1` into the shell environment via `eval`.
 
 - **`WORKTREE_GONE=1`**: both the worktree and local branch are already gone — the hook did its job. No further action is needed in Step 4; skip Step 5 and proceed directly to Step 6.
 - **`WORKTREE_GONE=0`**: hook did not fire (or rimba refused due to dirty/unpushed state). Select a removal strategy from `## Worktree Removal Strategies` below. Execute only the first strategy whose preconditions hold.

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -134,16 +134,12 @@ Execute the first strategy whose preconditions hold. Fall through to the next if
 
 **Preconditions — both must hold:**
 
-1. `core.hooksPath` resolves to a directory containing an executable `post-merge` file that invokes `rimba clean --merged --force`. Detection (uses `$MAIN_REPO` from Step 3):
+1. `core.hooksPath` resolves to a directory containing an executable `post-merge` file that invokes `rimba clean --merged --force`. Detection:
    ```bash
-   HOOKS_DIR=$(git -C "$MAIN_REPO" config --get core.hooksPath || echo "$MAIN_REPO/.git/hooks")
-   case "$HOOKS_DIR" in /*) ;; *) HOOKS_DIR="$MAIN_REPO/$HOOKS_DIR" ;; esac
-   HOOK_FILE="$HOOKS_DIR/post-merge"
-   RIMBA_HOOK_ACTIVE=0
-   [ -x "$HOOK_FILE" ] && grep -qE '^[^#]*rimba clean --merged --force' "$HOOK_FILE" \
-     && RIMBA_HOOK_ACTIVE=1
+   _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+   eval "$("$_SCRIPTS/check-rimba-hook.sh")"
    ```
-   `RIMBA_HOOK_ACTIVE=1` is required. (The grep excludes comment-only lines so a documented-but-disabled invocation does not yield a false positive.)
+   `RIMBA_HOOK_ACTIVE=1` is required. (The grep inside the script excludes comment-only lines so a documented-but-disabled invocation does not yield a false positive.)
 2. After Step 3 sync, HEAD on `$MAIN_REPO` is on `main` (the hook's own branch guard requires it).
 
 **Procedure:**

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -160,11 +160,9 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 
 **Preconditions:**
 - rimba MCP server is active in the session, OR the rimba binary resolves on PATH or a known install location:
-  ```sh
-  RIMBA=$(command -v rimba 2>/dev/null \
-    || { [ -x "$HOME/.local/bin/rimba" ] && echo "$HOME/.local/bin/rimba"; } \
-    || { [ -x "$HOME/go/bin/rimba" ]     && echo "$HOME/go/bin/rimba"; } \
-    || true)
+  ```bash
+  _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+  RIMBA=$("$_SCRIPTS/resolve-rimba.sh")
   ```
   `RIMBA` must be non-empty (or MCP server active).
 

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -56,14 +56,14 @@ If the session is currently inside a worktree (e.g. entered via `EnterWorktree p
 
 If `EnterWorktree` was never called this session (or the `ExitWorktree` tool is unavailable), this step is a no-op — proceed to 3b without aborting.
 
-**3b+3c. Anchor cwd, sync local main, and verify hook cleanup** with the companion script:
+**3b. Anchor cwd, sync local main, and verify hook cleanup** with the companion script:
 
 ```bash
 _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
 eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>")"
 ```
 
-The script: anchors the shell to the main repo root (so the rimba hook cannot strand a deleted cwd), runs `git checkout main && git pull --ff-only origin main` (best-effort — sync failure warns to stderr but does not abort), then checks whether the hook already removed the worktree and local branch. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
+The script: derives `MAIN_REPO=` (main worktree root via `git worktree list --porcelain`), anchors the shell there so the rimba hook cannot strand a deleted cwd, then runs `git checkout main && git pull --ff-only origin main` (best-effort — sync failure warns to stderr but does not abort), then checks whether the hook already removed the worktree and local branch. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
 
 When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast path)`), `git pull` fires the hook as a side-effect, which removes the merged worktree and local branch automatically. A sync failure on the fast path forces fall-through to the rimba-binary or shell strategy — it does NOT abort cleanup.
 

--- a/skills/workflow-cleanup-merged/scripts/check-rimba-hook.sh
+++ b/skills/workflow-cleanup-merged/scripts/check-rimba-hook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Checks whether the rimba post-merge hook is installed and active.
+# Stdout contract: RIMBA_HOOK_ACTIVE=0|1
+# Exit non-zero only if $MAIN_REPO cannot be resolved.
+set -euo pipefail
+
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+[ -n "${MAIN_REPO:-}" ] || { echo "check-rimba-hook: could not resolve main repo path" >&2; exit 1; }
+
+HOOKS_DIR=$(git -C "$MAIN_REPO" config --get core.hooksPath 2>/dev/null || echo "$MAIN_REPO/.git/hooks")
+case "$HOOKS_DIR" in
+  /*) ;;
+  *) HOOKS_DIR="$MAIN_REPO/$HOOKS_DIR" ;;
+esac
+
+HOOK_FILE="$HOOKS_DIR/post-merge"
+RIMBA_HOOK_ACTIVE=0
+[ -x "$HOOK_FILE" ] && grep -qE '^[^#]*rimba clean --merged --force' "$HOOK_FILE" \
+  && RIMBA_HOOK_ACTIVE=1
+
+printf 'RIMBA_HOOK_ACTIVE=%s\n' "$RIMBA_HOOK_ACTIVE"

--- a/skills/workflow-cleanup-merged/scripts/check-rimba-hook.sh
+++ b/skills/workflow-cleanup-merged/scripts/check-rimba-hook.sh
@@ -15,7 +15,9 @@ esac
 
 HOOK_FILE="$HOOKS_DIR/post-merge"
 RIMBA_HOOK_ACTIVE=0
-[ -x "$HOOK_FILE" ] && grep -qE '^[^#]*rimba clean --merged --force' "$HOOK_FILE" \
-  && RIMBA_HOOK_ACTIVE=1
+# Use if/fi so set -e doesn't fire when grep finds no match (grep exits 1 on no-match)
+if [ -x "$HOOK_FILE" ] && grep -qE '^[^#]*rimba clean --merged --force' "$HOOK_FILE" 2>/dev/null; then
+  RIMBA_HOOK_ACTIVE=1
+fi
 
 printf 'RIMBA_HOOK_ACTIVE=%s\n' "$RIMBA_HOOK_ACTIVE"

--- a/skills/workflow-cleanup-merged/scripts/probe-worktree.sh
+++ b/skills/workflow-cleanup-merged/scripts/probe-worktree.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Locates the worktree for a given branch and runs dirty/unpushed safety checks.
+# Usage: probe-worktree.sh <head_ref>
+# Stdout contract: WORKTREE=<path|empty>\nDIRTY=N\nUNPUSHED=N
+set -euo pipefail
+
+HEAD_REF="${1:?Usage: probe-worktree.sh <head_ref>}"
+
+WORKTREE=$(git worktree list --porcelain \
+  | awk '/^worktree /{p=$2} /^branch refs\/heads\/'"$HEAD_REF"'$/{print p; exit}')
+
+if [ -n "${WORKTREE:-}" ]; then
+  DIRTY=$(git -C "$WORKTREE" status --porcelain | grep -c . || echo 0)
+  UNPUSHED=$(git -C "$WORKTREE" log "@{upstream}..HEAD" --oneline 2>/dev/null | grep -c . || echo 0)
+else
+  DIRTY=0
+  UNPUSHED=0
+fi
+
+printf 'WORKTREE=%s\nDIRTY=%s\nUNPUSHED=%s\n' "${WORKTREE:-}" "$DIRTY" "$UNPUSHED"

--- a/skills/workflow-cleanup-merged/scripts/probe-worktree.sh
+++ b/skills/workflow-cleanup-merged/scripts/probe-worktree.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 
 HEAD_REF="${1:?Usage: probe-worktree.sh <head_ref>}"
 
+# Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF
 WORKTREE=$(git worktree list --porcelain \
-  | awk '/^worktree /{p=$2} /^branch refs\/heads\/'"$HEAD_REF"'$/{print p; exit}')
+  | awk -v ref="branch refs/heads/$HEAD_REF" '/^worktree /{p=$2} $0 == ref {print p; exit}')
 
 if [ -n "${WORKTREE:-}" ]; then
   DIRTY=$(git -C "$WORKTREE" status --porcelain | grep -c . || echo 0)
@@ -17,4 +18,5 @@ else
   UNPUSHED=0
 fi
 
-printf 'WORKTREE=%s\nDIRTY=%s\nUNPUSHED=%s\n' "${WORKTREE:-}" "$DIRTY" "$UNPUSHED"
+# %q shell-quotes WORKTREE so eval in the caller handles paths with spaces safely
+printf 'WORKTREE=%q\nDIRTY=%s\nUNPUSHED=%s\n' "${WORKTREE:-}" "$DIRTY" "$UNPUSHED"

--- a/skills/workflow-cleanup-merged/scripts/resolve-rimba.sh
+++ b/skills/workflow-cleanup-merged/scripts/resolve-rimba.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Resolves the rimba binary path, or prints nothing if absent.
+# Stdout contract: rimba binary path on stdout, or empty string if not found.
+# Exit non-zero only on a hard error (not on "rimba not installed").
+set -euo pipefail
+
+RIMBA=$(command -v rimba 2>/dev/null \
+  || { [ -x "$HOME/.local/bin/rimba" ] && echo "$HOME/.local/bin/rimba"; } \
+  || { [ -x "$HOME/go/bin/rimba" ]     && echo "$HOME/go/bin/rimba"; } \
+  || true)
+
+printf '%s\n' "${RIMBA:-}"

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -18,9 +18,10 @@ cd "$MAIN_REPO"
   || echo "sync-main: best-effort failed — reconcile main manually" >&2
 
 # Block C: verification gate — check whether hook already cleaned up
+# Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF
 WORKTREE_FOUND=$(git worktree list --porcelain \
-  | awk '/^branch refs\/heads\/'"$HEAD_REF"'$/{print 1; exit}')
-if git -C "$MAIN_REPO" rev-parse --verify "refs/heads/$HEAD_REF" 2>/dev/null; then
+  | awk -v ref="branch refs/heads/$HEAD_REF" '$0 == ref {print 1; exit}')
+if git rev-parse --verify "refs/heads/$HEAD_REF" 2>/dev/null; then
   BRANCH_FOUND=1
 else
   BRANCH_FOUND=

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Anchors cwd to the main repo, syncs local main, and checks whether the
+# rimba post-merge hook already cleaned up the given branch.
+# Usage: sync-and-verify.sh <head_ref>
+# Stdout contract: WORKTREE_GONE=0|1
+# Exit non-zero only if $MAIN_REPO cannot be resolved.
+set -euo pipefail
+
+HEAD_REF="${1:?Usage: sync-and-verify.sh <head_ref>}"
+
+# Block A: derive $MAIN_REPO and anchor cwd
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+[ -n "${MAIN_REPO:-}" ] || { echo "sync-and-verify: could not resolve main repo path — aborting" >&2; exit 1; }
+cd "$MAIN_REPO"
+
+# Block B: sync local main (best-effort — failure warns, does not abort)
+(git checkout main && git pull --ff-only origin main) \
+  || echo "sync-main: best-effort failed — reconcile main manually" >&2
+
+# Block C: verification gate — check whether hook already cleaned up
+WORKTREE_FOUND=$(git worktree list --porcelain \
+  | awk '/^branch refs\/heads\/'"$HEAD_REF"'$/{print 1; exit}')
+if git -C "$MAIN_REPO" rev-parse --verify "refs/heads/$HEAD_REF" 2>/dev/null; then
+  BRANCH_FOUND=1
+else
+  BRANCH_FOUND=
+fi
+
+WORKTREE_GONE=0
+[ -z "${WORKTREE_FOUND:-}" ] && [ -z "${BRANCH_FOUND:-}" ] && WORKTREE_GONE=1
+
+printf 'WORKTREE_GONE=%s\n' "$WORKTREE_GONE"


### PR DESCRIPTION
## Summary

- Extracts 4 gnarly multi-line bash blocks from `skills/workflow-cleanup-merged/SKILL.md` into companion shell scripts under `skills/workflow-cleanup-merged/scripts/`
- SKILL.md drops from 259 → 225 lines; each script invocation is a two-liner `eval` that restores the same shell variables
- Fixes discovered during review: awk regex metachar injection in branch names (use `-v ref=` string match), `grep -qE` abort under `set -e` in `&&`-chain, and unquoted `WORKTREE` paths in `eval` (use `%q`)

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `shellcheck skills/workflow-cleanup-merged/scripts/*.sh` — 0 issues
- [x] `bash scripts/validate.sh` — all checks passed
- [x] `python3 -m pytest tests/test_cleanup_merged_skill.py -v` — 5/5 passed

Issue: N/A — refactor of skill internals, no user-facing behavior change
