### PR TITLE
[feat] /review --mode routing + auto-inference (closes #172)

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -1,22 +1,58 @@
 ---
-description: Review the current git diff with senior-engineer depth — correctness, security, design, and test gaps. Pass a PR number (or accept the auto-detect prompt) to delegate PR-mode to the workflow-pr-review skill.
-argument-hint: "[PR number — optional; omit to review local diff]"
+description: Review the current git diff — auditor selected by --mode (general, security, a11y, deps, perf) or auto-inferred from the diff when omitted. Pass a PR number to review a specific PR; omit for local diff.
+argument-hint: "[--mode <general|security|a11y|deps|perf>] [PR number — optional]"
 ---
 
-Review code with senior-engineer depth. Two modes:
-- **Local-diff mode** (default, no arg): review the working/staged/branch diff. (Used by `workflow-development` Phase 4.)
-- **PR mode** (arg = PR number, or auto-detected from current branch with confirmation): delegate to `swe-workbench:workflow-pr-review` — fetch into ephemeral worktree, run reviewer, post deduped inline comments, submit APPROVE/COMMENT.
+Review code with senior-engineer depth. Two dimensions — fully orthogonal:
 
-## Step 1 — Argument resolution + mode select
+- **Auditor axis (`--mode`):** which specialist reviews the diff (general / security / accessibility / dependency / performance). Auto-inferred from the diff when omitted.
+- **Diff-source axis:** local working-tree diff vs. PR diff. Determined by the remaining arguments after `--mode` is stripped.
 
-1. If `$ARGUMENTS` matches a positive non-zero integer (`[1-9][0-9]*`, stripping a leading `#` if present) → **PR mode** with that number.
-2. Else, run `gh pr view --json number,headRefName 2>/dev/null`. If it succeeds (current branch has an open PR), print:
-   > "Detected PR #N on this branch — review it? Reply `yes` to enter PR mode, or `local` to review the local diff instead."
+## Step 1 — Argument resolution
 
-   Wait for the user's reply.
-   - `yes` → **PR mode** with the auto-detected number.
-   - `local` (or anything else) → **local-diff mode**.
-3. Else → **local-diff mode**.
+Parse `$ARGUMENTS` left-to-right:
+
+1. If a `--mode <value>` flag is present, extract it and normalize the alias:
+
+   | `--mode` value (and aliases) | Normalized mode | Delegates to |
+   |---|---|---|
+   | `general` | `general` | `reviewer` |
+   | `security`, `sec` | `security` | `security-auditor` |
+   | `accessibility`, `a11y` | `accessibility` | `accessibility-auditor` |
+   | `dependency`, `deps` | `dependency` | `dependency-auditor` |
+   | `performance`, `perf` | `performance` | `performance-tuner` |
+
+   Strip `--mode <value>` from `$ARGUMENTS`. Store the normalized mode. If the value is unrecognized, print an error listing valid values and stop.
+
+2. The remaining `$ARGUMENTS` (after stripping `--mode`) flow into diff-source detection:
+   - Matches `[1-9][0-9]*` (stripping a leading `#` if present) → **PR mode** with that number.
+   - Else, run `gh pr view --json number,headRefName 2>/dev/null`. If it succeeds (current branch has an open PR), print:
+     > "Detected PR #N on this branch — review it? Reply `yes` to enter PR mode, or `local` to review the local diff instead."
+
+     Wait for the user's reply. `yes` → **PR mode**. `local` (or anything else) → **local-diff mode**.
+   - Else → **local-diff mode**.
+
+## Step 2 — Mode resolution
+
+**If `--mode` was provided:** use the normalized mode from Step 1. Print:
+> `Mode: <normalized-mode> (explicit)`
+
+**If `--mode` was omitted:** obtain the changed-file list from the **resolved diff source** (not the local working tree):
+- PR mode: `gh pr diff <N> --name-only`
+- Local-diff mode: `git diff --name-only` (unstaged → staged → `origin/main...HEAD` cascade)
+
+Apply these inference rules **in precedence order** (first match wins; ties resolve to the earlier rule). For rules that inspect diff content (3, 4), read the full diff from the same source (`gh pr diff <N>` or the local-diff cascade):
+
+1. **dependency** — ALL changed files are manifest or lockfiles: `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, `go.mod`, `go.sum`, `requirements*.txt`, `pyproject.toml`, `poetry.lock`, `uv.lock`, `yarn.lock`, `pnpm-lock.yaml`.
+2. **security** — diff touches secret-handling, auth, or input-parsing surfaces: paths matching `**/auth*`, `**/security*`, `**/middleware*`, `**/sessions*`, `**/.env*`, `**/secrets*`, `**/parsers/**`, `**/serializers/**`.
+3. **accessibility** — ALL changed files are frontend surfaces (`*.jsx`, `*.tsx`, `*.html`, `*.css`, `*.svelte`, `*.vue`) AND the diff content includes interactive markup (`<button`, `<input`, `<a `, `<form`, `<dialog`, `role=`, `aria-`).
+4. **performance** — diff touches perf-sensitive hot-path globs (`**/cache/**`, `**/queries/**`, `**/db/**`, `**/index*`, `**/search*`) AND the diff is small (< 200 lines changed).
+5. **general** — fallthrough when none of the above match.
+
+Print exactly:
+> `Inferred mode: <mode> — reason: <one-sentence justification>`
+
+The user can override any inferred mode by re-invoking with an explicit `--mode`.
 
 ## Local-diff mode
 
@@ -25,7 +61,7 @@ Review code with senior-engineer depth. Two modes:
    - Run `git diff --staged` for staged changes.
    - If both are empty, run `git diff origin/main...HEAD` (or `origin/master...HEAD`).
 2. Detect ticket references: check `git rev-parse --abbrev-ref HEAD` and `git log --oneline -5` for ticket keys (`[A-Z]+-\d+`), `atlassian.net` URLs, Confluence wiki URLs, or GitHub issue/PR refs. If found, invoke `swe-workbench:ticket-context` and prepend its summary.
-3. Invoke the `reviewer` subagent with the diff and ask for a prioritized report. **Do not** instruct the agent to emit a Decision footer — local-diff mode output is unchanged.
+3. Invoke the **resolved auditor** (from Step 2) with the diff and ask for a prioritized report. Do not instruct the agent to emit a Decision footer — local-diff mode output is unchanged.
 4. Organize findings by severity, highest first:
    - **Critical** — data loss, security breach, production outage risk.
    - **High** — correctness bugs, broken contracts, missing auth/validation.
@@ -38,6 +74,10 @@ Ground judgements in SOLID and Clean Architecture principles. Do not nitpick for
 
 ## PR mode
 
-Invoke `swe-workbench:workflow-pr-review` via the `Skill` tool, passing the resolved PR number.
+**When `--mode` is absent or `--mode general`:** invoke `swe-workbench:workflow-pr-review` via the `Skill` tool, passing the resolved PR number.
 
 The skill owns: pre-flight (`gh auth`, `gh pr view`), ephemeral worktree under `/tmp/swe-workbench-pr-review/<N>`, ticket-context chain, reviewer invocation with footer instruction, decision-footer parsing, GraphQL thread fetch + dedup + REST inline-comment post, `gh pr review --approve|--comment` submission, non-blocking cleanup. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and failure-mode handling.
+
+**When `--mode` is set to a non-general value (security, accessibility, dependency, performance) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style. **Inline-comment posting and APPROVE/COMMENT submission are skipped** — output is severity-organized findings only (same format as local-diff mode above). This avoids re-architecting `workflow-pr-review` to accept an auditor parameter; the full PR-review flow is reserved for the general reviewer.
+
+If the PR number was obtained via auto-detect (user replied `yes` to the prompt in Step 1) rather than an explicit argument, the same branching applies: `--mode general` (or no `--mode`) delegates to `swe-workbench:workflow-pr-review`; non-general modes fetch `gh pr diff <N>` and run the specialist in local-diff style.

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,20 +1,6 @@
 ---
-description: Audit the current git diff for security vulnerabilities — OWASP Top 10, secrets, insecure APIs, dependency CVEs
-argument-hint: "[ticket ref or leave blank to audit current diff]"
+description: Alias for `/review --mode security`. Audit the current git diff for security vulnerabilities — OWASP Top 10, secrets, insecure APIs, dependency CVEs.
+argument-hint: "[PR number — optional; omit to audit local diff]"
 ---
 
-Audit the pending changes on this branch for security vulnerabilities.
-
-1. Gather the diff:
-   - Run `git diff` for unstaged changes.
-   - Run `git diff --staged` for staged changes.
-   - If both are empty, run `git diff origin/main...HEAD` (or `origin/master...HEAD`).
-2. Detect ticket references: check the current branch name (`git rev-parse --abbrev-ref HEAD`) and recent commit messages (`git log --oneline -5`) for ticket keys (`[A-Z]+-\d+`), `atlassian.net` URLs, Confluence wiki URLs, or GitHub issue/PR refs. If found, invoke `swe-workbench:ticket-context` with the ticket reference and prepend its summary to the auditor context — knowing the intended change helps identify which trust boundaries the diff crosses.
-3. Invoke the `security-auditor` subagent with the diff and ask for a prioritized security report.
-4. Organize findings by severity, highest first:
-   - **Critical** — exploitable now, no preconditions (exposed live secret, unauthenticated RCE, SQLi in user-reachable endpoint).
-   - **High** — exploitable with reasonable preconditions (SSRF, IDOR, missing auth on internal API, weak crypto for sensitive data).
-   - **Medium** — defense-in-depth gaps (missing rate limit, verbose error messages, missing security headers).
-   - **Low** — hygiene (outdated dep with no known exploit path, missing CSP `report-uri`).
-5. Each finding uses: `Severity | File:Line | Issue | Why it matters | Suggested fix`.
-6. Close with a short tally: number of Critical / High / Medium / Low findings, and one sentence per non-zero category summarizing the pattern.
+This command is an alias. Delegate to `/review --mode security $ARGUMENTS`.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -4,8 +4,8 @@
 
 | Command | Purpose |
 |---|---|
-| `/swe-workbench:review` | Review the current git diff — correctness, security, design, test gaps. |
-| `/swe-workbench:security-review` | Audit the current git diff for security vulnerabilities — OWASP Top 10, secrets, insecure APIs. |
+| `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf) or auto-inferred from the diff when omitted. PR number arg unchanged. |
+| `/swe-workbench:security-review` | Alias for `/swe-workbench:review --mode security`. Kept for backward compat. |
 | `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
 | `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
 | `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -1,0 +1,102 @@
+"""Structural tests for /review mode-routing (issue #172)."""
+import re
+from pathlib import Path
+
+
+REVIEW_PATH = Path(__file__).parent.parent / "commands" / "review.md"
+SECURITY_REVIEW_PATH = Path(__file__).parent.parent / "commands" / "security-review.md"
+
+
+class TestReviewModeRouting:
+    """Assert /review.md documents every routing rule from issue #172."""
+
+    def test_argument_hint_advertises_mode(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match
+        assert "--mode" in match.group(1)
+
+    def test_all_five_modes_present(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        for mode in ("general", "security", "accessibility", "dependency", "performance"):
+            assert mode in text, f"--mode {mode} must be documented"
+
+    def test_short_aliases_present(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        for alias in ("a11y", "deps", "perf", "sec"):
+            assert alias in text, f"alias '{alias}' must be documented"
+
+    def test_all_five_auditors_referenced(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        for agent in ("reviewer", "security-auditor", "accessibility-auditor",
+                      "dependency-auditor", "performance-tuner"):
+            assert agent in text, f"auditor '{agent}' must be referenced"
+
+    def test_auto_inference_output_format(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "Inferred mode:" in text
+        assert "reason:" in text
+
+    def test_explicit_mode_output_format(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "(explicit)" in text
+
+    def test_inference_rules_documented(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        # Manifest files for dependency mode
+        for token in ("package.json", "Cargo.toml", "go.mod", "pyproject.toml"):
+            assert token in text, f"{token} must appear in dependency-mode rules"
+        # Frontend surfaces for a11y mode
+        for token in ("jsx", "tsx", "aria-"):
+            assert token in text
+        # git diff --name-only must be used to drive inference
+        assert "git diff --name-only" in text
+
+    def test_inference_precedence_documented(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        # Locate each rule's bold header to assert precedence ordering is preserved
+        indices = {
+            name: text.find(f"**{name}**")
+            for name in ("dependency", "security", "accessibility", "performance", "general")
+        }
+        assert all(v != -1 for v in indices.values()), \
+            f"Missing bold rule header(s): {[k for k, v in indices.items() if v == -1]}"
+        ordered = ["dependency", "security", "accessibility", "performance", "general"]
+        for a, b in zip(ordered, ordered[1:]):
+            assert indices[a] < indices[b], \
+                f"Inference rule '{a}' must precede '{b}' in the document"
+
+    def test_pr_mode_caveat_documented(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        lower = text.lower()
+        # Must assert both that inline-comment posting is mentioned AND that it is skipped
+        assert "inline-comment posting" in lower and "skipped" in lower, \
+            "PR-mode + --mode must document that inline-comment posting is skipped"
+
+    def test_existing_pr_mode_preserved(self):
+        """Backward-compat: bare integer arg → PR mode still works."""
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "[1-9][0-9]*" in text, "integer-arg PR-mode regex must survive"
+        assert "swe-workbench:workflow-pr-review" in text
+
+
+class TestSecurityReviewIsStub:
+    """Assert /security-review.md is a thin alias for /review --mode security."""
+
+    def test_delegates_to_review(self):
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        assert "/review --mode security" in text or "review --mode security" in text
+
+    def test_does_not_invoke_security_auditor_directly(self):
+        """Prevents stub from silently re-growing the dispatch logic."""
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        # The agent name must not appear — delegation lives in /review
+        assert "security-auditor" not in text, \
+            "security-review.md must not reference security-auditor directly; " \
+            "delegation now lives in /review"
+
+    def test_frontmatter_preserved(self):
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match
+        assert "description:" in match.group(1)


### PR DESCRIPTION
## Summary
- Add `--mode <general|security|a11y|deps|perf>` argument to `/review` — routes to the matching specialist auditor (`reviewer`, `security-auditor`, `accessibility-auditor`, `dependency-auditor`, `performance-tuner`)
- Auto-infer mode from the diff when `--mode` is omitted: ordered precedence (dependency → security → accessibility → performance → general) driven by `git diff --name-only` (or `gh pr diff <N> --name-only` in PR mode)
- Reduce `/security-review` to a one-line alias stub (`Delegate to /review --mode security $ARGUMENTS`) — eliminates dual-maintenance of dispatch logic
- Update `docs/catalog.md` Commands table rows 1–2 to document the new `--mode` surface
- Add `tests/test_review_routing.py` (13 structural assertions across `TestReviewModeRouting` + `TestSecurityReviewIsStub`)

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_review_routing.py -v` — 13/13 pass
- [x] `pytest tests/ -v` — 294/294 pass (full suite, no regressions)
- [x] `python3 scripts/validate.py` — All checks passed
- [x] `grep security-auditor commands/security-review.md` — returns nothing (stub contract enforced)
- [x] `grep "review --mode security" commands/security-review.md` — delegation line present

Closes #172
