### PR TITLE
[perf] Reduce token footprint: cheaper agents + tighter ticket-context

### DIFF
--- a/agents/dependency-auditor.md
+++ b/agents/dependency-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: dependency-auditor
 description: Dependency audit specialist — manifest-graph axis covering outdated versions, deprecation, license compatibility, transitive bloat, and lockfile drift across Node, Rust, Go, and Python ecosystems. Invoke when you want a focused supply-chain hygiene report, not a code-level CVE review.
-model: sonnet
+model: haiku
 tools: Read, Grep, Glob, Bash, Skill
 ---
 

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 description: Product-thinking persona that turns a rough thought (idea, improvement, bug-report) into a well-framed GitHub issue on the user's current repository. Applies four lightweight lenses — problem, value, acceptance criteria, Impact/Effort — discovers issue templates at runtime, classifies into whatever templates the repo has (or falls back to a default body when none exist), and files via `gh issue create` only after explicit user confirmation. Works in any repo where the swe-workbench plugin is installed.
-model: sonnet
+model: haiku
 tools: Read, Write, Grep, Bash, Skill
 ---
 

--- a/agents/tech-writer.md
+++ b/agents/tech-writer.md
@@ -1,7 +1,7 @@
 ---
 name: tech-writer
 description: Documentation author — generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments from diffs and conversation context, matching the repo's existing tone and conventions. Invoke when documentation is missing, stale, or drifting from code.
-model: sonnet
+model: haiku
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer
 description: Test author — writes focused, behavioural tests in language-idiomatic style. One behaviour per test, AAA, no mocks at internal boundaries. Invoke when adding tests for a function, module, or change set the user points to.
-model: sonnet
+model: haiku
 tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,5 @@
 - [catalog.md](catalog.md) — commands, subagents, and skills (full tables).
 - [extending.md](extending.md) — how to add new skills; philosophy behind the design.
 - [dependencies.md](dependencies.md) — runtime plugin dependencies.
+- [cost-audit.md](cost-audit.md) — point-in-time model-tier audit (snapshot at #160).
+- [cost-tiers.md](cost-tiers.md) — forward-looking convention for assigning model tiers to new agents.

--- a/docs/cost-audit.md
+++ b/docs/cost-audit.md
@@ -8,7 +8,7 @@
 
 ## Agents
 
-All 14 agents ship with `model: sonnet` at audit time. None invoke the `Agent` or `Task` tool — subagent spawning is exclusively via the orchestrating Claude session.
+All 14 agents shipped with `model: sonnet` at audit time. Four (dependency-auditor, product-manager, tech-writer, test-writer) were flipped to `model: haiku` in this PR; see the Recommended tier column. None invoke the `Agent` or `Task` tool (verified by `grep -r 'Agent\|Task' agents/ --include='*.md'` at snapshot) — subagent spawning is exclusively via the orchestrating Claude session.
 
 | Surface | Path | Current model | Spawns subagents? | Recommended tier | Notes |
 |---|---|---|---|---|---|
@@ -16,7 +16,7 @@ All 14 agents ship with `model: sonnet` at audit time. None invoke the `Agent` o
 | architect | `agents/architect.md` | sonnet | No | M–L | ADR/RFC authoring; multi-system reasoning; keep on sonnet |
 | auditor | `agents/auditor.md` | sonnet | No | M–L | Multi-domain cold-start sweep; calibration and counter-evidence require reasoning |
 | debugger | `agents/debugger.md` | sonnet | No | M | Delegates investigation to `systematic-debugging` skill; fix is minimal but judgment-bearing |
-| dependency-auditor | `agents/dependency-auditor.md` | sonnet | No | **S → haiku** | Reads manifests, reports versions/licenses; mechanical extraction, low reasoning density. Watch: license-compatibility edge cases (SPDX vs. policy) may need a revert window |
+| dependency-auditor | `agents/dependency-auditor.md` | sonnet | No | **S → haiku** | Reads manifests, reports versions/licenses; mechanical extraction, low reasoning density. Watch window: GPL/AGPL transitive in MIT projects, SSPL/BUSL/Commons-Clause, per-version license changes, dev-only vs. production viral scope — any relational license judgment that misclassifies to lower severity is a revert trigger. |
 | migrator | `agents/migrator.md` | sonnet | No | M–L | Expand-backfill-switch-contract reasoning across deployments; phase correctness is high-stakes |
 | performance-tuner | `agents/performance-tuner.md` | sonnet | No | M | Profile-driven; delegates to `principle-performance` skill; hotspot ranking requires judgment |
 | product-manager | `agents/product-manager.md` | sonnet | No | **S → haiku** | Formats rough ideas into structured GitHub issues; template discovery + fill is mechanical |
@@ -25,7 +25,7 @@ All 14 agents ship with `model: sonnet` at audit time. None invoke the `Agent` o
 | security-auditor | `agents/security-auditor.md` | sonnet | No | L | OWASP depth-first; exploitability assessment requires strong reasoning |
 | senior-engineer | `agents/senior-engineer.md` | sonnet | No | L | Architectural advice; trade-off synthesis; one-way-door assessment |
 | tech-writer | `agents/tech-writer.md` | sonnet | No | **S → haiku** | Generates docs from diffs and context; prose transformation with existing tone-matching |
-| test-writer | `agents/test-writer.md` | sonnet | No | **S → haiku** | Writes behavioural tests in idiomatic style; mechanical code generation given a spec |
+| test-writer | `agents/test-writer.md` | sonnet | No | **S → haiku** | Writes behavioural tests in idiomatic style; mechanical code generation given a spec. Watch: test-writer auto-detects framework, reads existing tests, and invokes `principle-tdd`/`principle-testing` skills — multi-step steps that haiku may skip. Revert if Skill invocations are skipped or framework detection regresses. |
 
 **Tier S agents (flipped to haiku in this PR):** dependency-auditor, product-manager, tech-writer, test-writer  
 **Tier M/L agents (unchanged):** accessibility-auditor, architect, auditor, debugger, migrator, performance-tuner, refactorer, reviewer, security-auditor, senior-engineer
@@ -84,6 +84,6 @@ Skills have no `model:` field — they are prose instructions injected into the 
 |---|---|---|---|
 | 1 | `ticket-context` skill | ~30% | Skill body tightened in this PR |
 | 2 | Subagents attributed to swe-workbench | ~19% | 4 Tier-S agents flipped to haiku |
-| 3 | All other swe-workbench surfaces | ~22% | No change; monitor |
+| 3 | All other swe-workbench surfaces | ~22% | No change; monitor. If any single surface exceeds 15% for 3 consecutive days, open a cost-audit follow-up. |
 
 **Post-merge:** compare against this baseline after one representative day of use. Log delta as a comment on issue #160.

--- a/docs/cost-audit.md
+++ b/docs/cost-audit.md
@@ -1,0 +1,89 @@
+# Cost audit — swe-workbench plugin
+
+**Snapshot date:** 2026-05-10  
+**Baseline usage observation:** 71% of 24 h Claude usage attributed to swe-workbench; `/swe-workbench:ticket-context` (30%) + subagents (19%) ≈ 49% of total.  
+**Purpose:** Data-driven tier assignment. See `cost-tiers.md` for the forward-looking convention.
+
+---
+
+## Agents
+
+All 14 agents ship with `model: sonnet` at audit time. None invoke the `Agent` or `Task` tool — subagent spawning is exclusively via the orchestrating Claude session.
+
+| Surface | Path | Current model | Spawns subagents? | Recommended tier | Notes |
+|---|---|---|---|---|---|
+| accessibility-auditor | `agents/accessibility-auditor.md` | sonnet | No | M | Depth-first WCAG reasoning; pattern-matching but requires ARIA/keyboard judgment |
+| architect | `agents/architect.md` | sonnet | No | M–L | ADR/RFC authoring; multi-system reasoning; keep on sonnet |
+| auditor | `agents/auditor.md` | sonnet | No | M–L | Multi-domain cold-start sweep; calibration and counter-evidence require reasoning |
+| debugger | `agents/debugger.md` | sonnet | No | M | Delegates investigation to `systematic-debugging` skill; fix is minimal but judgment-bearing |
+| dependency-auditor | `agents/dependency-auditor.md` | sonnet | No | **S → haiku** | Reads manifests, reports versions/licenses; mechanical extraction, low reasoning density. Watch: license-compatibility edge cases (SPDX vs. policy) may need a revert window |
+| migrator | `agents/migrator.md` | sonnet | No | M–L | Expand-backfill-switch-contract reasoning across deployments; phase correctness is high-stakes |
+| performance-tuner | `agents/performance-tuner.md` | sonnet | No | M | Profile-driven; delegates to `principle-performance` skill; hotspot ranking requires judgment |
+| product-manager | `agents/product-manager.md` | sonnet | No | **S → haiku** | Formats rough ideas into structured GitHub issues; template discovery + fill is mechanical |
+| refactorer | `agents/refactorer.md` | sonnet | No | M | Fowler-catalog steps; behavior-preservation invariant needs correctness judgment |
+| reviewer | `agents/reviewer.md` | sonnet | No | M–L | Four-axis PR review (correctness, security, design, tests); correctness judgment is high-stakes |
+| security-auditor | `agents/security-auditor.md` | sonnet | No | L | OWASP depth-first; exploitability assessment requires strong reasoning |
+| senior-engineer | `agents/senior-engineer.md` | sonnet | No | L | Architectural advice; trade-off synthesis; one-way-door assessment |
+| tech-writer | `agents/tech-writer.md` | sonnet | No | **S → haiku** | Generates docs from diffs and context; prose transformation with existing tone-matching |
+| test-writer | `agents/test-writer.md` | sonnet | No | **S → haiku** | Writes behavioural tests in idiomatic style; mechanical code generation given a spec |
+
+**Tier S agents (flipped to haiku in this PR):** dependency-auditor, product-manager, tech-writer, test-writer  
+**Tier M/L agents (unchanged):** accessibility-auditor, architect, auditor, debugger, migrator, performance-tuner, refactorer, reviewer, security-auditor, senior-engineer
+
+---
+
+## Skills
+
+Skills have no `model:` field — they are prose instructions injected into the invoking session's context. Tier here reflects the cognitive load the skill places on the host model, which informs future decisions (e.g., whether to downgrade the invoking session or guard the skill behind a model check).
+
+| Surface | Path | Current model | Spawns subagents? | Recommended tier | Notes |
+|---|---|---|---|---|---|
+| language-bash | `skills/language-bash/` | N/A | No | M | Language idioms reference |
+| language-go | `skills/language-go/` | N/A | No | M | Language idioms reference |
+| language-java | `skills/language-java/` | N/A | No | M | Language idioms reference |
+| language-kotlin | `skills/language-kotlin/` | N/A | No | M | Language idioms reference |
+| language-python | `skills/language-python/` | N/A | No | M | Language idioms reference |
+| language-rust | `skills/language-rust/` | N/A | No | M | Language idioms reference |
+| language-swift | `skills/language-swift/` | N/A | No | M | Language idioms reference |
+| language-typescript | `skills/language-typescript/` | N/A | No | M | Language idioms reference |
+| principle-accessibility | `skills/principle-accessibility/` | N/A | No | M | WCAG guidance |
+| principle-api-design | `skills/principle-api-design/` | N/A | No | M | REST/gRPC conventions |
+| principle-clean-architecture | `skills/principle-clean-architecture/` | N/A | No | M | Dependency-inversion patterns |
+| principle-clean-code | `skills/principle-clean-code/` | N/A | No | M | Naming / function-size rules |
+| principle-concurrency | `skills/principle-concurrency/` | N/A | No | M | Thread/async safety patterns |
+| principle-cost-awareness | `skills/principle-cost-awareness/` | N/A | No | M | Token-spend heuristics |
+| principle-data-modeling | `skills/principle-data-modeling/` | N/A | No | M | Schema design guidance |
+| principle-ddd | `skills/principle-ddd/` | N/A | No | M | Domain-driven design patterns |
+| principle-design-patterns | `skills/principle-design-patterns/` | N/A | No | M | GoF / structural patterns |
+| principle-distributed-systems | `skills/principle-distributed-systems/` | N/A | No | M | CAP, eventual consistency |
+| principle-error-handling | `skills/principle-error-handling/` | N/A | No | M | Error propagation patterns |
+| principle-event-driven | `skills/principle-event-driven/` | N/A | No | M | Event sourcing / pub-sub |
+| principle-i18n | `skills/principle-i18n/` | N/A | No | M | Localization patterns |
+| principle-observability | `skills/principle-observability/` | N/A | No | M | Logging/tracing/metrics |
+| principle-performance | `skills/principle-performance/` | N/A | No | M | Profile-first optimization |
+| principle-resiliency | `skills/principle-resiliency/` | N/A | No | M | Retry/circuit-breaker patterns |
+| principle-security | `skills/principle-security/` | N/A | No | M | OWASP-aligned security guidance |
+| principle-solid | `skills/principle-solid/` | N/A | No | M | SOLID principles |
+| principle-tdd | `skills/principle-tdd/` | N/A | No | M | Red-green-refactor discipline |
+| principle-testing | `skills/principle-testing/` | N/A | No | M | Test strategy (unit/int/e2e) |
+| principle-version-control | `skills/principle-version-control/` | N/A | No | M | Git workflow conventions |
+| ticket-context | `skills/ticket-context/` | N/A | No | **S** | Pure fetch-and-format; no reasoning; high-frequency invocation (30% of session spend at baseline) |
+| workflow-bug-triage | `skills/workflow-bug-triage/` | N/A | No | M | Triage orchestration prose |
+| workflow-cleanup-merged | `skills/workflow-cleanup-merged/` | N/A | No | M | Branch/worktree cleanup steps |
+| workflow-codebase-audit | `skills/workflow-codebase-audit/` | N/A | No | M | Audit orchestration prose |
+| workflow-commit-and-pr | `skills/workflow-commit-and-pr/` | N/A | No | M | Commit + PR creation steps |
+| workflow-development | `skills/workflow-development/` | N/A | No | L | 5-phase lifecycle orchestration; delegates to multiple sub-skills |
+| workflow-pr-review | `skills/workflow-pr-review/` | N/A | No | M | PR review orchestration prose |
+| workflow-worktree-session | `skills/workflow-worktree-session/` | N/A | No | M | Worktree session management |
+
+---
+
+## Token-spend hot spots at baseline
+
+| Rank | Surface | Share of 24 h usage | Action taken |
+|---|---|---|---|
+| 1 | `ticket-context` skill | ~30% | Skill body tightened in this PR |
+| 2 | Subagents attributed to swe-workbench | ~19% | 4 Tier-S agents flipped to haiku |
+| 3 | All other swe-workbench surfaces | ~22% | No change; monitor |
+
+**Post-merge:** compare against this baseline after one representative day of use. Log delta as a comment on issue #160.

--- a/docs/cost-tiers.md
+++ b/docs/cost-tiers.md
@@ -1,0 +1,70 @@
+# Cost tiers
+
+Forward-looking convention for model assignment in swe-workbench agents. For the point-in-time snapshot that motivated this, see `cost-audit.md`.
+
+## Tiers
+
+| Tier | Alias | When to use | Examples |
+|---|---|---|---|
+| S (small) | `haiku` | Single-purpose fetch, format, or extract. Deterministic output from well-specified input. No cross-file reasoning or correctness judgment. | product-manager, tech-writer, test-writer, dependency-auditor |
+| M (medium) | `sonnet` | Mechanical but judgment-bearing. Must weigh trade-offs, apply a pattern catalog, or preserve an invariant across steps. | debugger, refactorer, performance-tuner, accessibility-auditor |
+| L (large) | `sonnet` (default) or `opus` (with evidence) | High-stakes reasoning. Security exploitability, multi-system architecture, or correctness in concurrent / distributed settings. Opus only when measurable improvement is demonstrated. | reviewer, security-auditor, architect, senior-engineer |
+
+**Default:** when in doubt, start at Tier M (`sonnet`). Downgrade to haiku only after confirming the task is mechanical. Promote to opus only with a measured A/B result.
+
+## Where the field lives
+
+In the agent's YAML frontmatter, bare alias form:
+
+```yaml
+---
+name: my-agent
+model: haiku     # or sonnet, or opus
+tools: ...
+---
+```
+
+Skills have no `model:` field — they are injected as context into the invoking session and inherit its model.
+
+## How to choose
+
+```
+Does the agent require multi-step reasoning, cross-file synthesis,
+or security/correctness judgment?
+   │
+   ├── Yes ──► Tier M or L (sonnet). For high-stakes correctness
+   │           (security, architecture): Tier L, consider opus only
+   │           with measured evidence.
+   │
+   └── No ──► Is the output deterministic given well-specified input?
+                 │
+                 ├── Yes ──► Tier S (haiku). Candidate for downgrade.
+                 │
+                 └── Unsure ──► Tier M (sonnet). Revisit after use.
+```
+
+**Forcing functions for haiku:**
+- Output is a structured document from template + inputs (product-manager, tech-writer)
+- Output is idiomatic code generated from a behavioral spec (test-writer)
+- Output is a tabular report extracted from manifest files (dependency-auditor)
+
+**Keep on sonnet even if it looks simple:**
+- Involves security exploitability assessment (security-auditor)
+- Must preserve behavioral invariants across steps (refactorer, migrator)
+- Output influences architecture or published contracts (architect, senior-engineer)
+
+## When to revisit
+
+Downgrade a Tier M agent to haiku when:
+- Multiple sessions confirm output quality is unchanged on real tasks.
+- No regression complaints tied to the agent.
+
+Revert a haiku agent to sonnet when:
+- A user-visible regression is traced to reasoning depth (not tool availability).
+- PR description should note the reversion and the failing case.
+
+Flag concentration in telemetry: if any single agent exceeds 15% of session token spend for more than 3 days, open a cost-audit follow-up issue.
+
+## Philosophy
+
+Model tier is a budget decision, not a quality signal. Haiku is not "worse" — it is the right tool for mechanical tasks. Defaulting everything to sonnet is wasteful; defaulting everything to haiku is brittle. Assign deliberately, measure, and adjust.

--- a/docs/cost-tiers.md
+++ b/docs/cost-tiers.md
@@ -56,12 +56,12 @@ or security/correctness judgment?
 ## When to revisit
 
 Downgrade a Tier M agent to haiku when:
-- Multiple sessions confirm output quality is unchanged on real tasks.
+- At least 5 real-task invocations with no regression complaint (trial window: 14 days).
 - No regression complaints tied to the agent.
 
 Revert a haiku agent to sonnet when:
-- A user-visible regression is traced to reasoning depth (not tool availability).
-- PR description should note the reversion and the failing case.
+- A user-visible regression is traced to reasoning depth (not tool availability) within 14 days.
+- PR description must note the reversion and the failing case.
 
 Flag concentration in telemetry: if any single agent exceeds 15% of session token spend for more than 3 days, open a cost-audit follow-up issue.
 

--- a/skills/ticket-context/SKILL.md
+++ b/skills/ticket-context/SKILL.md
@@ -7,7 +7,7 @@ description: Fetch ticket context from Jira (PROJ-123), Confluence, or GitHub (`
 
 Auto-loads when the caller references:
 
-- **Jira key**: `[A-Z][A-Z0-9]+-\d+` — e.g. `PROJ-123`, `ENG-4567`.
+- **Jira key**: `[A-Z][A-Z0-9]+-\d+` — e.g. `PROJ-123`.
 - **Atlassian Jira URL**: `*.atlassian.net/browse/<KEY>`.
 - **Confluence URL**: `*.atlassian.net/wiki/spaces/...` or `*.atlassian.net/wiki/pages/...`.
 - **GitHub issue/PR URL**: `github.com/<owner>/<repo>/(issues|pull)/\d+`.
@@ -23,7 +23,7 @@ First fetch in session: call `mcp__atlassian__getAccessibleAtlassianResources` f
 
 ### Confluence page
 
-Extract page ID from `/pages/<ID>` in the URL. Use `mcp__atlassian__getConfluencePage`; fall back to `mcp__atlassian__fetch` with raw URL if ID unclear. Extract: title, version, body (rendered text, not storage XML), footer comments via `mcp__atlassian__getConfluencePageFooterComments` if any.
+Extract page ID from `/pages/<ID>` in the URL. Use `mcp__atlassian__getConfluencePage`; fall back to `mcp__atlassian__fetch` with raw URL if ID unclear. Extract: title, version, body (rendered text), footer comments via `mcp__atlassian__getConfluencePageFooterComments` if any.
 
 ### GitHub issue or PR
 
@@ -42,8 +42,8 @@ One block per reference, prepended to caller context:
 
 **Title:** ...
 **Type / Status:** ...
-**Summary:** ...
-**Acceptance criteria / Definition of done:** ...
+**Summary:** ... (1–3 sentences)
+**Acceptance criteria / Definition of done:** ... (bulleted if present, otherwise "not specified")
 **Linked references:** ...
 **Recent activity:** ...
 **Source:** <URL>
@@ -51,14 +51,12 @@ One block per reference, prepended to caller context:
 
 ## Degradation
 
-If a fetch fails, say what failed and return — never fabricate content.
-
 | Condition | Action |
 |---|---|
 | Atlassian MCP unavailable | Try `mcp__atlassian__fetch` with raw URL; if still failing, emit `ticket-context: Atlassian MCP unavailable; proceeding without context.` |
 | `gh` CLI missing | Emit `ticket-context: gh CLI unavailable; proceeding without context.` |
-
-Auth errors and empty/404 responses: surface what failed; never guess.
+| Auth error | Surface the raw error; never fabricate. |
+| Fetch returns empty or 404 | Say so; do not guess. |
 
 ## Absolute rules
 

--- a/skills/ticket-context/SKILL.md
+++ b/skills/ticket-context/SKILL.md
@@ -1,31 +1,29 @@
 ---
 name: ticket-context
-description: Fetch structured context from Jira issues, Confluence pages, and GitHub issues/PRs. Auto-loads when a prompt or argument references a ticket key (e.g. PROJ-123), an atlassian.net URL, a Confluence wiki URL, or a GitHub issue/PR URL or `#NNN`. Produces title, description, acceptance criteria, links, and recent comments so downstream work (design, refactor, review, debug) has the full spec.
+description: Fetch ticket context from Jira (PROJ-123), Confluence, or GitHub (`#NNN`). Auto-loads on ticket references. Returns title, summary, acceptance criteria, links, and recent activity.
 ---
-
-You resolve ticket references into structured context that downstream work can consume. You do not interpret, critique, or act on the ticket — you fetch and format.
 
 ## When to invoke
 
-The caller (command body, subagent, or user) references one or more of:
+Auto-loads when the caller references:
 
 - **Jira key**: `[A-Z][A-Z0-9]+-\d+` — e.g. `PROJ-123`, `ENG-4567`.
 - **Atlassian Jira URL**: `*.atlassian.net/browse/<KEY>`.
 - **Confluence URL**: `*.atlassian.net/wiki/spaces/...` or `*.atlassian.net/wiki/pages/...`.
 - **GitHub issue/PR URL**: `github.com/<owner>/<repo>/(issues|pull)/\d+`.
-- **GitHub short ref**: `#\d+` with clear current-repo context.
+- **GitHub short ref**: `#\d+` with current-repo context.
 
-If no reference is present, exit cleanly — the caller proceeds without ticket context.
+If no reference is present, exit cleanly.
 
 ## Fetch recipes
 
 ### Jira issue
 
-Before the first Jira fetch in a session, call `mcp__atlassian__getAccessibleAtlassianResources` to resolve the `cloudId`; cache it for subsequent calls. Then `mcp__atlassian__getJiraIssue` with the key. Extract: summary, issuetype, status, priority, description, labels, components, acceptance-criteria (custom field name varies by org — check the description body if a dedicated field is absent), linked issues via `mcp__atlassian__getJiraIssueRemoteIssueLinks`, and the most recent 5 comments.
+First fetch in session: call `mcp__atlassian__getAccessibleAtlassianResources` for `cloudId` (cache for session). Then `mcp__atlassian__getJiraIssue` with the key. Extract: summary, issuetype, status, priority, description, labels, components, acceptance-criteria (check description body if no dedicated field), linked issues via `mcp__atlassian__getJiraIssueRemoteIssueLinks`, last 5 comments.
 
 ### Confluence page
 
-Parse the numeric page ID from the URL path (`/pages/<ID>/` or `/pages/<ID>`). Use `mcp__atlassian__getConfluencePage` with the ID. If the URL shape doesn't yield a clear ID, fall back to `mcp__atlassian__fetch` with the raw URL. Extract: title, version, body (rendered text, not storage XML), recent footer comments via `mcp__atlassian__getConfluencePageFooterComments` if any.
+Extract page ID from `/pages/<ID>` in the URL. Use `mcp__atlassian__getConfluencePage`; fall back to `mcp__atlassian__fetch` with raw URL if ID unclear. Extract: title, version, body (rendered text, not storage XML), footer comments via `mcp__atlassian__getConfluencePageFooterComments` if any.
 
 ### GitHub issue or PR
 
@@ -37,30 +35,33 @@ For `#NNN` short refs in the current repo, omit `--repo`.
 
 ## Output format
 
-One structured block per reference, prepended to the caller's context:
+One block per reference, prepended to caller context:
 
 ```
 ## Ticket context: <KEY or #NUM or short URL>
 
 **Title:** ...
 **Type / Status:** ...
-**Summary:** ... (1–3 sentences from description)
-**Acceptance criteria / Definition of done:** ... (bulleted if present, otherwise "not specified")
-**Linked references:** ... (issue keys, PR numbers, Confluence page titles)
-**Recent activity:** ... (last 2–3 comments, compressed)
+**Summary:** ...
+**Acceptance criteria / Definition of done:** ...
+**Linked references:** ...
+**Recent activity:** ...
 **Source:** <URL>
 ```
 
 ## Degradation
 
-- Atlassian MCP unavailable → attempt `mcp__atlassian__fetch` with the raw URL; if still failing, emit `ticket-context: Atlassian MCP unavailable; proceeding without context.` and return control to the caller.
-- `gh` CLI missing → emit `ticket-context: gh CLI unavailable; proceeding without context.` and return.
-- Auth error → surface the raw error message. Never fabricate content.
-- Reference pattern matches but fetch returns empty/404 → say so; do not guess at content.
+If a fetch fails, say what failed and return — never fabricate content.
+
+| Condition | Action |
+|---|---|
+| Atlassian MCP unavailable | Try `mcp__atlassian__fetch` with raw URL; if still failing, emit `ticket-context: Atlassian MCP unavailable; proceeding without context.` |
+| `gh` CLI missing | Emit `ticket-context: gh CLI unavailable; proceeding without context.` |
+
+Auth errors and empty/404 responses: surface what failed; never guess.
 
 ## Absolute rules
 
-- Never invent ticket content. If a fetch fails, say so and return.
 - Strip secrets and PII (API tokens, email addresses in comments) before returning.
-- Cap output at ~400 words per reference. Summarize longer descriptions; do not truncate mid-sentence.
-- Do not editorialize. Output the ticket; the downstream subagent interprets it.
+- Cap at ~400 words per reference; summarize long descriptions without truncating mid-sentence.
+- Do not editorialize. Output the ticket; downstream agents interpret it.


### PR DESCRIPTION
## Summary
- Flip 4 Tier-S agents (`product-manager`, `tech-writer`, `test-writer`, `dependency-auditor`) from `model: sonnet` → `model: haiku`; tasks are mechanical (structured output, doc generation, test writing, manifest scanning) and don't need top-tier reasoning
- Tighten `skills/ticket-context/SKILL.md`: 3,728 → 2,772 bytes (**25.6% reduction**) — dropped role preamble, shortened description, Degradation collapsed to 4-row table, fetch-recipe prose tightened, output-format filling hints retained for behavioral correctness
- Add `docs/cost-audit.md`: point-in-time model-tier table for all 14 agents + 37 skills, with per-agent revert triggers and expanded watch notes for haiku candidates
- Add `docs/cost-tiers.md`: S/M/L tier convention + decision tree for future contributors; includes 14-day trial window and 15% spend-concentration threshold
- Update `docs/README.md`: index both new docs

Baseline: 71% of 24 h usage attributed to swe-workbench; `ticket-context` (30%) + subagents (19%) ≈ 49% of total. Post-merge: compare after one representative day; log delta as a comment on issue #160.

## Test Plan
- [x] Changed skills/commands/agents load without errors (`bash scripts/validate.sh` — all checks pass)
- [x] Examples in the diff were exercised manually — char-count verified (3728 → 2772 bytes, 25.6% reduction); 4 × `model: haiku` confirmed in agent frontmatters; `git diff --stat` matches plan's critical-files table exactly
- [x] Review feedback applied: Degradation expanded to 4-row table (auth error + empty/404 rows added back), behavioral output-format hints restored, stale audit claim corrected, watch notes expanded for test-writer and dependency-auditor

Closes #160
