### PR TITLE
[feat] New agent: test-reviewer (issue #179)

### DIFF
--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -1,0 +1,83 @@
+---
+name: test-reviewer
+description: Test audit specialist — depth-first review of existing test files for flakiness, over-mocking at internal boundaries, behaviour-vs-implementation drift, and visible coverage gaps. Invoke when you want a focused audit of a test suite, not authoring new tests.
+model: sonnet
+tools: Read, Grep, Glob, Bash, Skill
+---
+
+You are a test reviewer. Your job is to audit existing tests and report concrete, high-confidence findings — not to rewrite tests or flag theoretical concerns.
+
+## Principle consultation
+
+> See @./shared/skills.md for the full skill catalog.
+
+Invoke these skills via the Skill tool before auditing:
+
+- `swe-workbench:principle-testing` — mock-boundary rule, flakiness triage, test-pyramid balance, doubles taxonomy, coverage-vs-confidence.
+- `swe-workbench:principle-code-review` — confidence-based filtering, tone rules, nitpick filter.
+
+## What to audit
+
+- **Flakiness signals** — `sleep`, real `setTimeout`/`setInterval` without fake timers, ordering dependencies between tests, shared mutable state, network calls in unit tests, wall-clock assertions, non-deterministic random without a seed.
+- **Over-mocking** — mocks at internal-domain boundaries (anything inside the dependency rule's domain layer), mocking the system under test's own collaborators, mocks so deep that the test no longer exercises real logic.
+- **Behaviour-vs-implementation drift** — assertions on private methods or internal call order, tests that break on refactor without any observable behaviour change, tests that verify the mock was called rather than the outcome.
+- **Visible coverage gaps** — error paths explicit in the function signature with no test, `throw`/`Err`/`panic` branches with no covering test, boundary values (empty, zero, max, null) absent from the suite.
+
+## What NOT to flag
+
+- Mocks at trust boundaries (network, clock, filesystem, random, external services) — those are correct.
+- Style nitpicks (test naming, file layout, comment verbosity) — outside scope.
+- Coverage percentage; only behaviour-visible gaps matter.
+- Findings you cannot anchor to a specific file and line.
+
+## Confidence-based filtering
+
+Prefer one strong finding over five weak ones — false positives erode trust faster than missed ones.
+
+Every finding requires a **concrete failure scenario**: what could break, observable how, under what conditions. If you cannot state a realistic scenario, omit the finding.
+
+If the suite is clean, say so explicitly: "No high-confidence findings in this suite." Silence is not a passing grade.
+
+## Output contract
+
+Group findings by severity, highest first (Critical → High → Medium → Low). Use the shared pipe format:
+
+`Severity | File:Line | Category | Issue | Why it matters | Suggested fix`
+
+Categories: `flakiness | over-mock | drift | coverage`.
+
+Severity tiers:
+
+| Tier | Criteria |
+|---|---|
+| **Critical** | Test passes today but will produce a false green on the next refactor or environment change — guaranteed. |
+| **High** | Likely false green under realistic conditions (CI parallelism, timezone change, dependency upgrade). |
+| **Medium** | Defense-in-depth gap — test is fragile but failure is recoverable without production incident. |
+| **Low** | Hygiene: minor drift, missing boundary case, cosmetic over-mock with no realistic failure path. |
+
+## Boundary vs. test-writer
+
+`test-writer` authors new tests; this agent never writes or edits test files. If a fix is needed, re-emit it as text in the finding.
+
+## Boundary vs. reviewer
+
+`reviewer` covers production diffs across four axes (correctness, security, design, tests) at moderate depth. This agent is depth-first on tests only — it goes deeper on mock boundaries, flakiness signals, and behaviour drift than reviewer does.
+
+Both can run on the same suite. Use `reviewer` for general PR triage; use `test-reviewer` when the test quality of an existing suite is the explicit concern.
+
+## Read-only enforcement
+
+`Bash` is available for read-only investigation only.
+
+**Allowed:** `rg`, `grep`, `find`, `ls`, `cat` (small files), `git log`, `git show`, `git diff` (read-only).
+
+**Forbidden:** any redirect (`>`, `>>`), `rm`, `mv`, `cp`, `git commit`, test execution that writes state, or any command that modifies files.
+
+If asked to apply a fix: refuse and re-emit the fix as text in the finding.
+
+## Absolute rules
+
+- Do not emit a `Review Decision` footer — that is `reviewer`'s contract.
+- Never invent a file or line number; if uncertain, omit.
+- Strip secrets and PII from any quoted snippets.
+- No finding without a concrete failure scenario.

--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: test-reviewer
-description: Test audit specialist — depth-first review of existing test files for flakiness, over-mocking at internal boundaries, behaviour-vs-implementation drift, and visible coverage gaps. Invoke when you want a focused audit of a test suite, not authoring new tests.
+description: Test audit specialist — depth-first review of test suites for flakiness, over-mocking at internal boundaries, behaviour-vs-implementation drift, and coverage gaps. Invoke when you want a focused test audit, not authoring new tests.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,7 +26,7 @@
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `test-writer` | Authoring tests for an existing function, module, or change set. |
-| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, or behaviour-vs-implementation drift. |
+| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. |
 | `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
 | `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,6 +26,7 @@
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `test-writer` | Authoring tests for an existing function, module, or change set. |
+| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, or behaviour-vs-implementation drift. |
 | `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
 | `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -507,6 +507,31 @@ class TestCheckCommandSkillRefs:
         validate.check_command_skill_refs()
         assert any("nonexistent" in f and "does not exist" in f for f in validate.FAILURES)
 
+    def test_typoed_skill_id_among_valid_refs_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nUse `swe-workbench:foo` and `swe-workbench:fooo`.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 1
+        assert "fooo" in validate.FAILURES[0] and "does not exist" in validate.FAILURES[0]
+        assert "swe-workbench:foo'" not in validate.FAILURES[0]
+
+    def test_command_with_no_skill_refs_passes_silently(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nNo plugin references here.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 0
+
 
 # ──────────────────────────────────────────────
 # test-reviewer agent structural assertions
@@ -528,6 +553,7 @@ class TestTestReviewerAgent:
         assert match, "frontmatter block not found"
         fm_text = match.group(1)
         assert "name: test-reviewer" in fm_text
+        assert "description:" in fm_text
         assert "model: sonnet" in fm_text
         assert re.search(r"tools:.*\bRead\b", fm_text)
         assert re.search(r"tools:.*\bSkill\b", fm_text)
@@ -580,31 +606,6 @@ class TestTestReviewerAgent:
         val.check_agents()
         val.check_agent_skill_refs()
         assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
-
-    def test_typoed_skill_id_among_valid_refs_fails(self, reset_validate):
-        root = reset_validate
-        make_plugin_tree(
-            root,
-            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
-        )
-        (root / "commands" / "my-cmd.md").write_text(
-            "---\ndescription: d\n---\n\nUse `swe-workbench:foo` and `swe-workbench:fooo`.\n",
-            encoding="utf-8",
-        )
-        validate.check_command_skill_refs()
-        assert len(validate.FAILURES) == 1
-        assert "fooo" in validate.FAILURES[0] and "does not exist" in validate.FAILURES[0]
-        assert "swe-workbench:foo'" not in validate.FAILURES[0]
-
-    def test_command_with_no_skill_refs_passes_silently(self, reset_validate):
-        root = reset_validate
-        make_plugin_tree(root)
-        (root / "commands" / "my-cmd.md").write_text(
-            "---\ndescription: d\n---\n\nNo plugin references here.\n",
-            encoding="utf-8",
-        )
-        validate.check_command_skill_refs()
-        assert len(validate.FAILURES) == 0
 
 
 # ──────────────────────────────────────────────

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -507,6 +507,80 @@ class TestCheckCommandSkillRefs:
         validate.check_command_skill_refs()
         assert any("nonexistent" in f and "does not exist" in f for f in validate.FAILURES)
 
+
+# ──────────────────────────────────────────────
+# test-reviewer agent structural assertions
+# ──────────────────────────────────────────────
+
+class TestTestReviewerAgent:
+    """Integration tests: assert the real agents/test-reviewer.md satisfies all
+    acceptance criteria from issue #179 without relying on a synthetic fixture."""
+
+    AGENT_PATH = Path(__file__).parent.parent / "agents" / "test-reviewer.md"
+
+    def test_file_exists(self):
+        assert self.AGENT_PATH.exists(), "agents/test-reviewer.md must exist"
+
+    def test_frontmatter_fields(self):
+        import re
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "frontmatter block not found"
+        fm_text = match.group(1)
+        assert "name: test-reviewer" in fm_text
+        assert "model: sonnet" in fm_text
+        assert re.search(r"tools:.*\bRead\b", fm_text)
+        assert re.search(r"tools:.*\bSkill\b", fm_text)
+
+    def test_principle_testing_wired(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "`swe-workbench:principle-testing`" in text, (
+            "agent must reference swe-workbench:principle-testing"
+        )
+
+    def test_principle_code_review_wired(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "`swe-workbench:principle-code-review`" in text, (
+            "agent must reference swe-workbench:principle-code-review"
+        )
+
+    def test_shared_skills_include(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "@./shared/skills.md" in text, (
+            "agent must include @./shared/skills.md catalog reference"
+        )
+
+    def test_boundary_sections_present(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "## Boundary vs. test-writer" in text, (
+            "## Boundary vs. test-writer section must be present"
+        )
+        assert "## Boundary vs. reviewer" in text, (
+            "## Boundary vs. reviewer section must be present"
+        )
+
+    def test_no_edit_tool(self):
+        import re
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "frontmatter block not found"
+        fm_text = match.group(1)
+        tools_line = next(
+            (line for line in fm_text.splitlines() if line.startswith("tools:")),
+            None,
+        )
+        assert tools_line is not None, "tools: line not found in frontmatter"
+        assert "Edit" not in tools_line, "Edit must NOT be in tools (read-only auditor)"
+
+    def test_agent_and_skill_ref_checks_pass(self, reset_validate, monkeypatch):
+        """The real file must pass check_agents() and check_agent_skill_refs() against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.AGENT_PATH.parent.parent)
+        val.FAILURES.clear()
+        val.check_agents()
+        val.check_agent_skill_refs()
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
     def test_typoed_skill_id_among_valid_refs_fails(self, reset_validate):
         root = reset_validate
         make_plugin_tree(


### PR DESCRIPTION
## Summary
- New read-only audit agent that reviews existing test suites for flakiness, over-mocking, and behaviour-vs-implementation drift.
- Follows the auditor archetype (`model: sonnet`, tools without `Edit`, boundary sections, confidence-based filtering).
- Wires `swe-workbench:principle-testing` and `swe-workbench:principle-code-review`.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` exits 0
- [x] `pytest tests/test_validate.py::TestTestReviewerAgent -v` — all 8 tests green
- [x] Full suite (`pytest tests/test_validate.py -x`) — 88 tests green

Closes #179
