### PR TITLE
[feat] workflow-commit-and-pr: scan staged files for likely secrets

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -86,9 +86,10 @@ Behaviour:
 
 Before the commit preview (or before running `git commit`), scan the staged
 file set for filenames that commonly hold secrets. This is a commit-layer
-twin of #181's write-time hook: #181 catches secrets the agent introduces
-via Write/Edit; this gate catches secrets staged by anyone (a human running
-`git add`, an IDE that auto-stages, or any other tool) before commit.
+twin of the PreToolUse Write/Edit hook: that hook catches secrets the agent
+introduces at authoring time; this gate catches secrets staged by anyone (a
+human running `git add`, an IDE that auto-stages, or any other tool) before
+commit.
 
 The scan is a filename heuristic, not a content scan — it cannot catch a
 secret pasted inside an otherwise innocuous `config.yaml`. False negatives

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -106,8 +106,10 @@ SUSPICIOUS=$(git diff --staged --name-only \
 ```
 
 The exclusion pass (`*.example`, `*.sample`, `*.template`, `*.dist`)
-prevents false-positives on sanitised template files that are conventional
-to commit (e.g. `.env.example`, `secrets.sample.yaml`).
+prevents false-positives on `.env` template variants (e.g. `.env.example`,
+`.env.sample`). Files like `secrets.example.yaml` are already excluded by
+the positive pattern (which requires a single trailing extension), so the
+exclusion pass is not their gate.
 
 **On no matches** → silent; continue to `## Doc-only [no ci] rule`.
 

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -82,6 +82,58 @@ Behaviour:
 - If branch doesn't match `<type>/<kebab>` → **warn-only** (don't auto-rename): "Branch `<name>` doesn't match the `<type>/<kebab>` convention. Continue anyway? Reply `yes` or rename first."
 - If branch matches → silent.
 
+## Pre-commit gate: suspicious staged files
+
+Before the commit preview (or before running `git commit`), scan the staged
+file set for filenames that commonly hold secrets. This is a commit-layer
+twin of #181's write-time hook: #181 catches secrets the agent introduces
+via Write/Edit; this gate catches secrets staged by anyone (a human running
+`git add`, an IDE that auto-stages, or any other tool) before commit.
+
+The scan is a filename heuristic, not a content scan — it cannot catch a
+secret pasted inside an otherwise innocuous `config.yaml`. False negatives
+are expected; treat a clean scan as "no obvious filename red flags", not
+"safe to commit".
+
+**Scan command** (run before `[no ci]` is computed):
+
+```bash
+SUSPICIOUS=$(git diff --staged --name-only \
+  | grep -iE '(^|/)([^/]*\.env(\.|$)|.+\.pem$|.+\.key$|credentials\.json$|secrets?\.[a-z]+$)' \
+  | grep -vE '\.(example|sample|template|dist)$' \
+  || true)
+```
+
+The exclusion pass (`*.example`, `*.sample`, `*.template`, `*.dist`)
+prevents false-positives on sanitised template files that are conventional
+to commit (e.g. `.env.example`, `secrets.sample.yaml`).
+
+**On no matches** → silent; continue to `## Doc-only [no ci] rule`.
+
+**On match**, print the file list verbatim to the user, then call
+`AskUserQuestion`:
+
+```json
+{
+  "questions": [{
+    "question": "Staged files have names that commonly contain secrets. Commit anyway, or cancel?",
+    "header": "Suspicious",
+    "multiSelect": false,
+    "options": [
+      { "label": "Commit anyway", "description": "Files were reviewed and are intentional — proceed to the commit preview." },
+      { "label": "Cancel",        "description": "Abort. No commit is made. Staging is NOT touched — unstaging is the user's call." }
+    ]
+  }]
+}
+```
+
+- **`Commit anyway`** → continue to `## Doc-only [no ci] rule` and the
+  normal commit flow.
+- **`Cancel`** → abort the flow. **Do NOT run `git restore --staged`** or
+  otherwise alter the index. The user inspects and unstages on their own.
+  If the user re-invokes the skill after staging changes, the scan re-runs
+  cleanly — no state machine.
+
 ## Doc-only `[no ci]` rule
 
 When ALL staged paths match doc-only patterns, append ` [no ci]` to the commit subject:
@@ -214,6 +266,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | `git push` rejected (non-FF) | Non-zero exit | Abort. Tell user to `git pull --rebase`; do NOT force-push. |
 | Doc-only `[no ci]` rule mis-triggers (ambiguous case) | User disagrees | Skip `[no ci]` and warn. The doc-only rule is conservative — when in doubt, run CI. |
 | Duplicate PR (already exists) | `gh pr view` returns `state == "OPEN"` before `gh pr create` | Surface URL via `AskUserQuestion` (see Pre-check section). On `Update existing PR`, skip `gh pr create`. **Never** re-run `gh pr create` to recover. |
+| Staged files look like secrets | `grep` matches against curated pattern set | Print file list. `AskUserQuestion` → on `Cancel`, abort with no `git restore --staged` and no commit. Never auto-unstage. |
 
 ## Common mistakes
 
@@ -228,6 +281,7 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Pass both `--body-file` and `--body` to `gh pr create` | `gh` silently uses `--body-file` and discards `--body`. Write the filled body to a temp file and pass `--body-file <tmp>` only — never both flags together. Pattern: `TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT; <fill template> > "$TMP"; gh pr create --body-file "$TMP"` (trap ensures cleanup on failure too). |
 | Auto-`gh pr create --draft` without asking | Always use `AskUserQuestion` to present `Draft` vs `Ready for review` — never ask via free-form prose. Drafts hide the PR from `assignees` and reviewers. |
 | Re-run `gh pr create` after a "pull request already exists" failure | The pre-check section detects this before it happens. After push, an existing OPEN PR is already updated — `gh pr create` has nothing left to do. Use the `Update existing PR` path instead. |
+| Auto-`git restore --staged` after a `Cancel` answer | Never. Leave staging untouched — the scan is advisory, not authoritative. The user may have reviewed the file and explicitly staged it. |
 
 ## Quick reference
 

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -100,7 +100,7 @@ are expected; treat a clean scan as "no obvious filename red flags", not
 ```bash
 SUSPICIOUS=$(git diff --staged --name-only \
   | grep -iE '(^|/)([^/]*\.env(\.|$)|.+\.pem$|.+\.key$|credentials\.json$|secrets?\.[a-z]+$)' \
-  | grep -vE '\.(example|sample|template|dist)$' \
+  | grep -ivE '\.(example|sample|template|dist)$' \
   || true)
 ```
 

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -104,6 +104,38 @@ def test_workflow_commit_and_pr_has_no_unguarded_this_repo_refs():
     )
 
 
+def test_workflow_commit_and_pr_has_no_bare_issue_refs():
+    """No bare #NNN issue references may appear in prose outside fenced/inline code.
+
+    When a skill is loaded into a foreign repo, #181 resolves to *that repo's*
+    issue #181, not swe-workbench's.  Explanatory cross-references must use
+    descriptive language (e.g. "the PreToolUse Write/Edit hook") rather than
+    a bare issue number.
+
+    Inline code (backtick-quoted) is excluded — those are example placeholders,
+    not claim-bearing references.
+    """
+    body = COMMIT_AND_PR_SKILL.read_text()
+    # Strip fenced code blocks first
+    outside_fences = _strip_fenced_code_blocks(body)
+    # Strip inline code (backtick spans) — these are examples, not claims
+    outside_inline = re.sub(r'`[^`\n]+`', '', outside_fences)
+
+    hits = []
+    for lineno, line in enumerate(outside_inline.splitlines(), 1):
+        if re.search(r'#\d+', line):
+            hits.append((lineno, line.strip()))
+
+    assert not hits, (
+        "Found bare #NNN issue reference(s) in "
+        "skills/workflow-commit-and-pr/SKILL.md (outside fenced/inline code).\n"
+        "Use descriptive language instead (e.g. 'the PreToolUse Write/Edit hook')\n"
+        "so the reference does not resolve to the wrong issue in a foreign repo.\n\n"
+        "Violations:\n"
+        + "\n".join(f"  ~line {ln}: {txt}" for ln, txt in hits)
+    )
+
+
 def test_principle_version_control_attributes_type_format_to_swe_workbench():
     """The [type] Subject enforcement sentence must name 'swe-workbench' explicitly.
 

--- a/tests/test_workflow_commit_and_pr_secret_scan.py
+++ b/tests/test_workflow_commit_and_pr_secret_scan.py
@@ -39,6 +39,8 @@ NEGATIVE_FILENAMES = [
     ".env.sample",
     ".env.template",
     ".env.dist",
+    ".env.EXAMPLE",   # case-insensitive exclusion must fire
+    ".env.Sample",    # mixed-case variant
     "secrets.example.yaml",
     "secrets.sample.json",
     "README.md",
@@ -134,7 +136,7 @@ def test_secret_scan_regex_matches_expected_positives_and_negatives():
     assert pos_match, "Could not extract grep -iE pattern from bash block"
     pos_pattern = pos_match.group(1)
 
-    excl_match = re.search(r"grep\s+-vE\s+'([^']+)'", bash_block)
+    excl_match = re.search(r"grep\s+-i?vE\s+'([^']+)'", bash_block)
     assert excl_match, "Could not extract grep -vE pattern from bash block"
     excl_pattern = excl_match.group(1)
 

--- a/tests/test_workflow_commit_and_pr_secret_scan.py
+++ b/tests/test_workflow_commit_and_pr_secret_scan.py
@@ -1,0 +1,160 @@
+"""Regression tests for the pre-commit gate: suspicious staged files (issue #203).
+
+The gate scans staged filenames for patterns that commonly indicate secrets
+before the commit preview runs. It is the commit-layer complement to #181's
+write-time hook: #181 catches secrets the agent introduces via Write/Edit;
+this gate catches secrets staged by anyone before commit.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SKILL_PATH = ROOT / "skills" / "workflow-commit-and-pr" / "SKILL.md"
+
+SECTION_HEADING = "## Pre-commit gate: suspicious staged files"
+
+# Positive matrix: filenames that MUST be flagged
+POSITIVE_FILENAMES = [
+    ".env",
+    ".env.local",
+    ".env.production",
+    "prod.env",
+    "path/to/.env",
+    "private.pem",
+    "tls.key",
+    "credentials.json",
+    "secrets.yaml",
+    "secrets.json",
+    "secret.yml",
+    "Secrets.yaml",  # case-insensitive
+    "config/credentials.json",  # path-prefixed variant (tests (^|/) anchor)
+    "certs/private.pem",
+    "path/to/secrets.yaml",
+    "my.sample.pem",  # .sample in prefix must NOT suppress .pem detection
+]
+
+# Negative matrix: filenames that must NOT be flagged
+NEGATIVE_FILENAMES = [
+    ".env.example",
+    ".env.sample",
+    ".env.template",
+    ".env.dist",
+    "secrets.example.yaml",
+    "secrets.sample.json",
+    "README.md",
+    "src/main.py",
+    "package.json",
+    "Cargo.lock",
+    "Makefile",
+]
+
+
+def _section_body(text: str, heading: str) -> str:
+    """Return text from heading to the next ## heading (exclusive)."""
+    start = text.find(heading)
+    if start == -1:
+        return ""
+    end = text.find("\n## ", start + len(heading))
+    return text[start:end] if end != -1 else text[start:]
+
+
+def _extract_fenced_block(text: str, fence_info: str) -> str | None:
+    """Return the content of the first ```{fence_info} ... ``` block in text."""
+    pattern = re.compile(
+        r"```" + re.escape(fence_info) + r"[ \t]*\n(.*?)```",
+        re.DOTALL,
+    )
+    m = pattern.search(text)
+    return m.group(1) if m else None
+
+
+def test_secret_scan_section_present_with_askuserquestion():
+    """The pre-commit gate section must exist in SKILL.md with the correct shape.
+
+    Asserts:
+    1. Section heading exists.
+    2. Body contains the scan command (git diff --staged --name-only).
+    3. Body contains a fenced JSON AskUserQuestion block with "Cancel" as the last option.
+    4. Body encodes the "don't auto-unstage" invariant ("NOT touched" or "untouched").
+    5. Body cross-references issue #181 (the write-time hook complement).
+    """
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' in skills/workflow-commit-and-pr/SKILL.md"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    assert "git diff --staged --name-only" in section, (
+        "Pre-commit gate section must contain 'git diff --staged --name-only'"
+    )
+
+    aq_block = _extract_fenced_block(section, "json")
+    assert aq_block is not None, (
+        "Pre-commit gate section must contain a fenced JSON block for AskUserQuestion"
+    )
+    assert '"Cancel"' in aq_block, (
+        "AskUserQuestion JSON block must include a 'Cancel' option"
+    )
+    commit_pos = aq_block.find('"Commit anyway"')
+    cancel_pos = aq_block.find('"Cancel"')
+    assert commit_pos != -1 and cancel_pos != -1 and cancel_pos > commit_pos, (
+        "'Cancel' must appear after 'Commit anyway' in the AskUserQuestion block"
+    )
+
+    assert re.search(r"NOT touched|untouched", section), (
+        "Pre-commit gate section must state staging is 'NOT touched' (or 'untouched') "
+        "on Cancel — encoding the no-auto-unstage invariant"
+    )
+
+    assert "#181" in section, (
+        "Pre-commit gate section must cross-reference issue #181 (write-time hook complement)"
+    )
+
+
+def test_secret_scan_regex_matches_expected_positives_and_negatives():
+    """The regex embedded in the skill must flag expected positives and spare negatives.
+
+    Extracts the grep -iE (positive) and grep -vE (exclusion) patterns from
+    the fenced bash block in the pre-commit gate section, then applies them to
+    a hand-picked filename matrix.
+    """
+    body = SKILL_PATH.read_text()
+    section = _section_body(body, SECTION_HEADING)
+
+    assert section, f"Section '{SECTION_HEADING}' not found in SKILL.md"
+
+    bash_block = _extract_fenced_block(section, "bash")
+    assert bash_block is not None, (
+        "Pre-commit gate section must contain a fenced bash block with the scan command"
+    )
+
+    pos_match = re.search(r"grep\s+-iE\s+'([^']+)'", bash_block)
+    assert pos_match, "Could not extract grep -iE pattern from bash block"
+    pos_pattern = pos_match.group(1)
+
+    excl_match = re.search(r"grep\s+-vE\s+'([^']+)'", bash_block)
+    assert excl_match, "Could not extract grep -vE pattern from bash block"
+    excl_pattern = excl_match.group(1)
+
+    def should_flag(filename: str) -> bool:
+        if not re.search(pos_pattern, filename, re.IGNORECASE):
+            return False
+        if re.search(excl_pattern, filename, re.IGNORECASE):
+            return False
+        return True
+
+    for fname in POSITIVE_FILENAMES:
+        assert should_flag(fname), (
+            f"Expected '{fname}' to be flagged as suspicious, but it was not.\n"
+            f"  pos_pattern:  {pos_pattern!r}\n"
+            f"  excl_pattern: {excl_pattern!r}"
+        )
+
+    for fname in NEGATIVE_FILENAMES:
+        assert not should_flag(fname), (
+            f"Expected '{fname}' NOT to be flagged, but it was.\n"
+            f"  pos_pattern:  {pos_pattern!r}\n"
+            f"  excl_pattern: {excl_pattern!r}"
+        )

--- a/tests/test_workflow_commit_and_pr_secret_scan.py
+++ b/tests/test_workflow_commit_and_pr_secret_scan.py
@@ -110,8 +110,9 @@ def test_secret_scan_section_present_with_askuserquestion():
         "on Cancel — encoding the no-auto-unstage invariant"
     )
 
-    assert "#181" in section, (
-        "Pre-commit gate section must cross-reference issue #181 (write-time hook complement)"
+    assert re.search(r"PreToolUse|Write/Edit hook|authoring time", section), (
+        "Pre-commit gate section must describe its write-time hook complement without "
+        "baking in a repo-specific issue number (e.g. '#181')"
     )
 
 


### PR DESCRIPTION
## Summary
- Add `## Pre-commit gate: suspicious staged files` section to `workflow-commit-and-pr` skill, inserted between `## Branch-naming check` and `## Doc-only [no ci] rule`
- Gate scans staged filenames with a `grep -iE` heuristic before the commit preview runs; matches `.env*`, `*.pem`, `*.key`, `credentials.json`, `secrets?.*`, and variants
- On a match, presents an `AskUserQuestion` prompt (`Commit anyway` / `Cancel`); `Cancel` aborts with no `git restore --staged` — staging is left untouched
- Exclusion pass uses terminal-suffix matching (`\.(example|sample|template|dist)$`) so `.env.example` / `secrets.sample.yaml` pass silently; `my.sample.pem` is correctly flagged
- Append rows to the Failure-modes and Common-mistakes tables documenting the new behaviour

## Layering note
Complements #181 (PreToolUse Write/Edit hook). #181 catches secrets Claude introduces at authoring time; this PR catches secrets staged by humans, IDEs, or other tools before commit. Ships independently. Related: #181.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_workflow_commit_and_pr_secret_scan.py -v` — 2 new tests green (prose-presence + regex matrix with 16 positive / 11 negative filenames)
- [x] `pytest tests/test_skill_repo_ambiguity.py -v` — no regression on "this repo" constraint
- [x] `pytest tests/test_skill_triggers.py -v` — no BM25 drift (no new trigger line added)
- [x] Full `pytest tests/` — 364 passed, 0 failed

Closes #203
