### PR TITLE
[fix] Block force pushes to destination refspecs

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]])(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]]|:)(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
           }
         ]
       }

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -98,6 +98,9 @@ class TestForcePushBlocker:
         "git push -f origin master",
         "git push --force origin main:main",
         "git push --force origin master:master",
+        "git push --force origin HEAD:main",
+        "git push --force origin feature:main",
+        "git push --force origin HEAD:master",
         "git push origin main --force",       # --force at end-of-string: exercises $ branch
     ])
     def test_blocked(self, hook_patterns, cmd):


### PR DESCRIPTION
## Summary
- Block force-pushes that target protected branches via destination-form refspecs.
- Add regression coverage for `HEAD:main`, `feature:main`, and `HEAD:master`.

Fixes #164.

## Test plan
- `python3 -m pytest tests/test_hooks.py -q`