### PR TITLE
[feat] Subagent skill-usage telemetry surfaced by the orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ cd swe-workbench
 
 Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide and philosophy → [docs/extending.md](docs/extending.md). Runtime dependencies → [docs/dependencies.md](docs/dependencies.md).
 
+## Skill-usage telemetry
+
+When the orchestrator dispatches a subagent, the skills that subagent invokes are surfaced in the transcript:
+
+```
+Skills used by reviewer: swe-workbench:principle-code-review, swe-workbench:principle-clean-code
+```
+
+Top-level skill calls and zero-skill runs produce no output. Individual agents can opt out via `skill_telemetry: false` in their frontmatter. See [docs/skill-usage-telemetry.md](docs/skill-usage-telemetry.md) for full details.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/skill-usage-telemetry.md
+++ b/docs/skill-usage-telemetry.md
@@ -39,7 +39,7 @@ model: sonnet
 ---
 ```
 
-Both hooks check this flag independently, so a crash between `PreToolUse` and `SubagentStop` cannot cause a buffer to accumulate for an opted-out agent.
+Both hooks check this flag independently. In the common case — where the flag is present before the subagent starts — no buffer is ever written. If the flag is added mid-run, any in-flight buffer is cleaned up by the 24-hour sweep.
 
 ## Scope
 

--- a/docs/skill-usage-telemetry.md
+++ b/docs/skill-usage-telemetry.md
@@ -1,0 +1,58 @@
+# Skill-usage telemetry
+
+When the orchestrator dispatches a subagent via the `Agent` tool, any skills that subagent invokes are invisible to the orchestrator — it only receives the subagent's final text output.  The telemetry hooks surface those invocations by printing a single informational line into the orchestrator's transcript after each subagent finishes:
+
+```
+Skills used by <agent-type>: <skill-1>, <skill-2>, ...
+```
+
+## How it works
+
+Two hooks cooperate:
+
+| Hook | Script | Event |
+|---|---|---|
+| `PreToolUse:Skill` | `hooks/skill_usage_record.sh` | Fires on every `Skill` tool call.  When inside a subagent (`agent_id` present in stdin), appends the skill name to a date-stamped buffer: `.claude/cache/skill-usage/YYYYMMDD-<agent_id>.txt`. |
+| `SubagentStop` | `hooks/skill_usage_flush.sh` | Fires when a subagent finishes.  Reads the buffer, deduplicates (preserving first-seen order), formats the line, emits it via `systemMessage`, then deletes the buffer. |
+
+Top-level orchestrator skill calls produce **no line**. Zero-skill subagent runs produce **no line**.  The feature is information-only — it never blocks or modifies tool calls.
+
+## Where buffers live
+
+```
+<project-root>/.claude/cache/skill-usage/
+  20260517-abc-123.txt      ← one file per in-flight subagent
+  .errors.log               ← hook errors (only present when something went wrong)
+```
+
+Buffers older than 24 hours are swept opportunistically on each `PreToolUse:Skill` call.  `SubagentStop` deletes the buffer immediately after flushing.  Under normal operation the directory stays empty between agent runs.
+
+## Opting out
+
+An agent can suppress telemetry for itself by adding `skill_telemetry: false` to its YAML frontmatter (within the first 20 lines of the file):
+
+```markdown
+---
+name: my-agent
+skill_telemetry: false
+model: sonnet
+---
+```
+
+Both hooks check this flag independently, so a crash between `PreToolUse` and `SubagentStop` cannot cause a buffer to accumulate for an opted-out agent.
+
+## Scope
+
+The hooks only track agents whose `.md` file lives under `<plugin-root>/agents/`.  Other plugins ship their own equivalent hooks if they want telemetry for their subagents.
+
+## Troubleshooting
+
+If you expect a "Skills used by …" line but don't see one:
+
+1. Check `.claude/cache/skill-usage/.errors.log` for hook errors.
+2. Confirm the subagent's `.md` file exists under `agents/` and does **not** have `skill_telemetry: false`.
+3. Confirm `CLAUDE_PLUGIN_ROOT` resolves to the plugin root (hooks use this to locate agent files).
+
+## Security note
+
+Skill names land in the `systemMessage` field visible in the orchestrator's transcript.  If a future plugin author ever encodes sensitive data into skill names, those names would appear in the transcript.  Skill names in this plugin are all short, non-sensitive identifiers (e.g. `swe-workbench:principle-code-review`).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,6 +9,25 @@
             "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]]|:)(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_usage_record.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_usage_flush.sh"
+          }
+        ]
       }
     ]
   }

--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -12,7 +12,8 @@ agent_id=$(printf '%s' "$input" | jq -r '.agent_id // empty')
 agent_type=$(printf '%s' "$input" | jq -r '.agent_type // empty')
 { [ -z "$agent_id" ] || [ -z "$agent_type" ]; } && { printf '{}'; exit 0; }
 
-# Sanitize agent_type: plain identifiers only — reject path-traversal attempts.
+# Sanitize agent_id and agent_type: plain identifiers only — reject path-traversal attempts.
+[[ "$agent_id" =~ ^[A-Za-z0-9_-]+$ ]] || { printf '{}'; exit 0; }
 [[ "$agent_type" =~ ^[A-Za-z0-9_-]+$ ]] || { printf '{}'; exit 0; }
 
 # Scope + opt-out (same gates as the record hook).

--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SubagentStop handler — flushes the per-subagent buffer when a dispatched
+# subagent finishes.  Emits a single telemetry line via systemMessage so the
+# orchestrator's transcript shows which skills the subagent invoked.
+#
+# Exits 0 unconditionally; emits {} when there is nothing to report.
+set -u
+
+input=$(cat)
+
+agent_id=$(printf '%s' "$input" | jq -r '.agent_id // empty')
+agent_type=$(printf '%s' "$input" | jq -r '.agent_type // empty')
+{ [ -z "$agent_id" ] || [ -z "$agent_type" ]; } && { printf '{}'; exit 0; }
+
+# Sanitize agent_type: plain identifiers only — reject path-traversal attempts.
+[[ "$agent_type" =~ ^[A-Za-z0-9_-]+$ ]] || { printf '{}'; exit 0; }
+
+# Scope + opt-out (same gates as the record hook).
+plugin_root="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+agent_file="$plugin_root/agents/$agent_type.md"
+[ -f "$agent_file" ] || { printf '{}'; exit 0; }
+if head -20 "$agent_file" | grep -Eq '^skill_telemetry:[[:space:]]*false[[:space:]]*$'; then
+  printf '{}'; exit 0
+fi
+
+cache_dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/cache/skill-usage"
+
+# Buffer may span today's and yesterday's date-stamped file (straddle midnight).
+# Use a glob loop so paths with spaces are handled correctly (compatible with bash 3.2+).
+buffers=()
+for f in "$cache_dir"/*-"$agent_id".txt; do
+  [ -f "$f" ] && buffers+=("$f")
+done
+[ "${#buffers[@]}" -eq 0 ] && { printf '{}'; exit 0; }
+
+# Dedupe preserving first-seen order; join with ", ".
+skills=$(cat "${buffers[@]}" 2>/dev/null | awk '!seen[$0]++' | paste -sd, - | sed 's/,/, /g')
+[ -z "$skills" ] && { printf '{}'; exit 0; }
+
+# Clean up all matching buffers regardless of whether the emit succeeds below.
+rm -f "${buffers[@]}" 2>/dev/null || true
+
+# Safely JSON-encode the message.
+msg=$(printf 'Skills used by %s: %s' "$agent_type" "$skills" | jq -Rs .)
+printf '{"systemMessage": %s, "suppressOutput": true}\n' "$msg"
+exit 0

--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -33,8 +33,8 @@ for f in "$cache_dir"/*-"$agent_id".txt; do
 done
 [ "${#buffers[@]}" -eq 0 ] && { printf '{}'; exit 0; }
 
-# Dedupe preserving first-seen order; join with ", ".
-skills=$(cat "${buffers[@]}" 2>/dev/null | awk '!seen[$0]++' | paste -sd, - | sed 's/,/, /g')
+# Dedupe preserving first-seen order; join with ", " in one pass (POSIX awk, no paste/sed).
+skills=$(cat "${buffers[@]}" 2>/dev/null | awk '!seen[$0]++ { out = (out ? out ", " : "") $0 } END { print out }')
 [ -z "$skills" ] && { printf '{}'; exit 0; }
 
 # Clean up all matching buffers regardless of whether the emit succeeds below.

--- a/hooks/skill_usage_record.sh
+++ b/hooks/skill_usage_record.sh
@@ -11,9 +11,15 @@ input=$(cat)
 agent_id=$(printf '%s' "$input" | jq -r '.agent_id // empty')
 [ -z "$agent_id" ] && exit 0          # top-level orchestrator → no-op
 
+# Sanitize agent_id: plain identifiers only — same rule as agent_type.
+[[ "$agent_id" =~ ^[A-Za-z0-9_-]+$ ]] || exit 0
+
 agent_type=$(printf '%s' "$input" | jq -r '.agent_type // empty')
 skill=$(printf '%s' "$input" | jq -r '.tool_input.skill // empty')
 [ -z "$skill" ] && exit 0             # malformed input → no-op
+
+# Sanitize skill: reject values that jq -r would expand to newlines or shell metas.
+[[ "$skill" =~ ^[A-Za-z0-9_:/-]+$ ]] || exit 0
 
 # Sanitize agent_type: plain identifiers only — reject path-traversal attempts.
 [[ "$agent_type" =~ ^[A-Za-z0-9_-]+$ ]] || exit 0

--- a/hooks/skill_usage_record.sh
+++ b/hooks/skill_usage_record.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PreToolUse:Skill handler — records skill name into a per-subagent buffer
+# when the call originates inside a dispatched subagent.
+#
+# Never blocks: exit 2 from a PreToolUse hook would deny the Skill call,
+# which is unacceptable for an observation-only hook. Exit 0 always.
+set -u
+
+input=$(cat)
+
+agent_id=$(printf '%s' "$input" | jq -r '.agent_id // empty')
+[ -z "$agent_id" ] && exit 0          # top-level orchestrator → no-op
+
+agent_type=$(printf '%s' "$input" | jq -r '.agent_type // empty')
+skill=$(printf '%s' "$input" | jq -r '.tool_input.skill // empty')
+[ -z "$skill" ] && exit 0             # malformed input → no-op
+
+# Sanitize agent_type: plain identifiers only — reject path-traversal attempts.
+[[ "$agent_type" =~ ^[A-Za-z0-9_-]+$ ]] || exit 0
+
+# Scope: only track agents owned by this plugin.
+plugin_root="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+agent_file="$plugin_root/agents/$agent_type.md"
+[ -f "$agent_file" ] || exit 0
+
+# Opt-out: frontmatter `skill_telemetry: false` in the first 20 lines.
+if head -20 "$agent_file" | grep -Eq '^skill_telemetry:[[:space:]]*false[[:space:]]*$'; then
+  exit 0
+fi
+
+cache_dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/cache/skill-usage"
+mkdir -p "$cache_dir" 2>/dev/null || exit 0
+buffer="$cache_dir/$(date +%Y%m%d)-$agent_id.txt"
+
+# Append skill name. Dedup happens at flush time so this path stays fast.
+printf '%s\n' "$skill" >>"$buffer" 2>>"$cache_dir/.errors.log" || true
+
+# Opportunistic sweep: drop buffers older than 24h (-mmin +1440 is portable to
+# both GNU and BSD find and gives a true 24h sliding window).
+find "$cache_dir" -maxdepth 1 -name '*-*.txt' -mmin +1440 -delete 2>/dev/null || true
+
+exit 0

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -10,6 +10,8 @@ ROOT = Path(__file__).parent.parent
 FAILURES = []
 
 # Hook events that fire unconditionally and have no tool name to match against.
+# Do NOT add PreToolUse / PostToolUse here — those are tool-matcher events and
+# must carry a "matcher" field. Only true lifecycle events belong in this set.
 _LIFECYCLE_HOOK_EVENTS = frozenset({"SubagentStop", "PreCompact", "Stop", "Notification"})
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -9,6 +9,9 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent
 FAILURES = []
 
+# Hook events that fire unconditionally and have no tool name to match against.
+_LIFECYCLE_HOOK_EVENTS = frozenset({"SubagentStop", "PreCompact", "Stop", "Notification"})
+
 
 def fail(path, reason):
     FAILURES.append(f"  {path}: {reason}")
@@ -134,7 +137,7 @@ def check_hooks_json():
             if not isinstance(entry, dict):
                 fail(path.relative_to(ROOT), f"hooks.{event}[{i}] must be an object")
                 continue
-            if not isinstance(entry.get("matcher"), str):
+            if event not in _LIFECYCLE_HOOK_EVENTS and not isinstance(entry.get("matcher"), str):
                 fail(path.relative_to(ROOT), f"hooks.{event}[{i}].matcher must be a string")
             sub_hooks = entry.get("hooks")
             if not isinstance(sub_hooks, list):

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -170,6 +170,21 @@ class TestRecordHook:
             assert result.returncode == 0, f"Expected exit 0 for agent_type={malicious!r}"
             assert _buffer_files(cache_dir) == [], f"Expected no buffer for agent_type={malicious!r}"
 
+    def test_path_traversal_agent_id_is_noop(self, plugin_root, cache_dir):
+        """agent_id with path-traversal chars must be rejected — no buffer written."""
+        for malicious in ["../../evil", "../sensitive", "foo/bar", "foo bar"]:
+            result = _run_record(
+                {
+                    "agent_id": malicious,
+                    "agent_type": "reviewer",
+                    "tool_input": {"skill": "swe-workbench:principle-code-review"},
+                },
+                plugin_root,
+                cache_dir,
+            )
+            assert result.returncode == 0, f"Expected exit 0 for agent_id={malicious!r}"
+            assert _buffer_files(cache_dir) == [], f"Expected no buffer for agent_id={malicious!r}"
+
     def test_missing_skill_is_noop(self, plugin_root, cache_dir):
         """tool_input.skill absent → exit 0, no buffer."""
         result = _run_record(
@@ -348,3 +363,66 @@ class TestHooksJson:
         cmd = bash_hooks[0]["hooks"][0]["command"]
         # The guard pattern for destructive rm must be present verbatim
         assert "rm" in cmd and "exit 2" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Integration — record → flush pipeline (end-to-end acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordFlushIntegration:
+    def test_record_then_flush_emits_skill_line(self, plugin_root, cache_dir):
+        """Sequential record→flush with matching agent_id produces the telemetry line."""
+        _run_record(
+            {
+                "agent_id": "integ-001",
+                "agent_type": "reviewer",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            plugin_root,
+            cache_dir,
+        )
+        # Buffer should exist after record
+        assert len(_buffer_files(cache_dir)) == 1
+
+        result = _run_flush(
+            {"agent_id": "integ-001", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        assert "systemMessage" in out
+        assert "Skills used by reviewer" in out["systemMessage"]
+        assert "swe-workbench:principle-code-review" in out["systemMessage"]
+        # Buffer cleaned up
+        assert _buffer_files(cache_dir) == []
+
+    def test_record_multiple_skills_then_flush_dedupes(self, plugin_root, cache_dir):
+        """Multiple record calls with a duplicate produce a single deduped line."""
+        for skill in [
+            "swe-workbench:principle-tdd",
+            "swe-workbench:principle-clean-code",
+            "swe-workbench:principle-tdd",  # duplicate
+        ]:
+            _run_record(
+                {
+                    "agent_id": "integ-002",
+                    "agent_type": "reviewer",
+                    "tool_input": {"skill": skill},
+                },
+                plugin_root,
+                cache_dir,
+            )
+
+        result = _run_flush(
+            {"agent_id": "integ-002", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        msg = json.loads(result.stdout)["systemMessage"]
+        # Dedup: tdd appears exactly once
+        assert msg.count("principle-tdd") == 1
+        # First-seen order preserved
+        assert msg.index("principle-tdd") < msg.index("principle-clean-code")

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -1,0 +1,350 @@
+"""Tests for hooks/skill_usage_record.sh and hooks/skill_usage_flush.sh.
+
+Subprocess-driven so they exercise real POSIX sh logic.  Each test gets an
+isolated cache dir via tmp_path + CLAUDE_PROJECT_DIR, and a minimal agents/
+tree via CLAUDE_PLUGIN_ROOT.
+"""
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+RECORD_SH = ROOT / "hooks" / "skill_usage_record.sh"
+FLUSH_SH = ROOT / "hooks" / "skill_usage_flush.sh"
+HOOKS_JSON = ROOT / "hooks" / "hooks.json"
+
+# Strip GIT_* vars so hook-context env doesn't leak into ephemeral test paths.
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plugin_root(tmp_path: Path) -> Path:
+    """Minimal plugin dir with an agents/reviewer.md (no opt-out)."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "reviewer.md").write_text(
+        "---\nname: reviewer\nmodel: sonnet\n---\nReviewer body.\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def optout_plugin_root(tmp_path: Path) -> Path:
+    """Minimal plugin dir with an agent that has skill_telemetry: false."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "reviewer.md").write_text(
+        "---\nname: reviewer\nskill_telemetry: false\nmodel: sonnet\n---\nReviewer body.\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def cache_dir(tmp_path: Path) -> Path:
+    """Isolated cache directory; CLAUDE_PROJECT_DIR points here."""
+    d = tmp_path / "project"
+    d.mkdir()
+    return d
+
+
+def _env(plugin_root: Path, cache_dir: Path) -> dict:
+    env = dict(_CLEAN_ENV)
+    env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+    env["CLAUDE_PROJECT_DIR"] = str(cache_dir)
+    return env
+
+
+def _run_record(stdin_json: dict, plugin_root: Path, cache_dir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(RECORD_SH)],
+        input=json.dumps(stdin_json),
+        capture_output=True,
+        text=True,
+        env=_env(plugin_root, cache_dir),
+    )
+
+
+def _run_flush(stdin_json: dict, plugin_root: Path, cache_dir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(FLUSH_SH)],
+        input=json.dumps(stdin_json),
+        capture_output=True,
+        text=True,
+        env=_env(plugin_root, cache_dir),
+    )
+
+
+def _skill_cache(cache_dir: Path) -> Path:
+    return cache_dir / ".claude" / "cache" / "skill-usage"
+
+
+def _buffer_files(cache_dir: Path) -> list[Path]:
+    d = _skill_cache(cache_dir)
+    if not d.exists():
+        return []
+    return sorted(d.glob("*-*.txt"))
+
+
+# ---------------------------------------------------------------------------
+# record hook — tests 1–6
+# ---------------------------------------------------------------------------
+
+
+class TestRecordHook:
+    def test_top_level_is_noop(self, plugin_root, cache_dir):
+        """No agent_id in stdin → exit 0, no buffer written."""
+        result = _run_record(
+            {"tool_input": {"skill": "swe-workbench:principle-code-review"}},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert _buffer_files(cache_dir) == []
+
+    def test_subagent_writes_buffer(self, plugin_root, cache_dir):
+        """Subagent invocation writes the skill name to a buffer file."""
+        result = _run_record(
+            {
+                "agent_id": "abc-123",
+                "agent_type": "reviewer",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        buffers = _buffer_files(cache_dir)
+        assert len(buffers) == 1
+        assert buffers[0].name.endswith("-abc-123.txt")
+        assert "swe-workbench:principle-code-review" in buffers[0].read_text()
+
+    def test_unknown_agent_type_is_noop(self, plugin_root, cache_dir):
+        """agent_type with no matching agent file → no buffer written."""
+        result = _run_record(
+            {
+                "agent_id": "abc-123",
+                "agent_type": "NotARealAgent",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert _buffer_files(cache_dir) == []
+
+    def test_opted_out_agent_is_noop(self, optout_plugin_root, cache_dir):
+        """agent with skill_telemetry: false → no buffer written."""
+        result = _run_record(
+            {
+                "agent_id": "abc-123",
+                "agent_type": "reviewer",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            optout_plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert _buffer_files(cache_dir) == []
+
+    def test_path_traversal_agent_type_is_noop(self, plugin_root, cache_dir):
+        """agent_type with path-traversal chars must be rejected — no buffer, no file probe."""
+        for malicious in ["../../etc/passwd", "../sensitive", "foo/bar", "foo bar"]:
+            result = _run_record(
+                {
+                    "agent_id": "abc-123",
+                    "agent_type": malicious,
+                    "tool_input": {"skill": "swe-workbench:principle-code-review"},
+                },
+                plugin_root,
+                cache_dir,
+            )
+            assert result.returncode == 0, f"Expected exit 0 for agent_type={malicious!r}"
+            assert _buffer_files(cache_dir) == [], f"Expected no buffer for agent_type={malicious!r}"
+
+    def test_missing_skill_is_noop(self, plugin_root, cache_dir):
+        """tool_input.skill absent → exit 0, no buffer."""
+        result = _run_record(
+            {
+                "agent_id": "abc-123",
+                "agent_type": "reviewer",
+                "tool_input": {},
+            },
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert _buffer_files(cache_dir) == []
+
+    def test_sweep_removes_old_buffers(self, plugin_root, cache_dir):
+        """Files older than 24h are swept on each hook invocation."""
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        old_file = skill_cache / "20240101-old-agent.txt"
+        old_file.write_text("old-skill\n")
+        # Set mtime to 48h ago
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        _run_record(
+            {
+                "agent_id": "new-123",
+                "agent_type": "reviewer",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            plugin_root,
+            cache_dir,
+        )
+        assert not old_file.exists(), "Old buffer should have been swept"
+
+
+# ---------------------------------------------------------------------------
+# flush hook — tests 7–11
+# ---------------------------------------------------------------------------
+
+
+class TestFlushHook:
+    def test_emits_formatted_system_message(self, plugin_root, cache_dir):
+        """Buffer with three entries (one duplicate) → deduped, first-seen order."""
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = __import__("datetime").date.today().strftime("%Y%m%d")
+        buf = skill_cache / f"{today}-flush-001.txt"
+        buf.write_text("skill-a\nskill-b\nskill-a\nskill-c\n")
+
+        result = _run_flush(
+            {"agent_id": "flush-001", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        assert "systemMessage" in out
+        msg = out["systemMessage"]
+        assert msg.startswith("Skills used by reviewer:")
+        assert "skill-a" in msg
+        assert "skill-b" in msg
+        assert "skill-c" in msg
+        # Dedup: skill-a must appear exactly once
+        assert msg.count("skill-a") == 1
+        # Order: skill-a before skill-b before skill-c
+        assert msg.index("skill-a") < msg.index("skill-b") < msg.index("skill-c")
+        # suppressOutput present
+        assert out.get("suppressOutput") is True
+
+    def test_deletes_buffer_after_emit(self, plugin_root, cache_dir):
+        """Buffer file is removed after successful flush."""
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = __import__("datetime").date.today().strftime("%Y%m%d")
+        buf = skill_cache / f"{today}-flush-002.txt"
+        buf.write_text("skill-a\n")
+
+        _run_flush(
+            {"agent_id": "flush-002", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert not buf.exists(), "Buffer should be deleted after flush"
+
+    def test_missing_buffer_is_noop(self, plugin_root, cache_dir):
+        """No buffer for agent_id → stdout is {}, exit 0."""
+        result = _run_flush(
+            {"agent_id": "no-such-agent", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+
+    def test_opted_out_agent_is_noop_even_with_buffer(self, optout_plugin_root, cache_dir):
+        """Opted-out agent: flush emits {}, buffer left untouched."""
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = __import__("datetime").date.today().strftime("%Y%m%d")
+        buf = skill_cache / f"{today}-flush-003.txt"
+        buf.write_text("skill-a\n")
+
+        result = _run_flush(
+            {"agent_id": "flush-003", "agent_type": "reviewer"},
+            optout_plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}
+        assert buf.exists(), "Buffer should remain when agent is opted out"
+
+    def test_path_traversal_agent_type_is_noop(self, plugin_root, cache_dir):
+        """Flush rejects agent_type values with path-traversal characters."""
+        for malicious in ["../../etc/passwd", "../sensitive", "foo/bar"]:
+            result = _run_flush(
+                {"agent_id": "trav-001", "agent_type": malicious},
+                plugin_root,
+                cache_dir,
+            )
+            assert result.returncode == 0, f"Expected exit 0 for agent_type={malicious!r}"
+            assert json.loads(result.stdout) == {}, f"Expected {{}} for agent_type={malicious!r}"
+
+    def test_midnight_straddle(self, plugin_root, cache_dir):
+        """Buffers from both today and yesterday contribute to the flush line."""
+        import datetime
+
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = datetime.date.today().strftime("%Y%m%d")
+        yesterday = (datetime.date.today() - datetime.timedelta(days=1)).strftime("%Y%m%d")
+        buf_today = skill_cache / f"{today}-straddle-99.txt"
+        buf_yesterday = skill_cache / f"{yesterday}-straddle-99.txt"
+        buf_today.write_text("skill-today\n")
+        buf_yesterday.write_text("skill-yesterday\n")
+
+        result = _run_flush(
+            {"agent_id": "straddle-99", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        msg = out.get("systemMessage", "")
+        assert "skill-today" in msg
+        assert "skill-yesterday" in msg
+        # Both buffers cleaned up
+        assert not buf_today.exists()
+        assert not buf_yesterday.exists()
+
+
+# ---------------------------------------------------------------------------
+# hooks.json schema — tests 12–13
+# ---------------------------------------------------------------------------
+
+
+class TestHooksJson:
+    def test_schema_valid(self):
+        """validate.py must exit 0 with the updated hooks.json."""
+        result = subprocess.run(
+            ["python", str(ROOT / "scripts" / "validate.py")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_rm_rf_blocker_still_present(self):
+        """Regression: the Bash guard command must still block rm -rf /."""
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        bash_hooks = [
+            entry
+            for entry in data["hooks"]["PreToolUse"]
+            if entry.get("matcher") == "Bash"
+        ]
+        assert bash_hooks, "Bash PreToolUse entry missing"
+        cmd = bash_hooks[0]["hooks"][0]["command"]
+        # The guard pattern for destructive rm must be present verbatim
+        assert "rm" in cmd and "exit 2" in cmd

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -308,6 +308,17 @@ class TestFlushHook:
             assert result.returncode == 0, f"Expected exit 0 for agent_type={malicious!r}"
             assert json.loads(result.stdout) == {}, f"Expected {{}} for agent_type={malicious!r}"
 
+    def test_path_traversal_agent_id_is_noop(self, plugin_root, cache_dir):
+        """Flush rejects agent_id values with path-traversal characters."""
+        for malicious in ["../../evil", "../sensitive", "foo/bar", "foo bar"]:
+            result = _run_flush(
+                {"agent_id": malicious, "agent_type": "reviewer"},
+                plugin_root,
+                cache_dir,
+            )
+            assert result.returncode == 0, f"Expected exit 0 for agent_id={malicious!r}"
+            assert json.loads(result.stdout) == {}, f"Expected {{}} for agent_id={malicious!r}"
+
     def test_midnight_straddle(self, plugin_root, cache_dir):
         """Buffers from both today and yesterday contribute to the flush line."""
         import datetime

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -299,7 +299,7 @@ class TestFlushHook:
 
     def test_path_traversal_agent_type_is_noop(self, plugin_root, cache_dir):
         """Flush rejects agent_type values with path-traversal characters."""
-        for malicious in ["../../etc/passwd", "../sensitive", "foo/bar"]:
+        for malicious in ["../../etc/passwd", "../sensitive", "foo/bar", "foo bar"]:
             result = _run_flush(
                 {"agent_id": "trav-001", "agent_type": malicious},
                 plugin_root,


### PR DESCRIPTION
## Summary
- Add two runtime-instrumentation hooks (`skill_usage_record.sh` + `skill_usage_flush.sh`) that surface subagent skill invocations into the orchestrator transcript after each dispatched subagent finishes.
- Emit `Skills used by <agent-type>: skill-1, skill-2, ...` via `systemMessage`; top-level calls and zero-skill runs produce no output.
- Update `hooks.json` with `PreToolUse:Skill` and `SubagentStop` entries; update `scripts/validate.py` to allow lifecycle events without a `matcher` field.
- Add 15 subprocess-based pytest tests (TDD, red → green) covering no-ops, buffer write/flush, dedup, midnight straddle, opt-out, sweep, and path-traversal rejection.
- Add `docs/skill-usage-telemetry.md` opt-out guide; link from README.

## Test Plan
- [x] `python scripts/validate.py` — exit 0
- [x] `pytest tests/` — 475/475 pass (15 new telemetry tests)
- [x] Record hook: top-level no-op, subagent writes buffer, unknown agent no-op, opted-out no-op, missing skill no-op, 24h sweep
- [x] Flush hook: formatted systemMessage, buffer deleted, missing buffer `{}`, opted-out `{}`, midnight straddle
- [x] Path-traversal rejection in both hooks (agent_type sanitisation guard)
- [x] Existing rm -rf / Bash guard regression test still passes
- [ ] Live smoke test: dispatch a subagent that invokes a skill; verify "Skills used by …" line appears and cache dir is empty afterwards

### Type-tailored checks (feat)
- [x] New behaviour is information-only: both hooks exit 0 unconditionally; no tool call is blocked or modified
- [x] Opt-out mechanism confirmed by test: `skill_telemetry: false` in agent frontmatter suppresses telemetry in both hooks independently
- [x] No `agents/*.md` files modified (Path B — zero prompt changes)

Closes #227
