### PR TITLE
[fix] Prevent temp-file re-glob in capture / product-manager

### DIFF
--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -51,7 +51,7 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
      ## Additional context
      ```
 
-7. **Write temp file.** Derive `<repo-slug>` from the `nameWithOwner` value, replacing `/` with `-` and stripping any character outside `[a-zA-Z0-9_-]`. Write the drafted body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool. Also write a one-line command file to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` containing the exact `gh issue create --title "..." --body-file <path>` command (title double-quoted, path absolute). Do NOT run `gh issue create` yet.
+7. **Write temp file.** Derive `<repo-slug>` from the `nameWithOwner` value, replacing `/` with `-` and stripping any character outside `[a-zA-Z0-9_-]`. Obtain a Unix timestamp once via `date +%s` and store it — reuse the same value for both filenames below; never re-derive or re-glob. Write the drafted body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (never via Bash heredoc). Also write a one-line command file to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool, containing the exact `gh issue create --title "..." --body-file <absolute-path>` command (title double-quoted, path absolute and matching the body file written above). Do NOT run `gh issue create` yet.
 
 8. **Preview gate.** Print the following to the user and wait. Do NOT execute on this turn:
    ```

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -23,7 +23,7 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
 6. **Draft.** With a template: fill its sections, prepend `## Product framing`. Without a template: use `## Problem` / `## Value` / `## Acceptance criteria` / `## Impact / Effort` / `## Additional context`.
 
-7. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<timestamp>.md` using the `Write` tool (not a Bash heredoc), then print:
+7. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write the exact `gh issue create --title "..." --body-file <path>` command to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool. Then print:
    ```
    Filing into: <owner>/<repo>
    Template: <chosen template> | none — default body
@@ -39,4 +39,4 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
    ```
    **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
-8. **File on confirm.** Only when the user replies `confirm`, run the exact printed command and return the issue URL.
+8. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 7 and run it exactly as written — do not regenerate the title or path. Return the issue URL.

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -23,7 +23,7 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
 6. **Draft.** With a template: fill its sections, prepend `## Product framing`. Without a template: use `## Problem` / `## Value` / `## Acceptance criteria` / `## Impact / Effort` / `## Additional context`.
 
-7. **Preview gate.** Write the body to `/tmp/capture-<repo-slug>-<timestamp>.md`, then print:
+7. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<timestamp>.md` using the `Write` tool (not a Bash heredoc), then print:
    ```
    Filing into: <owner>/<repo>
    Template: <chosen template> | none — default body


### PR DESCRIPTION
## Summary

- `product-manager.md` step 7: obtain timestamp once via `date +%s`, reuse for both the body file and `.cmd` sidecar — never re-derive or re-glob.
- Both files: enforce `Write` tool over Bash heredoc so the file path is always deterministic.

## Root cause

A prior `/capture` session wrote the body to `/tmp/capture-swe-workbench-<timestamp>.md` via a Bash heredoc, then re-found it with `ls /tmp/capture-swe-workbench-*.md | tail -1`. A stale file from a different session (`capture-swe-workbench-rimba.md`) sorted last alphabetically, so the wrong body was filed as issue #160. The `.cmd` sidecar pattern (step 9 reads the pre-written command verbatim) was already the right defense; this closes the one remaining gap where two independently derived timestamps could produce mismatched filenames.

Closes #160

## Test plan

- [ ] Run `/capture` in a repo that has a stale `/tmp/capture-*` file from a prior session — confirm the preview and filed issue use the correct body.
- [ ] Confirm `product-manager` step 9 reads the `.cmd` sidecar and runs it verbatim without regenerating the path.