### PR TITLE
[test] Add coverage for check_command_skill_refs (closes #169)

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -444,6 +444,60 @@ class TestCheckAgentSkillRefs:
 
 
 # ──────────────────────────────────────────────
+# check_command_skill_refs
+# ──────────────────────────────────────────────
+
+class TestCheckCommandSkillRefs:
+    def test_ref_to_existing_skill_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nRun `swe-workbench:foo` skill.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 0
+
+    def test_ref_to_absent_skill_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nRun `swe-workbench:nonexistent` skill.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert any("nonexistent" in f and "does not exist" in f for f in validate.FAILURES)
+
+    def test_typoed_skill_id_among_valid_refs_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nUse `swe-workbench:foo` and `swe-workbench:fooo`.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 1
+        assert "fooo" in validate.FAILURES[0] and "does not exist" in validate.FAILURES[0]
+        assert "swe-workbench:foo'" not in validate.FAILURES[0]
+
+    def test_command_with_no_skill_refs_passes_silently(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nNo plugin references here.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 0
+
+
+# ──────────────────────────────────────────────
 # check_catalog_completeness
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `TestCheckCommandSkillRefs` to `tests/test_validate.py`, mirroring the shape of the existing `TestCheckAgentSkillRefs` class
- 4 test methods covering: valid ref passes, absent ref fails, typo among valid refs fails (exactly one failure for the typo, none for the valid ref), and no refs passes silently
- Strengthened assertions: checks both skill id and "does not exist" in failure messages for specificity; adds explicit `"swe-workbench:foo'"` exclusion in the typo test to verify the valid ref produces no failure
- Removed redundant `commands_dir.mkdir()` calls — `make_plugin_tree` already creates `commands/`

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `pytest tests/test_validate.py -k CheckCommandSkillRefs -v` → 4 passed
- [x] `pytest tests/test_validate.py -v` → 69 passed (65 baseline + 4 new)
- [x] `pytest tests/ -v` → 298 passed, no regressions
- [x] `python scripts/validate.py` → All checks passed
- [x] Deliberate-break protocol: disabling `fail()` in `check_command_skill_refs` caused tests 2 and 3 to fail, confirming regression-catching power

Closes #169
