### PR TITLE
[fix] Disambiguate "this repo" in skill prose

### DIFF
--- a/skills/principle-version-control/SKILL.md
+++ b/skills/principle-version-control/SKILL.md
@@ -25,7 +25,7 @@ Why this change was made. What would break if reverted.
 Link the issue or ticket. Note non-obvious constraints.
 ```
 
-Format schemes — Conventional Commits (`feat:`, `fix:`), `[type] Subject`, JIRA-prefix — are all valid conventions. Pick one; apply consistently. **This repo enforces `[type] Subject`** via `.githooks/commit-msg`; Conventional Commits will be rejected by the hook. See `swe-workbench:workflow-commit-and-pr` for the enforced regex and the `[no ci]` rule.
+Format schemes — Conventional Commits (`feat:`, `fix:`), `[type] Subject`, JIRA-prefix — are all valid conventions. Pick one; apply consistently and enforce via a `commit-msg` hook. Example: the swe-workbench plugin repo enforces `[type] Subject` via `.githooks/commit-msg`. Before authoring commit messages, detect the host repo's convention via the detection step in `swe-workbench:workflow-commit-and-pr`.
 
 ## Never mix formatting and logic
 

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -56,14 +56,24 @@ If the session is currently inside a worktree (e.g. entered via `EnterWorktree p
 
 If `EnterWorktree` was never called this session (or the `ExitWorktree` tool is unavailable), this step is a no-op — proceed to 3b without aborting.
 
-**3b. Anchor cwd, sync local main, and verify hook cleanup** with the companion script:
+**3b. Resolve the default branch, anchor cwd, sync, and verify hook cleanup.**
+
+First, detect the default branch of the host repo:
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null \
+  || git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' \
+  || echo main)
+```
+
+Then invoke the companion script, passing the resolved default branch as `$2`:
 
 ```bash
 _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
-eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>")"
+eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>" "$DEFAULT_BRANCH")"
 ```
 
-The script: derives `MAIN_REPO=` (main worktree root via `git worktree list --porcelain`), anchors the shell there so the rimba hook cannot strand a deleted cwd, then runs `git checkout main && git pull --ff-only origin main` (best-effort — sync failure warns to stderr but does not abort), then checks whether the hook already removed the worktree and local branch. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
+The script: derives `MAIN_REPO=` (main worktree root via `git worktree list --porcelain`), anchors the shell there so the rimba hook cannot strand a deleted cwd, then runs `git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH"` (best-effort — sync failure warns to stderr but does not abort), then checks whether the hook already removed the worktree and local branch. `--ff-only` is non-negotiable; plain `git pull` can synthesize a merge commit on divergence.
 
 When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast path)`), `git pull` fires the hook as a side-effect, which removes the merged worktree and local branch automatically. A sync failure on the fast path forces fall-through to the rimba-binary or shell strategy — it does NOT abort cleanup.
 
@@ -116,11 +126,11 @@ Execute the first strategy whose preconditions hold. Fall through to the next if
    eval "$("$_SCRIPTS/check-rimba-hook.sh")"
    ```
    `RIMBA_HOOK_ACTIVE=1` is required. (The grep inside the script excludes comment-only lines so a documented-but-disabled invocation does not yield a false positive.)
-2. After Step 3 sync, HEAD on `$MAIN_REPO` is on `main` (the hook's own branch guard requires it).
+2. After Step 3 sync, HEAD on `$MAIN_REPO` is on `$DEFAULT_BRANCH` (the hook's own branch guard requires it).
 
 **Procedure:**
 
-Nothing strategy-specific. The `git pull --ff-only origin main` in Step 3 fired the post-merge hook, which ran `rimba clean --merged --force` and removed the worktree and local branch as a side-effect.
+Nothing strategy-specific. The `git pull --ff-only origin "$DEFAULT_BRANCH"` in Step 3 fired the post-merge hook, which ran `rimba clean --merged --force` and removed the worktree and local branch as a side-effect.
 
 The verification gate in Step 4 (`WORKTREE_GONE=1`) confirms the hook succeeded and routes the spine to skip Steps 4 and 5 directly to Step 6.
 

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -6,16 +6,17 @@
 # Exit non-zero only if $MAIN_REPO cannot be resolved.
 set -euo pipefail
 
-HEAD_REF="${1:?Usage: sync-and-verify.sh <head_ref>}"
+HEAD_REF="${1:?Usage: sync-and-verify.sh <head_ref> [default_branch]}"
+DEFAULT_BRANCH="${2:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo main)}"
 
 # Block A: derive $MAIN_REPO and anchor cwd
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 [ -n "${MAIN_REPO:-}" ] || { echo "sync-and-verify: could not resolve main repo path — aborting" >&2; exit 1; }
 cd "$MAIN_REPO"
 
-# Block B: sync local main (best-effort — failure warns, does not abort)
-(git checkout main && git pull --ff-only origin main) >/dev/null \
-  || echo "sync-main: best-effort failed — reconcile main manually" >&2
+# Block B: sync local default branch (best-effort — failure warns, does not abort)
+(git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH") >/dev/null \
+  || echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually" >&2
 
 # Block C: verification gate — check whether hook already cleaned up
 # Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -36,7 +36,17 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
 
 ## Codified commit format
 
-This repo enforces `[type] Subject` via `.githooks/commit-msg`. The regex (load-bearing — quote, do not re-derive):
+**Detect commit format.** Probe the host repo before authoring any commit message:
+
+1. If `.githooks/commit-msg` exists (or `.git/hooks/commit-msg` symlinked from `core.hooksPath`), read it and **quote the regex verbatim** from the hook file — do not re-derive. Examples of conventions you may detect:
+   - `[type] Subject` (swe-workbench plugin style) — enforced by the regex below
+   - `type(scope): subject` (Conventional Commits)
+   - `JIRA-123: subject` (JIRA-prefix style)
+   Apply whichever convention the hook enforces for this host repo.
+2. If no commit-msg hook exists, infer convention from `git log --oneline -10`. Default to Conventional Commits if no pattern dominates.
+3. If both fail (new repo, empty history), ask the user which convention to follow.
+
+**When the host repo uses the swe-workbench plugin's `[type] Subject` convention**, the enforcing regex is (load-bearing — quote, do not re-derive):
 
 ```
 ^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+
@@ -94,7 +104,13 @@ MATCHED=$(git diff --staged --name-only | grep -Ev '^(commands|skills|agents)/' 
 
 If every staged path matches (`MATCHED == TOTAL`), append ` [no ci]`. Otherwise, do not.
 
-**Warning:** PR-level `[no ci]` is NOT honoured by this repo's CI (`.github/workflows/pr.yml` has no `[no ci]` guard). The marker is per-commit only. If all commits in a docs-only PR have `[no ci]`, the CI still runs on the PR — note this to the user.
+**Detect `[no ci]` behaviour.** Whether per-PR `[no ci]` is honoured depends on the host repo's CI configuration:
+
+- If `.github/workflows/` exists, grep each PR-triggering workflow for `[no ci]` / `skip-ci` / `ci-skip` markers in `if:` conditions. If none honour the marker, warn the user: "Per-PR `[no ci]` will not skip CI — the marker is per-commit only. If all commits in a docs-only PR have `[no ci]`, the CI still runs on the PR."
+- If the host uses GitLab CI, note that the equivalent marker is `[ci skip]` or `[skip ci]` in the commit message.
+- If the host uses Bitbucket Pipelines or other CI, check its docs for the skip marker.
+
+**Note for the swe-workbench plugin repo specifically:** `.github/workflows/pr.yml` has no `[no ci]` guard at the PR level. The marker is per-commit only in that repo.
 
 ## Project Detection
 
@@ -124,7 +140,12 @@ Ready to push to GitHub? Reply with one of:
 
 **Wait for the user to reply** with one of those exact words. Reject any other reply (re-prompt).
 
-Plain-prose ask (NOT the AskUserQuestion tool — zero usage in this repo; convention is plain-prose preview-gate-then-confirm, mirroring `commands/capture.md`).
+**Choose the asking medium by question shape:**
+
+- **Binary or short-list selections** (≤4 mutually exclusive options) — e.g., draft vs. ready PR, commit `[type]` when ambiguous, branch-rename vs. continue — prefer **`AskUserQuestion`**.
+- **Confirmation-with-preview** (show the diff/message and ask "ship it?") — prefer plain prose so the user can read the artifact inline.
+
+The two forms coexist; neither replaces the other.
 
 ## Ticket-context chain
 
@@ -163,7 +184,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Auto-escalate "I'm done" to a full ship | Always preview-only on completion phrases. Wait for the user's explicit "commit" or "ship". |
 | Use `--no-verify` to bypass a failing hook | Never. Re-read the hook, fix the cause, re-commit. The hook is the contract. |
 | Force-push to recover from a hook failure | Never. Hook failures don't create commits — there's nothing to force-push. |
-| Use `(scope):` in commit subject | This repo uses `[type] Subject` not `type(scope): Subject`. Quote the regex. |
+| Use `(scope):` in commit subject when the detected hook enforces `[type]` | Quote the regex from the detected commit-msg hook (see Detect commit format step). If the host repo enforces Conventional Commits instead, `(scope):` is correct — ignore this row. |
 | Append `[no ci]` to a commit touching `commands/foo.md` | The exclusion of `commands/`, `skills/`, `agents/` is load-bearing. |
 | Use `gh pr create --fill` | Use `--body-file <PR template path>` so the `Closes #` line is filled correctly. |
 | Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT; <fill template> > "$TMP"; gh pr create --body-file "$TMP"` (trap ensures cleanup on failure too). |

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -1,0 +1,189 @@
+"""Regression tests pinning the 'this repo' referential-ambiguity fix.
+
+Background
+----------
+Skills are loaded by the dispatcher into sessions whose cwd is the *user's*
+repo, not the swe-workbench plugin repo.  Any phrase like "this repo enforces
+X" or "zero usage in this repo" is interpreted by the agent as a claim about
+the user's workspace — causing incorrect commit-format rewriting, spurious
+[no ci] warnings, and suppression of AskUserQuestion in every host repo.
+
+These tests enforce:
+1. workflow-commit-and-pr/SKILL.md has no unguarded "this repo" references
+   outside fenced code blocks.
+2. principle-version-control/SKILL.md attributes [type] Subject enforcement
+   to "swe-workbench" explicitly, not to "this repo".
+3. workflow-cleanup-merged/SKILL.md + sync-and-verify.sh resolve the default
+   branch dynamically rather than hardcoding "main".
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+COMMIT_AND_PR_SKILL = ROOT / "skills" / "workflow-commit-and-pr" / "SKILL.md"
+VERSION_CONTROL_SKILL = ROOT / "skills" / "principle-version-control" / "SKILL.md"
+CLEANUP_MERGED_SKILL = ROOT / "skills" / "workflow-cleanup-merged" / "SKILL.md"
+SYNC_SCRIPT = ROOT / "skills" / "workflow-cleanup-merged" / "scripts" / "sync-and-verify.sh"
+
+# Regex matching literal "main" used as a branch name in checkout/pull commands
+_LITERAL_MAIN_IN_GIT_CMD = re.compile(
+    r'git\s+(checkout|pull)\s+.*\bmain\b'
+)
+# Acceptable dynamic-resolution patterns
+_DYNAMIC_BRANCH_PATTERNS = [
+    re.compile(r'gh repo view.*defaultBranchRef'),
+    re.compile(r'symbolic-ref refs/remotes/origin/HEAD'),
+]
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Return text with content inside fenced code blocks removed.
+
+    Fenced blocks (``` or ~~~) may contain quoted examples; they are not
+    subject to the prose-ambiguity constraint.
+
+    Per CommonMark: a closing fence must be a bare sequence of the same
+    fence character (no info string).  An opener like ```bash opens a block;
+    only a line that is exactly the fence marker (e.g. ```) closes it.
+    Storing the opener prefix length lets us match the closing fence correctly.
+    """
+    result = []
+    in_fence = False
+    fence_char: str | None = None  # ` or ~
+    fence_len: int = 0
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not in_fence:
+            # Detect opening fence: 3+ backticks or tildes, optional info string
+            for fc in ("`", "~"):
+                if stripped.startswith(fc * 3):
+                    run = len(stripped) - len(stripped.lstrip(fc))
+                    in_fence = True
+                    fence_char = fc
+                    fence_len = run
+                    break
+            else:
+                result.append(line)
+        else:
+            # Closing fence: same character, at least fence_len long, no info string
+            if (
+                stripped.startswith(fence_char * fence_len)
+                and all(c == fence_char for c in stripped)
+            ):
+                in_fence = False
+
+    return "\n".join(result)
+
+
+def test_workflow_commit_and_pr_has_no_unguarded_this_repo_refs():
+    """No 'this repo'/'This repo' assertion may appear outside fenced code blocks.
+
+    These phrases resolve deictic to the *user's* repo when the skill is loaded
+    into a foreign workspace, causing the skill to impose swe-workbench
+    conventions as if they were facts about the user's codebase.
+
+    Fails today at (at least) lines 39, 97, 127, 166 of SKILL.md.
+    """
+    body = COMMIT_AND_PR_SKILL.read_text()
+    outside_code_blocks = _strip_fenced_code_blocks(body)
+
+    hits = []
+    for lineno, line in enumerate(outside_code_blocks.splitlines(), 1):
+        if re.search(r'\bthis repo\b', line, re.IGNORECASE):
+            hits.append((lineno, line.strip()))
+
+    assert not hits, (
+        "Found unguarded 'this repo' reference(s) in "
+        "skills/workflow-commit-and-pr/SKILL.md (outside fenced code blocks).\n"
+        "These phrases must be replaced with runtime-detection steps or explicit\n"
+        "'the swe-workbench plugin' naming so they do not mis-apply to host repos.\n\n"
+        "Violations:\n"
+        + "\n".join(f"  ~line {ln}: {txt}" for ln, txt in hits)
+    )
+
+
+def test_principle_version_control_attributes_type_format_to_swe_workbench():
+    """The [type] Subject enforcement sentence must name 'swe-workbench' explicitly.
+
+    Currently line 28 reads '**This repo enforces `[type] Subject`**', which
+    is interpreted as a claim about the user's workspace.  After the fix it
+    must read something like 'Example: the swe-workbench plugin repo enforces
+    `[type] Subject` via `.githooks/commit-msg`'.
+
+    Fails today because the line begins with '**This repo enforces'.
+    """
+    body = VERSION_CONTROL_SKILL.read_text()
+
+    # Find all lines that mention [type] Subject AND enforcement
+    enforcement_lines = [
+        (i + 1, line)
+        for i, line in enumerate(body.splitlines())
+        if "[type] Subject" in line and re.search(r'\benforce', line, re.IGNORECASE)
+    ]
+
+    assert enforcement_lines, (
+        "Expected at least one line in skills/principle-version-control/SKILL.md "
+        "mentioning '[type] Subject' enforcement — none found."
+    )
+
+    for lineno, line in enforcement_lines:
+        assert "swe-workbench" in line, (
+            f"Line {lineno} mentions '[type] Subject' enforcement but does not name "
+            f"'swe-workbench' explicitly as the example repo.\n"
+            f"  Found: {line.strip()}\n"
+            f"  Expected: 'swe-workbench' to appear in the same sentence so the "
+            f"enforcement claim is scoped to the plugin, not to the host repo."
+        )
+        # The old "This repo enforces" pattern must be gone (anywhere in the line)
+        assert not re.search(r"This repo enforces", line), (
+            f"Line {lineno} still uses the ambiguous 'This repo enforces' phrasing.\n"
+            f"  Found: {line.strip()}\n"
+            f"  'This repo' resolves to the user's workspace when the skill is loaded "
+            f"into a foreign repo. Use 'swe-workbench plugin repo' as the explicit subject."
+        )
+
+
+def test_cleanup_merged_resolves_default_branch_dynamically():
+    """cleanup-merged SKILL.md and sync-and-verify.sh must not hardcode 'main'.
+
+    The default branch of the host repo may be 'master', 'trunk', 'develop',
+    or anything else.  Hardcoding 'main' silently checks out the wrong branch
+    in every non-GitHub-default repo.
+
+    Assertions:
+    (a) SKILL.md contains a default-branch resolution step (gh repo view or
+        symbolic-ref).
+    (b) sync-and-verify.sh uses a variable (e.g. $DEFAULT_BRANCH) in every
+        git checkout / git pull command; no bare literal 'main' as branch name.
+
+    Fails today because sync-and-verify.sh line 17 has:
+        git checkout main && git pull --ff-only origin main
+    """
+    skill_body = CLEANUP_MERGED_SKILL.read_text()
+    script_body = SYNC_SCRIPT.read_text()
+
+    # (a) SKILL.md has a dynamic resolution step
+    has_resolution = any(
+        pattern.search(skill_body) for pattern in _DYNAMIC_BRANCH_PATTERNS
+    )
+    assert has_resolution, (
+        "skills/workflow-cleanup-merged/SKILL.md must contain a default-branch "
+        "resolution step (e.g. 'gh repo view --json defaultBranchRef' or "
+        "'symbolic-ref refs/remotes/origin/HEAD') so it works in repos whose "
+        "default branch is not 'main'."
+    )
+
+    # (b) sync-and-verify.sh does not hardcode 'main' as a branch name in git commands
+    offending_lines = []
+    for lineno, line in enumerate(script_body.splitlines(), 1):
+        if _LITERAL_MAIN_IN_GIT_CMD.search(line) and not line.strip().startswith("#"):
+            offending_lines.append((lineno, line.strip()))
+
+    assert not offending_lines, (
+        "skills/workflow-cleanup-merged/scripts/sync-and-verify.sh hardcodes 'main' "
+        "as the branch name in git checkout/pull commands.\n"
+        "Use a variable resolved at script entry (e.g. DEFAULT_BRANCH) instead:\n\n"
+        + "\n".join(f"  line {ln}: {txt}" for ln, txt in offending_lines)
+    )

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -44,6 +44,12 @@ def _build_repo(base: Path, default_branch: str = "main") -> Path:
     origin = base / "origin.git"
     repo = base / "main_repo"
 
+    # Strip inherited GIT_* env vars so fixture git operations use the tmp repo,
+    # not a parent worktree whose GIT_DIR may be set by a calling git hook.
+    import os as _os
+    _clean_env = {k: v for k, v in _os.environ.items() if not k.startswith("GIT_")}
+    _clean_env["GIT_CONFIG_NOSYSTEM"] = "1"
+
     def run(*args, cwd=None):
         return subprocess.run(
             list(args),
@@ -51,6 +57,7 @@ def _build_repo(base: Path, default_branch: str = "main") -> Path:
             check=True,
             capture_output=True,
             text=True,
+            env=_clean_env,
         )
 
     run("git", "init", "--bare", str(origin))

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -35,8 +35,12 @@ NOISE_STRINGS = [
 ]
 
 
-def _build_repo(base: Path) -> Path:
-    """Create a minimal git environment: bare origin + working main_repo."""
+def _build_repo(base: Path, default_branch: str = "main") -> Path:
+    """Create a minimal git environment: bare origin + working main_repo.
+
+    default_branch controls the name of the default branch so tests can verify
+    Treatment D works on repos whose default branch is not 'main'.
+    """
     origin = base / "origin.git"
     repo = base / "main_repo"
 
@@ -53,35 +57,56 @@ def _build_repo(base: Path) -> Path:
     run("git", "init", str(repo))
     run("git", "config", "user.email", "test@example.com", cwd=repo)
     run("git", "config", "user.name", "Test", cwd=repo)
+    # Prevent the global core.hooksPath (set to swe-workbench hooks) from
+    # running the commit-msg hook inside test fixture repos.  The fixture
+    # tests sync-and-verify.sh, not commit formatting.
+    no_hooks = base / ".nohooks"
+    no_hooks.mkdir(exist_ok=True)
+    run("git", "config", "core.hooksPath", str(no_hooks), cwd=repo)
 
     (repo / "README.md").write_text("hello\n")
     run("git", "add", "README.md", cwd=repo)
     run("git", "commit", "-m", "init", cwd=repo)
-    run("git", "branch", "-M", "main", cwd=repo)
+    run("git", "branch", "-M", default_branch, cwd=repo)
     run("git", "remote", "add", "origin", str(origin), cwd=repo)
-    run("git", "push", "-u", "origin", "main", cwd=repo)
+    run("git", "push", "-u", "origin", default_branch, cwd=repo)
 
     run("git", "checkout", "-b", BRANCH, cwd=repo)
     (repo / "feature.txt").write_text("feature\n")
     run("git", "add", "feature.txt", cwd=repo)
     run("git", "commit", "-m", "add feature", cwd=repo)
     run("git", "push", "-u", "origin", BRANCH, cwd=repo)
-    run("git", "checkout", "main", cwd=repo)
+    run("git", "checkout", default_branch, cwd=repo)
 
     return repo
 
 
 @pytest.fixture
 def git_repo(tmp_path):
-    return _build_repo(tmp_path)
+    return _build_repo(tmp_path, default_branch="main")
 
 
-def _run_script(repo: Path, head_ref: str):
+@pytest.fixture
+def git_repo_trunk(tmp_path):
+    """Repo whose default branch is 'trunk', not 'main' (Treatment D coverage)."""
+    return _build_repo(tmp_path, default_branch="trunk")
+
+
+def _run_script(repo: Path, head_ref: str, default_branch: str = "main"):
+    # Clear git environment variables so the script operates on the fixture
+    # repo, not on a parent worktree whose GIT_DIR may be inherited when tests
+    # run inside a git hook (e.g. pre-push).  Without this, sync-and-verify.sh
+    # would derive MAIN_REPO from the parent worktree and git checkout would
+    # switch the parent worktree's branch as a side-effect.
+    env = {k: v for k, v in __import__("os").environ.items()
+           if not k.startswith("GIT_")}
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
     return subprocess.run(
-        ["bash", str(SCRIPT), head_ref],
+        ["bash", str(SCRIPT), head_ref, default_branch],
         cwd=str(repo),
         capture_output=True,
         text=True,
+        env=env,
     )
 
 
@@ -124,5 +149,24 @@ class TestSyncAndVerifyStdoutContract:
                 text=True,
             )
 
-        result = _run_script(git_repo, BRANCH)
+        result = _run_script(git_repo, BRANCH, default_branch="main")
         _assert_contract(result, expected)
+
+
+class TestSyncAndVerifyNonMainDefaultBranch:
+    """Treatment D: script must work when the default branch is not 'main'."""
+
+    def test_branch_present_trunk_default(self, git_repo_trunk):
+        result = _run_script(git_repo_trunk, BRANCH, default_branch="trunk")
+        _assert_contract(result, "0")
+
+    def test_branch_absent_trunk_default(self, git_repo_trunk):
+        subprocess.run(
+            ["git", "branch", "-D", BRANCH],
+            cwd=str(git_repo_trunk),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        result = _run_script(git_repo_trunk, BRANCH, default_branch="trunk")
+        _assert_contract(result, "1")


### PR DESCRIPTION
## Summary
- Replace all "this repo" prose assertions in `workflow-commit-and-pr`, `principle-version-control`, and `workflow-cleanup-merged` skills with either runtime-detection steps or explicit `swe-workbench plugin` naming
- When a skill loads into a foreign repo the phrase "this repo" resolves to the user's workspace, causing the skill to impose swe-workbench conventions (commit format, `[no ci]` CI layout, `AskUserQuestion` prohibition) as if they were facts about every host repo
- Treatment D also fixes hardcoded `main` in `sync-and-verify.sh` and the cleanup-merged skill: the default branch is now resolved dynamically via `gh repo view` / `git symbolic-ref`
- Adds `tests/test_skill_repo_ambiguity.py` with 3 regression tests; updates `tests/test_sync_and_verify.py` with non-`main` default-branch coverage and environment isolation (strips `GIT_*` vars so fixture git ops don't escape into parent worktrees during pre-push hook runs)

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/` — 318/318 pass (includes 3 new tests in `test_skill_repo_ambiguity.py` and 2 new trunk-branch tests in `test_sync_and_verify.py`)
- [x] Spot-check: `grep -in "this repo"` returns zero hits across all three SKILL.md files
- [x] Pre-push hook passes (GIT_* env isolation prevents fixture git ops from escaping worktree context)

Issue: N/A — referential ambiguity surfaced via /debug; downstream symptom is AskUserQuestion suppression in every host repo (tracked in #202)
