### PR TITLE
[feat] workflow-commit-and-pr: pre-check existing PR

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -128,6 +128,39 @@ done
 
 If no template is found, use a heredoc fallback.
 
+## Pre-check: existing PR for this branch
+
+Before running `gh pr create`, check whether an OPEN PR already exists for this branch:
+
+```bash
+PR_INFO=$(gh pr view --json url,state -q '.state + "\t" + .url' 2>/dev/null || true)
+PR_STATE=$(echo "$PR_INFO" | cut -f1)
+PR_URL=$(echo "$PR_INFO"   | cut -f2)
+```
+
+Filter: act only when `PR_STATE == "OPEN"`. Ignore `CLOSED` or `MERGED` PRs — those do not block new-PR creation.
+
+If an OPEN PR is found, call `AskUserQuestion` with:
+
+```json
+{
+  "questions": [{
+    "question": "An open PR already exists for this branch. Update it or cancel?",
+    "header": "Existing PR",
+    "multiSelect": false,
+    "options": [
+      { "label": "Update existing PR", "description": "New commits are already on the branch — skip gh pr create and use the existing PR URL." },
+      { "label": "Cancel",             "description": "Abort the flow. No PR is created or modified." }
+    ]
+  }]
+}
+```
+
+- **`Update existing PR`** → skip `gh pr create`. Use the existing PR URL in all output. Run the Post-create CTA (offer `/review`) against the existing PR number.
+- **`Cancel`** → abort. Print the existing PR URL for reference.
+
+If no OPEN PR is found → proceed to the `## Draft vs ready prompt` step normally.
+
 ## Draft vs ready prompt
 
 Before running `gh pr create`, call the `AskUserQuestion` tool with:
@@ -180,6 +213,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | `gh pr create` fails on PR-template body validation | CI rejects empty `Closes #` | Re-read `.github/PULL_REQUEST_TEMPLATE.md` instructions; substitute `Closes #<issue>` or standalone `Issue: N/A — <reason>`; re-attempt. |
 | `git push` rejected (non-FF) | Non-zero exit | Abort. Tell user to `git pull --rebase`; do NOT force-push. |
 | Doc-only `[no ci]` rule mis-triggers (ambiguous case) | User disagrees | Skip `[no ci]` and warn. The doc-only rule is conservative — when in doubt, run CI. |
+| Duplicate PR (already exists) | `gh pr view` returns `state == "OPEN"` before `gh pr create` | Surface URL via `AskUserQuestion` (see Pre-check section). On `Update existing PR`, skip `gh pr create`. **Never** re-run `gh pr create` to recover. |
 
 ## Common mistakes
 
@@ -193,6 +227,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Use `gh pr create --fill` | Use `--body-file <PR template path>` so the `Closes #` line is filled correctly. |
 | Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT; <fill template> > "$TMP"; gh pr create --body-file "$TMP"` (trap ensures cleanup on failure too). |
 | Auto-`gh pr create --draft` without asking | Always use `AskUserQuestion` to present `Draft` vs `Ready for review` — never ask via free-form prose. Drafts hide the PR from `assignees` and reviewers. |
+| Re-run `gh pr create` after a "pull request already exists" failure | The pre-check section detects this before it happens. After push, an existing OPEN PR is already updated — `gh pr create` has nothing left to do. Use the `Update existing PR` path instead. |
 
 ## Quick reference
 
@@ -201,5 +236,6 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | "I finished the feature" | Preview | Show diff + drafted commit msg. Do NOT commit. |
 | "Commit this" | Commit | `git commit -m "[type] …"`. Stop. No push. |
 | "Push it" | Push | `git push -u origin <branch>`. Stop. No PR. |
-| "Ship this" | Ship | Commit → push → draft/ready prompt → `gh pr create`. |
-| "Open a PR for what I just pushed" | PR-only | Skip commit. Run draft/ready prompt → `gh pr create`. |
+| "Ship this" | Ship | Commit → push → existing-PR check → draft/ready prompt → `gh pr create`. |
+| "Ship this" (existing OPEN PR found) | Ship | Commit → push → existing-PR check surfaces URL → `AskUserQuestion` → skip `gh pr create`. |
+| "Open a PR for what I just pushed" | PR-only | Skip commit. Run existing-PR check → draft/ready prompt → `gh pr create`. |


### PR DESCRIPTION
## Summary
- Add `## Pre-check: existing PR for this branch` section — runs after push, before `gh pr create`, using `gh pr view --json url,state` to detect an OPEN PR on the current branch
- If an OPEN PR is found, surface it via `AskUserQuestion` with `Update existing PR` (skip `gh pr create`, reuse existing URL + post-create CTA) or `Cancel` options
- `CLOSED`/`MERGED` PRs are non-blocking; only `OPEN` state triggers the prompt
- Add `Duplicate PR` row to `## Failure modes` table
- Add "Re-run `gh pr create` after a conflict" row to `## Common mistakes` table
- Update `## Quick reference` to show the existing-PR check between push and draft/ready prompt

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 318 passed, no regressions

Closes #200
