### PR TITLE
[chore] Sync marketing surfaces with shipping languages and agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "swe-workbench",
-      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript), and pragmatic workflows.",
       "version": "0.1.9",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
   "version": "0.1.9",
-  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Go, Rust, TypeScript), and pragmatic workflows.",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
     "email": "11341007+lugassawan@users.noreply.github.com",
@@ -19,8 +19,13 @@
     "ddd",
     "tdd",
     "solid",
+    "bash",
     "golang",
+    "java",
+    "kotlin",
+    "python",
     "rust",
+    "swift",
     "typescript"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What it is
 
-`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Go, Rust, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
+`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, Go, Java, Kotlin, Python, Rust, Swift, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
 
 ## Install
 
@@ -27,9 +27,9 @@ cd swe-workbench
 ## What's inside
 
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:cleanup-merged` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `reviewer`, `senior-engineer`, `refactorer`, `debugger`, `security-auditor`, `test-writer`, `product-manager`, `tech-writer`, `performance-tuner` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
-- **Languages** — Go, Rust, TypeScript, Python — auto-load by file extension.
+- **Languages** — Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
 


### PR DESCRIPTION
## Summary
- Expand language list in README, plugin.json, and marketplace.json from 3 (Go, Rust, TypeScript) to all 8 shipped: Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript
- Expand README subagents list from 9 to all 14 shipped: accessibility-auditor, architect, auditor, debugger, dependency-auditor, migrator, performance-tuner, product-manager, refactorer, reviewer, security-auditor, senior-engineer, tech-writer, test-writer
- Add missing language keywords (bash, java, kotlin, python, swift) to plugin.json keywords array, alphabetised

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` passes; JSON lint clean; acceptance greps confirm all 8 languages and 5 previously-missing agents now appear in every targeted file

Closes #168
