### PR TITLE
[chore] Script and test hygiene (closes #236)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -125,6 +125,10 @@ fi
 
 # ── PR (reuse if open, create otherwise) ─────────────────────
 
+# EXISTING_PR resolves to the literal string "null" via two independent paths:
+#   1. gh succeeds but finds no open PRs → `--jq '.[0]'` on an empty array emits "null"
+#   2. gh itself fails (auth error, network, etc.) → `|| echo "null"` fires
+# The `!= "null"` guard below catches both; do not simplify this without preserving both paths.
 EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --state open --json number,url --jq '.[0]' 2>/dev/null || echo "null")
 if [[ -n "$EXISTING_PR" && "$EXISTING_PR" != "null" ]]; then
   PR_NUM=$(echo "$EXISTING_PR" | jq -r .number)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -46,8 +46,11 @@ def parse_frontmatter(path, text=None):
 def _build_cache():
     """Read every agent .md and every skills/*/SKILL.md exactly once.
 
-    Returns (agents, skills) where each is a dict[Path, str]. Paths that
-    cannot be read are omitted so per-check OSError handling is preserved.
+    Returns (agents, skills) where each is a dict[Path, str | None].
+    rglob("*.md") is intentional: it covers check_unwired_principle_skills
+    (which uses rglob) in addition to the flat-glob consumers.
+    Unreadable files are stored as None so consumers that track failures
+    (e.g. check_catalog_completeness) can report them without re-reading.
     ROOT is resolved inside this function so test monkeypatching of ROOT works.
     """
     agents_dir = ROOT / "agents"
@@ -58,12 +61,12 @@ def _build_cache():
         try:
             agents[p] = p.read_text(encoding="utf-8")
         except OSError:
-            pass
+            agents[p] = None  # sentinel: present but unreadable
     for p in skills_dir.glob("*/SKILL.md"):
         try:
             skills[p] = p.read_text(encoding="utf-8")
         except OSError:
-            pass
+            skills[p] = None  # sentinel: present but unreadable
     return agents, skills
 
 
@@ -327,9 +330,11 @@ def check_catalog_completeness(cache=None):
              f"stale entry 'swe-workbench:{sid}' has no skills/{sid}/ on disk")
 
     for agent_md in sorted(agents_dir.glob("*.md")):
-        cached = agents_cache.get(agent_md) if agents_cache is not None else None
-        if cached is not None:
-            agent_text = cached
+        if agents_cache is not None and agent_md in agents_cache:
+            agent_text = agents_cache[agent_md]
+            if agent_text is None:
+                fail(agent_md.relative_to(ROOT), "could not read file")
+                continue
         else:
             try:
                 agent_text = agent_md.read_text(encoding="utf-8")

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -52,6 +52,9 @@ def _build_cache():
     Unreadable files are stored as None so consumers that track failures
     (e.g. check_catalog_completeness) can report them without re-reading.
     ROOT is resolved inside this function so test monkeypatching of ROOT works.
+
+    Note: skills/*/templates/*.md files are NOT cached here; check_template_placeholders
+    reads each template file directly (one read_text() call per template).
     """
     agents_dir = ROOT / "agents"
     skills_dir = ROOT / "skills"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -40,6 +40,34 @@ def parse_frontmatter(path, text=None):
 
 
 # ──────────────────────────────────────────────
+# File-read cache
+# ──────────────────────────────────────────────
+
+def _build_cache():
+    """Read every agent .md and every skills/*/SKILL.md exactly once.
+
+    Returns (agents, skills) where each is a dict[Path, str]. Paths that
+    cannot be read are omitted so per-check OSError handling is preserved.
+    ROOT is resolved inside this function so test monkeypatching of ROOT works.
+    """
+    agents_dir = ROOT / "agents"
+    skills_dir = ROOT / "skills"
+    agents: dict = {}
+    skills: dict = {}
+    for p in agents_dir.rglob("*.md"):
+        try:
+            agents[p] = p.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    for p in skills_dir.glob("*/SKILL.md"):
+        try:
+            skills[p] = p.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    return agents, skills
+
+
+# ──────────────────────────────────────────────
 # Validators
 # ──────────────────────────────────────────────
 
@@ -116,12 +144,14 @@ def check_hooks_json():
                     fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].command must be a string")
 
 
-def check_skills():
+def check_skills(cache=None):
     skills_dir = ROOT / "skills"
+    skills_cache = cache[1] if cache is not None else None
     # glob("*/SKILL.md") matches exactly depth-2 paths; no need for a post-hoc depth guard.
     for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
         skill_dir_name = skill_md.parent.name
-        text = skill_md.read_text(encoding="utf-8")
+        text = (skills_cache.get(skill_md) if skills_cache is not None else None) \
+            or skill_md.read_text(encoding="utf-8")
         line_count = len(text.splitlines())  # total file length including frontmatter
         fm = parse_frontmatter(skill_md, text=text)
         if fm is None:
@@ -146,10 +176,12 @@ def check_skills():
             )
 
 
-def check_agents():
+def check_agents(cache=None):
     agents_dir = ROOT / "agents"
+    agents_cache = cache[0] if cache is not None else None
     for agent_md in sorted(agents_dir.glob("*.md")):
-        text = agent_md.read_text(encoding="utf-8")
+        text = (agents_cache.get(agent_md) if agents_cache is not None else None) \
+            or agent_md.read_text(encoding="utf-8")
         fm = parse_frontmatter(agent_md, text=text)
         if fm is None:
             fail(agent_md.relative_to(ROOT), "missing or malformed frontmatter")
@@ -172,13 +204,15 @@ def check_commands():
             fail(cmd_md.relative_to(ROOT), "frontmatter missing required field: 'description'")
 
 
-def check_agent_skill_refs():
+def check_agent_skill_refs(cache=None):
     """Every `swe-workbench:<id>` in agents/*.md must resolve to skills/<id>/ on disk."""
     agents_dir = ROOT / "agents"
     skills_dir = ROOT / "skills"
+    agents_cache = cache[0] if cache is not None else None
     pattern = re.compile(r'`swe-workbench:([\w-]+)`')
     for agent_md in sorted(agents_dir.glob("*.md")):
-        text = agent_md.read_text(encoding="utf-8")
+        text = (agents_cache.get(agent_md) if agents_cache is not None else None) \
+            or agent_md.read_text(encoding="utf-8")
         for skill_id in set(pattern.findall(text)):
             if not (skills_dir / skill_id).is_dir():
                 fail(
@@ -205,15 +239,17 @@ def check_command_skill_refs():
 TEMPLATE_MARKER_RE = re.compile(r'\[\[detect:([a-z][a-z0-9-]*)\]\]')
 
 
-def check_template_placeholders():
+def check_template_placeholders(cache=None):
     """Every [[detect:KEY]] in skills/*/templates/*.md must be documented in the
     adjacent SKILL.md's '## Project Detection' section as a backtick-wrapped key."""
     skills_dir = ROOT / "skills"
+    skills_cache = cache[1] if cache is not None else None
     for template in sorted(skills_dir.glob("*/templates/*.md")):
         skill_md = template.parent.parent / "SKILL.md"
         if not skill_md.is_file():
             continue
-        skill_text = skill_md.read_text(encoding="utf-8")
+        skill_text = (skills_cache.get(skill_md) if skills_cache is not None else None) \
+            or skill_md.read_text(encoding="utf-8")
         pd_idx = skill_text.find("## Project Detection")
         if pd_idx >= 0:
             next_h2 = skill_text.find("\n## ", pd_idx + 4)
@@ -261,11 +297,12 @@ def check_skill_trigger_fixtures():
                 )
 
 
-def check_catalog_completeness():
+def check_catalog_completeness(cache=None):
     """Catalog at agents/shared/skills.md must list every skill, and every agent must include it."""
     catalog = ROOT / "agents" / "shared" / "skills.md"
     skills_dir = ROOT / "skills"
     agents_dir = ROOT / "agents"
+    agents_cache = cache[0] if cache is not None else None
 
     if not catalog.is_file():
         fail(catalog.relative_to(ROOT), "missing — required catalog file")
@@ -275,7 +312,8 @@ def check_catalog_completeness():
         fail(skills_dir.relative_to(ROOT), "missing — required skills directory")
         return
 
-    text = catalog.read_text(encoding="utf-8")
+    text = (agents_cache.get(catalog) if agents_cache is not None else None) \
+        or catalog.read_text(encoding="utf-8")
     # — = EM DASH; [^\r\n]* avoids capturing CRLF carriage returns in description
     entry_re = re.compile(r'^-\s+`swe-workbench:([\w-]+)`\s+—\s+(\S[^\r\n]*)$', re.MULTILINE)
     catalog_ids = {sid for sid, _ in entry_re.findall(text)}
@@ -289,11 +327,15 @@ def check_catalog_completeness():
              f"stale entry 'swe-workbench:{sid}' has no skills/{sid}/ on disk")
 
     for agent_md in sorted(agents_dir.glob("*.md")):
-        try:
-            agent_text = agent_md.read_text(encoding="utf-8")
-        except OSError as e:
-            fail(agent_md.relative_to(ROOT), f"could not read file: {e}")
-            continue
+        cached = agents_cache.get(agent_md) if agents_cache is not None else None
+        if cached is not None:
+            agent_text = cached
+        else:
+            try:
+                agent_text = agent_md.read_text(encoding="utf-8")
+            except OSError as e:
+                fail(agent_md.relative_to(ROOT), f"could not read file: {e}")
+                continue
         if "@./shared/skills.md" not in agent_text:
             fail(agent_md.relative_to(ROOT),
                  "missing required '@./shared/skills.md' include"
@@ -318,7 +360,7 @@ def check_examples():
             )
 
 
-def check_unwired_principle_skills():
+def check_unwired_principle_skills(cache=None):
     """Every skills/principle-*/ must be referenced by at least one agent.
 
     agents/shared/skills.md (the catalog) is explicitly excluded — it lists
@@ -327,6 +369,7 @@ def check_unwired_principle_skills():
     skills_dir = ROOT / "skills"
     agents_dir = ROOT / "agents"
     catalog = agents_dir / "shared" / "skills.md"
+    agents_cache = cache[0] if cache is not None else None
 
     principle_skills = sorted(
         p.name for p in skills_dir.glob("principle-*")
@@ -337,7 +380,13 @@ def check_unwired_principle_skills():
 
     for skill_id in principle_skills:
         needle = f"`swe-workbench:{skill_id}`"
-        wired = any(needle in f.read_text(encoding="utf-8") for f in agent_files)
+        wired = any(
+            needle in (
+                (agents_cache.get(f) if agents_cache is not None else None)
+                or f.read_text(encoding="utf-8")
+            )
+            for f in agent_files
+        )
         if not wired:
             fail(
                 Path("agents") / "<unwired>",
@@ -355,18 +404,20 @@ def main():
     print("Validating swe-workbench plugin files...")
     print()
 
+    cache = _build_cache()
+
     plugin_data = check_plugin_json()
     check_marketplace_json(plugin_data)
     check_hooks_json()
-    check_skills()
+    check_skills(cache=cache)
     check_skill_trigger_fixtures()
-    check_agents()
+    check_agents(cache=cache)
     check_commands()
-    check_agent_skill_refs()
+    check_agent_skill_refs(cache=cache)
     check_command_skill_refs()
-    check_catalog_completeness()
-    check_template_placeholders()
-    check_unwired_principle_skills()
+    check_catalog_completeness(cache=cache)
+    check_template_placeholders(cache=cache)
+    check_unwired_principle_skills(cache=cache)
     check_examples()
 
     if FAILURES:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -335,8 +335,17 @@ def check_catalog_completeness(cache=None):
         fail(skills_dir.relative_to(ROOT), "missing — required skills directory")
         return
 
-    text = (agents_cache.get(catalog) if agents_cache is not None else None) \
-        or catalog.read_text(encoding="utf-8")
+    if agents_cache is not None and catalog in agents_cache:
+        text = agents_cache[catalog]
+        if text is None:
+            fail(catalog.relative_to(ROOT), "could not read file")
+            return
+    else:
+        try:
+            text = catalog.read_text(encoding="utf-8")
+        except OSError as e:
+            fail(catalog.relative_to(ROOT), f"could not read file: {e}")
+            return
     # — = EM DASH; [^\r\n]* avoids capturing CRLF carriage returns in description
     entry_re = re.compile(r'^-\s+`swe-workbench:([\w-]+)`\s+—\s+(\S[^\r\n]*)$', re.MULTILINE)
     catalog_ids = {sid for sid, _ in entry_re.findall(text)}

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -153,8 +153,13 @@ def check_skills(cache=None):
     # glob("*/SKILL.md") matches exactly depth-2 paths; no need for a post-hoc depth guard.
     for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
         skill_dir_name = skill_md.parent.name
-        text = (skills_cache.get(skill_md) if skills_cache is not None else None) \
-            or skill_md.read_text(encoding="utf-8")
+        if skills_cache is not None and skill_md in skills_cache:
+            text = skills_cache[skill_md]
+            if text is None:
+                fail(skill_md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            text = skill_md.read_text(encoding="utf-8")
         line_count = len(text.splitlines())  # total file length including frontmatter
         fm = parse_frontmatter(skill_md, text=text)
         if fm is None:
@@ -183,8 +188,13 @@ def check_agents(cache=None):
     agents_dir = ROOT / "agents"
     agents_cache = cache[0] if cache is not None else None
     for agent_md in sorted(agents_dir.glob("*.md")):
-        text = (agents_cache.get(agent_md) if agents_cache is not None else None) \
-            or agent_md.read_text(encoding="utf-8")
+        if agents_cache is not None and agent_md in agents_cache:
+            text = agents_cache[agent_md]
+            if text is None:
+                fail(agent_md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            text = agent_md.read_text(encoding="utf-8")
         fm = parse_frontmatter(agent_md, text=text)
         if fm is None:
             fail(agent_md.relative_to(ROOT), "missing or malformed frontmatter")
@@ -214,8 +224,13 @@ def check_agent_skill_refs(cache=None):
     agents_cache = cache[0] if cache is not None else None
     pattern = re.compile(r'`swe-workbench:([\w-]+)`')
     for agent_md in sorted(agents_dir.glob("*.md")):
-        text = (agents_cache.get(agent_md) if agents_cache is not None else None) \
-            or agent_md.read_text(encoding="utf-8")
+        if agents_cache is not None and agent_md in agents_cache:
+            text = agents_cache[agent_md]
+            if text is None:
+                fail(agent_md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            text = agent_md.read_text(encoding="utf-8")
         for skill_id in set(pattern.findall(text)):
             if not (skills_dir / skill_id).is_dir():
                 fail(
@@ -251,8 +266,13 @@ def check_template_placeholders(cache=None):
         skill_md = template.parent.parent / "SKILL.md"
         if not skill_md.is_file():
             continue
-        skill_text = (skills_cache.get(skill_md) if skills_cache is not None else None) \
-            or skill_md.read_text(encoding="utf-8")
+        if skills_cache is not None and skill_md in skills_cache:
+            skill_text = skills_cache[skill_md]
+            if skill_text is None:
+                fail(skill_md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            skill_text = skill_md.read_text(encoding="utf-8")
         pd_idx = skill_text.find("## Project Detection")
         if pd_idx >= 0:
             next_h2 = skill_text.find("\n## ", pd_idx + 4)
@@ -381,15 +401,15 @@ def check_unwired_principle_skills(cache=None):
         if (p / "SKILL.md").is_file()
     )
 
-    agent_files = sorted(f for f in agents_dir.rglob("*.md") if f != catalog)
+    agent_files = [
+        f for f in sorted(agents_dir.rglob("*.md"))
+        if f != catalog and (agents_cache is None or agents_cache.get(f) is not None)
+    ]
 
     for skill_id in principle_skills:
         needle = f"`swe-workbench:{skill_id}`"
         wired = any(
-            needle in (
-                (agents_cache.get(f) if agents_cache is not None else None)
-                or f.read_text(encoding="utf-8")
-            )
+            needle in (agents_cache[f] if agents_cache is not None else f.read_text(encoding="utf-8"))
             for f in agent_files
         )
         if not wired:

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -7,17 +7,24 @@ These tests replicate the strip-then-match pipeline from
 import re
 from pathlib import Path
 
+import pytest
+
 _PR_YML_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "pr.yml"
-_PR_YML_TEXT = _PR_YML_PATH.read_text(encoding="utf-8")
+try:
+    _PR_YML_TEXT: str | None = _PR_YML_PATH.read_text(encoding="utf-8")
+except FileNotFoundError:
+    _PR_YML_TEXT = None
 
 
 def _extract_pr_yml_pattern(anchor: str) -> str:
     """Extract the first capture group from pr.yml using a stable anchor regex.
 
-    Uses re.DOTALL so anchors can span lines. Raises AssertionError with a
-    diagnostic message if the anchor cannot be located — callers can rely on
-    pytest surfacing it as a clear failure.
+    Uses re.DOTALL so anchors can span lines. Skips the test (pytest.skip) if
+    pr.yml is absent — avoids a FileNotFoundError at collection time for partial
+    checkouts. Raises AssertionError if the anchor cannot be located.
     """
+    if _PR_YML_TEXT is None:
+        pytest.skip(f"pr.yml not found at {_PR_YML_PATH} — skipping sync tests")
     m = re.search(anchor, _PR_YML_TEXT, re.DOTALL)
     if not m:
         raise AssertionError(
@@ -173,7 +180,9 @@ class TestPrYamlSync:
 
     def test_html_stripper_matches_pr_yml(self):
         """strip_html_comments() must use the exact same regex as pr.yml."""
-        extracted = _extract_pr_yml_pattern(r"re\.sub\(r'([^']+)'")
+        # Anchor includes 'python3 -c' context so a future re.sub addition
+        # above line 61 in pr.yml doesn't silently redirect extraction.
+        extracted = _extract_pr_yml_pattern(r"python3 -c.*?re\.sub\(r'([^']+)'")
         # No POSIX classes — pattern is byte-identical between shell and Python.
         assert extracted == r"<!--.*?(?:-->|$)", (
             f"pr.yml HTML-stripper pattern {extracted!r} diverged from the "
@@ -203,6 +212,10 @@ class TestPrYamlSync:
         for text, expected in samples:
             yml_result = bool(yml_re.search(text))
             py_result = _na_optout(text)
+            assert yml_result == py_result, (
+                f"yml_re and _na_optout() disagree on {text!r}: "
+                f"yml={yml_result}, py={py_result}"
+            )
             assert yml_result == expected, (
                 f"yml regex gave {yml_result!r} for {text!r}, expected {expected}"
             )

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -257,7 +257,7 @@ class TestPrYamlSync:
 
     def test_title_pattern_locks_allowed_types(self):
         """PR title regex in pr.yml must accept only defined types."""
-        pattern = _extract_pr_yml_pattern(r"PATTERN='([^']+)'")
+        pattern = _extract_pr_yml_pattern(r"Validate PR title.*?PATTERN='([^']+)'")
         title_re = re.compile(pattern)
 
         positives = [

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -12,7 +12,7 @@ import pytest
 _PR_YML_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "pr.yml"
 try:
     _PR_YML_TEXT: str | None = _PR_YML_PATH.read_text(encoding="utf-8")
-except FileNotFoundError:
+except OSError:
     _PR_YML_TEXT = None
 
 

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -186,7 +186,8 @@ class TestPrYamlSync:
         # No POSIX classes — pattern is byte-identical between shell and Python.
         assert extracted == r"<!--.*?(?:-->|$)", (
             f"pr.yml HTML-stripper pattern {extracted!r} diverged from the "
-            "pattern used in strip_html_comments() — sync one of them."
+            "pattern used in strip_html_comments() — "
+            "update strip_html_comments() or the expected string in this test."
         )
 
     def test_na_optout_matches_pr_yml(self):

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -5,6 +5,26 @@ These tests replicate the strip-then-match pipeline from
 .github/workflows/pr.yml so the logic is verifiable without CI.
 """
 import re
+from pathlib import Path
+
+_PR_YML_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "pr.yml"
+_PR_YML_TEXT = _PR_YML_PATH.read_text(encoding="utf-8")
+
+
+def _extract_pr_yml_pattern(anchor: str) -> str:
+    """Extract the first capture group from pr.yml using a stable anchor regex.
+
+    Uses re.DOTALL so anchors can span lines. Raises AssertionError with a
+    diagnostic message if the anchor cannot be located — callers can rely on
+    pytest surfacing it as a clear failure.
+    """
+    m = re.search(anchor, _PR_YML_TEXT, re.DOTALL)
+    if not m:
+        raise AssertionError(
+            f"could not locate anchor {anchor!r} in pr.yml — "
+            "did the workflow change? Update the test or sync the drift."
+        )
+    return m.group(1)
 
 
 def strip_html_comments(text: str) -> str:
@@ -142,3 +162,119 @@ class TestValidOptout:
         body = "## Summary\n- x\n\nFixes #99\n"
         visible = strip_html_comments(body)
         assert has_closing_keyword(visible)
+
+
+class TestPrYamlSync:
+    """Tie Python helper functions to the source-of-truth regexes in pr.yml.
+
+    If someone edits a pattern in pr.yml without updating its Python mirror
+    (or vice-versa), these tests fail with a clear diagnostic.
+    """
+
+    def test_html_stripper_matches_pr_yml(self):
+        """strip_html_comments() must use the exact same regex as pr.yml."""
+        extracted = _extract_pr_yml_pattern(r"re\.sub\(r'([^']+)'")
+        # No POSIX classes — pattern is byte-identical between shell and Python.
+        assert extracted == r"<!--.*?(?:-->|$)", (
+            f"pr.yml HTML-stripper pattern {extracted!r} diverged from the "
+            "pattern used in strip_html_comments() — sync one of them."
+        )
+
+    def test_na_optout_matches_pr_yml(self):
+        """_na_optout() behaviour must match the pr.yml grep -iqE N/A pattern."""
+        raw = _extract_pr_yml_pattern(
+            r"Allow ad-hoc PRs.*?grep -iqE '([^']+)'"
+        )
+        # Translate POSIX [[:space:]] → [ \t] for Python re.
+        py_pattern = raw.replace("[[:space:]]", r"[ \t]")
+        yml_re = re.compile(py_pattern, re.IGNORECASE | re.MULTILINE)
+
+        samples = [
+            ("N/A",                                      True),
+            ("Issue: N/A",                               True),
+            ("Issue: N/A — internal tooling",            True),
+            ("Issue: N/A — reason with trailing space ", True),
+            ("\tN/A",                                    True),
+            ("  N/A  ",                                  True),
+            ("This is N/A",                              False),
+            ("Closes #42",                               False),
+            ("Fix N/A issue",                            False),
+        ]
+        for text, expected in samples:
+            yml_result = bool(yml_re.search(text))
+            py_result = _na_optout(text)
+            assert yml_result == expected, (
+                f"yml regex gave {yml_result!r} for {text!r}, expected {expected}"
+            )
+            assert py_result == expected, (
+                f"_na_optout() gave {py_result!r} for {text!r}, expected {expected}"
+            )
+
+    def test_closing_keyword_matches_pr_yml(self):
+        """has_closing_keyword() behaviour must match the pr.yml grep -iqE closing pattern."""
+        raw = _extract_pr_yml_pattern(
+            r"Require a GitHub closing keyword.*?grep -iqE '([^']+)'"
+        )
+        yml_re = re.compile(raw, re.IGNORECASE)
+
+        samples = [
+            ("Closes #42",         True),
+            ("closes #1",          True),
+            ("Fixes #99",          True),
+            ("Fixed #7",           True),
+            ("Resolves #100",      True),
+            ("resolved #99",       True),   # resolve[sd]? matches 'resolved'
+            ("Fix #5",             True),   # fix(e[sd])? matches plain 'fix'
+            ("Close #3",           True),   # close[sd]? matches plain 'close'
+            ("see Closes #42",     True),   # keyword not required at line start
+            ("Closes N/A",         False),
+            ("Closes #N/A",        False),
+            ("fixes the bug",      False),  # no #number
+        ]
+        for text, expected in samples:
+            yml_result = bool(yml_re.search(text))
+            py_result = has_closing_keyword(text)
+            assert yml_result == py_result, (
+                f"yml_re and has_closing_keyword() disagree on {text!r}: "
+                f"yml={yml_result}, py={py_result}"
+            )
+            assert yml_result == expected, (
+                f"yml regex gave {yml_result!r} for {text!r}, expected {expected}"
+            )
+
+    def test_title_pattern_locks_allowed_types(self):
+        """PR title regex in pr.yml must accept only defined types."""
+        pattern = _extract_pr_yml_pattern(r"PATTERN='([^']+)'")
+        title_re = re.compile(pattern)
+
+        positives = [
+            "[feat] Add something",
+            "[fix] Fix the bug",
+            "[refactor] Clean up code",
+            "[test] Add tests",
+            "[ci] Update workflow",
+            "[docs] Update readme",
+            "[perf] Improve speed",
+            "[chore] Bump deps",
+            "[polish] Minor cleanup",
+            "[breaking] Remove old API",
+            "[feat]: Add something with colon",
+            "[fix]: Fix with colon",
+        ]
+        negatives = [
+            "feat: foo",        # no brackets
+            "[unknown] foo",    # unknown type
+            "[fix]foo",         # missing space after bracket
+            "[fix] ",           # empty description (only a space)
+            "Fix the bug",      # no brackets at all
+            "[FEAT] uppercase", # case-sensitive — uppercase not in allowed list
+        ]
+
+        for title in positives:
+            assert title_re.match(title), (
+                f"Expected {title!r} to match PR title pattern"
+            )
+        for title in negatives:
+            assert not title_re.match(title), (
+                f"Expected {title!r} NOT to match PR title pattern"
+            )

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -236,7 +236,8 @@ class TestPrYamlSync:
             ("Fixes #99",          True),
             ("Fixed #7",           True),
             ("Resolves #100",      True),
-            ("resolved #99",       True),   # resolve[sd]? matches 'resolved'
+            ("resolved #99",       True),   # resolve[sd]? matches 'resolved' and 'resolves'
+            ("resolves #99",       True),
             ("Fix #5",             True),   # fix(e[sd])? matches plain 'fix'
             ("Close #3",           True),   # close[sd]? matches plain 'close'
             ("see Closes #42",     True),   # keyword not required at line start

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -15,9 +15,11 @@ _CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
 def _run_setup(tmp_path: Path) -> subprocess.CompletedProcess:
     """Run setup.sh inside a minimal git repo rooted at tmp_path."""
-    subprocess.run(
-        ["git", "init", str(tmp_path)], check=True, capture_output=True, env=_CLEAN_ENV
+    init = subprocess.run(
+        ["git", "init", str(tmp_path)], capture_output=True, text=True, env=_CLEAN_ENV
     )
+    if init.returncode != 0:
+        raise RuntimeError(f"git init failed: {init.stderr.strip()}")
     return subprocess.run(
         ["sh", str(SETUP_SH)],
         cwd=str(tmp_path),

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -1,0 +1,56 @@
+"""
+Tests for scripts/setup.sh — subprocess-based so they exercise the real POSIX sh logic.
+"""
+import subprocess
+from pathlib import Path
+
+SETUP_SH = Path(__file__).parent.parent / "scripts" / "setup.sh"
+
+
+def _run_setup(tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run setup.sh inside a minimal git repo rooted at tmp_path."""
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    return subprocess.run(
+        ["sh", str(SETUP_SH)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestSetupShGlobGuard:
+    def test_empty_githooks_creates_no_symlinks(self, tmp_path):
+        """When .githooks/ exists but is empty, no symlinks are created."""
+        (tmp_path / ".githooks").mkdir()
+        result = _run_setup(tmp_path)
+        assert result.returncode == 0, result.stderr
+        hooks_dir = tmp_path / ".git" / "hooks"
+        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()]
+        assert symlinks == [], (
+            f"Expected no symlinks in .git/hooks/ when .githooks/ is empty, "
+            f"but found: {[p.name for p in symlinks]}"
+        )
+
+    def test_hook_file_creates_symlink(self, tmp_path):
+        """When .githooks/ has a hook file, setup.sh creates a symlink for it."""
+        githooks_dir = tmp_path / ".githooks"
+        githooks_dir.mkdir()
+        (githooks_dir / "commit-msg").write_text("#!/bin/sh\n")
+        result = _run_setup(tmp_path)
+        assert result.returncode == 0, result.stderr
+        link = tmp_path / ".git" / "hooks" / "commit-msg"
+        assert link.is_symlink(), "Expected a commit-msg symlink in .git/hooks/"
+        assert link.resolve() == (githooks_dir / "commit-msg").resolve()
+
+    def test_multiple_hooks_create_multiple_symlinks(self, tmp_path):
+        """Multiple hook files each get their own symlink."""
+        githooks_dir = tmp_path / ".githooks"
+        githooks_dir.mkdir()
+        for name in ("commit-msg", "pre-push", "pre-commit"):
+            (githooks_dir / name).write_text("#!/bin/sh\n")
+        result = _run_setup(tmp_path)
+        assert result.returncode == 0, result.stderr
+        hooks_dir = tmp_path / ".git" / "hooks"
+        for name in ("commit-msg", "pre-push", "pre-commit"):
+            link = hooks_dir / name
+            assert link.is_symlink(), f"Expected symlink for {name}"

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -54,3 +54,14 @@ class TestSetupShGlobGuard:
         for name in ("commit-msg", "pre-push", "pre-commit"):
             link = hooks_dir / name
             assert link.is_symlink(), f"Expected symlink for {name}"
+
+    def test_no_githooks_dir_exits_cleanly(self, tmp_path):
+        """When .githooks/ does not exist at all, setup.sh exits 0 without errors."""
+        result = _run_setup(tmp_path)
+        assert result.returncode == 0, result.stderr
+        hooks_dir = tmp_path / ".git" / "hooks"
+        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()]
+        assert symlinks == [], (
+            f"Expected no symlinks when .githooks/ is absent, "
+            f"but found: {[p.name for p in symlinks]}"
+        )

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -1,20 +1,29 @@
 """
 Tests for scripts/setup.sh — subprocess-based so they exercise the real POSIX sh logic.
 """
+import os
 import subprocess
 from pathlib import Path
 
 SETUP_SH = Path(__file__).parent.parent / "scripts" / "setup.sh"
 
+# Strip GIT_* vars so hook-context env doesn't leak into ephemeral test repos.
+# When tests run inside a git pre-push hook, GIT_DIR points to the host repo —
+# setup.sh's `git rev-parse` would then target the host instead of tmp_path.
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
 
 def _run_setup(tmp_path: Path) -> subprocess.CompletedProcess:
     """Run setup.sh inside a minimal git repo rooted at tmp_path."""
-    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", str(tmp_path)], check=True, capture_output=True, env=_CLEAN_ENV
+    )
     return subprocess.run(
         ["sh", str(SETUP_SH)],
         cwd=str(tmp_path),
         capture_output=True,
         text=True,
+        env=_CLEAN_ENV,
     )
 
 

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -34,7 +34,7 @@ class TestSetupShGlobGuard:
         result = _run_setup(tmp_path)
         assert result.returncode == 0, result.stderr
         hooks_dir = tmp_path / ".git" / "hooks"
-        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()]
+        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()] if hooks_dir.exists() else []
         assert symlinks == [], (
             f"Expected no symlinks in .git/hooks/ when .githooks/ is empty, "
             f"but found: {[p.name for p in symlinks]}"
@@ -69,7 +69,7 @@ class TestSetupShGlobGuard:
         result = _run_setup(tmp_path)
         assert result.returncode == 0, result.stderr
         hooks_dir = tmp_path / ".git" / "hooks"
-        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()]
+        symlinks = [p for p in hooks_dir.iterdir() if p.is_symlink()] if hooks_dir.exists() else []
         assert symlinks == [], (
             f"Expected no symlinks when .githooks/ is absent, "
             f"but found: {[p.name for p in symlinks]}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -952,7 +952,6 @@ class TestFileReadCaching:
         except SystemExit:
             pass  # we care about read counts, not pass/fail
 
-        monkeypatch.setattr(Path, "read_text", original)
         return read_counts
 
     def test_each_agent_md_read_at_most_once(self, reset_validate, monkeypatch):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -908,3 +908,82 @@ class TestCheckUnwiredPrincipleSkills:
         (root / "skills" / "principle-bare").mkdir(parents=True, exist_ok=True)
         validate.check_unwired_principle_skills()
         assert len(validate.FAILURES) == 0
+
+
+# ──────────────────────────────────────────────
+# File-read caching
+# ──────────────────────────────────────────────
+
+def _make_full_valid_tree(root: Path) -> None:
+    """Build a minimal plugin tree that passes all validate.main() checks."""
+    skills = {
+        "skill-a": "---\nname: skill-a\ndescription: Skill A\n---\n",
+        "skill-b": "---\nname: skill-b\ndescription: Skill B\n---\n",
+    }
+    agents = [
+        {"name": "agent-a", "description": "Agent A"},
+        {"name": "agent-b", "description": "Agent B"},
+        {"name": "agent-c", "description": "Agent C"},
+    ]
+    make_plugin_tree(root, skills=skills, agents=agents)
+    for skill_name in ("skill-a", "skill-b"):
+        (root / "skills" / skill_name / "triggers.txt").write_text(
+            "trigger phrase one\ntrigger phrase two\n", encoding="utf-8"
+        )
+
+
+class TestFileReadCaching:
+    """After the cache refactor, main() reads each agent and skill file exactly once."""
+
+    def _count_reads(self, root: Path, monkeypatch):
+        """Patch Path.read_text, run main(), return per-path read counts."""
+        read_counts: dict[str, int] = {}
+        original = Path.read_text
+
+        def counting_read_text(self_path, *args, **kwargs):
+            key = str(self_path.resolve())
+            read_counts[key] = read_counts.get(key, 0) + 1
+            return original(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+        try:
+            validate.main()
+        except SystemExit:
+            pass  # we care about read counts, not pass/fail
+
+        monkeypatch.setattr(Path, "read_text", original)
+        return read_counts
+
+    def test_each_agent_md_read_at_most_once(self, reset_validate, monkeypatch):
+        root = reset_validate
+        _make_full_valid_tree(root)
+        read_counts = self._count_reads(root, monkeypatch)
+
+        agents_dir = root / "agents"
+        agent_files = [p for p in agents_dir.glob("*.md")]
+        assert agent_files, "Expected at least one agent .md file"
+
+        for agent_path in agent_files:
+            count = read_counts.get(str(agent_path.resolve()), 0)
+            assert count <= 1, (
+                f"{agent_path.name} was read {count} times; expected ≤1 "
+                "(check_agents, check_agent_skill_refs, check_catalog_completeness, "
+                "and check_unwired_principle_skills share the same cache)"
+            )
+
+    def test_each_skill_md_read_at_most_once(self, reset_validate, monkeypatch):
+        root = reset_validate
+        _make_full_valid_tree(root)
+        read_counts = self._count_reads(root, monkeypatch)
+
+        skills_dir = root / "skills"
+        skill_files = list(skills_dir.glob("*/SKILL.md"))
+        assert skill_files, "Expected at least one SKILL.md"
+
+        for skill_path in skill_files:
+            count = read_counts.get(str(skill_path.resolve()), 0)
+            assert count <= 1, (
+                f"{skill_path.parent.name}/SKILL.md was read {count} times; expected ≤1 "
+                "(check_skills and check_template_placeholders share the same cache)"
+            )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -960,7 +960,7 @@ class TestFileReadCaching:
         read_counts = self._count_reads(root, monkeypatch)
 
         agents_dir = root / "agents"
-        agent_files = [p for p in agents_dir.glob("*.md")]
+        agent_files = [p for p in agents_dir.rglob("*.md")]
         assert agent_files, "Expected at least one agent .md file"
 
         for agent_path in agent_files:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -986,3 +986,34 @@ class TestFileReadCaching:
                 f"{skill_path.parent.name}/SKILL.md was read {count} times; expected ≤1 "
                 "(check_skills and check_template_placeholders share the same cache)"
             )
+
+    def test_unreadable_agent_cached_as_failure(self, reset_validate, monkeypatch):
+        root = reset_validate
+        _make_full_valid_tree(root)
+
+        agents_dir = root / "agents"
+        unreadable = sorted(agents_dir.glob("*.md"))[0]
+
+        original = Path.read_text
+        read_count = {"n": 0}
+
+        def patched_read_text(self_path, *args, **kwargs):
+            if self_path.resolve() == unreadable.resolve():
+                read_count["n"] += 1
+                raise OSError("simulated read failure")
+            return original(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", patched_read_text)
+        try:
+            validate.main()
+        except SystemExit:
+            pass
+
+        assert read_count["n"] == 1, (
+            f"Expected unreadable file to be attempted exactly once (cache build only), "
+            f"got {read_count['n']} — None sentinel may not be preventing consumer re-reads"
+        )
+        rel = str(unreadable.relative_to(root))
+        assert any(rel in entry for entry in validate.FAILURES), (
+            f"Expected a failure entry for unreadable {rel!r}, got: {validate.FAILURES}"
+        )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -942,7 +942,8 @@ class TestFileReadCaching:
 
         def counting_read_text(self_path, *args, **kwargs):
             key = str(self_path.resolve())
-            read_counts[key] = read_counts.get(key, 0) + 1
+            if str(root) in key:  # only count reads under the test tree
+                read_counts[key] = read_counts.get(key, 0) + 1
             return original(self_path, *args, **kwargs)
 
         monkeypatch.setattr(Path, "read_text", counting_read_text)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1017,3 +1017,33 @@ class TestFileReadCaching:
         assert any(rel in entry for entry in validate.FAILURES), (
             f"Expected a failure entry for unreadable {rel!r}, got: {validate.FAILURES}"
         )
+
+    def test_unreadable_catalog_cached_as_failure(self, reset_validate, monkeypatch):
+        root = reset_validate
+        _make_full_valid_tree(root)
+
+        catalog = root / "agents" / "shared" / "skills.md"
+
+        original = Path.read_text
+        read_count = {"n": 0}
+
+        def patched_read_text(self_path, *args, **kwargs):
+            if self_path.resolve() == catalog.resolve():
+                read_count["n"] += 1
+                raise OSError("simulated catalog read failure")
+            return original(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", patched_read_text)
+        try:
+            validate.main()
+        except SystemExit:
+            pass
+
+        assert read_count["n"] == 1, (
+            f"Catalog should be attempted exactly once (cache build only), "
+            f"got {read_count['n']} — check_catalog_completeness may bypass the None sentinel"
+        )
+        rel = str(catalog.relative_to(root))
+        assert any(rel in entry for entry in validate.FAILURES), (
+            f"Expected a failure entry for unreadable catalog {rel!r}, got: {validate.FAILURES}"
+        )


### PR DESCRIPTION
## Summary
- `scripts/setup.sh`: add `[ -e "$src" ] || continue` guard — POSIX sh leaves the literal `*` when `.githooks/` is empty, which previously created a dangling symlink named `*`
- `scripts/release.sh`: comment explaining the two independent paths that produce the `"null"` sentinel (jq empty-array path and gh-failure fallback)
- `tests/test_pr_validation.py`: new `TestPrYamlSync` class — extracts live regexes from `.github/workflows/pr.yml` via `re.DOTALL` anchors and asserts behavioural equivalence against the Python helpers; now covers all 4 patterns including the previously-unmirrored title regex
- `scripts/validate.py`: `_build_cache()` reads every `agents/*.md` and `skills/*/SKILL.md` exactly once; `cache=None` kwarg threaded through 6 check functions so per-file read count drops from 3–4× to 1×
- `tests/test_setup_sh.py`: new — subprocess-based tests for the glob guard (empty dir, absent dir, happy path, multi-hook)
- `tests/test_validate.py`: `TestFileReadCaching` monkeypatches `Path.read_text` to assert ≤1 read per path after the cache refactor

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 441 passed, 0 failed
- [x] `python3 scripts/validate.py` — All checks passed
- [x] `shellcheck scripts/setup.sh scripts/release.sh -S warning` — clean
- [x] Manual smoke test: empty `.githooks/` repo produces no `*` symlink
- [x] Mutation test: changing `pr.yml` title regex causes `TestPrYamlSync::test_title_pattern_locks_allowed_types` to fail noisily

### Type-tailored checks ([fix] / [refactor])
- [x] `setup.sh` — before fix: `ls .git/hooks/` shows dangling `*` symlink on empty `.githooks/`; after fix: symlink absent
- [x] `validate.py` — read count confirmed ≤1 per agent file and ≤1 per SKILL.md via `TestFileReadCaching`

Closes #236
