### PR TITLE
[fix] Guard check_hooks_json against non-dict entries (closes #166)

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -97,6 +97,9 @@ def check_hooks_json():
             fail(path.relative_to(ROOT), f"hooks.{event} must be a list")
             continue
         for i, entry in enumerate(matchers):
+            if not isinstance(entry, dict):
+                fail(path.relative_to(ROOT), f"hooks.{event}[{i}] must be an object")
+                continue
             if not isinstance(entry.get("matcher"), str):
                 fail(path.relative_to(ROOT), f"hooks.{event}[{i}].matcher must be a string")
             sub_hooks = entry.get("hooks")
@@ -104,6 +107,9 @@ def check_hooks_json():
                 fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks must be a list")
                 continue
             for j, hook in enumerate(sub_hooks):
+                if not isinstance(hook, dict):
+                    fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}] must be an object")
+                    continue
                 if not isinstance(hook.get("type"), str):
                     fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].type must be a string")
                 if not isinstance(hook.get("command"), str):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -172,6 +172,45 @@ class TestCheckHooksJson:
         validate.check_hooks_json()
         assert any("matcher" in f for f in validate.FAILURES)
 
+    def test_string_matcher_entry(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, hooks_json={"hooks": {"PreToolUse": ["bad"]}})
+        validate.check_hooks_json()
+        assert any("PreToolUse[0] must be an object" in f for f in validate.FAILURES)
+
+    def test_int_matcher_entry(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, hooks_json={"hooks": {"PreToolUse": [42]}})
+        validate.check_hooks_json()
+        assert any("PreToolUse[0] must be an object" in f for f in validate.FAILURES)
+
+    def test_null_matcher_entry(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, hooks_json={"hooks": {"PreToolUse": [None]}})
+        validate.check_hooks_json()
+        assert any("PreToolUse[0] must be an object" in f for f in validate.FAILURES)
+
+    def test_string_sub_hook(self, reset_validate):
+        root = reset_validate
+        bad = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": ["bad"]}]}}
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("PreToolUse[0].hooks[0] must be an object" in f for f in validate.FAILURES)
+
+    def test_int_sub_hook(self, reset_validate):
+        root = reset_validate
+        bad = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [42]}]}}
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("PreToolUse[0].hooks[0] must be an object" in f for f in validate.FAILURES)
+
+    def test_null_sub_hook(self, reset_validate):
+        root = reset_validate
+        bad = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [None]}]}}
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("PreToolUse[0].hooks[0] must be an object" in f for f in validate.FAILURES)
+
 
 # ──────────────────────────────────────────────
 # check_skills


### PR DESCRIPTION
## Summary
- Add `isinstance(entry, dict)` guard in `check_hooks_json` so non-dict elements in a hook event array emit a clean error (`hooks.{event}[{i}] must be an object`) instead of crashing with `AttributeError`
- Add `isinstance(hook, dict)` guard for nested sub-hook list entries for the same reason
- Add 6 new tests covering string, int, and null elements at both layers (matcher entries + sub-hook entries)

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` — exits 0 (all checks passed)
- [x] `pytest tests/ -v` — 300/300 pass, including 6 new tests in `TestCheckHooksJson`

Closes #166
