### PR TITLE
[feat] Extract review heuristics into principle-code-review skill

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -85,6 +85,7 @@ Every finding must include all 11 fields. **Omit any finding you cannot fill all
 
 Invoke these skills via the Skill tool when a finding surfaces a concern in their domain:
 
+- `swe-workbench:principle-code-review` — review heuristics: four-axis lens, confidence-based filtering, tone, nitpick filtering
 - `swe-workbench:principle-security` — trust boundaries, input validation, secrets handling
 - `swe-workbench:principle-performance` — latency, throughput, N+1, allocation pressure
 - `swe-workbench:principle-resiliency` — reliability findings: failure domains, bulkheads, graceful degradation, retry patterns

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -7,9 +7,8 @@ tools: Read, Grep, Glob, Bash, Skill
 
 You are a senior code reviewer. Your job is to catch the issues a careful colleague would flag on a Monday-morning PR — not to restate what the code does.
 
-> Review heuristics (four-axis lens, confidence filtering, tone, what's not a finding): invoke `swe-workbench:principle-code-review`.
-
 ## Process
+0. **Load heuristics.** Invoke `swe-workbench:principle-code-review` before reading the diff — this loads the four-axis lens, confidence floors, tone rules, and nitpick filter.
 1. Read the diff end-to-end before commenting.
 2. Use `Grep`/`Glob` to understand callers and blast radius.
 3. For non-trivial changes, read the modified files in full, not just the hunks.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -7,16 +7,7 @@ tools: Read, Grep, Glob, Bash, Skill
 
 You are a senior code reviewer. Your job is to catch the issues a careful colleague would flag on a Monday-morning PR — not to restate what the code does.
 
-## Focus
-- **Correctness** — off-by-ones, null paths, concurrency races, lost errors, unhandled edge cases.
-- **Security** — injection, auth/authz gaps, secrets in code, unsafe deserialization, SSRF, missing input validation at trust boundaries.
-- **Design integrity** — SOLID violations, leaky abstractions, tight coupling, circular deps, domain logic bleeding into infrastructure.
-- **Tests** — missing coverage on new branches, brittle tests, tests that mirror implementation rather than behavior.
-
-## Explicitly ignore
-- Formatting, import order, quote style — that is the linter.
-- Stylistic preferences with no behavioral impact.
-- Speculative "could be" comments without a concrete failure mode.
+> Review heuristics (four-axis lens, confidence filtering, tone, what's not a finding): invoke `swe-workbench:principle-code-review`.
 
 ## Process
 1. Read the diff end-to-end before commenting.
@@ -28,12 +19,6 @@ You are a senior code reviewer. Your job is to catch the issues a careful collea
 7. **Diff-size-aware path.** Count files and changed lines first (`git diff --shortstat`, `git diff --name-only`).
    - **>50 files OR >1000 lines**: review per-file in a loop. Emit findings as you go; never hold a giant in-memory model of the whole diff.
    - Otherwise: read the full diff once and emit findings.
-
-## Judgement rules
-- No finding without a concrete failure scenario.
-- Prefer one strong comment over five weak ones.
-- If something is well done, say so briefly — silence is not approval.
-- Missing tests are a finding, not an afterthought.
 
 ## Suggestion-block decision tree
 
@@ -71,6 +56,7 @@ When the invoker (e.g. `/review` PR mode) explicitly asks for a Review Decision 
 
 Invoke these skills via the Skill tool when the review surfaces a concern in their domain:
 
+- `swe-workbench:principle-code-review` — review heuristics: four-axis lens, confidence-based filtering, tone, nitpick filtering
 - `swe-workbench:principle-clean-code` — naming, duplication, readability
 - `swe-workbench:principle-error-handling` — failure modes, error wrapping
 - `swe-workbench:principle-solid` — responsibility violations, coupling

--- a/agents/shared/skills.md
+++ b/agents/shared/skills.md
@@ -8,6 +8,7 @@ All `swe-workbench` skills available in this plugin. Use the `Skill` tool to inv
 - `swe-workbench:principle-api-design` — API design: contract-first, versioning, idempotency, REST/RPC/event trade-offs.
 - `swe-workbench:principle-clean-architecture` — Clean Architecture: dependency rule, ports and adapters, domain-centric layering.
 - `swe-workbench:principle-clean-code` — Clean code: DRY, KISS, YAGNI, naming, function length, abstraction level.
+- `swe-workbench:principle-code-review` — Code review: four-axis lens (correctness, security, design, tests), confidence-based filtering, comment tone, nitpick filtering.
 - `swe-workbench:principle-concurrency` — Concurrency: race conditions, deadlock, structured concurrency, cancellation, backpressure.
 - `swe-workbench:principle-cost-awareness` — Cost awareness: FinOps mindset, egress, right-sizing, scale-to-zero, cost-per-request, storage tiers, observability cost.
 - `swe-workbench:principle-data-modeling` — Data modeling: storage paradigm selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution, query-first design, retention.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -41,6 +41,7 @@
 | `principle-testing` | "test pyramid", "test double", "mock", "stub", "fake", "fixture", "coverage", "mutation testing", "flaky", "contract test", "property-based test", "characterization test". |
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
+| `principle-code-review` | "code review checklist", "PR review heuristics", "review comment", "review finding", "nitpick filtering", "reviewing a diff". |
 | `principle-refactoring` | "refactor", "Fowler", "Extract Function", "Inline Variable", "Move Function", "smell", "Long Method", "Feature Envy", "Data Clumps", "Primitive Obsession", "characterization test", "behavior-preserving". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |
 | `principle-api-design` | "api versioning", "idempotency", "idempotency key", "pagination", "cursor pagination", "error shape", "REST vs RPC", "event-driven", "API deprecation", "API contract". |

--- a/skills/principle-code-review/SKILL.md
+++ b/skills/principle-code-review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: principle-code-review
+description: Code review heuristics — four-axis review lens (correctness, security, design integrity, test coverage); confidence-based filtering (no finding without a concrete failure scenario); review comment tone (observation over accusation); nitpick filtering; what counts as a real finding vs linter noise. Auto-load when writing or framing a review comment, deciding whether a PR finding is worth surfacing, reviewing a diff for correctness, or filtering review nitpicks.
+---
+
+# Code Review
+
+Principles for high-signal code review. For tool-specific mechanics (diff-size routing, suggestion-block format, GitHub workflow), see the `reviewer` agent.
+
+## Four-Axis Review Lens
+
+Every review covers four axes:
+
+- **Correctness** — off-by-ones, null paths, concurrency races, lost errors, unhandled edge cases.
+- **Security** — injection, auth/authz gaps, secrets in code, unsafe deserialization, SSRF, missing input validation at trust boundaries.
+- **Design integrity** — SOLID violations, leaky abstractions, tight coupling, circular deps, domain logic bleeding into infrastructure.
+- **Tests** — missing coverage on new branches, brittle tests, tests that mirror implementation rather than behavior.
+
+## What's Not a Finding
+
+Do not surface these:
+
+- Formatting, import order, quote style — owned by the linter, not the reviewer.
+- Stylistic preferences with no behavioral impact.
+- Speculative "could be" comments without a concrete failure mode.
+
+These erode review signal. If your only comment is a style preference, stay silent.
+
+## Confidence-Based Filtering
+
+Before surfacing a finding, apply this filter:
+
+1. **Name the failure scenario.** What breaks, under what inputs, in what deployment context? If you cannot articulate it, the finding is speculative — drop it.
+2. **One strong comment over five weak ones.** Ten medium-confidence findings force the author to triage; two high-confidence findings close the loop.
+3. **Missing tests are a finding, not an afterthought.** Untested new branches are incomplete work.
+
+Confidence floor by severity:
+
+| Severity | Minimum confidence | Action if below floor |
+|---|---|---|
+| Critical | 0.9 | Must name an exploit or data-loss path |
+| High | 0.75 | Must name a realistic failure scenario |
+| Medium | 0.5 | Can surface; mark as "likely" |
+| Low / Nit | Any | Drop unless the fix is a one-liner |
+
+## Tone
+
+Review the code, not the author.
+
+- **Observation language:** "This path returns nil without checking the error" — not "You forgot to check the error."
+- **Acknowledge good work briefly.** Silence is not approval; a short note reduces defensive reading.
+- **Frame as options for Medium/Low.** "One option: …" not "You should …".
+- **Reserve mandates for Critical/High.** Direct language is appropriate when the stakes are real.
+
+## Red Flags
+
+| Pattern | What it signals |
+|---|---|
+| Finding with no named failure scenario | Speculation — refine or drop |
+| Five+ findings, none above Medium | Signal-to-noise failure — prioritize |
+| Only linter-owned comments (style, formatting) | Scope creep — let the linter own these |
+| Zero positive observations in a long review | Adversarial culture risk |
+| Nitpick marked Critical | Severity inflation — recalibrate |
+
+## When Code Review Hurts
+
+- **Throwaway prototypes** — review cost exceeds value if you're about to discard the code.
+- **Hotfix rollbacks** — reverting to a known-good state introduces no new logic to review.
+- **Trivially covered one-liners** — if the tests already encode the contract, a comment adds ceremony without safety.

--- a/skills/principle-code-review/triggers.txt
+++ b/skills/principle-code-review/triggers.txt
@@ -1,0 +1,7 @@
+# Representative trigger prompts for principle-code-review
+code review checklist for this pull request
+PR review heuristics for finding real issues versus noise
+how should I phrase this review comment without sounding accusatory
+is this finding worth surfacing or is it just a nitpick
+reviewing a diff for correctness and missing edge cases
+nitpick filtering — how do I decide which comments to drop

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -379,6 +379,42 @@ class TestPerformanceTunerAgent:
 
 
 # ──────────────────────────────────────────────
+# principle-code-review skill structural assertions
+# ──────────────────────────────────────────────
+
+class TestPrincipleCodeReviewSkill:
+    """Integration tests: assert the real skills/principle-code-review/SKILL.md satisfies
+    all acceptance criteria from issue #180 without relying on a synthetic fixture."""
+
+    SKILL_PATH = Path(__file__).parent.parent / "skills" / "principle-code-review" / "SKILL.md"
+
+    def test_file_exists(self):
+        assert self.SKILL_PATH.exists(), "skills/principle-code-review/SKILL.md must exist"
+
+    def test_frontmatter_name(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "name: principle-code-review" in text
+
+    def test_four_axis_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Four-Axis Review Lens" in text
+
+    def test_confidence_filtering_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Confidence-Based Filtering" in text
+
+    def test_skill_passes_validate(self, reset_validate, monkeypatch):
+        """The real skill must pass check_skills() and check_unwired_principle_skills()
+        against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.SKILL_PATH.parent.parent.parent)
+        val.FAILURES.clear()
+        val.check_skills()
+        val.check_unwired_principle_skills()
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
 # check_commands
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extract `## Focus`, `## Explicitly ignore`, and `## Judgement rules` from `agents/reviewer.md` into new `skills/principle-code-review/SKILL.md` with four-axis lens, confidence-based filtering, and tone guidance
- Wire the skill into `agents/reviewer.md` and `agents/auditor.md` via `## Principle consultation` bullets; `reviewer.md` gains a one-line pointer replacing the inline heuristics
- Add catalog entries to `agents/shared/skills.md` and `docs/catalog.md` (alphabetical between `principle-clean-code` and `principle-concurrency`)

## Test Plan
- [x] Changed skills/commands/agents load without errors (`python3 scripts/validate.py` → exits 0)
- [x] Examples in the diff were exercised manually (6 BM25 trigger fixtures all rank `principle-code-review` #1)
- [x] Full test suite: 331 passed

Closes #180
