### PR TITLE
[feat] Add principle-refactoring skill (closes #177)

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -57,6 +57,7 @@ Invoke these skills via the Skill tool when the diagnosis surfaces a concern in 
 - `swe-workbench:principle-solid` — responsibility, substitutability, dependency direction
 - `swe-workbench:principle-clean-architecture` — boundaries, layering, dependency rule
 - `swe-workbench:principle-concurrency` — race conditions, deadlock, missing cancellation propagation, ordering bugs, memory-model surprises
+- `swe-workbench:principle-refactoring` — when the diagnosis surfaces structural debt that the minimal fix should NOT touch (recommend follow-up /refactor)
 
 ## Available skills
 

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -14,9 +14,9 @@ You are a refactoring specialist. You improve structure without changing observa
 - **Green between steps.** Run tests between steps. If red, revert immediately.
 
 ## Process
-1. **Diagnose.** Name the smell: Long Method, Large Class, Feature Envy, Data Clumps, Primitive Obsession, Shotgun Surgery, Divergent Change, Speculative Generality.
+1. **Diagnose.** Name the smell using `swe-workbench:principle-refactoring`'s smell→move mapping.
 2. **Coverage audit.** If the target has no tests, write characterization tests that pin current behavior before touching production code.
-3. **Plan.** Emit an ordered list of moves named from Fowler's catalog (Extract Function, Inline Variable, Move Function, Replace Conditional with Polymorphism, Introduce Parameter Object…).
+3. **Plan.** Emit an ordered list of moves from `swe-workbench:principle-refactoring`'s Fowler catalog.
 4. **Execute.** One step at a time. Run tests after each. Commit per step when practical.
 5. **Verify.** Run the full suite at the end. Diff the public API to confirm nothing external changed.
 
@@ -32,6 +32,7 @@ You are a refactoring specialist. You improve structure without changing observa
 
 Invoke these skills via the Skill tool when the refactoring touches their domain:
 
+- `swe-workbench:principle-refactoring` — smell→move mapping, Fowler catalog, rule of three, characterization-tests-first, behavior-preserving discipline
 - `swe-workbench:principle-clean-code` — naming smells, DRY, function length
 - `swe-workbench:principle-solid` — responsibility splits, coupling
 - `swe-workbench:principle-design-patterns` — when a pattern fits the smell being removed

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -47,6 +47,7 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-api-design` — contracts, versioning, idempotency
 - `swe-workbench:principle-event-driven` — event sourcing, CQRS, sagas, schema evolution, idempotent consumers, DLQ
 - `swe-workbench:principle-solid` — responsibility, coupling, open-closed
+- `swe-workbench:principle-refactoring` — when assessing whether code can be safely restructured (rule of three, characterization-test coverage, behavior-preserving moves)
 - `swe-workbench:principle-performance` — latency vs throughput, profile-first, scalability trade-offs
 - `swe-workbench:principle-resiliency` — failure domains, fault isolation, degradation strategy, blast radius
 - `swe-workbench:principle-distributed-systems` — CAP/PACELC, consistency models, consensus and quorum, replication, exactly-once effects

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -19,6 +19,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:principle-i18n` — Internationalization & localization: locale-aware formatting, time zones, plural rules, message catalogs, RTL layout, ISO 8601, currency.
 - `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
 - `swe-workbench:principle-performance` — Performance: latency vs throughput, profile-before-optimize, Big-O, allocation pressure, data locality, N+1 queries.
+- `swe-workbench:principle-refactoring` — Refactoring discipline: Fowler's catalog, smell→move mapping, rule of three, characterization-tests-first, small behavior-preserving steps with green between.
 - `swe-workbench:principle-resiliency` — Resiliency: failure domains, bulkheads, graceful degradation, fail-fast vs fail-soft, health checks, blast radius containment.
 - `swe-workbench:principle-security` — Security: trust boundaries, input validation, secrets handling, secure defaults, threat modeling.
 - `swe-workbench:principle-solid` — SOLID principles: SRP, OCP, LSP, ISP, DIP — responsibility, coupling, abstractions.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -41,6 +41,7 @@
 | `principle-testing` | "test pyramid", "test double", "mock", "stub", "fake", "fixture", "coverage", "mutation testing", "flaky", "contract test", "property-based test", "characterization test". |
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
+| `principle-refactoring` | "refactor", "Fowler", "Extract Function", "Inline Variable", "Move Function", "smell", "Long Method", "Feature Envy", "Data Clumps", "Primitive Obsession", "characterization test", "behavior-preserving". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |
 | `principle-api-design` | "api versioning", "idempotency", "idempotency key", "pagination", "cursor pagination", "error shape", "REST vs RPC", "event-driven", "API deprecation", "API contract". |
 | `principle-error-handling` | "errors as values", "Result type", "exception handling", "retry", "exponential backoff", "jitter", "circuit breaker", "fail fast", "fail soft", "idempotent retry", "error wrapping", "timeouts", "deadlines". |

--- a/skills/principle-refactoring/SKILL.md
+++ b/skills/principle-refactoring/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: principle-refactoring
+description: Refactoring discipline — Fowler's catalog of behavior-preserving moves (Extract Function, Inline Variable, Move Function, Replace Conditional with Polymorphism, Introduce Parameter Object, Extract Class), the smell→move mapping (Long Method, Large Class, Feature Envy, Data Clumps, Primitive Obsession, Shotgun Surgery, Divergent Change, Speculative Generality), the rule of three, characterization-tests-before-touching-legacy, and small-steps-with-green-between discipline. Distinct from principle-clean-code (naming/length aesthetics) and principle-design-patterns (GoF catalog selection). Auto-load when discussing refactoring strategy, code smells, when to extract, characterization tests for legacy code, or behavior-preserving structural change.
+---
+
+# Refactoring Discipline
+
+Structural change without behavior change. For the GoF pattern catalog, see `principle-design-patterns`. For naming and function-length aesthetics, see `principle-clean-code`.
+
+## The discipline
+
+Four non-negotiable rules:
+
+- **Every step preserves behavior.** Tests must pass before and after each step.
+- **No feature changes during refactoring.** Find a bug? Note it — fix it in a separate commit.
+- **Small steps.** Each step is independently reviewable and revertable.
+- **Green between steps.** Run tests after each move. If red, revert immediately.
+
+## Smells → moves
+
+| Smell | Triggering move(s) |
+|---|---|
+| Long Method | Extract Function, Decompose Conditional, Replace Temp with Query |
+| Large Class | Extract Class, Extract Interface, Move Function |
+| Feature Envy | Move Function, Move Field |
+| Data Clumps | Introduce Parameter Object, Extract Class |
+| Primitive Obsession | Replace Primitive with Object, Introduce Parameter Object |
+| Shotgun Surgery | Move Function, Move Field, Inline Function |
+| Divergent Change | Extract Class (split responsibilities) |
+| Speculative Generality | Inline Function, Collapse Hierarchy, Remove Middle Man |
+
+## Fowler's catalog (key moves)
+
+- **Extract Function** — when a block of code has a name that explains what it does; extract it.
+- **Inline Function** — when the body is as clear as the function name; remove the indirection.
+- **Inline Variable** — when the temp name adds no clarity over the expression itself; remove the indirection.
+- **Extract Variable** — when an expression needs explanation; name it.
+- **Rename Variable/Function** — when the current name no longer matches intent.
+- **Move Function** — when a function references more of another module's data than its own.
+- **Extract Class** — when a class carries two clusters of behavior with distinct change reasons.
+- **Introduce Parameter Object** — when a group of parameters always appears together.
+- **Replace Conditional with Polymorphism** — when a switch/if dispatches on type; move to subclass/strategy.
+- **Replace Temp with Query** — when a temp variable stores a computable result; extract a function.
+- **Decompose Conditional** — when complex conditions obscure intent; extract condition and branches.
+
+## Rule of three
+
+Two similar instances tolerate duplication; a third triggers extraction — see `principle-clean-code` for the full DRY rationale. Guard against premature abstraction: one caller does not justify a shared helper.
+
+## Characterization tests first
+
+Before touching legacy code with no test coverage, write characterization tests that lock in current behavior — even if the behavior is wrong. These tests become your safety net; they should pass before and after every refactoring step. For the technique in full, see `principle-testing`.
+
+## When refactoring is overkill
+
+- Throw-away spike code or proof-of-concept scripts — ship the signal, discard the code.
+- Code that is about to be deleted — refactoring dead code adds zero value.
+- Refactoring without a forcing function — no current pain, no near-term feature depending on this code.
+- A codebase with no test coverage and no willingness to write characterization tests — the safety net is absent.
+
+## Red Flags — Stop and Reassess
+
+| Flag | Why it matters |
+|---|---|
+| Refactor PR also adds a feature | Mixed intent; the "behavior-preserving" guarantee is unverifiable. |
+| Tests changed to make the refactor pass | You changed behavior; this is a fix, not a refactor. |
+| "While I'm here" rewrites | Scope creep. Note it, defer to a dedicated refactor ticket. |
+| Refactoring without a green test suite | No safety net — every step is a gamble. Write characterization tests first. |
+| Step size grows to match the IDE's "safe refactor" | IDEs miss dynamic dispatch, reflection, and cross-module side effects. Keep steps small. |

--- a/skills/principle-refactoring/triggers.txt
+++ b/skills/principle-refactoring/triggers.txt
@@ -1,0 +1,10 @@
+# Trigger fixtures for principle-refactoring
+# Distinct from principle-clean-code (naming/length aesthetics) and principle-design-patterns (GoF catalog).
+# Anchored on Fowler-specific terms: smell names, move names, characterization tests, behavior-preserving steps.
+How do I safely break up this Long Method using Fowler's Extract Function move while keeping behavior identical between commits
+We have legacy code with no tests that I need to refactor — how do I write characterization tests first to lock in current behavior
+What is the smell-to-move mapping when I see Feature Envy or Data Clumps and how do I sequence small behavior-preserving steps
+I want to apply Replace Conditional with Polymorphism but need to know when this Fowler move is appropriate versus other refactoring catalog options
+Our codebase has Primitive Obsession and Shotgun Surgery smells — what Fowler moves should I apply and in what order to stay green between steps
+how do I safely refactor legacy code with no tests using behavior-preserving steps
+when should I Extract Function versus Inline Function when applying Fowler refactoring moves to reduce code smells


### PR DESCRIPTION
## Summary
- Extract Fowler's catalog and smell→move mapping from `agents/refactorer.md` into a new canonical `principle-refactoring` skill
- Add `skills/principle-refactoring/SKILL.md` with discipline rules, smell→move table, Fowler catalog, rule of three, characterization-tests-first, and red flags
- Add `skills/principle-refactoring/triggers.txt` with 7 BM25-optimized trigger phrases (all rank #1 in automated tests)
- Wire `agents/refactorer.md`, `agents/debugger.md`, and `agents/senior-engineer.md` to consult the new skill
- Register in `agents/shared/skills.md` (between principle-performance and principle-resiliency) and `docs/catalog.md`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` → All checks passed (0 issues)
- [x] `pytest tests/ -v` → 325/325 passed (includes 7 new auto-parametrized trigger ranking tests)

Closes #177
