### PR TITLE
[feat] /document command (entry-point for tech-writer agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd swe-workbench
 
 ## What's inside
 
-- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback` — see [docs/catalog.md](docs/catalog.md).
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
 - **Languages** — Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript — auto-load by file extension.

--- a/commands/document.md
+++ b/commands/document.md
@@ -1,0 +1,20 @@
+---
+description: Generate or update documentation (README, ADR, ARCHITECTURE, inline comments) via the tech-writer subagent
+argument-hint: <artifact, file, or topic>
+---
+
+Target: $ARGUMENTS
+
+If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. (Trigger patterns are defined in that skill's "When to invoke" section.)
+
+Delegate to the `tech-writer` subagent. Its output must include:
+
+1. **Artifact type** — which category (README section, ADR, ARCHITECTURE/OVERVIEW, inline comment).
+2. **Target path** — the exact file path the artifact will live at.
+3. **Style notes detected** — heading case, voice, list style, em-dash usage, and any other conventions observed in existing top-level docs.
+4. **Draft or diff** — the content to be written.
+5. **Citations** — commit hash or file:line for every factual claim in committed artifacts; conversation excerpt is acceptable only in drafts.
+
+Absolute rule: never invent behavior. If the diff doesn't show it, don't document it.
+
+**Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `[[detect:…]]`. Skip Mode A if the plan is pure analysis, design recommendation, or any output that does not introduce file edits — the Workflow section's phases (Branch / Verify / Deliver) do not apply.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -12,6 +12,7 @@
 | `/swe-workbench:migrate <description>` | Multi-deployment migration via expand → backfill → dual-write → switch → contract. Use when a single revertable commit will not do. |
 | `/swe-workbench:debug <symptom>` | Diagnose a bug or failing test via systematic-debugging, then minimal fix + regression test. |
 | `/swe-workbench:test <target>` | Write focused, behavioural tests in the target language's idiom. |
+| `/swe-workbench:document <topic>` | Generate or update documentation (README, ADR, ARCHITECTURE, inline comments) via the tech-writer subagent. Style auto-detected from existing docs; cites commit hashes or file:line for every factual claim. |
 | `/swe-workbench:implement <ticket or description>` | Drive a feature end-to-end — branch, plan, TDD build, verify, review, PR. Orchestrates the full 5-phase `workflow-development` lifecycle. |
 | `/swe-workbench:capture <one-line thought>` | Capture an idea, bug, or improvement as a well-framed GitHub issue via the `product-manager` subagent. Auth + repo detection, product framing, duplicate scan, draft preview, and user-confirm gate before filing. |
 | `/swe-workbench:report-issue [<one-line thought>]` | File a plugin bug or feature request directly into `lugassawan/swe-workbench` from any working directory. Mirrors `/capture`'s flow but hardcodes the target repo, auto-attaches plugin + Claude Code versions, and drafts from conversation/memory when invoked with no argument. |
@@ -32,7 +33,7 @@
 | `test-writer` | Authoring tests for an existing function, module, or change set. |
 | `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. |
 | `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
-| `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. |
+| `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. Invoked by `/swe-workbench:document`. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |
 | `performance-tuner` | Profile-driven hotspot triage — ranks bottlenecks from a flame graph or benchmark and recommends targeted optimizations. Refuses speculative optimization without profiling evidence. |
 

--- a/tests/test_document_command.py
+++ b/tests/test_document_command.py
@@ -1,0 +1,74 @@
+"""Tests for the /swe-workbench:document command (closes #176)."""
+
+import re
+from pathlib import Path
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+COMMANDS_DIR = ROOT / "commands"
+DOCUMENT_CMD = COMMANDS_DIR / "document.md"
+DOCS_CATALOG = ROOT / "docs" / "catalog.md"
+README = ROOT / "README.md"
+
+
+def test_document_command_file_exists():
+    """commands/document.md must exist, have valid frontmatter, and reference `tech-writer`."""
+    assert DOCUMENT_CMD.exists(), "commands/document.md must exist"
+    text = DOCUMENT_CMD.read_text()
+    fm = validate.parse_frontmatter(DOCUMENT_CMD, text=text)
+    assert fm is not None, "document.md must have valid frontmatter"
+    assert "description" in fm, "document.md frontmatter must have a description field"
+    assert "`tech-writer`" in text, "document.md must reference the `tech-writer` subagent"
+
+
+def test_document_command_invokes_ticket_context():
+    """commands/document.md must reference `swe-workbench:ticket-context`."""
+    assert DOCUMENT_CMD.exists(), "commands/document.md must exist"
+    text = DOCUMENT_CMD.read_text()
+    assert "`swe-workbench:ticket-context`" in text, (
+        "document.md must reference `swe-workbench:ticket-context` "
+        "(ticket-context fetch is acceptance criterion #2)"
+    )
+
+
+def test_document_skill_referenced_in_command():
+    """All swe-workbench: skill refs in document.md must resolve to skills/ or agents/ on disk."""
+    skills_dir = ROOT / "skills"
+    agents_dir = ROOT / "agents"
+    text = DOCUMENT_CMD.read_text()
+    pattern = re.compile(r"`swe-workbench:([\w-]+)`")
+    missing = [
+        sid for sid in set(pattern.findall(text))
+        if not (skills_dir / sid).is_dir() and not (agents_dir / f"{sid}.md").is_file()
+    ]
+    assert not missing, f"document.md references non-existent skills or agents: {missing}"
+
+
+def test_document_in_docs_catalog():
+    """docs/catalog.md must have a row for /swe-workbench:document in the Commands table."""
+    assert DOCS_CATALOG.exists(), "docs/catalog.md must exist"
+    text = DOCS_CATALOG.read_text()
+    assert "/swe-workbench:document" in text, (
+        "docs/catalog.md must contain a row for /swe-workbench:document in the Commands table"
+    )
+
+
+def test_document_in_readme():
+    """README.md Commands bullet must include /swe-workbench:document."""
+    assert README.exists(), "README.md must exist"
+    text = README.read_text()
+    assert "/swe-workbench:document" in text, (
+        "README.md must mention /swe-workbench:document"
+    )
+    lines = text.splitlines()
+    commands_line = next(
+        (ln for ln in lines if ln.strip().startswith("- **Commands**")),
+        None,
+    )
+    assert commands_line is not None, (
+        "README.md must have a '- **Commands**' bullet line"
+    )
+    assert "/swe-workbench:document" in commands_line, (
+        "README.md '- **Commands**' bullet must include /swe-workbench:document"
+    )


### PR DESCRIPTION
## Summary
- Add `/swe-workbench:document` slash command as a thin-wrapper entry point for the `tech-writer` subagent — closing the same discoverability gap that `/architect` (#221) and `/migrate` (#173) addressed.
- New `commands/document.md` mirrors the `architect.md` skeleton: gathers optional ticket context via `swe-workbench:ticket-context`, delegates to `tech-writer` with a 5-item numbered output contract sourced from the agent's own spec, and carries the "skip Mode A if pure analysis" footer.
- `docs/catalog.md`: new command row after `/swe-workbench:test`; `tech-writer` subagent row updated with "Invoked by `/swe-workbench:document`."
- `README.md` Commands bullet includes `/swe-workbench:document`.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` — exit 0 (frontmatter valid, all skill refs resolve)
- [x] `pytest tests/` — 490/490 pass (485 baseline + 5 new)

### Type-tailored checks ([feat])
- [x] New command file exists and frontmatter parses cleanly (`parse_frontmatter` in test)
- [x] Ticket-context delegation sentence present (`swe-workbench:ticket-context` ref verified by test)
- [x] All `swe-workbench:*` refs in `document.md` resolve to `skills/` or `agents/` on disk
- [x] `/swe-workbench:document` appears in `docs/catalog.md` Commands table
- [x] `/swe-workbench:document` appears on the `- **Commands**` bullet in `README.md`

Closes #176
