### PR TITLE
[fix] Anchor --force boundary to prevent --force-with-lease false positive

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]])(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]])(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
           }
         ]
       }

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -98,6 +98,7 @@ class TestForcePushBlocker:
         "git push -f origin master",
         "git push --force origin main:main",
         "git push --force origin master:master",
+        "git push origin main --force",       # --force at end-of-string: exercises $ branch
     ])
     def test_blocked(self, hook_patterns, cmd):
         assert force_push_blocked(hook_patterns, cmd), f"Expected BLOCK for: {cmd!r}"
@@ -107,6 +108,10 @@ class TestForcePushBlocker:
         "git push --force origin feature/x",  # force but not main/master
         "git push --force origin mainline",   # "mainline" is not main (boundary check)
         "git push --force origin my-master",  # "my-master" is not master
+        "git push --force-with-lease origin main",              # safe force variant — must not be blocked
+        "git push --force-with-lease origin master",            # safe force variant — must not be blocked
+        "git push --force-if-includes origin main",             # safe force variant — must not be blocked
+        "git push --force-with-lease=origin/main origin main",  # = form: boundary ([[:space:]]|$) excludes '='
     ])
     def test_allowed(self, hook_patterns, cmd):
         assert not force_push_blocked(hook_patterns, cmd), f"Expected ALLOW for: {cmd!r}"


### PR DESCRIPTION
## Summary
- Fix force-push regex in `hooks/hooks.json` to add a trailing word boundary
  `([[:space:]]|$)` after `--force`, mirroring the existing `-f` anchor pattern.
  Previously `--force` matched as a prefix of `--force-with-lease`, incorrectly
  blocking the safe force variant used by `scripts/release.sh`.
- Add 5 new regression cases to `TestForcePushBlocker` in `tests/test_hooks.py`:
  `--force-with-lease origin main/master`, `--force-if-includes origin main`,
  `--force-with-lease=<refname>` (= form), and `--force` at end-of-string.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 -m pytest tests/ -q` → 299 passed (up from 294 baseline)
- [x] Smoke-tested `grep -Eq` directly: `--force-with-lease` → allowed, bare `--force` → BLOCKED

Closes #163
