### PR TITLE
[fix] sync-and-verify.sh: suppress stdout leaks

### DIFF
--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -14,14 +14,14 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 cd "$MAIN_REPO"
 
 # Block B: sync local main (best-effort — failure warns, does not abort)
-(git checkout main && git pull --ff-only origin main) \
+(git checkout main && git pull --ff-only origin main) >/dev/null \
   || echo "sync-main: best-effort failed — reconcile main manually" >&2
 
 # Block C: verification gate — check whether hook already cleaned up
 # Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF
 WORKTREE_FOUND=$(git worktree list --porcelain \
   | awk -v ref="branch refs/heads/$HEAD_REF" '$0 == ref {print 1; exit}')
-if git rev-parse --verify "refs/heads/$HEAD_REF" 2>/dev/null; then
+if git rev-parse --verify "refs/heads/$HEAD_REF" >/dev/null 2>&1; then
   BRANCH_FOUND=1
 else
   BRANCH_FOUND=

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -1,0 +1,128 @@
+"""Regression test for sync-and-verify.sh stdout contract (issue #197).
+
+The script declares: Stdout contract: WORKTREE_GONE=0|1.
+It is invoked via ``eval "$(...)"`` so any byte on stdout that isn't that
+exact assignment becomes a shell command in the caller's environment.
+
+Block B (git pull --ff-only) leaked "Already up to date." to stdout.
+Block C (git rev-parse --verify) leaked the resolved SHA to stdout.
+Both were eval'd by the caller, causing "command not found" errors.
+
+This test pins the contract: stdout must be exactly one line.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).parent.parent
+    / "skills"
+    / "workflow-cleanup-merged"
+    / "scripts"
+    / "sync-and-verify.sh"
+)
+BRANCH = "feature/197-fixture-branch"
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+NOISE_STRINGS = [
+    "Switched to branch",
+    "Already on",
+    "Already up to date",
+    "Fast-forward",
+    "Updating",
+]
+
+
+def _build_repo(base: Path) -> Path:
+    """Create a minimal git environment: bare origin + working main_repo."""
+    origin = base / "origin.git"
+    repo = base / "main_repo"
+
+    def run(*args, cwd=None):
+        return subprocess.run(
+            list(args),
+            cwd=str(cwd or base),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    run("git", "init", "--bare", str(origin))
+    run("git", "init", str(repo))
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    run("git", "config", "user.name", "Test", cwd=repo)
+
+    (repo / "README.md").write_text("hello\n")
+    run("git", "add", "README.md", cwd=repo)
+    run("git", "commit", "-m", "init", cwd=repo)
+    run("git", "branch", "-M", "main", cwd=repo)
+    run("git", "remote", "add", "origin", str(origin), cwd=repo)
+    run("git", "push", "-u", "origin", "main", cwd=repo)
+
+    run("git", "checkout", "-b", BRANCH, cwd=repo)
+    (repo / "feature.txt").write_text("feature\n")
+    run("git", "add", "feature.txt", cwd=repo)
+    run("git", "commit", "-m", "add feature", cwd=repo)
+    run("git", "push", "-u", "origin", BRANCH, cwd=repo)
+    run("git", "checkout", "main", cwd=repo)
+
+    return repo
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    return _build_repo(tmp_path)
+
+
+def _run_script(repo: Path, head_ref: str):
+    return subprocess.run(
+        ["bash", str(SCRIPT), head_ref],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_contract(result, expected: str) -> None:
+    assert result.returncode == 0, (
+        f"Script exited {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    lines = result.stdout.strip().splitlines()
+    assert lines == [f"WORKTREE_GONE={expected}"], (
+        f"Expected stdout=['WORKTREE_GONE={expected}'], got {lines!r}\n"
+        f"Full stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert not SHA_PATTERN.search(result.stdout), (
+        f"stdout must not contain a 40-hex SHA: {result.stdout!r}"
+    )
+    for noise in NOISE_STRINGS:
+        assert noise not in result.stdout, (
+            f"stdout must not contain {noise!r}: {result.stdout!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "case,expected",
+    [
+        ("branch_present", "0"),
+        ("branch_absent", "1"),
+    ],
+)
+class TestSyncAndVerifyStdoutContract:
+    """Pin the stdout contract: exactly one line, WORKTREE_GONE=0|1, no git noise."""
+
+    def test_stdout_is_exact_contract(self, git_repo, case, expected):
+        if case == "branch_absent":
+            subprocess.run(
+                ["git", "branch", "-D", BRANCH],
+                cwd=str(git_repo),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        result = _run_script(git_repo, BRANCH)
+        _assert_contract(result, expected)


### PR DESCRIPTION
## Summary
- **Block B** (`sync-and-verify.sh:17`): appended `>/dev/null` to `(git checkout main && git pull --ff-only origin main)` — `git pull` was emitting "Already up to date." (and fast-forward summaries) to stdout, which the caller's `eval "$(...)"` executed as shell code.
- **Block C** (`sync-and-verify.sh:24`): changed `2>/dev/null` → `>/dev/null 2>&1` on `git rev-parse --verify` — the resolved commit SHA was emitted to stdout and hit the caller as `zsh: command not found: <sha>`.
- Both leaks share the same root cause: git commands run outside `$(...)` with no stdout redirect in a script whose stdout is a shell-code channel.
- Added `tests/test_sync_and_verify.py`: pytest regression test with a self-contained tmp-repo fixture + two parametrized cases (`branch_present` → `WORKTREE_GONE=0`, `branch_absent` → `WORKTREE_GONE=1`). Asserts exact single-line stdout, no SHA, no git noise strings.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually (`eval "$(sync-and-verify.sh test-197-repro)"` → `WORKTREE_GONE=0`, no `command not found`)
- [x] `python3 -m pytest tests/test_sync_and_verify.py -v` — 2/2 pass (RED confirmed on unpatched code, GREEN after fix)
- [x] `python3 -m pytest tests/ -v` — 313/313 pass, no regressions
- [x] `shellcheck skills/workflow-cleanup-merged/scripts/sync-and-verify.sh` — clean

Closes #197
