### PR TITLE
[feat] /architect command (entry-point for architect agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd swe-workbench
 
 ## What's inside
 
-- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:cleanup-merged` — see [docs/catalog.md](docs/catalog.md).
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:cleanup-merged` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
 - **Languages** — Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript — auto-load by file extension.

--- a/commands/architect.md
+++ b/commands/architect.md
@@ -1,0 +1,19 @@
+---
+description: Author an ADR, RFC, or cross-service contract via the architect subagent
+argument-hint: <decision question>
+---
+
+Decision: $ARGUMENTS
+
+If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. (Trigger patterns are defined in that skill's "When to invoke" section.)
+
+Delegate to the `architect` subagent. Its output must include:
+
+1. **Decision** — one paragraph stating what was chosen and why.
+2. **Context & forcing function** — why this decision is needed now.
+3. **Options considered** — table or bullets; all four sub-fields required for each option: strengths, weaknesses, operational cost, reversibility classification (one-way / two-way door).
+4. **Consequences** — positive and negative; what becomes easier and what becomes harder or more expensive.
+5. **Open questions** — what remains undecided and why it is safe to defer.
+6. **References** — RFC numbers, prior ADRs, principle skills consulted, external standards cited.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `[[detect:…]]`. Skip Mode A if the plan is pure analysis, design recommendation, or any output that does not introduce file edits — the Workflow section's phases (Branch / Verify / Deliver) do not apply.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -23,8 +23,8 @@
 |---|---|
 | `reviewer` | PR review, diff audit, post-feature sanity check. |
 | `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |
-| `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
 | `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
+| `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `test-writer` | Authoring tests for an existing function, module, or change set. |

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -7,6 +7,7 @@
 | `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf) or auto-inferred from the diff when omitted. PR number arg unchanged. |
 | `/swe-workbench:security-review` | Alias for `/swe-workbench:review --mode security`. Kept for backward compat. |
 | `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
+| `/swe-workbench:architect <decision>` | Author an ADR, RFC, or cross-service contract via the architect subagent. Use when the output must be a written decision record — service decomposition, multi-system tech selection, cross-team contract — not advice about existing code. |
 | `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
 | `/swe-workbench:migrate <description>` | Multi-deployment migration via expand → backfill → dual-write → switch → contract. Use when a single revertable commit will not do. |
 | `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |
@@ -22,6 +23,7 @@
 |---|---|
 | `reviewer` | PR review, diff audit, post-feature sanity check. |
 | `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |
+| `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
 | `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |

--- a/tests/test_architect_command.py
+++ b/tests/test_architect_command.py
@@ -1,0 +1,74 @@
+"""Tests for the /swe-workbench:architect command (closes #174)."""
+
+import re
+from pathlib import Path
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+COMMANDS_DIR = ROOT / "commands"
+ARCHITECT_CMD = COMMANDS_DIR / "architect.md"
+DOCS_CATALOG = ROOT / "docs" / "catalog.md"
+README = ROOT / "README.md"
+
+
+def test_architect_command_file_exists():
+    """commands/architect.md must exist, have valid frontmatter, and reference `architect`."""
+    assert ARCHITECT_CMD.exists(), "commands/architect.md must exist"
+    text = ARCHITECT_CMD.read_text()
+    fm = validate.parse_frontmatter(ARCHITECT_CMD, text=text)
+    assert fm is not None, "architect.md must have valid frontmatter"
+    assert "description" in fm, "architect.md frontmatter must have a description field"
+    assert "`architect`" in text, "architect.md must reference the `architect` subagent"
+
+
+def test_architect_command_invokes_ticket_context():
+    """commands/architect.md must reference `swe-workbench:ticket-context`."""
+    assert ARCHITECT_CMD.exists(), "commands/architect.md must exist"
+    text = ARCHITECT_CMD.read_text()
+    assert "`swe-workbench:ticket-context`" in text, (
+        "architect.md must reference `swe-workbench:ticket-context` "
+        "(ticket-context fetch is acceptance criterion #2)"
+    )
+
+
+def test_architect_skill_referenced_in_command():
+    """All swe-workbench: skill refs in architect.md must resolve to skills/ or agents/ on disk."""
+    skills_dir = ROOT / "skills"
+    agents_dir = ROOT / "agents"
+    text = ARCHITECT_CMD.read_text()
+    pattern = re.compile(r"`swe-workbench:([\w-]+)`")
+    missing = [
+        sid for sid in set(pattern.findall(text))
+        if not (skills_dir / sid).is_dir() and not (agents_dir / f"{sid}.md").is_file()
+    ]
+    assert not missing, f"architect.md references non-existent skills or agents: {missing}"
+
+
+def test_architect_in_docs_catalog():
+    """docs/catalog.md must have a row for /swe-workbench:architect in the Commands table."""
+    assert DOCS_CATALOG.exists(), "docs/catalog.md must exist"
+    text = DOCS_CATALOG.read_text()
+    assert "/swe-workbench:architect" in text, (
+        "docs/catalog.md must contain a row for /swe-workbench:architect in the Commands table"
+    )
+
+
+def test_architect_in_readme():
+    """README.md Commands bullet must include /swe-workbench:architect."""
+    assert README.exists(), "README.md must exist"
+    text = README.read_text()
+    assert "/swe-workbench:architect" in text, (
+        "README.md must mention /swe-workbench:architect"
+    )
+    lines = text.splitlines()
+    commands_line = next(
+        (ln for ln in lines if ln.strip().startswith("- **Commands**")),
+        None,
+    )
+    assert commands_line is not None, (
+        "README.md must have a '- **Commands**' bullet line"
+    )
+    assert "/swe-workbench:architect" in commands_line, (
+        "README.md '- **Commands**' bullet must include /swe-workbench:architect"
+    )

--- a/tests/test_architect_command.py
+++ b/tests/test_architect_command.py
@@ -19,6 +19,7 @@ def test_architect_command_file_exists():
     fm = validate.parse_frontmatter(ARCHITECT_CMD, text=text)
     assert fm is not None, "architect.md must have valid frontmatter"
     assert "description" in fm, "architect.md frontmatter must have a description field"
+    # `name` is intentionally absent: commands are auto-discovered by filename; validate.py only requires `description`.
     assert "`architect`" in text, "architect.md must reference the `architect` subagent"
 
 


### PR DESCRIPTION
## Summary
- Add `commands/architect.md` — thin command wrapper that delegates to the `architect` subagent, following the same 4-section skeleton as `design.md` and `migrate.md` (frontmatter, topic prelude, ticket-context conditional, delegation + output contract, plan-output gate)
- Insert `/swe-workbench:architect` row in `docs/catalog.md` between `/design` and `/refactor`, including architect vs. senior-engineer disambiguation
- Add `architect` row to the Subagents table in `docs/catalog.md`
- Add `/swe-workbench:architect` to the `- **Commands**` bullet in `README.md` between `/design` and `/refactor`
- Add `tests/test_architect_command.py` (5 tests mirroring `test_migrate_command.py`: file existence + frontmatter, ticket-context ref, skill-ref resolution, catalog row, README bullet)

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` exits 0
- [x] `python3 -m pytest tests/` → 384 passed (379 baseline + 5 new)
- [x] `python3 -m pytest tests/test_architect_command.py -v` → 5/5 PASSED

Closes #174
