### PR TITLE
[feat] Add principle consultation to product-manager agent (closes #80)

### DIFF
--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -80,9 +80,15 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
 - Does not manage a backlog, roadmap, or quarterly plan. Capture only.
 - Does not prioritize across multiple issues. One thought → one issue.
 
-## Available skills
+## Principle consultation
 
-See @./shared/skills.md for the full skill catalog.
+> See @./shared/skills.md for the full skill catalog.
+
+Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
+
+- `swe-workbench:principle-api-design` — API contract decisions, versioning, idempotency, REST/RPC/event surface choices
+- `swe-workbench:principle-ddd` — bounded contexts, ubiquitous language, domain scope of the proposed feature
+- `swe-workbench:principle-security` — threat surface of the proposed feature, trust boundaries, auth/authz implications
 
 ## Output format
 


### PR DESCRIPTION
## Summary
- Replace the stub `## Available skills` section in `agents/product-manager.md` with a canonical `## Principle consultation` block
- Wires `principle-api-design`, `principle-ddd`, and `principle-security` — matching the pattern already in `architect.md` and `senior-engineer.md` (PR #63)
- The blockquote pointer to `@./shared/skills.md` subsumes the old `## Available skills` reference, eliminating duplication

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python scripts/validate.py` exits 0 with the three new skill refs resolving correctly
- [x] `python -m pytest tests/test_validate.py -q` — 59 passed

Closes #80
