### PR TITLE
[feat] workflow-commit-and-pr: type-tailored test-plan generation

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -31,6 +31,8 @@ The user's exact phrasing determines what action you take. **Never escalate with
 | **Preview only** | "I finished the feature", "I'm done", "feature is complete", "ready to commit" | Show: diff summary, drafted commit message, current branch name, doc-only `[no ci]` check. **Do NOT commit.** Wait for user to escalate to "commit this" or "ship this". |
 | **Commit only** | "commit this", "make a commit", "commit these changes" | Run `git commit` with the drafted message. **Stop.** Do NOT push. Do NOT create a PR. Tell the user: "Committed. Reply `push` to push, or `ship` to push and open a PR." |
 | **One-shot ship** | "commit and create a PR", "ship this", "ship it", "ship this branch" | Run commit → push → `gh pr create`. No intermediate pause. Run draft-vs-ready prompt before `gh pr create`. |
+| **Push only** | "push this", "push it", "push my branch" | `git push -u origin <branch>`. **Stop.** No commit. No PR. |
+| **PR only** | "open a PR for what I just pushed", "create a PR" (no staged changes) | Skip commit. Run existing-PR check → draft/ready prompt → `gh pr create`. |
 
 Ambiguous wording: **default to preview-only** and ask the user to escalate.
 
@@ -249,6 +251,12 @@ If the prompt OR current branch name OR last-5 commit messages mention a ticket 
 
 Prepend the ticket-context summary to the PR body so the reviewer has the full spec.
 
+## Test plan generation
+
+Seed `## Test Plan` with type-tailored bullets BEFORE `gh pr create --body-file "$TMP"` runs. Never strip or replace host bullets — append `### Type-tailored checks ([type])` only. Heredoc fallback: replace `- [ ] <verification steps>` placeholder. See `swe-workbench:principle-testing`.
+
+**Precedence:** `breaking` → `feat` → `fix` → `perf` → most-frequent → latest → `feat`. **Types:** `breaking` migration+compat; `feat` new-behaviour; `fix` reproduce+verify; `refactor` same-outputs; `perf` baseline; `test` passes; `ci` parses; `docs` links; `chore` builds; `polish` clean.
+
 ## Post-create CTA
 
 After `gh pr create` succeeds and prints the PR URL, append:
@@ -285,14 +293,6 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Auto-`gh pr create --draft` without asking | Always use `AskUserQuestion` to present `Draft` vs `Ready for review` — never ask via free-form prose. Drafts hide the PR from `assignees` and reviewers. |
 | Re-run `gh pr create` after a "pull request already exists" failure | The pre-check section detects this before it happens. After push, an existing OPEN PR is already updated — `gh pr create` has nothing left to do. Use the `Update existing PR` path instead. |
 | Auto-`git restore --staged` after a `Cancel` answer | Never. Leave staging untouched — the scan is advisory, not authoritative. The user may have reviewed the file and explicitly staged it. |
-
-## Quick reference
-
-| User says | Phase | Action |
-|---|---|---|
-| "I finished the feature" | Preview | Show diff + drafted commit msg. Do NOT commit. |
-| "Commit this" | Commit | `git commit -m "[type] …"`. Stop. No push. |
-| "Push it" | Push | `git push -u origin <branch>`. Stop. No PR. |
-| "Ship this" | Ship | Commit → push → existing-PR check → draft/ready prompt → `gh pr create`. |
-| "Ship this" (existing OPEN PR found) | Ship | Commit → push → existing-PR check surfaces URL → `AskUserQuestion` → skip `gh pr create`. |
-| "Open a PR for what I just pushed" | PR-only | Skip commit. Run existing-PR check → draft/ready prompt → `gh pr create`. |
+| Seed type-tailored bullets AFTER `gh pr create` (no-op) | Seeding mutates the body BEFORE the `$TMP` write; once `gh pr create` runs, the body is immutable via this flow. |
+| Strip host-template bullets to make room for type-tailored ones | Append under the `### Type-tailored checks` sub-heading; never delete host bullets. The only allowed strip is a trailing empty `- [ ]` placeholder on the host section. |
+| Pick a `[test]` or `[chore]` type when the PR also contains a `[feat]` commit | Apply the precedence ladder over all commits since merge-base. `feat`, `fix`, and `breaking` outrank prep-commits. |

--- a/tests/test_workflow_commit_and_pr_test_plan_generation.py
+++ b/tests/test_workflow_commit_and_pr_test_plan_generation.py
@@ -1,0 +1,197 @@
+"""Structural tests for the test-plan generation section (issue #201).
+
+Asserts that skills/workflow-commit-and-pr/SKILL.md documents:
+  1. A '## Test plan generation' section.
+  2. A type→focus table covering every commit type from the enforcing regex.
+  3. The precedence ladder (breaking → feat → fix → perf).
+  4. The append-under-subheading seeding invariant (mutates body BEFORE gh pr create).
+  5. The heredoc-fallback path (replace <verification steps> placeholder).
+  6. A cross-reference to swe-workbench:principle-testing.
+
+Pattern mirrors tests/test_workflow_commit_and_pr_secret_scan.py.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SKILL_PATH = ROOT / "skills" / "workflow-commit-and-pr" / "SKILL.md"
+
+SECTION_HEADING = "## Test plan generation"
+
+
+def _section_body(text: str, heading: str) -> str:
+    """Return text from heading to the next ## heading (exclusive)."""
+    start = text.find(heading)
+    if start == -1:
+        return ""
+    end = text.find("\n## ", start + len(heading))
+    return text[start:end] if end != -1 else text[start:]
+
+
+def _extract_fenced_block(text: str, fence_info: str) -> str | None:
+    """Return the content of the first ```{fence_info} ... ``` block in text."""
+    pattern = re.compile(
+        r"```" + re.escape(fence_info) + r"[ \t]*\n(.*?)```",
+        re.DOTALL,
+    )
+    m = pattern.search(text)
+    return m.group(1) if m else None
+
+
+def _parse_commit_types_from_skill(text: str) -> list[str]:
+    """Extract the commit types listed inside the fenced regex block in SKILL.md.
+
+    Looks for the bare fenced block that contains the enforcing regex, e.g.:
+        ```
+        ^\\[(feat|fix|refactor|...)\\] .+
+        ```
+    Returns the alternation as a list of strings.
+    """
+    # Find fenced block (no language tag) containing the enforcing regex
+    bare_fence = re.compile(r"```\s*\n(.*?)```", re.DOTALL)
+    for m in bare_fence.finditer(text):
+        content = m.group(1).strip()
+        # Must look like the commit-msg enforcing regex
+        alt_match = re.search(r"\\\[\\?\(?([a-z|]+)\)?\\?\\\]", content)
+        if alt_match:
+            return alt_match.group(1).split("|")
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_test_plan_generation_section_present():
+    """'## Test plan generation' heading must exist in SKILL.md."""
+    body = SKILL_PATH.read_text()
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' in skills/workflow-commit-and-pr/SKILL.md"
+    )
+
+
+def test_table_covers_all_commit_types():
+    """The type→focus entries must mention every commit type from the enforcing regex."""
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' — cannot check table coverage"
+    )
+
+    # Parse the 10 commit types from the same regex block the skill enforces
+    commit_types = _parse_commit_types_from_skill(body)
+    assert commit_types, (
+        "Could not parse commit types from the enforcing regex fenced block in SKILL.md"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    missing = []
+    for t in commit_types:
+        if f"`{t}`" not in section:
+            missing.append(t)
+
+    assert not missing, (
+        f"Type→focus table in '{SECTION_HEADING}' is missing rows for: {missing}. "
+        f"Expected all 10 types from the enforcing regex to appear as `type` in the table."
+    )
+
+
+def test_precedence_ladder_documented():
+    """The precedence ladder must document breaking → feat → fix → perf in that order."""
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' — cannot check precedence ladder"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    # All four anchor types must appear as whole words
+    for t in ("breaking", "feat", "fix", "perf"):
+        assert re.search(rf"\b{re.escape(t)}\b", section), (
+            f"Precedence ladder in '{SECTION_HEADING}' must mention '{t}' as a whole word"
+        )
+
+    # Order constraint: breaking < feat < fix < perf (first whole-word occurrence)
+    positions = {
+        t: re.search(rf"\b{re.escape(t)}\b", section).start()
+        for t in ("breaking", "feat", "fix", "perf")
+    }
+    ordered = sorted(positions, key=lambda t: positions[t])
+    expected_order = ["breaking", "feat", "fix", "perf"]
+    assert ordered[:4] == expected_order, (
+        f"Precedence ladder must appear in order breaking→feat→fix→perf, "
+        f"but found order: {ordered[:4]}"
+    )
+
+
+def test_seeding_strategy_is_append_under_subheading():
+    """Seeding must append under '### Type-tailored checks' BEFORE gh pr create runs.
+
+    Asserts:
+    1. Sub-heading '### Type-tailored checks' is mentioned.
+    2. Section encodes the mutability invariant: body is mutated before gh pr create /
+       --body-file / $TMP.
+    3. Section says 'do not' or 'never' near 'strip' or 'replace' for host bullets.
+    """
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' — cannot check seeding strategy"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    # 1. Sub-heading present
+    assert "### Type-tailored checks" in section, (
+        "Seeding section must mention '### Type-tailored checks' sub-heading "
+        "(used to append type bullets without overwriting host bullets)"
+    )
+
+    # 2. Mutability invariant: seed happens BEFORE gh pr create / --body-file / $TMP
+    has_before = re.search(r"\bBEFORE\b|\bbefore\b", section)
+    has_gh_ref = re.search(r"gh pr create|--body-file|\$TMP", section)
+    assert has_before and has_gh_ref, (
+        "Seeding section must state that the body is mutated BEFORE 'gh pr create' "
+        "/ '--body-file' / '$TMP' — encoding the immutability-after-create invariant"
+    )
+
+    # 3. Host-bullet preservation
+    assert re.search(r"(?:do not|never|Do not|Never)\b.{0,80}(?:strip|replace)", section), (
+        "Seeding section must explicitly say 'do not' or 'never' strip/replace host bullets "
+        "(append-only invariant)"
+    )
+
+
+def test_heredoc_fallback_path_documented():
+    """The heredoc-fallback path (replace <verification steps> placeholder) must be documented."""
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' — cannot check heredoc fallback"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    assert re.search(r"heredoc|<verification steps>", section, re.IGNORECASE), (
+        "Seeding section must document the heredoc-fallback path, including how the "
+        "'<verification steps>' placeholder is handled when no PR template is detected"
+    )
+
+
+def test_principle_testing_cross_reference():
+    """The section must cross-reference swe-workbench:principle-testing."""
+    body = SKILL_PATH.read_text()
+
+    assert SECTION_HEADING in body, (
+        f"Missing section '{SECTION_HEADING}' — cannot check cross-reference"
+    )
+
+    section = _section_body(body, SECTION_HEADING)
+
+    assert "swe-workbench:principle-testing" in section, (
+        "Test-plan generation section must link to 'swe-workbench:principle-testing' "
+        "for deeper test-design guidance"
+    )


### PR DESCRIPTION
## Summary
- Add `## Test plan generation` section to `workflow-commit-and-pr` SKILL.md: type→focus mapping (10 types), precedence ladder (`breaking` → `feat` → `fix` → `perf`), and seeding algorithm (append `### Type-tailored checks ([type])` before `gh pr create --body-file "$TMP"` runs)
- Add 6 structural tests in `tests/test_workflow_commit_and_pr_test_plan_generation.py` asserting section presence, type coverage, precedence order, append-under-subheading invariant, heredoc fallback, and `principle-testing` cross-reference
- Restore `Push only` and `PR only` trigger-phrase classes to the trigger-phrase discipline table (were in the now-removed duplicate `## Quick reference` section)
- 3 new `## Common mistakes` rows for the most common seeding misuses

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually

### Type-tailored checks (feat)
- [ ] New behaviour exercised end-to-end: 6 new tests added; all pass (371/371 total)
- [ ] Edge cases listed: precedence ladder, heredoc fallback, host-bullet preservation, 300-line cap constraint
- [ ] No regression in nearby features: 371/371 tests pass; `python3 scripts/validate.py` clean

Closes #201
