### PR TITLE
[fix] Hook: close $HOME bypass and short-circuit non-rm/non-git

### DIFF
--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -2,7 +2,7 @@
 # PreToolUse:Bash guard — block destructive commands and short-circuit safe ones.
 #
 # Blocks:
-#   - rm -rf against /, ~, $HOME (literal or shell-expanded /Users/*|/home/*)
+#   - rm -rf against /, /*, ~, $HOME, /Users[/<user>], /home[/<user>]
 #   - git push --force / -f to main/master
 #   - git reset --hard on main/master/release/*
 #
@@ -10,15 +10,18 @@
 # "git". This is the common case (ls, cat, echo, make, npm, …) and removes the
 # per-call grep tax flagged in #233.
 #
-# Out of scope: ${HOME} brace-form; path normalization via .. traversal.
+# Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal.
 
 set -u
 
-cmd=$(jq -r '.tool_input.command // ""')
+if ! cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null); then
+  echo 'bash_guard: jq parse error — blocking by default' >&2
+  exit 2
+fi
 
 case "$cmd" in
-  *rm*|*git*) ;;
-  *)          exit 0 ;;
+  rm\ *|*\ rm\ *|*git*) ;;
+  *)                    exit 0 ;;
 esac
 
 # Strip quotes so quoted paths cannot bypass the rm regex.

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -20,12 +20,12 @@ if ! cmd=$(jq -r '.tool_input.command // ""'); then
 fi
 
 case "$cmd" in
-  rm\ *|*\ rm\ *|*\(rm\ *|*git*) ;;
+  rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;
   *)                              exit 0 ;;
 esac
 
-# Strip quotes so quoted paths cannot bypass the rm regex.
-norm=$(printf '%s' "$cmd" | tr -d "'\"")
+# Strip quotes and subshell parens so they cannot mask the rm command or path.
+norm=$(printf '%s' "$cmd" | tr -d "'\"()")
 
 # shellcheck disable=SC2016  # $HOME in single quotes is intentional: matches literal text, not the shell variable
 # [rR] covers both -rf and -Rf (BSD/macOS rm accepts -R as synonym for -r).

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# PreToolUse:Bash guard — block destructive commands and short-circuit safe ones.
+#
+# Blocks:
+#   - rm -rf against /, ~, $HOME (literal or shell-expanded /Users/*|/home/*)
+#   - git push --force / -f to main/master
+#   - git reset --hard on main/master/release/*
+#
+# Short-circuits (exit 0, no greps) for commands that contain neither "rm" nor
+# "git". This is the common case (ls, cat, echo, make, npm, …) and removes the
+# per-call grep tax flagged in #233.
+#
+# Out of scope: ${HOME} brace-form; path normalization via .. traversal.
+
+set -u
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+case "$cmd" in
+  *rm*|*git*) ;;
+  *)          exit 0 ;;
+esac
+
+# Strip quotes so quoted paths cannot bypass the rm regex.
+norm=$(printf '%s' "$cmd" | tr -d "'\"")
+
+# shellcheck disable=SC2016  # $HOME in single quotes is intentional: matches literal text, not the shell variable
+# [rR] covers both -rf and -Rf (BSD/macOS rm accepts -R as synonym for -r).
+if echo "$norm" | grep -Eq \
+   '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*[rR][a-zA-Z]*[fF]?[[:space:]]+(/(\*|[[:space:]]|$)|(~|\$HOME)(/[^[:space:]]*)?([[:space:]]|$)|(/Users|/home)(/[^/[:space:]]+)?([[:space:]]|/|$))'; then
+  echo 'BLOCKED: destructive rm against root or home' >&2
+  exit 2
+fi
+
+if echo "$norm" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' \
+   && echo "$norm" | grep -Eq '(^|[[:space:]]|:)(main|master)([[:space:]]|:|$)'; then
+  echo 'BLOCKED: force push to main/master' >&2
+  exit 2
+fi
+
+if echo "$norm" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  case "$branch" in
+    main|master|release/*)
+      echo "BLOCKED: git reset --hard on protected branch '$branch'" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+exit 0

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -14,14 +14,14 @@
 
 set -u
 
-if ! cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null); then
+if ! cmd=$(jq -r '.tool_input.command // ""'); then
   echo 'bash_guard: jq parse error — blocking by default' >&2
   exit 2
 fi
 
 case "$cmd" in
-  rm\ *|*\ rm\ *|*git*) ;;
-  *)                    exit 0 ;;
+  rm\ *|*\ rm\ *|*\(rm\ *|*git*) ;;
+  *)                              exit 0 ;;
 esac
 
 # Strip quotes so quoted paths cannot bypass the rm regex.

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -10,7 +10,7 @@
 # "git". This is the common case (ls, cat, echo, make, npm, …) and removes the
 # per-call grep tax flagged in #233.
 #
-# Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal.
+# Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal; compound cd (cwd not in hook payload).
 
 set -u
 
@@ -19,13 +19,16 @@ if ! cmd=$(jq -r '.tool_input.command // ""'); then
   exit 2
 fi
 
-case "$cmd" in
+# Normalise shell separators to spaces so rm/git after ; | & are still detected.
+_norm=$(printf '%s' "$cmd" | tr ';|&' '   ')
+
+case "$_norm" in
   rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;
   *)                              exit 0 ;;
 esac
 
-# Strip quotes and subshell parens so they cannot mask the rm command or path.
-norm=$(printf '%s' "$cmd" | tr -d "'\"()")
+# Strip quotes and bracket metacharacters that could mask paths.
+norm=$(printf '%s' "$_norm" | tr -d "'\"()[]{}")
 
 # shellcheck disable=SC2016  # $HOME in single quotes is intentional: matches literal text, not the shell variable
 # [rR] covers both -rf and -Rf (BSD/macOS rm accepts -R as synonym for -r).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f?[[:space:]]+(/|/\\*|~|\\$HOME)([[:space:]]|$)'; then echo 'BLOCKED: destructive rm against root or home' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' && echo \"$cmd\" | grep -Eq '(^|[[:space:]]|:)(main|master)([[:space:]]|:|$)'; then echo 'BLOCKED: force push to main/master' >&2; exit 2; fi; if echo \"$cmd\" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); case \"$branch\" in main|master|release/*) echo \"BLOCKED: git reset --hard on protected branch '$branch'\" >&2; exit 2 ;; esac; fi; exit 0"
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/bash_guard.sh"
           }
         ]
       },

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,60 +1,36 @@
-"""Tests for hooks/hooks.json regex blockers (issue #81).
+"""Tests for hooks/bash_guard.sh — end-to-end guard invocation (issue #233).
 
-Each of the three embedded grep -Eq patterns is extracted from the real
-hooks.json and tested with subprocess.run(["grep", "-Eq", ...]) — the same
-regex engine the hook uses — so platform-specific POSIX character classes
-(e.g. [[:space:]]) behave identically.
-
-Note on hard-reset: the hook only exits 2 when BOTH the regex matches AND the
-current branch is main/master/release/*. TestHardResetPatternMatch verifies the
-first gate (regex match); branch-protection logic requires a live git environment
-and is intentionally out of scope for unit tests.
+Each test class invokes hooks/bash_guard.sh directly with a JSON payload on
+stdin, mirroring exactly how Claude Code calls the PreToolUse:Bash hook.
+Exit code 2 + "BLOCKED" in stderr → command was blocked.
+Exit code 0, empty stderr              → command was allowed.
 """
 
 import json
-import re
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
-HOOKS_PATH = Path(__file__).parent.parent / "hooks" / "hooks.json"
+GUARD = Path(__file__).parent.parent / "hooks" / "bash_guard.sh"
 
 
 @pytest.fixture(scope="module")
-def hook_patterns():
-    """Return a dict of named grep -Eq patterns extracted from hooks.json.
-
-    Keys: 'rm_rf', 'force_push', 'main_master', 'hard_reset'
-    """
-    data = json.loads(HOOKS_PATH.read_text(encoding="utf-8"))
-    command = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-    raw = re.findall(r"grep -Eq '([^']+)'", command)
-    assert len(raw) == 4, f"Expected 4 patterns, found {len(raw)}: {raw}"
-
-    # Match by characteristic substring to survive reordering in hooks.json.
-    def find(keyword):
-        matches = [p for p in raw if keyword in p]
-        assert len(matches) == 1, f"Expected 1 pattern containing {keyword!r}, got {matches}"
-        return matches[0]
-
-    return {
-        "rm_rf": find("rm"),
-        "force_push": find("push"),
-        "main_master": find("main|master"),
-        "hard_reset": find("reset"),
-    }
+def guard_script():
+    assert GUARD.exists(), f"missing {GUARD}"
+    assert os.access(GUARD, os.X_OK), f"{GUARD} must be executable"
+    return GUARD
 
 
-def grep_matches(pattern: str, text: str) -> bool:
-    """Return True if *text* matches *pattern* using grep -Eq."""
-    result = subprocess.run(
-        ["grep", "-Eq", pattern],
-        input=text,
-        text=True,
-        capture_output=True,
+def run_guard(script, cmd, *, cwd=None, env=None):
+    payload = json.dumps({"tool_input": {"command": cmd}})
+    return subprocess.run(
+        [str(script)],
+        input=payload, text=True, capture_output=True,
+        cwd=cwd, env=env,
     )
-    return result.returncode == 0
 
 
 # ──────────────────────────────────────────────
@@ -64,33 +40,59 @@ def grep_matches(pattern: str, text: str) -> bool:
 class TestRmRfBlocker:
     @pytest.mark.parametrize("cmd", [
         "rm -rf /",
-        "rm -rf $HOME",
-        "rm -rf ~",
         "rm -rf /*",
+        "rm -rf ~",
+        "rm -rf $HOME",
+        'rm -rf "$HOME"',
         "sudo rm -rf /",
+        "rm -rf /Users/foo",
+        "rm -rf /Users/foo/Documents",
+        "rm -rf /Users/foo/a/b/c",
+        "rm -rf /home/foo",
+        "rm -rf /home/foo/.config",
+        "rm -rf $HOME/Documents",
+        "rm -rf ~/.config",
+        "rm -rf /Users",
+        "rm -rf /home",
+        'rm -rf "/Users/foo"',
+        "rm -rf '/home/foo'",
+        "rm -Rf /Users/foo",
+        "rm -RF /Users/foo",
     ])
-    def test_pattern_matches(self, hook_patterns, cmd):
-        assert grep_matches(hook_patterns["rm_rf"], cmd), f"Expected match for: {cmd!r}"
+    def test_blocked(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 2, (
+            f"Expected exit 2 (BLOCKED) for {cmd!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr, (
+            f"Expected 'BLOCKED' in stderr for {cmd!r}\nstderr: {result.stderr!r}"
+        )
 
     @pytest.mark.parametrize("cmd", [
         "rm -rf ./build",
         "rm -rf node_modules",
         "rm -rf /tmp/foo",
+        "rm -rf /var/log",
         "rm -f somefile",
         "rm -r ./dist",
+        "rm -rf /UsersHome",
+        "rm -rf /homestead",
     ])
-    def test_pattern_does_not_match(self, hook_patterns, cmd):
-        assert not grep_matches(hook_patterns["rm_rf"], cmd), f"Expected no match for: {cmd!r}"
+    def test_allowed(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 0, (
+            f"Expected exit 0 (ALLOWED) for {cmd!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert result.stderr == "", (
+            f"Expected empty stderr for {cmd!r}\nstderr: {result.stderr!r}"
+        )
 
 
 # ──────────────────────────────────────────────
-# force-push to main/master (AND of two patterns)
+# force-push to main/master
 # ──────────────────────────────────────────────
-
-def force_push_blocked(hook_patterns, cmd: str) -> bool:
-    """Mirror the hook logic: block iff BOTH force-push patterns match."""
-    return grep_matches(hook_patterns["force_push"], cmd) and grep_matches(hook_patterns["main_master"], cmd)
-
 
 class TestForcePushBlocker:
     @pytest.mark.parametrize("cmd", [
@@ -101,49 +103,120 @@ class TestForcePushBlocker:
         "git push --force origin HEAD:main",
         "git push --force origin feature:main",
         "git push --force origin HEAD:master",
-        "git push origin main --force",       # --force at end-of-string: exercises $ branch
+        "git push origin main --force",
     ])
-    def test_blocked(self, hook_patterns, cmd):
-        assert force_push_blocked(hook_patterns, cmd), f"Expected BLOCK for: {cmd!r}"
+    def test_blocked(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 2, (
+            f"Expected exit 2 (BLOCKED) for {cmd!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
 
     @pytest.mark.parametrize("cmd", [
-        "git push origin main",               # no force flag
-        "git push --force origin feature/x",  # force but not main/master
-        "git push --force origin mainline",   # "mainline" is not main (boundary check)
-        "git push --force origin my-master",  # "my-master" is not master
-        "git push --force-with-lease origin main",              # safe force variant — must not be blocked
-        "git push --force-with-lease origin master",            # safe force variant — must not be blocked
-        "git push --force-if-includes origin main",             # safe force variant — must not be blocked
-        "git push --force-with-lease=origin/main origin main",  # = form: boundary ([[:space:]]|$) excludes '='
+        "git push origin main",
+        "git push --force origin feature/x",
+        "git push --force origin mainline",
+        "git push --force origin my-master",
+        "git push --force-with-lease origin main",
+        "git push --force-with-lease origin master",
+        "git push --force-if-includes origin main",
+        "git push --force-with-lease=origin/main origin main",
     ])
-    def test_allowed(self, hook_patterns, cmd):
-        assert not force_push_blocked(hook_patterns, cmd), f"Expected ALLOW for: {cmd!r}"
+    def test_allowed(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 0, (
+            f"Expected exit 0 (ALLOWED) for {cmd!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
 
 
 # ──────────────────────────────────────────────
-# hard reset — pattern-match gate only
-# (full block requires branch == main/master/release/*)
+# hard reset — branch-aware (requires temp git repo)
 # ──────────────────────────────────────────────
 
-class TestHardResetPatternMatch:
-    @pytest.mark.parametrize("cmd", [
-        "git reset --hard",
-        "git reset --hard HEAD~1",
-        "  git reset --hard origin/main",
-        "git reset --hard HEAD",
-    ])
-    def test_pattern_matches(self, hook_patterns, cmd):
-        assert grep_matches(hook_patterns["hard_reset"], cmd), f"Expected pattern match for: {cmd!r}"
+@pytest.fixture
+def repo_on(tmp_path):
+    """Factory for temp git repos on a given branch."""
+    def _make(branch: str) -> Path:
+        subprocess.run(["git", "init", "-q", "-b", branch], cwd=tmp_path, check=True)
+        (tmp_path / "README").write_text("init")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t.com", "-c", "user.name=T",
+             "commit", "-qm", "init"],
+            cwd=tmp_path, check=True,
+        )
+        return tmp_path
+    return _make
 
-    @pytest.mark.parametrize("cmd", [
-        "git reset HEAD",
-        "git reset --soft HEAD~1",
-        "git reset --mixed",
-        "git reset --keep HEAD~1",
-    ])
-    def test_pattern_does_not_match(self, hook_patterns, cmd):
-        assert not grep_matches(hook_patterns["hard_reset"], cmd), f"Expected no match for: {cmd!r}"
 
+class TestHardResetBlocker:
+    @pytest.mark.parametrize("branch", ["main", "master", "release/2025-01"])
+    def test_blocked_on_protected_branch(self, guard_script, repo_on, branch):
+        repo = repo_on(branch)
+        result = run_guard(guard_script, "git reset --hard HEAD~1", cwd=str(repo))
+        assert result.returncode == 2, (
+            f"Expected BLOCKED on branch {branch!r}, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_allowed_on_feature_branch(self, guard_script, repo_on):
+        repo = repo_on("feature/x")
+        result = run_guard(guard_script, "git reset --hard HEAD~1", cwd=str(repo))
+        assert result.returncode == 0, (
+            f"Expected ALLOWED on feature/x, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_soft_reset_always_allowed(self, guard_script, repo_on):
+        repo = repo_on("main")
+        result = run_guard(guard_script, "git reset --soft HEAD~1", cwd=str(repo))
+        assert result.returncode == 0, (
+            f"Expected ALLOWED for --soft on main, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+
+# ──────────────────────────────────────────────
+# short-circuit: non-rm/non-git commands skip grep
+# ──────────────────────────────────────────────
+
+class TestShortCircuit:
+    def _run_with_shims(self, script, cmd, tmp_path):
+        trace = tmp_path / "trace"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        real_jq = shutil.which("jq")
+        real_grep = shutil.which("grep")
+        for tool, real in [("jq", real_jq), ("grep", real_grep)]:
+            shim = bin_dir / tool
+            shim.write_text(
+                f'#!/bin/sh\necho "{tool}" >> "{trace}"\nexec "{real}" "$@"\n'
+            )
+            shim.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        run_guard(script, cmd, env=env)
+        return trace.read_text() if trace.exists() else ""
+
+    @pytest.mark.parametrize("cmd", ["ls .", "cat foo.txt", "echo hello", "make build"])
+    def test_no_grep_for_safe_commands(self, guard_script, cmd, tmp_path):
+        trace = self._run_with_shims(guard_script, cmd, tmp_path)
+        assert "jq" in trace, f"Expected jq to run for {cmd!r}"
+        assert "grep" not in trace, f"Expected grep to be skipped for {cmd!r}"
+
+    @pytest.mark.parametrize("cmd", ["rm -rf /tmp/foo", "git status"])
+    def test_grep_runs_for_rm_and_git(self, guard_script, cmd, tmp_path):
+        trace = self._run_with_shims(guard_script, cmd, tmp_path)
+        assert "jq" in trace, f"Expected jq to run for {cmd!r}"
+        assert "grep" in trace, f"Expected grep to run for {cmd!r}"
+
+
+# ──────────────────────────────────────────────
+# pre-push hook — unchanged
+# ──────────────────────────────────────────────
 
 class TestPrePushHook:
     """Verify .githooks/pre-push contains the expected invocations."""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -213,8 +213,8 @@ class TestShortCircuit:
                 f'#!/bin/sh\necho "{tool}" >> "{trace}"\nexec "{real}" "$@"\n'
             )
             shim.chmod(0o755)
-        env = os.environ.copy()
-        env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+        env = dict(_CLEAN_ENV)
+        env["PATH"] = f"{bin_dir}:{_CLEAN_ENV.get('PATH', '')}"
         run_guard(script, cmd, env=env)
         return trace.read_text() if trace.exists() else ""
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -67,6 +67,12 @@ class TestRmRfBlocker:
         "rm -RF /Users/foo",
         "(rm -rf /)",
         "((rm -rf /))",
+        "rm -rf /[U]sers/foo",
+        "rm -rf /[h]ome/foo",
+        "rm -rf /[h]ome",
+        "ls;rm -rf /",
+        "ls;rm -rf /Users/foo",
+        "ls&&rm -rf /home/foo",
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -16,6 +16,10 @@ import pytest
 
 GUARD = Path(__file__).parent.parent / "hooks" / "bash_guard.sh"
 
+# When tests run inside a git pre-push hook, GIT_DIR points to the hook's repo.
+# Strip GIT_* so subprocess git calls use normal cwd-based repo detection.
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
 
 @pytest.fixture(scope="module")
 def guard_script():
@@ -26,10 +30,13 @@ def guard_script():
 
 def run_guard(script, cmd, *, cwd=None, env=None):
     payload = json.dumps({"tool_input": {"command": cmd}})
+    merged_env = dict(_CLEAN_ENV)
+    if env is not None:
+        merged_env.update(env)
     return subprocess.run(
         [str(script)],
         input=payload, text=True, capture_output=True,
-        cwd=cwd, env=env,
+        cwd=cwd, env=merged_env,
     )
 
 
@@ -139,15 +146,25 @@ class TestForcePushBlocker:
 def repo_on(tmp_path):
     """Factory for temp git repos on a given branch."""
     def _make(branch: str) -> Path:
-        subprocess.run(["git", "init", "-q", "-b", branch], cwd=tmp_path, check=True)
-        (tmp_path / "README").write_text("init")
-        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        # Use a named subdirectory so stale .git dirs from previous pytest
+        # sessions never cause re-init or branch contamination.
+        repo_dir = tmp_path / "repo"
+        if repo_dir.exists():
+            shutil.rmtree(repo_dir)
+        repo_dir.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", branch], cwd=repo_dir,
+                       env=_CLEAN_ENV, check=True)
+        (repo_dir / "README").write_text("init")
+        subprocess.run(["git", "add", "."], cwd=repo_dir, env=_CLEAN_ENV, check=True)
+        # Disable hooks so the host repo's commit-msg hook (which enforces
+        # [type] format) does not reject the plain "init" fixture message.
         subprocess.run(
-            ["git", "-c", "user.email=t@t.com", "-c", "user.name=T",
+            ["git", "-c", "core.hooksPath=/dev/null",
+             "-c", "user.email=t@t.com", "-c", "user.name=T",
              "commit", "-qm", "init"],
-            cwd=tmp_path, check=True,
+            cwd=repo_dir, env=_CLEAN_ENV, check=True,
         )
-        return tmp_path
+        return repo_dir
     return _make
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -65,6 +65,8 @@ class TestRmRfBlocker:
         "rm -rf '/home/foo'",
         "rm -Rf /Users/foo",
         "rm -RF /Users/foo",
+        "(rm -rf /)",
+        "((rm -rf /))",
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -363,7 +363,11 @@ class TestHooksJson:
         assert result.returncode == 0, result.stdout + result.stderr
 
     def test_rm_rf_blocker_still_present(self):
-        """Regression: the Bash guard command must still block rm -rf /."""
+        """Regression: the Bash guard must still block rm -rf /.
+
+        After extraction to bash_guard.sh the hooks.json command is a path
+        reference; the guard logic lives in the script itself.
+        """
         data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         bash_hooks = [
             entry
@@ -372,8 +376,15 @@ class TestHooksJson:
         ]
         assert bash_hooks, "Bash PreToolUse entry missing"
         cmd = bash_hooks[0]["hooks"][0]["command"]
-        # The guard pattern for destructive rm must be present verbatim
-        assert "rm" in cmd and "exit 2" in cmd
+        # Command must reference the extracted guard script.
+        assert "bash_guard.sh" in cmd, f"Expected bash_guard.sh reference, got: {cmd!r}"
+        # The guard logic must live in bash_guard.sh.
+        guard = ROOT / "hooks" / "bash_guard.sh"
+        assert guard.exists(), f"missing {guard}"
+        content = guard.read_text(encoding="utf-8")
+        assert "rm" in content and "exit 2" in content, (
+            "bash_guard.sh must contain rm-blocker logic with exit 2"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract the PreToolUse:Bash inline one-liner to `hooks/bash_guard.sh`, matching the `skill_usage_record.sh` pattern — shellcheck auto-discovers it, tests invoke it end-to-end.
- Fix `$HOME` guard bypass: shell-expanded paths like `/Users/foo/Documents` were not matched by the old regex `(/|/\*|~|\$HOME)`. New regex covers `/Users/<user>/…`, `/home/<user>/…`, `~`, literal `$HOME`, bare `/Users` and `/home`, quoted paths (via `tr -d` quote stripping), and `-Rf`/`-RF` (BSD/macOS uppercase-R synonym).
- Add `case`-glob short-circuit: commands containing neither `rm` nor `git` exit 0 after one `jq` call — eliminates the per-call 3× grep overhead for `ls`, `echo`, `make`, etc.

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` → "All checks passed"

### Type-tailored checks ([fix])

- [ ] `shellcheck hooks/bash_guard.sh` → clean
- [ ] `python3 -m pytest tests/test_hooks.py -v` → 56/56 pass (all new e2e cases)
- [ ] `python3 -m pytest tests/ -q` → 529/529 pass
- [ ] Manual: `echo '{"tool_input":{"command":"rm -rf /Users/foo"}}' | hooks/bash_guard.sh; echo "exit=$?"` → `BLOCKED` + `exit=2`
- [ ] Manual: `echo '{"tool_input":{"command":"ls ."}}' | hooks/bash_guard.sh; echo "exit=$?"` → `exit=0` (no grep invoked)
- [ ] Manual: `echo '{"tool_input":{"command":"rm -rf \"/Users/foo\""}}' | hooks/bash_guard.sh; echo "exit=$?"` → `BLOCKED` + `exit=2` (quote-strip verified)
- [ ] Verified: `git ls-files --stage hooks/bash_guard.sh` → mode `100755`

Closes #233
