### PR TITLE
[feat] workflow-pr-review: narrative summary in Step 7 review body

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -49,6 +49,18 @@ When the invoker (e.g. `/review` PR mode) explicitly asks for a Review Decision 
 
 **When NOT instructed** (e.g. local-diff mode, ad-hoc invocation), do not emit this footer — keep output to severity-grouped findings only.
 
+## Review Summary (when instructed)
+
+When the invoker (e.g. `workflow-pr-review` Step 4) explicitly asks for a Review Summary, begin the review with a `## Review Summary` section — before any severity-grouped findings. Write 2–4 sentences covering:
+
+1. **Overall posture** — APPROVE-lean or COMMENT-lean, and why in one clause.
+2. **Strongest positives** — what the diff does well (architecture, test coverage, clarity).
+3. **Most important concerns** — top 1–2 issues the author should know before reading inline comments.
+
+Do **not** repeat per-finding detail in this section — that belongs in the severity-grouped findings below. The orchestrator extracts these paragraphs verbatim and uses them as the top-level PR review body.
+
+**When NOT instructed** (e.g. local-diff mode, ad-hoc invocation), do not emit this section — keep output to severity-grouped findings only.
+
 ## Principle consultation
 
 > See @./shared/skills.md for the full skill catalog.

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -85,7 +85,7 @@ Pass the agent:
   > "Begin the review with a `## Review Summary` section: 2–4 sentences capturing overall posture, the strongest positives, and the most important concerns. The orchestrator uses these paragraphs as the top-level PR review body. Do not repeat per-finding detail there — that goes in the severity-grouped findings below."
 - Ticket-context prelude (if Step 3 produced one).
 
-Store the agent's complete text response as a shell variable: `REVIEWER_OUTPUT=<agent response>`. Step 7's awk block reads from this variable via `<<< "$REVIEWER_OUTPUT"`.
+Store the agent's complete text response as `REVIEWER_OUTPUT` before Step 7 runs — in practice the orchestrator assigns the subagent's full text reply to this variable. Step 7's awk block reads from it via `<<< "$REVIEWER_OUTPUT"`.
 
 ### Step 5 — Parse decision footer
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -81,7 +81,11 @@ Pass the agent:
   > "Emit **repo-relative** paths in every finding (e.g. `src/foo.ts:42`, NOT `$WT/src/foo.ts:42`). The orchestrator uses these paths to position GitHub comments."
 - Footer instruction (load-bearing — opt-in per the agent's `## Decision footer (when instructed)` block):
   > "End the review with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**` on its own line, no prefix or trailing text. Never `REQUEST_CHANGES`."
+- Narrative instruction (load-bearing — opt-in per the agent's `## Review Summary (when instructed)` block):
+  > "Begin the review with a `## Review Summary` section: 2–4 sentences capturing overall posture, the strongest positives, and the most important concerns. The orchestrator uses these paragraphs as the top-level PR review body. Do not repeat per-finding detail there — that goes in the severity-grouped findings below."
 - Ticket-context prelude (if Step 3 produced one).
+
+Store the agent's complete text response as a shell variable: `REVIEWER_OUTPUT=<agent response>`. Step 7's awk block reads from this variable via `<<< "$REVIEWER_OUTPUT"`.
 
 ### Step 5 — Parse decision footer
 
@@ -159,9 +163,26 @@ Do NOT clean up the worktree on abort — leave it for inspection.
 
 ### Step 7 — Submit + cleanup
 
-Body summary:
-```
-Reviewed by `reviewer` (swe-workbench). Posted N inline comments, deduped M.
+Build `$SUMMARY` from `$REVIEWER_OUTPUT` (captured in Step 4):
+
+```bash
+NARRATIVE=$(awk '
+  /^[[:space:]]*(Critical|High|Medium|Low|Severity)[[:space:]]*\|/ { exit }
+  /^###[[:space:]]+(Critical|High|Medium|Low)\b/ { exit }
+  /^\*\*Review Decision:/ { exit }
+  { print }
+' <<< "$REVIEWER_OUTPUT" | sed -e '/^[[:space:]]*$/d' -e '/^## Review Summary[[:space:]]*$/d')
+
+# $posted and $deduped are set in Step 6.
+BYLINE="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/${OWNER}/${REPO})). Posted ${posted} inline comments, deduped ${deduped}._"
+
+if [ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ]; then
+  SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s\n' \
+    "$NARRATIVE" "$DECISION" "$BYLINE")
+else
+  # Fallback: no prose above the findings table — use the legacy one-liner.
+  SUMMARY="Reviewed by \`reviewer\` (swe-workbench). Posted $posted inline comments, deduped $deduped."
+fi
 ```
 
 Submit per the parsed decision:
@@ -221,3 +242,4 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Parse threads from REST `pulls/{N}/comments` | REST returns review-comment-by-comment; threading is reconstructed by the GraphQL `reviewThreads` shape. Use GraphQL to fetch, REST to post. |
 | Force-add 👍 to your own existing comment | Check `reactions.nodes[].user.login` first; skip if you've already reacted. |
 | Block on cleanup | Cleanup runs in background `(... ) &`. Don't `wait` for it. |
+| Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the legacy one-liner silently — body is not wrong but loses the prose narrative. |


### PR DESCRIPTION
## Summary
- `skills/workflow-pr-review/SKILL.md` — Step 4: adds a third load-bearing "Narrative instruction" asking the reviewer to begin with a `## Review Summary` block (2–4 sentences: overall posture, strongest positives, top concerns). Adds a `$REVIEWER_OUTPUT` capture note.
- `skills/workflow-pr-review/SKILL.md` — Step 7: replaces the static one-liner body with an awk-extraction block that extracts prose above the first findings row or severity heading, builds a rich `## Review Summary` review body, and gracefully falls back to the legacy one-liner when no narrative prose is present.
- `agents/reviewer.md` — adds `## Review Summary (when instructed)` section mirroring the existing `## Decision footer (when instructed)` opt-in pattern.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — exit 0, "All checks passed"
- [x] `python3 -m pytest tests/ -q` — 357/357 pass

Closes #213
