### PR TITLE
[fix] workflow-pr-review(-followup): suppress address-feedback CTA on clean APPROVE

### DIFF
--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -206,11 +206,15 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, if `CURRENT_USER != AUTHOR_LOGIN`, append:
+**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below only when ALL of the following hold:
+- `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
+- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0`.
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 
-Suppress this CTA silently when `CURRENT_USER == AUTHOR_LOGIN`.
+Suppress silently when:
+- `CURRENT_USER == AUTHOR_LOGIN` — self-review; asking the author to address their own feedback is noise.
+- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address.
 
 Cleanup non-blocking:
 ```bash
@@ -262,5 +266,5 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Omit the footer instruction in Step 4 | Without it, the agent does NOT emit the footer. Step 5 will then abort. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when `CURRENT_USER == AUTHOR_LOGIN` | Always suppress for self-review. |
+| Emit the address-feedback CTA when there is nothing to address | Suppress on self-review **and** on clean APPROVE-with-no-feedback. Emit only when cross-author AND (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). |
 | Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false` — same policy axis as the address-feedback CTA suppression above. The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -206,15 +206,15 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below only when ALL of the following hold:
+**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below **only when ALL of the following hold**:
 - `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
-- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0`.
+- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing).
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 
 Suppress silently when:
 - `CURRENT_USER == AUTHOR_LOGIN` — self-review; asking the author to address their own feedback is noise.
-- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address.
+- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 Cleanup non-blocking:
 ```bash
@@ -266,5 +266,5 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Omit the footer instruction in Step 4 | Without it, the agent does NOT emit the footer. Step 5 will then abort. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when there is nothing to address | Suppress on self-review **and** on clean APPROVE-with-no-feedback. Emit only when cross-author AND (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on TWO axes: identity (`CURRENT_USER != AUTHOR_LOGIN`) AND outcome (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). Suppress on self-review **and** on clean APPROVE-with-no-feedback. |
 | Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false` — same policy axis as the address-feedback CTA suppression above. The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -205,11 +205,15 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, if `CURRENT_USER != AUTHOR_LOGIN` (i.e., the reviewer is not also the PR author), append:
+**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below **only when ALL of the following hold**:
+- `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
+- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0`.
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 
-Suppress this CTA silently when `CURRENT_USER == AUTHOR_LOGIN` — self-review is a legitimate flow; asking the author if they want to address their own feedback is noise.
+Suppress this CTA silently when:
+- `CURRENT_USER == AUTHOR_LOGIN` — self-review is a legitimate flow; asking the author to address their own feedback is noise.
+- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 Cleanup non-blocking:
 ```bash
@@ -266,5 +270,5 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Force-add 👍 to your own existing comment | Check `reactions.nodes[].user.login` first; skip if you've already reacted. |
 | Block on cleanup | Cleanup runs in background `(... ) &`. Don't `wait` for it. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when `CURRENT_USER == AUTHOR_LOGIN` | Always suppress for self-review — asking the author if they want to address their own feedback is noise. Only emit the CTA when `CURRENT_USER != AUTHOR_LOGIN`. |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on TWO axes: identity (`CURRENT_USER != AUTHOR_LOGIN`) AND outcome (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). Suppress on self-review **and** on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). |
 | Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false` — same policy axis as the address-feedback CTA suppression above. The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -207,7 +207,7 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below **only when ALL of the following hold**:
 - `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
-- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0`.
+- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing).
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 


### PR DESCRIPTION
## Summary

- Extend the address-feedback CTA guard from a single axis (identity: `CURRENT_USER != AUTHOR_LOGIN`) to two axes: identity **and** outcome.
- The CTA now emits only when the review produced something actionable: `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0`.
- A cross-author `APPROVE` with `posted = 0` and `deduped = 0` suppresses the CTA silently — nothing for the author to address.
- Both `workflow-pr-review` and `workflow-pr-review-followup` skill files receive symmetric edits: CTA block rewrite and common-mistakes row update. Both now use the explicit two-bullet suppress pattern for unambiguous model interpretation.

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 -m pytest tests/ -q` — 428/428 pass (no regression in unrelated tests)

### Type-tailored checks ([fix])

- [ ] Reproduce original symptom: run `/swe-workbench:review` on a PR with cross-author `APPROVE` + `posted=0` + `deduped=0` (e.g. PR #199 re-reviewed) — confirm CTA is **not** emitted.
- [ ] Approval with inline comments: `APPROVE` + `posted > 0` → CTA **is** emitted.
- [ ] Comment decision: `COMMENT` + any posted/deduped values → CTA **is** emitted.
- [ ] Self-review regression (#242): `CURRENT_USER == AUTHOR_LOGIN`, any outcome → CTA suppressed.
- [ ] Followup skill: same scenarios via `--check-followup <N>` → same suppression behaviour.

Issue: N/A — caught in-session while reviewing PR #199; CTA emitted on cross-author APPROVE with posted=0 and deduped=0.
