### PR TITLE
[fix] Loosen commit-msg hook regex to accept optional colon

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -9,7 +9,7 @@ case "$SUBJECT" in
 esac
 
 # Keep in sync with .github/workflows/pr.yml
-PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\] .+'
+PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\]:? .+'
 
 if ! echo "$SUBJECT" | grep -qE "$PATTERN"; then
     echo ""
@@ -18,6 +18,7 @@ if ! echo "$SUBJECT" | grep -qE "$PATTERN"; then
     echo ""
     echo "Expected format:"
     echo "  [type] Description"
+    echo "  [type]: Description"
     echo ""
     echo "Allowed types:"
     echo "  feat, fix, refactor, test, ci, docs, perf, chore, polish, breaking"
@@ -26,5 +27,6 @@ if ! echo "$SUBJECT" | grep -qE "$PATTERN"; then
     echo "  [feat] Add worktree sync command"
     echo "  [fix] Resolve branch detection on Windows"
     echo "  [ci] Add coverage gate to CI pipeline"
+    echo "  [chore]: Bump actions/setup-python from 5 to 6"
     exit 1
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ The `commit-msg` hook enforces a `[type] Subject` prefix on every commit:
 [feat] Add Python language skill
 [fix] Resolve trigger keyword collision in DDD skill
 [docs] Clarify F.I.R.S.T. principle in TDD skill
+[chore]: Bump actions/setup-python from 5 to 6
 ```
 
 Allowed types: `feat`, `fix`, `refactor`, `test`, `ci`, `docs`, `perf`, `chore`, `polish`, `breaking`.

--- a/tests/test_commit_msg_pr_parity.py
+++ b/tests/test_commit_msg_pr_parity.py
@@ -6,7 +6,7 @@ REPO = Path(__file__).resolve().parents[1]
 
 
 def _extract_pattern(path: Path) -> str:
-    matches = re.findall(r"PATTERN='([^']+)'", path.read_text())
+    matches = re.findall(r"PATTERN='([^']+)'", path.read_text())  # single-quoted shell assignment
     assert len(matches) == 1, (
         f"Expected exactly one PATTERN='...' assignment in {path}, found {len(matches)}"
     )
@@ -15,6 +15,8 @@ def _extract_pattern(path: Path) -> str:
 
 class TestCommitMsgPrParity:
     def test_hook_and_ci_patterns_match(self):
+        """Assert structural parity only — pattern correctness is out of scope here.
+        Add behavioral tests in test_pr_validation.py if the pattern semantics change."""
         hook = _extract_pattern(REPO / ".githooks/commit-msg")
         ci = _extract_pattern(REPO / ".github/workflows/pr.yml")
         assert hook == ci, (

--- a/tests/test_commit_msg_pr_parity.py
+++ b/tests/test_commit_msg_pr_parity.py
@@ -1,0 +1,24 @@
+"""Parity guard: the commit-msg hook and PR-title CI check must use the same regex."""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _extract_pattern(path: Path) -> str:
+    matches = re.findall(r"PATTERN='([^']+)'", path.read_text())
+    assert len(matches) == 1, (
+        f"Expected exactly one PATTERN='...' assignment in {path}, found {len(matches)}"
+    )
+    return matches[0]
+
+
+class TestCommitMsgPrParity:
+    def test_hook_and_ci_patterns_match(self):
+        hook = _extract_pattern(REPO / ".githooks/commit-msg")
+        ci = _extract_pattern(REPO / ".github/workflows/pr.yml")
+        assert hook == ci, (
+            f"commit-msg hook and pr.yml regexes have drifted.\n"
+            f"  hook ({len(hook)} chars): {hook}\n"
+            f"  ci   ({len(ci)} chars): {ci}"
+        )


### PR DESCRIPTION
## Summary
- The `.githooks/commit-msg` hook rejected `[type]: Description` (colon form) while the CI check in `.github/workflows/pr.yml` accepted it — causing commits like Dependabot's `[chore]: Bump actions/setup-python from 5 to 6` to pass CI but fail the local hook.
- Added `:?` to the hook regex (line 12) so both files now use an identical `PATTERN='^\[(feat|fix|refactor|test|ci|docs|perf|chore|polish|breaking)\]:? .+'`.
- Expanded the hook error message to document both accepted forms.
- Added `tests/test_commit_msg_pr_parity.py` — a parity guard that extracts `PATTERN='...'` from both files and asserts string equality, turning the "Keep in sync" comment into an enforced CI invariant.
- Updated `CONTRIBUTING.md` examples to show the colon form.

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `pytest tests/test_commit_msg_pr_parity.py -v` — RED before fix, GREEN after
- [x] `pytest tests/ -v` — all 432 tests pass (no regressions)
- [x] `shellcheck .githooks/commit-msg` — clean
- [x] Manual smoke: `[chore]: Bump foo` accepted; `[chore] Bump foo` accepted; `chore: missing brackets` rejected

### Type-tailored checks (fix)
- [x] Reproduced the problem: local hook rejected `[chore]: Bump foo from 1 to 2` before the patch
- [x] Verified the fix: both forms accepted after `:?` added; garbage still rejected
- [ ] Run `git commit` with each form locally to confirm hook passes end-to-end

Closes #229
