### PR TITLE
[fix] workflows: strip Co-authored-by trailer + clean pr-review branch

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -74,7 +74,6 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
 - Optional scope as a colon-prefix inside subject: `[chore] cleanup-merged: sync local main first`.
 
 **Trailer hygiene.** Never emit a `Co-authored-by`, `Signed-off-by`, or similar trailer in the commit message body or PR body **unless the user explicitly asked for it in this turn**. Do not derive trailers from `git config user.email` / `user.name`, the harness environment, or any auto-detected identity. If the staged work has multiple genuine authors, ask the user whether to attribute them rather than guessing.
-
 **Sync source:** `.githooks/commit-msg` is canonical. If a commit fails the hook, re-read the hook (don't guess).
 
 ## Branch-naming check

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -73,6 +73,8 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
 - No trailing period.
 - Optional scope as a colon-prefix inside subject: `[chore] cleanup-merged: sync local main first`.
 
+**Trailer hygiene.** Never emit a `Co-authored-by`, `Signed-off-by`, or similar trailer in the commit message body or PR body **unless the user explicitly asked for it in this turn**. Do not derive trailers from `git config user.email` / `user.name`, the harness environment, or any auto-detected identity. If the staged work has multiple genuine authors, ask the user whether to attribute them rather than guessing.
+
 **Sync source:** `.githooks/commit-msg` is canonical. If a commit fails the hook, re-read the hook (don't guess).
 
 ## Branch-naming check
@@ -296,3 +298,4 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | Seed type-tailored bullets AFTER `gh pr create` (no-op) | Seeding mutates the body BEFORE the `$TMP` write; once `gh pr create` runs, the body is immutable via this flow. |
 | Strip host-template bullets to make room for type-tailored ones | Append under the `### Type-tailored checks` sub-heading; never delete host bullets. The only allowed strip is a trailing empty `- [ ]` placeholder on the host section. |
 | Pick a `[test]` or `[chore]` type when the PR also contains a `[feat]` commit | Apply the precedence ladder over all commits since merge-base. `feat`, `fix`, and `breaking` outrank prep-commits. |
+| Append `Co-authored-by: <harness identity>` to commits or PR bodies | The placeholder identity from git config leaks into public output. Trailers must reflect a real human collaborator the user named. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -49,12 +49,12 @@ Extract `BASE`, `HEAD_SHA`, `OWNER`, `REPO` from the JSON for downstream steps.
 **When rimba is available** (preferred — handles cross-fork remotes automatically and skips dep installation):
 
 ```bash
-RIMBA_OUT=$(rimba add pr:$PR --skip-deps --skip-hooks 2>&1)
+RIMBA_OUT=$(rimba add pr:$PR --task "pr-review-$PR" --skip-deps --skip-hooks 2>&1)
 WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 [ -d "$WT" ] || { echo "rimba add failed: $RIMBA_OUT"; exit 1; }
 ```
 
-rimba derives the task name as `review/<PR>-<slug>` and places the worktree in the configured worktrees base directory. `--skip-deps` suppresses dep installation; `--skip-hooks` suppresses post-create hooks — both unnecessary for a read-only diff review.
+rimba registers the task as `pr-review-<PR>` (overriding its default `review/<N>-<slug>` derivation) and places the worktree in the configured worktrees base directory. `--skip-deps` suppresses dep installation; `--skip-hooks` suppresses post-create hooks — both unnecessary for a read-only diff review.
 
 **When rimba is absent** (fallback — direct git, NOT `superpowers:using-git-worktrees` which is consent-gated for durable feature work):
 
@@ -64,8 +64,8 @@ if [ -d "$WT" ]; then
   git worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
 fi
 mkdir -p "$(dirname "$WT")"
-git fetch origin "pull/${PR}/head:pr-review/${PR}" --force
-git worktree add --detach "$WT" "pr-review/${PR}"
+git fetch origin "pull/${PR}/head:pr-review-${PR}" --force
+git worktree add --detach "$WT" "pr-review-${PR}"
 ```
 
 ### Step 3 — Ticket-context chain
@@ -193,10 +193,13 @@ Submit per the parsed decision:
 
 Cleanup non-blocking:
 ```bash
-( rimba remove "$(basename "$WT")" --force 2>/dev/null || git worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT" ) &
+( rimba remove "pr-review-$PR" --force 2>/dev/null \
+  || { git worktree remove --force "$WT" 2>/dev/null; \
+       git branch -D "pr-review-$PR" 2>/dev/null; \
+       rm -rf "$WT" 2>/dev/null; } ) &
 ```
 
-`rimba remove` also deletes the local branch; `git worktree remove` is the fallback when rimba is absent.
+`rimba remove` deletes both the worktree and the local `pr-review-<N>` branch (task name pinned via `--task` in Step 2 to keep it consistent). The `git worktree remove` + `git branch -D` group is the defensive fallback for rimba-absent or rimba-failure environments.
 
 ## Footer parsing contract
 
@@ -235,7 +238,7 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 
 | Mistake | Fix |
 |---|---|
-| Use `superpowers:using-git-worktrees` for the PR worktree | That skill is consent-gated and durable-feature-oriented. Use `rimba add pr:$PR --skip-deps --skip-hooks` when rimba is available; direct `git worktree add` otherwise. |
+| Use `superpowers:using-git-worktrees` for the PR worktree | That skill is consent-gated and durable-feature-oriented. Use `rimba add pr:$PR --task "pr-review-$PR" --skip-deps --skip-hooks` when rimba is available; direct `git worktree add` otherwise. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise — comments won't anchor. |
 | Skip the footer instruction | Without it, the agent does NOT emit the footer (per its `## Decision footer (when instructed)` block). Step 5 will then abort. |
 | Use `--request-changes` | Never. APPROVE / COMMENT only. The agent footer never produces this value. |


### PR DESCRIPTION
## Summary
- `workflow-commit-and-pr`: add **Trailer hygiene** rule under "Codified commit format" forbidding `Co-authored-by`/`Signed-off-by` trailers unless the user explicitly asked for one in the current turn; add matching "Common mistakes" row
- `workflow-pr-review`: force rimba task name to `pr-review-<N>` via `--task` flag so both paths (rimba and rimba-absent) produce the same branch name; fix Step 7 cleanup to pass the literal `pr-review-$PR` to `rimba remove` and add `git branch -D` to the fallback group

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Bash syntax (`bash -n`) passes on all new shell snippets in Step 2 and Step 7
- [x] Diff is surgical — only the four planned hunks changed across two files
- [x] Acceptance criteria traced: AC1 (no trailer from placeholder identity), AC2 (branch deleted — rimba path), AC3 (branch deleted — fallback path), abort-preservation unchanged

### Type-tailored checks (fix)
- [ ] Reproduce Bug 1: configure placeholder `git config user.email` in scratch worktree, stage a change, run `workflow-commit-and-pr` — verify no `Co-authored-by` in resulting commit or PR body
- [ ] Reproduce Bug 2 (rimba path): complete a full `/review <PR>` run, then `git branch | grep pr-review` and `git worktree list | grep pr-review` — both empty
- [ ] Reproduce Bug 2 (rimba-absent path): mask rimba, complete `/review <PR>`, same empty check
- [ ] Abort preservation: force Step 5 abort — confirm worktree and `pr-review-<N>` branch survive

Closes #217
