### PR TITLE
[feat] workflow-commit-and-pr: AskUserQuestion for draft/ready prompt

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -130,22 +130,26 @@ If no template is found, use a heredoc fallback.
 
 ## Draft vs ready prompt
 
-Before running `gh pr create`, ask the user:
+Before running `gh pr create`, call the `AskUserQuestion` tool with:
 
+```json
+{
+  "questions": [{
+    "question": "Open this PR as draft or ready for review?",
+    "header": "PR mode",
+    "multiSelect": false,
+    "options": [
+      { "label": "Ready for review", "description": "Default; runs `gh pr create`" },
+      { "label": "Draft",            "description": "Adds `--draft` flag; hides from reviewers" }
+    ]
+  }]
+}
 ```
-Ready to push to GitHub? Reply with one of:
-  - `draft`  — open the PR as a draft (gh pr create --draft)
-  - `ready`  — open the PR for review (default)
-```
 
-**Wait for the user to reply** with one of those exact words. Reject any other reply (re-prompt).
-
-**Choose the asking medium by question shape:**
-
-- **Binary or short-list selections** (≤4 mutually exclusive options) — e.g., draft vs. ready PR, commit `[type]` when ambiguous, branch-rename vs. continue — prefer **`AskUserQuestion`**.
-- **Confirmation-with-preview** (show the diff/message and ask "ship it?") — prefer plain prose so the user can read the artifact inline.
-
-The two forms coexist; neither replaces the other.
+Map the `Draft` answer → append `--draft` to `gh pr create`. Any other
+answer (including `Ready for review` and the free-text `Other` channel) →
+no flag. If the user supplies an `Other` reply that signals abort/cancel,
+stop and re-confirm before running `gh pr create`.
 
 ## Ticket-context chain
 
@@ -188,7 +192,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Append `[no ci]` to a commit touching `commands/foo.md` | The exclusion of `commands/`, `skills/`, `agents/` is load-bearing. |
 | Use `gh pr create --fill` | Use `--body-file <PR template path>` so the `Closes #` line is filled correctly. |
 | Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT; <fill template> > "$TMP"; gh pr create --body-file "$TMP"` (trap ensures cleanup on failure too). |
-| Auto-`gh pr create --draft` without asking | Always ask `draft` vs `ready`. Drafts hide the PR from `assignees` and reviewers. |
+| Auto-`gh pr create --draft` without asking | Always use `AskUserQuestion` to present `Draft` vs `Ready for review` — never ask via free-form prose. Drafts hide the PR from `assignees` and reviewers. |
 
 ## Quick reference
 

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -11,11 +11,17 @@ Both were eval'd by the caller, causing "command not found" errors.
 This test pins the contract: stdout must be exactly one line.
 """
 
+import os
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
+
+# Strip GIT_* env vars for all subprocess calls so tests running inside a git
+# hook or worktree context cannot cross-contaminate the parent repository.
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+_CLEAN_ENV["GIT_CONFIG_NOSYSTEM"] = "1"
 
 SCRIPT = (
     Path(__file__).parent.parent
@@ -44,12 +50,6 @@ def _build_repo(base: Path, default_branch: str = "main") -> Path:
     origin = base / "origin.git"
     repo = base / "main_repo"
 
-    # Strip inherited GIT_* env vars so fixture git operations use the tmp repo,
-    # not a parent worktree whose GIT_DIR may be set by a calling git hook.
-    import os as _os
-    _clean_env = {k: v for k, v in _os.environ.items() if not k.startswith("GIT_")}
-    _clean_env["GIT_CONFIG_NOSYSTEM"] = "1"
-
     def run(*args, cwd=None):
         return subprocess.run(
             list(args),
@@ -57,7 +57,7 @@ def _build_repo(base: Path, default_branch: str = "main") -> Path:
             check=True,
             capture_output=True,
             text=True,
-            env=_clean_env,
+            env=_CLEAN_ENV,
         )
 
     run("git", "init", "--bare", str(origin))
@@ -100,20 +100,12 @@ def git_repo_trunk(tmp_path):
 
 
 def _run_script(repo: Path, head_ref: str, default_branch: str = "main"):
-    # Clear git environment variables so the script operates on the fixture
-    # repo, not on a parent worktree whose GIT_DIR may be inherited when tests
-    # run inside a git hook (e.g. pre-push).  Without this, sync-and-verify.sh
-    # would derive MAIN_REPO from the parent worktree and git checkout would
-    # switch the parent worktree's branch as a side-effect.
-    env = {k: v for k, v in __import__("os").environ.items()
-           if not k.startswith("GIT_")}
-    env["GIT_CONFIG_NOSYSTEM"] = "1"
     return subprocess.run(
         ["bash", str(SCRIPT), head_ref, default_branch],
         cwd=str(repo),
         capture_output=True,
         text=True,
-        env=env,
+        env=_CLEAN_ENV,
     )
 
 
@@ -154,6 +146,7 @@ class TestSyncAndVerifyStdoutContract:
                 check=True,
                 capture_output=True,
                 text=True,
+                env=_CLEAN_ENV,
             )
 
         result = _run_script(git_repo, BRANCH, default_branch="main")
@@ -174,6 +167,7 @@ class TestSyncAndVerifyNonMainDefaultBranch:
             check=True,
             capture_output=True,
             text=True,
+            env=_CLEAN_ENV,
         )
         result = _run_script(git_repo_trunk, BRANCH, default_branch="trunk")
         _assert_contract(result, "1")


### PR DESCRIPTION
## Summary
- Replace the plain-prose `draft`/`ready` ask block in `workflow-commit-and-pr` with a structured `AskUserQuestion` two-button choice — removes typo / case-mismatch friction for end-users in consumer repos
- Use JSON payload form (not JS pseudocode) so models invoke the real tool; add explicit mapping rule and Other/cancel handling; update the common-mistakes table to reference `AskUserQuestion` by name
- Also centralise `_CLEAN_ENV` in `test_sync_and_verify.py` — closes the gap where bare `subprocess.run` calls inherited `GIT_COMMON_DIR` and could redirect git operations to the parent repo, polluting its config

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` → All checks passed
- [x] `pytest tests/ -v` → 318/318 passed

Closes #202
