### PR TITLE
[fix] Issue-filing surfaces: discover and apply --label in gh issue create

### DIFF
--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -38,6 +38,13 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
    - **No templates found:** note "No issue templates found in this repo; using default body shape." Proceed to draft with default body.
    - **Discovery fails (no `.github/` dir, permission error):** fall through to default body shape with a one-line note.
 
+   After classifying the template, run `gh label list --json name -q '.[].name'` and select a label using this chain:
+
+   1. **Template frontmatter:** if the chosen template's `labels:` field value exists verbatim in the repo's label list, use it.
+   2. **Fallback — substring match (case-insensitive):** if not present verbatim, pick the first repo label whose name contains (or is contained by) the template value.
+   3. **No template:** map commit-tag → label (`[feat]` → `enhancement`, `[bug]` → `bug`, `[chore]` → `documentation`) and apply the same chain.
+   4. **No match:** record "no label" and omit `--label` from the command.
+
 5. **Dup-scan.** Extract 2–3 keywords from the thought. Strip each keyword to `[a-zA-Z0-9_-]` only (drop shell metacharacters, quotes, and flags) and single-quote them when building the search string. Run `gh issue list --search '<sanitized keywords>' --state open --limit 5`. Surface any matches inline. If a match looks duplicative, ask before continuing.
 
 6. **Draft.**
@@ -51,29 +58,31 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
      ## Additional context
      ```
 
-7. **Write temp file.** Derive `<repo-slug>` from the `nameWithOwner` value, replacing `/` with `-` and stripping any character outside `[a-zA-Z0-9_-]`. Obtain a Unix timestamp once via `date +%s` and store it — reuse the same value for both filenames below; never re-derive or re-glob. Write the drafted body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (never via Bash heredoc). Also write a one-line command file to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool, containing the exact `gh issue create --title "..." --body-file <absolute-path>` command (title double-quoted, path absolute and matching the body file written above). Do NOT run `gh issue create` yet.
+7. **Write temp file.** Derive `<repo-slug>` from the `nameWithOwner` value, replacing `/` with `-` and stripping any character outside `[a-zA-Z0-9_-]`. Obtain a Unix timestamp once via `date +%s` and store it — reuse the same value for both filenames below; never re-derive or re-glob. Write the drafted body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (never via Bash heredoc). Also write a one-line command file to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool, containing the exact `gh issue create --title "..." --body-file <absolute-path> --label "<chosen-label>"` command (title double-quoted, path absolute and matching the body file written above). Omit the `--label` segment when no label was matched. Do NOT run `gh issue create` yet.
 
 8. **Preview gate.** Print the following to the user and wait. Do NOT execute on this turn:
    ```
    Filing into: <owner>/<repo>
    Template: <chosen template filename> | none — default body
    Title: <drafted title>
+   Label: <chosen label> | none — no matching label
    Possibly related: <#N list, or "none">
 
    Body:
    <code-fenced rendered body>
 
-   Command: gh issue create --title "<title>" --body-file <path>
+   Command: gh issue create --title "<title>" --body-file <path> --label "<chosen-label>"
 
-   Reply 'confirm' to file, or edit any of the above and I'll redraft.
+   Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.
    ```
+   When no label was matched, drop the `--label "<chosen-label>"` segment from the `Command:` line and show `Label: none — no matching label` instead.
 
 9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar file written in step 7 and run it exactly as written — do not regenerate the title or path. Return the issue URL. If the user requests edits, revise draft and return to step 7 (overwrite both temp files, then re-present step 8 preview).
 
 ## Decision boundaries
 
 - Does not assume any template names. Discovers at runtime.
-- Does not edit, close, label, assign, or milestone issues. v1 only files.
+- Does not edit, close, assign, or milestone issues. v1 only files (with the discovered label applied at filing time).
 - Does not score numerically beyond Impact/Effort letters.
 - Does not run any mutating command other than `gh issue create`, and only after explicit `confirm`.
 - Does not pass `--repo` explicitly to `gh issue create` — relies on the current-repo context, which `gh` resolves via the local remote.
@@ -96,4 +105,4 @@ On the preview turn (step 8): one response containing, in order — repo detecte
 
 ## Mutation rule
 
-> **The only mutating command you may run is `gh issue create`, and only after the user replies `confirm` to a rendered preview. Never use `--label`, `--assignee`, or `--milestone` in v1. Never combine `gh issue create` with any other write command. Never pass `--repo` — rely on the detected current-repo context.**
+> **The only mutating command you may run is `gh issue create`, and only after the user replies `confirm` to a rendered preview. Never use `--assignee` or `--milestone` in v1. You MAY pass `--label "<name>"` when the value was discovered via the Step 4 label-selection chain (template frontmatter → repo-label match → omit if no match). Never combine `gh issue create` with any other write command. Never pass `--repo` — rely on the detected current-repo context.**

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -38,7 +38,7 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
    - **No templates found:** note "No issue templates found in this repo; using default body shape." Proceed to draft with default body.
    - **Discovery fails (no `.github/` dir, permission error):** fall through to default body shape with a one-line note.
 
-   After classifying the template, run `gh label list --json name -q '.[].name'` and select a label using this chain:
+   After classifying the template, run `gh label list --json name -q '.[].name'`. If the command fails or returns empty output, treat the label list as empty and proceed directly to chain step 4 (no match → omit `--label`). Otherwise select a label using this chain:
 
    1. **Template frontmatter:** if the chosen template's `labels:` field value exists verbatim in the repo's label list, use it.
    2. **Fallback — substring match (case-insensitive):** if not present verbatim, pick the first repo label whose name contains (or is contained by) the template value.
@@ -101,7 +101,7 @@ Invoke these skills via the Skill tool when the question directly concerns their
 
 ## Output format
 
-On the preview turn (step 8): one response containing, in order — repo detected, restatement, product framing (4 lenses), classification + reason (or "no templates → default"), dup-scan results, drafted title, drafted body (code-fenced), and the exact `gh issue create` command — followed by `Reply 'confirm' to file, or edit any of the above and I'll redraft.`
+On the preview turn (step 8): one response containing, in order — repo detected, restatement, product framing (4 lenses), classification + reason (or "no templates → default"), dup-scan results, drafted title, chosen label (or "none — no matching label"), drafted body (code-fenced), and the exact `gh issue create --title "..." --body-file <path> --label "<chosen-label>"` command (omitting `--label` when no label was matched) — followed by `Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.`
 
 ## Mutation rule
 

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -19,24 +19,32 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
 4. **Template discovery.** List `.github/ISSUE_TEMPLATE/` filtered to `*.md`, skipping `config.yml`. Read each template's frontmatter and first ~20 body lines. Classify the thought into the closest-fit template with a one-sentence reason, or note "No issue templates found; using default body shape" when none exist.
 
-5. **Duplicate scan.** `gh issue list --search "<2-3 keywords>" --state open --limit 5`. Surface matches. Ask before drafting if any look duplicative.
+5. **Label discovery.** Run `gh label list --json name -q '.[].name'` to get the repo's available labels. Select a label using this chain:
 
-6. **Draft.** With a template: fill its sections, prepend `## Product framing`. Without a template: use `## Problem` / `## Value` / `## Acceptance criteria` / `## Impact / Effort` / `## Additional context`.
+   a. **Template frontmatter:** if the chosen template has a `labels:` field and that value exists verbatim in the repo's label list, use it.
+   b. **Fallback — substring match (case-insensitive):** if the frontmatter label is not present verbatim, pick the first repo label whose name case-insensitively contains (or is contained by) the template's value.
+   c. **No template chosen:** map by commit-tag — `[feat]` → `enhancement`, `[bug]` → `bug`, `[chore]` → `documentation` — then apply the same chain against the repo's label list.
+   d. **No match found:** omit `--label`; record this so the preview can warn the user ("No matching label found; filing without label").
 
-7. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write the exact `gh issue create --title "..." --body-file <path>` command to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool. Then print:
+6. **Duplicate scan.** `gh issue list --search "<2-3 keywords>" --state open --limit 5`. Surface matches. Ask before drafting if any look duplicative.
+
+7. **Draft.** With a template: fill its sections, prepend `## Product framing`. Without a template: use `## Problem` / `## Value` / `## Acceptance criteria` / `## Impact / Effort` / `## Additional context`.
+
+8. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write the exact `gh issue create --title "..." --body-file <path> --label "<chosen-label>"` command to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool (omit `--label` when no label was matched). Then print:
    ```
    Filing into: <owner>/<repo>
    Template: <chosen template> | none — default body
    Title: <drafted title>
+   Label: <chosen label> | none — no matching label found
    Possibly related: <#N list, or "none">
 
    Body:
    <code-fenced body>
 
-   Command: gh issue create --title "<title>" --body-file <path>
+   Command: gh issue create --title "<title>" --body-file <path> --label "<chosen-label>"
 
-   Reply 'confirm' to file, or edit any of the above and I'll redraft.
+   Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.
    ```
-   **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
+   When no label was matched, drop the `--label "<chosen-label>"` segment from the `Command:` line. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
-8. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 7 and run it exactly as written — do not regenerate the title or path. Return the issue URL.
+9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -19,18 +19,18 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
 4. **Template discovery.** List `.github/ISSUE_TEMPLATE/` filtered to `*.md`, skipping `config.yml`. Read each template's frontmatter and first ~20 body lines. Classify the thought into the closest-fit template with a one-sentence reason, or note "No issue templates found; using default body shape" when none exist.
 
-5. **Label discovery.** Run `gh label list --json name -q '.[].name'` to get the repo's available labels. Select a label using this chain:
+5. **Label discovery.** Run `gh label list --json name -q '.[].name'` to get the repo's available labels. If the command fails or returns empty output, treat the label list as empty and proceed directly to step d (no match → omit `--label`). Otherwise select a label using this chain:
 
    a. **Template frontmatter:** if the chosen template has a `labels:` field and that value exists verbatim in the repo's label list, use it.
    b. **Fallback — substring match (case-insensitive):** if the frontmatter label is not present verbatim, pick the first repo label whose name case-insensitively contains (or is contained by) the template's value.
-   c. **No template chosen:** map by commit-tag — `[feat]` → `enhancement`, `[bug]` → `bug`, `[chore]` → `documentation` — then apply the same chain against the repo's label list.
+   c. **No template chosen:** map by commit-tag — `[feat]` → `enhancement`, `[bug]` → `bug`, `[chore]` → `documentation` — then apply the same chain against the repo's label list. If no commit-tag is recognisable in the user's input, proceed directly to step d.
    d. **No match found:** omit `--label`; record this so the preview can warn the user ("No matching label found; filing without label").
 
 6. **Duplicate scan.** `gh issue list --search "<2-3 keywords>" --state open --limit 5`. Surface matches. Ask before drafting if any look duplicative.
 
 7. **Draft.** With a template: fill its sections, prepend `## Product framing`. Without a template: use `## Problem` / `## Value` / `## Acceptance criteria` / `## Impact / Effort` / `## Additional context`.
 
-8. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write the exact `gh issue create --title "..." --body-file <path> --label "<chosen-label>"` command to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool (omit `--label` when no label was matched). Then print:
+8. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it — never re-derive or re-glob. Write the body to `/tmp/capture-<repo-slug>-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write a one-line command to `/tmp/capture-<repo-slug>-<unix-timestamp>.cmd` using the `Write` tool: when a label was matched, write `gh issue create --title "..." --body-file <path> --label "<matched-label>"`; when no label was matched, write `gh issue create --title "..." --body-file <path>` (no `--label` segment). Then print:
    ```
    Filing into: <owner>/<repo>
    Template: <chosen template> | none — default body

--- a/skills/workflow-bug-triage/SKILL.md
+++ b/skills/workflow-bug-triage/SKILL.md
@@ -86,6 +86,8 @@ If the hypothesis fails to explain one symptom, return to Phase 1 with that symp
 Goal: produce a structured GitHub issue that documents the diagnosis.
 
 1. **Discover the issue template.** Read `.github/ISSUE_TEMPLATE/bug_report.md` if it exists. If not, use the default body shape below.
+
+   **Discover labels.** Run `gh label list --json name -q '.[].name'`. Bug-triage defaults to `bug`. If `bug` exists in the repo label list, use it. If not, pick the first label whose name case-insensitively contains "bug" (e.g. `bug-report`, `kind/bug`). If still no match, omit `--label` and warn in the preview ("No bug-like label found; filing without label"). Surface the chosen label (or absence) in the preview so the user can change it before replying `confirm`.
 2. **Augment the template** by prepending the Root-Cause / Pattern-Analysis / Impact sections. **Do NOT use `gh issue create --template`** — that gives the user no in-skill editing. Use `--body-file` instead, mirroring `agents/product-manager.md`.
 3. **Render the body** using the schema below.
 4. **Preview-gate-then-confirm.** Print the body, the title, the target repo, and the `gh issue create` command. Wait for user to reply `confirm`. **Do NOT** run `gh issue create` until the user replies.
@@ -139,12 +141,15 @@ or `/swe-workbench:implement` invocation.>
 ```bash
 gh issue create \
   --title "[bug] <short subject>" \
-  --body-file /tmp/swe-workbench-bug-triage-<repo-slug>-<unix-ts>.md
+  --body-file /tmp/swe-workbench-bug-triage-<repo-slug>-<unix-ts>.md \
+  --label "bug"
 ```
+
+Omit `--label` when no `bug`-like label exists in the repo.
 
 Always preview-gate-then-confirm (mirrors `commands/capture.md`). The skill MUST:
 1. Run `gh repo view --json nameWithOwner -q '.nameWithOwner'` to confirm target repo.
-2. Print: filing target, title, body (code-fenced), and the exact command.
+2. Print: filing target, title, **chosen label** (or "none — no matching label"), body (code-fenced), and the exact command. Tell the user they may change the label before replying `confirm`.
 3. Wait for `confirm`. Reject any other reply (re-prompt).
 4. On `confirm`, run the command and return the issue URL.
 

--- a/skills/workflow-bug-triage/SKILL.md
+++ b/skills/workflow-bug-triage/SKILL.md
@@ -91,7 +91,7 @@ Goal: produce a structured GitHub issue that documents the diagnosis.
 2. **Augment the template** by prepending the Root-Cause / Pattern-Analysis / Impact sections. **Do NOT use `gh issue create --template`** — that gives the user no in-skill editing. Use `--body-file` instead, mirroring `agents/product-manager.md`.
 3. **Render the body** using the schema below.
 4. **Preview-gate-then-confirm.** Print the body, the title, the target repo, and the `gh issue create` command. Wait for user to reply `confirm`. **Do NOT** run `gh issue create` until the user replies.
-5. **On `confirm`**, run the printed command and return the issue URL.
+5. **On `confirm`**, run the **exact** `gh issue create` command as printed in the preview above — do not regenerate or rephrase it. Return the issue URL.
 
 ## Output: issue body schema
 

--- a/tests/test_issue_filing_label_discovery.py
+++ b/tests/test_issue_filing_label_discovery.py
@@ -1,0 +1,69 @@
+"""Tests for issue-filing surfaces including --label (#247)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+CAPTURE_MD = ROOT / "commands" / "capture.md"
+PRODUCT_MANAGER_MD = ROOT / "agents" / "product-manager.md"
+BUG_TRIAGE_MD = ROOT / "skills" / "workflow-bug-triage" / "SKILL.md"
+
+
+def test_capture_runs_gh_label_list():
+    """commands/capture.md must run `gh label list` during template discovery."""
+    text = CAPTURE_MD.read_text()
+    assert "gh label list" in text, (
+        "commands/capture.md must call `gh label list` to discover repo labels"
+    )
+
+
+def test_capture_preview_shows_label_flag():
+    """commands/capture.md preview block and .cmd sidecar must include --label."""
+    text = CAPTURE_MD.read_text()
+    assert "--label" in text, (
+        "commands/capture.md must include --label in the preview command and .cmd sidecar"
+    )
+
+
+def test_capture_documents_label_override():
+    """commands/capture.md preview gate must mention that the user can change the label."""
+    text = CAPTURE_MD.read_text().lower()
+    assert "label" in text and ("override" in text or "change" in text or "edit" in text), (
+        "commands/capture.md must tell the user how to override the chosen label"
+    )
+
+
+def test_product_manager_runs_gh_label_list():
+    """agents/product-manager.md must call `gh label list` during template discovery."""
+    text = PRODUCT_MANAGER_MD.read_text()
+    assert "gh label list" in text, (
+        "agents/product-manager.md must call `gh label list`"
+    )
+
+
+def test_product_manager_v1_ban_lifted():
+    """agents/product-manager.md must no longer ban --label under v1."""
+    text = PRODUCT_MANAGER_MD.read_text()
+    assert "Never use `--label`" not in text, (
+        "v1 ban on --label must be lifted; "
+        "agents/product-manager.md still contains the backtick-quoted prohibition"
+    )
+    assert "Never use --label" not in text, (
+        "v1 ban on --label must be lifted (unquoted form)"
+    )
+
+
+def test_product_manager_preview_shows_label_flag():
+    """agents/product-manager.md preview/sidecar lines must include --label."""
+    text = PRODUCT_MANAGER_MD.read_text()
+    assert "--label" in text, (
+        "agents/product-manager.md must include --label in preview and .cmd sidecar"
+    )
+
+
+def test_product_manager_still_bans_assignee_and_milestone():
+    """v1 ban on --assignee and --milestone must remain (scope discipline)."""
+    text = PRODUCT_MANAGER_MD.read_text()
+    assert "--assignee" in text and "--milestone" in text, (
+        "agents/product-manager.md must still document the v1 restrictions on "
+        "--assignee and --milestone (only --label is being lifted)"
+    )

--- a/tests/test_workflow_bug_triage_label.py
+++ b/tests/test_workflow_bug_triage_label.py
@@ -1,0 +1,31 @@
+"""Tests for workflow-bug-triage label discovery (#247)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SKILL_MD = ROOT / "skills" / "workflow-bug-triage" / "SKILL.md"
+
+
+def test_bug_triage_runs_gh_label_list():
+    """SKILL.md must call `gh label list` during template discovery (Phase 4)."""
+    text = SKILL_MD.read_text()
+    assert "gh label list" in text, (
+        "skills/workflow-bug-triage/SKILL.md must call `gh label list`"
+    )
+
+
+def test_bug_triage_default_label_is_bug():
+    """The default label for bug-triage-filed issues must be `bug`."""
+    text = SKILL_MD.read_text()
+    assert '--label "bug"' in text or "--label 'bug'" in text, (
+        'skills/workflow-bug-triage/SKILL.md must show --label "bug" '
+        "in the example gh issue create command"
+    )
+
+
+def test_bug_triage_preview_documents_label_override():
+    """Preview gate must mention the user can override the chosen label."""
+    text = SKILL_MD.read_text().lower()
+    assert "label" in text and ("override" in text or "change" in text), (
+        "SKILL.md must tell the user how to override the chosen label"
+    )


### PR DESCRIPTION
## Summary
- Add `gh label list` label-discovery step to all three issue-filing surfaces (`commands/capture.md`, `agents/product-manager.md`, `skills/workflow-bug-triage/SKILL.md`) — best-fit label is now selected automatically via template frontmatter → substring match → commit-tag fallback chain
- Lift the v1 `--label` ban in `agents/product-manager.md` (line ~99); `--assignee` and `--milestone` bans remain
- Add two new content-introspection test files (`tests/test_issue_filing_label_discovery.py`, `tests/test_workflow_bug_triage_label.py`) asserting each surface calls `gh label list` and includes `--label` in the preview and `.cmd` sidecar

## Test Plan
- [x] Changed skills/commands/agents load without errors (`pytest tests/test_validate.py` — 441/441 pass)
- [x] New cross-surface tests pass (`pytest tests/test_issue_filing_label_discovery.py -v` — 7/7 pass)
- [x] New bug-triage tests pass (`pytest tests/test_workflow_bug_triage_label.py -v` — 3/3 pass)
- [x] Full suite passes (`pytest tests/ -q` — 441/441 pass)

Closes #247
