### PR TITLE
[fix] workflow-pr-review: fix byline URL + guard against placeholder commit identity

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,3 +17,14 @@ if [ "$_rimba_branch" = "main" ] || [ "$_rimba_branch" = "master" ]; then
   exit 1
 fi
 # END RIMBA HOOK
+
+# Block commits from placeholder/test identities that leak from test fixtures.
+_email=$(git config user.email 2>/dev/null)
+case "$_email" in
+  test@example.com|t@t)
+    echo "ERROR: Refusing to commit with placeholder email '$_email'."
+    echo "       This identity comes from a test fixture. Fix with:"
+    echo "         git config --unset user.email  # restore global identity"
+    exit 1
+    ;;
+esac

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,21 @@ jobs:
             exit 1
           fi
 
+      - name: Validate commit authorship
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BAD=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+            --jq '.[].commit.author.email' \
+            | grep -E '^(test@example\.com|t@t)$' || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::PR contains commits from a placeholder test identity: $BAD"
+            echo "Rewrite with: git rebase main --exec 'git commit --amend --reset-author --no-edit'"
+            exit 1
+          fi
+
       - name: Validate issue reference
         # Dependabot cannot inject closing keywords; dependency bumps have no linked issue.
         if: github.actor != 'dependabot[bot]'

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -175,13 +175,13 @@ NARRATIVE=$(awk '
 ' <<< "$REVIEWER_OUTPUT" | sed -e '/^[[:space:]]*$/d' -e '/^## Review Summary[[:space:]]*$/d')
 
 # $posted and $deduped are set in Step 6.
-BYLINE="_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/${OWNER}/${REPO})). Posted ${posted} inline comments, deduped ${deduped}._"
+BYLINE="_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted ${posted} inline comments, deduped ${deduped}._"
 
 if [ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ]; then
   SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s\n' \
     "$NARRATIVE" "$DECISION" "$BYLINE")
 else
-  SUMMARY="Re-reviewed by \`reviewer\` (swe-workbench). Posted $posted inline comments, deduped $deduped."
+  SUMMARY="_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted $posted inline comments, deduped $deduped._"
 fi
 ```
 

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -181,7 +181,7 @@ if [ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ]; then
   SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s\n' \
     "$NARRATIVE" "$DECISION" "$BYLINE")
 else
-  SUMMARY="_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted $posted inline comments, deduped $deduped._"
+  SUMMARY="$BYLINE"
 fi
 ```
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -174,14 +174,14 @@ NARRATIVE=$(awk '
 ' <<< "$REVIEWER_OUTPUT" | sed -e '/^[[:space:]]*$/d' -e '/^## Review Summary[[:space:]]*$/d')
 
 # $posted and $deduped are set in Step 6.
-BYLINE="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/${OWNER}/${REPO})). Posted ${posted} inline comments, deduped ${deduped}._"
+BYLINE="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted ${posted} inline comments, deduped ${deduped}._"
 
 if [ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ]; then
   SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s\n' \
     "$NARRATIVE" "$DECISION" "$BYLINE")
 else
   # Fallback: no prose above the findings table — use the legacy one-liner.
-  SUMMARY="Reviewed by \`reviewer\` (swe-workbench). Posted $posted inline comments, deduped $deduped."
+  SUMMARY="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted $posted inline comments, deduped $deduped._"
 fi
 ```
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -180,8 +180,8 @@ if [ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ]; then
   SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s\n' \
     "$NARRATIVE" "$DECISION" "$BYLINE")
 else
-  # Fallback: no prose above the findings table — use the legacy one-liner.
-  SUMMARY="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted $posted inline comments, deduped $deduped._"
+  # Fallback: no prose above the findings table — reuse BYLINE directly.
+  SUMMARY="$BYLINE"
 fi
 ```
 

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -25,6 +25,8 @@ COMMIT_AND_PR_SKILL = ROOT / "skills" / "workflow-commit-and-pr" / "SKILL.md"
 VERSION_CONTROL_SKILL = ROOT / "skills" / "principle-version-control" / "SKILL.md"
 CLEANUP_MERGED_SKILL = ROOT / "skills" / "workflow-cleanup-merged" / "SKILL.md"
 SYNC_SCRIPT = ROOT / "skills" / "workflow-cleanup-merged" / "scripts" / "sync-and-verify.sh"
+PR_REVIEW_SKILL = ROOT / "skills" / "workflow-pr-review" / "SKILL.md"
+PR_REVIEW_FOLLOWUP_SKILL = ROOT / "skills" / "workflow-pr-review-followup" / "SKILL.md"
 
 # Regex matching literal "main" used as a branch name in checkout/pull commands
 _LITERAL_MAIN_IN_GIT_CMD = re.compile(
@@ -219,3 +221,48 @@ def test_cleanup_merged_resolves_default_branch_dynamically():
         "Use a variable resolved at script entry (e.g. DEFAULT_BRANCH) instead:\n\n"
         + "\n".join(f"  line {ln}: {txt}" for ln, txt in offending_lines)
     )
+
+
+def test_pr_review_byline_and_summary_link_to_tool_repo():
+    """BYLINE and SUMMARY in both pr-review skills must link to the tool repo.
+
+    The bug: BYLINE used https://github.com/${OWNER}/${REPO} — the PR's repo —
+    instead of the constant https://github.com/lugassawan/swe-workbench. The
+    fallback SUMMARY had no URL at all (bare parenthetical "(swe-workbench)").
+
+    Assertions per file:
+    1. Templated URL ${OWNER}/${REPO} is gone — not present anywhere in the file.
+    2. No BYLINE= or SUMMARY= assignment contains a bare "(swe-workbench)" without
+       a markdown link.
+    3. The canonical markdown link appears at least twice (BYLINE + SUMMARY fallback).
+    """
+    canonical = "[swe-workbench](https://github.com/lugassawan/swe-workbench)"
+    buggy_url = "https://github.com/${OWNER}/${REPO}"
+    bare_paren = re.compile(r'^(BYLINE|SUMMARY)=.*\(swe-workbench\)', re.MULTILINE)
+
+    for skill_path in (PR_REVIEW_SKILL, PR_REVIEW_FOLLOWUP_SKILL):
+        body = skill_path.read_text()
+        skill_name = skill_path.parent.name
+
+        # 1. Templated buggy URL must be gone
+        assert buggy_url not in body, (
+            f"{skill_name}/SKILL.md still contains the templated URL "
+            f"'{buggy_url}' in the byline.\n"
+            f"Replace with the hardcoded tool URL: https://github.com/lugassawan/swe-workbench"
+        )
+
+        # 2. No BYLINE= or SUMMARY= assignment with bare (swe-workbench) — no link
+        bare_hits = bare_paren.findall(body)
+        assert not bare_hits, (
+            f"{skill_name}/SKILL.md has a BYLINE= or SUMMARY= assignment with bare "
+            f"'(swe-workbench)' (no markdown link).\n"
+            f"Replace with '[swe-workbench](https://github.com/lugassawan/swe-workbench)'."
+        )
+
+        # 3. Canonical link must appear at least twice (primary BYLINE + fallback SUMMARY)
+        count = body.count(canonical)
+        assert count >= 2, (
+            f"{skill_name}/SKILL.md contains {count} occurrence(s) of the canonical "
+            f"link '{canonical}', expected at least 2 (one for BYLINE, one for SUMMARY).\n"
+            f"Both the primary byline and the fallback summary must be clickable links."
+        )

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -234,7 +234,9 @@ def test_pr_review_byline_and_summary_link_to_tool_repo():
     1. Templated URL ${OWNER}/${REPO} is gone — not present anywhere in the file.
     2. No BYLINE= or SUMMARY= assignment contains a bare "(swe-workbench)" without
        a markdown link.
-    3. The canonical markdown link appears at least twice (BYLINE + SUMMARY fallback).
+    3. BYLINE carries the canonical markdown link (at least one occurrence).
+    4. The fallback SUMMARY reuses $BYLINE by variable reference, not by repeating
+       the URL string — i.e. SUMMARY="$BYLINE" is the expected form.
     """
     canonical = "[swe-workbench](https://github.com/lugassawan/swe-workbench)"
     buggy_url = "https://github.com/${OWNER}/${REPO}"
@@ -259,10 +261,15 @@ def test_pr_review_byline_and_summary_link_to_tool_repo():
             f"Replace with '[swe-workbench](https://github.com/lugassawan/swe-workbench)'."
         )
 
-        # 3. Canonical link must appear at least twice (primary BYLINE + fallback SUMMARY)
-        count = body.count(canonical)
-        assert count >= 2, (
-            f"{skill_name}/SKILL.md contains {count} occurrence(s) of the canonical "
-            f"link '{canonical}', expected at least 2 (one for BYLINE, one for SUMMARY).\n"
-            f"Both the primary byline and the fallback summary must be clickable links."
+        # 3. Canonical link must appear in BYLINE (at least once in the file)
+        assert canonical in body, (
+            f"{skill_name}/SKILL.md does not contain the canonical link '{canonical}'.\n"
+            f"BYLINE must hardcode the tool URL, not interpolate the review-target repo."
+        )
+
+        # 4. Fallback SUMMARY must delegate to $BYLINE rather than duplicate the URL string
+        assert 'SUMMARY="$BYLINE"' in body, (
+            f"{skill_name}/SKILL.md fallback SUMMARY does not reuse $BYLINE.\n"
+            f"Expected:  SUMMARY=\"$BYLINE\"\n"
+            f"This keeps the two branches in sync automatically — the URL lives in one place."
         )


### PR DESCRIPTION
## Summary

- **Byline URL bug:** both `workflow-pr-review` and `workflow-pr-review-followup` skills had `BYLINE` using `https://github.com/${OWNER}/${REPO}` — the repo of the PR being reviewed — instead of the constant swe-workbench tool URL (`lugassawan/swe-workbench`). Fixed in both skills.
- **Fallback SUMMARY:** the prose-only fallback had a bare `(swe-workbench)` with no URL and no italic styling. Simplified to `SUMMARY="$BYLINE"` — single source of truth, both code paths stay in sync automatically.
- **Regression test:** added `test_pr_review_byline_and_summary_link_to_tool_repo` to `tests/test_skill_repo_ambiguity.py` asserting: (1) templated URL gone, (2) no bare `(swe-workbench)` in any assignment, (3) fallback delegates to `$BYLINE` by variable reference.
- **Placeholder identity guard:** discovered commits were authored as `Test <test@example.com>` due to a stale local git config override. Added two complementary layers to prevent recurrence:
  - `.githooks/pre-commit` — blocks commits whose effective `user.email` is a known test-fixture placeholder (`test@example.com`, `t@t`).
  - `.github/workflows/pr.yml` — new CI step checks every PR commit via the GitHub API and fails if any author email matches the placeholder pattern.

## Test Plan

- [x] Skills/commands/agents load without errors
- [x] `pytest tests/test_skill_repo_ambiguity.py -v` — 5/5 pass (TDD red→green verified)
- [x] `pytest tests/ -v` — 428/428 pass, no regressions
- [x] `bash scripts/validate.sh` — `All checks passed`
- [x] `grep -nE 'BYLINE=|SUMMARY=' skills/workflow-pr-review{,-followup}/SKILL.md` — all target lines show `lugassawan/swe-workbench` inside a markdown link
- [x] All commits rewritten with correct authorship (`lugassawan <lugassawan@gmail.com>`) after removing stale local git config

Issue: N/A — byline URL fix found during plan review; conflated ${OWNER}/${REPO} (review target) with lugassawan/swe-workbench (tool identity)
