### PR TITLE
[fix] workflow-pr-review: emit address-feedback CTA on self-review too

### DIFF
--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -206,15 +206,11 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below **only when ALL of the following hold**:
-- `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
-- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing).
+**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing). Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 
-Suppress silently when:
-- `CURRENT_USER == AUTHOR_LOGIN` — self-review; asking the author to address their own feedback is noise.
-- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
+Suppress silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 Cleanup non-blocking:
 ```bash
@@ -266,5 +262,5 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Omit the footer instruction in Step 4 | Without it, the agent does NOT emit the footer. Step 5 will then abort. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on TWO axes: identity (`CURRENT_USER != AUTHOR_LOGIN`) AND outcome (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). Suppress on self-review **and** on clean APPROVE-with-no-feedback. |
-| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false` — same policy axis as the address-feedback CTA suppression above. The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: emit when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger — the user invoked Claude to review their own work and presumably wants Claude's help acting on actionable findings. |
+| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -205,15 +205,11 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below **only when ALL of the following hold**:
-- `CURRENT_USER != AUTHOR_LOGIN` (cross-author review), AND
-- the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing).
+**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing). Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 
 > "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
 
-Suppress this CTA silently when:
-- `CURRENT_USER == AUTHOR_LOGIN` — self-review is a legitimate flow; asking the author to address their own feedback is noise.
-- `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
+Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 Cleanup non-blocking:
 ```bash
@@ -270,5 +266,5 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Force-add 👍 to your own existing comment | Check `reactions.nodes[].user.login` first; skip if you've already reacted. |
 | Block on cleanup | Cleanup runs in background `(... ) &`. Don't `wait` for it. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on TWO axes: identity (`CURRENT_USER != AUTHOR_LOGIN`) AND outcome (`DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`). Suppress on self-review **and** on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). |
-| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false` — same policy axis as the address-feedback CTA suppression above. The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: emit when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger — the user invoked Claude to review their own work and presumably wants Claude's help acting on actionable findings. |
+| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/tests/test_workflow_pr_review_cta_suppression.py
+++ b/tests/test_workflow_pr_review_cta_suppression.py
@@ -17,13 +17,16 @@ PR_REVIEW_FOLLOWUP_SKILL = ROOT / "skills" / "workflow-pr-review-followup" / "SK
 
 def _suppression_block(text: str) -> str:
     """Extract the paragraph(s) immediately following the CTA quote block."""
-    # Grab text from the CTA header through to the next ## section or end
     match = re.search(
         r"Address-feedback CTA \(conditional\):.*?(?=\n## |\Z)",
         text,
         re.DOTALL,
     )
-    return match.group(0) if match else ""
+    assert match is not None, (
+        "Could not locate 'Address-feedback CTA (conditional):' section. "
+        "The CTA section header was renamed or removed — update the regex in _suppression_block."
+    )
+    return match.group(0)
 
 
 # ── workflow-pr-review/SKILL.md ───────────────────────────────────────────────

--- a/tests/test_workflow_pr_review_cta_suppression.py
+++ b/tests/test_workflow_pr_review_cta_suppression.py
@@ -1,0 +1,118 @@
+# tests/test_workflow_pr_review_cta_suppression.py
+
+"""Pin the address-feedback CTA suppression contract for both pr-review skills.
+
+Bug: IS_SELF_REVIEW caused the CTA to be silently dropped when the user ran
+/implement → /review on their own PR, even when findings were posted. The fix
+removes the identity axis from the CTA gate — only the outcome axis gates it.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PR_REVIEW_SKILL = ROOT / "skills" / "workflow-pr-review" / "SKILL.md"
+PR_REVIEW_FOLLOWUP_SKILL = ROOT / "skills" / "workflow-pr-review-followup" / "SKILL.md"
+
+
+def _suppression_block(text: str) -> str:
+    """Extract the paragraph(s) immediately following the CTA quote block."""
+    # Grab text from the CTA header through to the next ## section or end
+    match = re.search(
+        r"Address-feedback CTA \(conditional\):.*?(?=\n## |\Z)",
+        text,
+        re.DOTALL,
+    )
+    return match.group(0) if match else ""
+
+
+# ── workflow-pr-review/SKILL.md ───────────────────────────────────────────────
+
+
+def test_pr_review_cta_no_identity_suppression():
+    """The CTA suppression block must NOT gate on CURRENT_USER == AUTHOR_LOGIN."""
+    text = PR_REVIEW_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "CURRENT_USER == AUTHOR_LOGIN" not in block, (
+        "workflow-pr-review/SKILL.md still suppresses the CTA based on author identity. "
+        "Remove the identity axis — suppression should be outcome-only."
+    )
+
+
+def test_pr_review_cta_no_self_review_suppression():
+    """The CTA suppression block must NOT reference IS_SELF_REVIEW or self-review."""
+    text = PR_REVIEW_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "IS_SELF_REVIEW" not in block, (
+        "CTA block must not gate on IS_SELF_REVIEW — outcome axis only. "
+        "IS_SELF_REVIEW belongs on the GitHub-submission gate, not the CTA."
+    )
+    assert not re.search(r"(?i)self.?review", block), (
+        "CTA block must not mention self-review as a suppression trigger."
+    )
+
+
+def test_pr_review_cta_outcome_axis_present():
+    """The CTA emission block must reference the outcome axis conditions."""
+    text = PR_REVIEW_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "DECISION = COMMENT" in block or "DECISION=COMMENT" in block, (
+        "CTA block must mention DECISION = COMMENT as an actionable outcome"
+    )
+    assert "posted > 0" in block, "CTA block must mention posted > 0 as an actionable outcome"
+    assert "deduped > 0" in block, "CTA block must mention deduped > 0 as an actionable outcome"
+
+
+def test_pr_review_cta_clean_approval_suppression_preserved():
+    """The clean-approval suppression (APPROVE + no findings) must remain."""
+    text = PR_REVIEW_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "APPROVE" in block, "CTA block must still suppress on clean APPROVE"
+    assert "posted = 0" in block, "CTA block must still reference posted = 0 in suppression"
+    assert "deduped = 0" in block, "CTA block must still reference deduped = 0 in suppression"
+
+
+# ── workflow-pr-review-followup/SKILL.md ─────────────────────────────────────
+
+
+def test_pr_review_followup_cta_no_identity_suppression():
+    """The CTA suppression block must NOT gate on CURRENT_USER == AUTHOR_LOGIN."""
+    text = PR_REVIEW_FOLLOWUP_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "CURRENT_USER == AUTHOR_LOGIN" not in block, (
+        "workflow-pr-review-followup/SKILL.md still suppresses the CTA on author identity. "
+        "Remove the identity axis — suppression should be outcome-only."
+    )
+
+
+def test_pr_review_followup_cta_no_self_review_suppression():
+    """The CTA suppression block must NOT reference IS_SELF_REVIEW or self-review."""
+    text = PR_REVIEW_FOLLOWUP_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "IS_SELF_REVIEW" not in block, (
+        "CTA block (followup) must not gate on IS_SELF_REVIEW — outcome axis only. "
+        "IS_SELF_REVIEW belongs on the GitHub-submission gate, not the CTA."
+    )
+    assert not re.search(r"(?i)self.?review", block), (
+        "CTA block (followup) must not mention self-review as a suppression trigger."
+    )
+
+
+def test_pr_review_followup_cta_outcome_axis_present():
+    """The CTA emission block must reference the outcome axis conditions."""
+    text = PR_REVIEW_FOLLOWUP_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "DECISION = COMMENT" in block or "DECISION=COMMENT" in block, (
+        "CTA block (followup) must mention DECISION = COMMENT as an actionable outcome"
+    )
+    assert "posted > 0" in block, "CTA block (followup) must mention posted > 0"
+    assert "deduped > 0" in block, "CTA block (followup) must mention deduped > 0"
+
+
+def test_pr_review_followup_cta_clean_approval_suppression_preserved():
+    """The clean-approval suppression (APPROVE + no findings) must remain."""
+    text = PR_REVIEW_FOLLOWUP_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "APPROVE" in block, "CTA block (followup) must still suppress on clean APPROVE"
+    assert "posted = 0" in block, "CTA block (followup) must still reference posted = 0"
+    assert "deduped = 0" in block, "CTA block (followup) must still reference deduped = 0"


### PR DESCRIPTION
## Summary
- The address-feedback CTA (`"Want me to help address this feedback? Reply yes to start /address-feedback N"`) was silently suppressed on self-review (`CURRENT_USER == AUTHOR_LOGIN`), breaking the `/implement → /review → /address-feedback` chain observed during PR #263.
- Root cause: the CTA gate incorrectly AND-combined two orthogonal policy axes — identity (who authored the PR) and outcome (whether findings are actionable). Only the outcome axis should gate the CTA.
- Fix: remove the identity-axis bullet from the CTA suppression block in both `workflow-pr-review/SKILL.md` and `workflow-pr-review-followup/SKILL.md`. The clean-approval suppression (`DECISION=APPROVE AND posted=0 AND deduped=0`) is preserved.
- Also fixes a stale "same policy axis" cross-reference in the Common Mistakes table that would have caused future LLM readers to re-introduce the identity suppression.
- Adds 8 pytest assertions pinning the CTA contract for both skill files.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_workflow_pr_review_cta_suppression.py -v` — 8/8 pass
- [x] `pytest tests/ -k workflow_pr_review` — 14/14 pass (no regressions)
- [x] `grep -n "CURRENT_USER == AUTHOR_LOGIN" skills/workflow-pr-review/SKILL.md skills/workflow-pr-review-followup/SKILL.md` — 0 matches
- [x] `grep -n "CURRENT_USER != AUTHOR_LOGIN" skills/workflow-pr-review/SKILL.md skills/workflow-pr-review-followup/SKILL.md` — 0 matches

### Type-tailored checks ([fix])
- [x] Reproducing scenario confirmed: self-review with posted findings previously dropped the CTA
- [x] Non-regression: cross-author review CTA still fires when findings are actionable
- [x] Non-regression: clean-approval CTA suppression (`APPROVE + posted=0 + deduped=0`) still in place
- [x] Deliberately untouched: `IS_SELF_REVIEW` gate on GitHub review-event submission (lines 200-205) — GitHub blocks self-approval, correct to preserve
- [x] Deliberately untouched: `IS_SELF_REVIEW` gate on `## Review Summary` narrative — separate axis, out of scope

Issue: N/A — bug observed during PR #263 self-review workflow
