### PR TITLE
[feat] Add SQL language skill

### DIFF
--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -32,6 +32,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:language-kotlin` — Kotlin idioms: null safety, coroutines, sealed interfaces, scope functions, Flow.
 - `swe-workbench:language-python` — Python idioms: PEP 8, type hints, dataclasses, asyncio, generators, pytest.
 - `swe-workbench:language-rust` — Rust idioms: ownership, borrowing, lifetimes, traits, iterators, error handling.
+- `swe-workbench:language-sql` — SQL idioms: query optimization, EXPLAIN plans, schema design, transactions, window functions, CTEs, and pagination.
 - `swe-workbench:language-swift` — Swift idioms: optionals, value types, actors, async/await, protocols, Result builders.
 - `swe-workbench:language-typescript` — TypeScript/JavaScript idioms: strict mode, discriminated unions, async patterns, Node.
 

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -32,7 +32,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:language-kotlin` — Kotlin idioms: null safety, coroutines, sealed interfaces, scope functions, Flow.
 - `swe-workbench:language-python` — Python idioms: PEP 8, type hints, dataclasses, asyncio, generators, pytest.
 - `swe-workbench:language-rust` — Rust idioms: ownership, borrowing, lifetimes, traits, iterators, error handling.
-- `swe-workbench:language-sql` — SQL idioms: query optimization, EXPLAIN plans, schema design, transactions, window functions, CTEs, and pagination.
+- `swe-workbench:language-sql` — SQL idioms: query optimization, EXPLAIN plans, schema design, transactions, deadlock avoidance, window functions, CTEs, and pagination.
 - `swe-workbench:language-swift` — Swift idioms: optionals, value types, actors, async/await, protocols, Result builders.
 - `swe-workbench:language-typescript` — TypeScript/JavaScript idioms: strict mode, discriminated unions, async patterns, Node.
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -51,6 +51,7 @@
 
 | Skill | Triggers |
 |---|---|
+| `language-sql` | `.sql` files, migration files; keywords: SQL, SELECT, JOIN, EXPLAIN, CTE, window function, transaction isolation, deadlock, pagination. |
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-java` | `.java` files, `pom.xml`, `build.gradle`, keywords: Java, JVM, Spring, Maven, Gradle, records, sealed classes, virtual threads. |
 | `language-kotlin` | `.kt` files, `build.gradle.kts`, keywords: Kotlin, coroutines, suspend, StateFlow, sealed interface, Kotlin DSL. |

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: language-sql
+description: SQL idioms - query tuning, EXPLAIN plans, table definitions, constraints, indexes, transactions, window functions, CTEs, and pagination. Auto-load when working with .sql files or migrations, or when the user mentions SQL syntax, SELECT, JOIN, EXPLAIN, CTE, window functions, transaction isolation, deadlocks, or SQL indexes.
+---
+
+# SQL
+
+## Query optimization basics
+- Start with the access pattern: filters, joins, grouping, sorting, and result size.
+- Index columns used for selective `WHERE`, join keys, and stable `ORDER BY` clauses.
+- Prefer narrow projections over `SELECT *`; return only the columns callers need.
+- Avoid accidental row multiplication in joins; check cardinality before adding `DISTINCT`.
+- Watch for N+1 query loops at application boundaries.
+
+## EXPLAIN and EXPLAIN ANALYZE
+- Use `EXPLAIN` to inspect the planned access path before changing indexes or query shape.
+- Use `EXPLAIN ANALYZE` when you need actual timing and row counts; run it against safe data and statements.
+- Compare estimated vs actual rows. Large gaps often mean stale statistics, skewed data, or missing predicates.
+- Optimize the highest-cost operation first, but confirm the full query got faster.
+
+## Schema design
+- Model durable facts, not current screens. Let queries influence indexes, not table names.
+- Choose primary keys deliberately; use foreign keys for integrity unless there is a measured reason not to.
+- Normalize to remove update anomalies, then denormalize only for proven read pressure.
+- Encode invariants with constraints: `NOT NULL`, `UNIQUE`, `CHECK`, and referential actions.
+- Plan migrations as expand-and-contract changes when existing clients need compatibility.
+
+## Transactions and isolation
+- Keep transactions short; do not wait on users or remote services while holding locks.
+- Pick the weakest isolation level that preserves correctness for the workflow.
+- Know the anomalies you are allowing: dirty reads, non-repeatable reads, phantoms, and write skew.
+- Use optimistic concurrency with version columns when conflicts are rare and retriable.
+
+## Deadlock avoidance
+- Touch shared tables and rows in a consistent order across code paths.
+- Lock only what you need, as late as possible, and commit as soon as the invariant is protected.
+- Add retry logic for deadlock and serialization failures; they are expected under contention.
+- Index foreign keys and hot predicates so updates do not scan and lock more rows than intended.
+
+## Window functions
+- Use window functions for rankings, running totals, deduplication, and "top N per group" queries.
+- Keep `PARTITION BY` and `ORDER BY` explicit; frame clauses matter for aggregates.
+
+```sql
+SELECT customer_id, order_id, total,
+       row_number() OVER (
+         PARTITION BY customer_id
+         ORDER BY created_at DESC
+       ) AS recency_rank
+FROM orders;
+```
+
+## CTEs vs subqueries
+- Use CTEs to name meaningful intermediate results or reuse the same derived relation.
+- Use subqueries when the scope is local and the surrounding query stays readable.
+- Check your database's optimizer behavior; some engines inline CTEs, others may materialize them.
+- Do not use CTEs as a performance hint unless the engine documents that behavior.
+
+## Pagination patterns
+- Prefer keyset pagination for large or frequently changing result sets.
+- Use `LIMIT`/`OFFSET` only for small, stable lists; deep offsets get slower and can skip or duplicate rows.
+- Make ordering deterministic with a unique tie-breaker.
+
+```sql
+SELECT id, customer_id, created_at, total
+FROM orders
+WHERE (created_at, id) < (:last_created_at, :last_id)
+ORDER BY created_at DESC, id DESC
+LIMIT 50;
+```
+
+## Avoid
+- Schema changes without rollback or compatibility planning.
+- Unbounded queries in production paths.
+- Relying on implicit ordering without `ORDER BY`.
+- Building SQL with string concatenation and untrusted input; use parameters.

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -73,4 +73,4 @@ LIMIT 50;
 - Schema changes without rollback or compatibility planning.
 - Unbounded queries in production paths.
 - Relying on implicit ordering without `ORDER BY`.
-- Building SQL with string concatenation and untrusted input; use parameters.
+- Never build SQL by concatenating untrusted input — use parameterized queries or prepared statements. ORM raw-query escape hatches (e.g. Django's `extra()`, SQLAlchemy's `text()`) are equally dangerous. See `swe-workbench:principle-security`.

--- a/skills/language-sql/triggers.txt
+++ b/skills/language-sql/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-sql
+how do I optimize this SQL query using EXPLAIN ANALYZE and better indexes
+should this report query use a CTE, subquery, or window function for pagination
+what transaction isolation level should I use to avoid deadlocks in this SQL workflow
+review this schema design for constraints indexes and migration safety


### PR DESCRIPTION
## Summary
- Add `language-sql` skill covering SQL query and schema engineering guidance.
- Include guidance for query tuning, EXPLAIN plans, schema constraints, transaction isolation, deadlock avoidance, window functions, CTEs, and pagination.
- Add trigger prompts and register the skill in `agents/shared/skills.md`.

## Test Plan
- [x] Changed skills/commands/agents load without errors: `python scripts/validate.py`
- [x] Skill trigger ranking checks: `python3 -m pytest tests/test_skill_triggers.py -q`
- [ ] Full test suite: attempted locally; 267 passed, 2 unrelated Windows/Git Bash hook-pattern tests failed in `tests/test_hooks.py`
- [ ] Examples in the diff were exercised manually

Closes #94
