### PR TITLE
[chore] Add post-merge cleanup hint + clarify pr-review stale-SHA recovery

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -26,7 +26,7 @@ Run `superpowers:verification-before-completion` before claiming any phase done.
 Dispatch both reviewers: `superpowers:code-reviewer` (plan-alignment) and the `reviewer` subagent (diff correctness/security/design). Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
-Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery. After the PR merges, run `/swe-workbench:cleanup-merged <N>` to remove the worktree and local + remote branch.
+Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery. After the PR is merged (by you or a reviewer), run `/swe-workbench:cleanup-merged <N>` to remove the worktree and local + remote branch.
 
 Absolute rules:
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -26,7 +26,7 @@ Run `superpowers:verification-before-completion` before claiming any phase done.
 Dispatch both reviewers: `superpowers:code-reviewer` (plan-alignment) and the `reviewer` subagent (diff correctness/security/design). Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
-Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery.
+Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery. After the PR merges, run `/swe-workbench:cleanup-merged <N>` to remove the worktree and local + remote branch.
 
 Absolute rules:
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope.

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -254,7 +254,7 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Reviewer aborts mid-scan | Agent error | Skip submit. **Leave worktree** for inspection (do not remove). |
 | Decision footer missing or malformed | Regex no-match | Abort with explicit message. Worktree preserved. |
 | Comment-post returns 422 (line out of range) | HTTP 422 | Skip that finding, log "skipped (line out of range)", continue. |
-| All POSTs returned 422 (stale `commit_id` — PR head advanced between Step 1 and Step 6) | `posted == 0` AND every finding skipped with 422 | Re-fetch `HEAD_SHA` via `gh pr view "$PR" --json headRefOid -q .headRefOid` and retry once. If still failing, abort with "HEAD_SHA mismatch — PR updated mid-review". |
+| All POSTs returned 422 (stale `commit_id` — PR head advanced between Step 1 and Step 6) | `posted == 0` AND every finding skipped with 422 | The cached `$HEAD_SHA` (from Step 1) is provably stale here — 422 on every POST means the PR head advanced. Re-fetch a fresh SHA via `gh pr view "$PR" --json headRefOid -q .headRefOid` and retry once. If still failing, abort with "HEAD_SHA mismatch — PR updated mid-review". |
 | All findings dedup-matched | `posted == 0` | Submit with body "no new findings — all previously raised". Decision footer still respected. |
 | GraphQL pagination needed (PR > 100 threads) | `hasNextPage == true` | Loop with `after: endCursor`. Document as known limit if not implemented in v1. |
 


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- **E7 — `commands/implement.md`**: Appended a post-merge cleanup hint to Phase 5. After `/implement` opens a PR, new users had no signal that `/swe-workbench:cleanup-merged <N>` is the natural follow-up once the PR merges, leaving stale worktrees and branches.
- **O8 — `skills/workflow-pr-review/SKILL.md`**: Reworded the `All POSTs returned 422` failure-modes table row to make stale-recovery intent explicit. The original text said "Re-fetch HEAD_SHA ... and retry" without explaining why — a future reader could mistake the re-fetch for redundancy. The new wording leads with the diagnosis: cached `$HEAD_SHA` is *provably* stale when 422 fires on every POST (the PR head advanced between Step 1 and Step 6). **Note:** AC #2 of the original ticket ("error-recovery block reuses the captured variable") was amended after `senior-engineer` review — the re-fetch at line 257 is intentional stale-recovery, not redundant; removing it would defeat the recovery path. The fix is clarification, not deletion.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Diff is exactly two prose-only hunks; `gh pr view` count in SKILL.md unchanged (3 → 3); `cleanup-merged` reference appears exactly once in `implement.md`; table pipe characters verified intact; SKILL.md frontmatter confirmed intact

### Type-tailored checks ([chore])
- [x] Both edited files build/load correctly in the plugin (no syntax errors in Markdown)
- [x] No behavioural change introduced — diff is prose-only rewording

Closes #237
