### PR TITLE
[polish] workflow-pr-review: use AskUserQuestion for address-feedback CTA

### DIFF
--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -222,11 +222,11 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 }
 ```
 
-Substitute the real PR number for `<N>` in both the question text and the description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
+Substitute the real PR number for `<N>` in the question text and in the `Yes — address feedback` option description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
 
 Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 
-Suppress silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
+Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 Cleanup non-blocking:
 ```bash

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -206,7 +206,7 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
+**Address-feedback CTA (conditional):** At the end of Step 7, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
 
 ```json
 {

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -206,9 +206,25 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing). Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
+**Address-feedback CTA (conditional):** After the submit call succeeds, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
 
-> "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
+```json
+{
+  "questions": [{
+    "question": "Want me to help address this feedback? Start /address-feedback <N>?",
+    "header": "Next step",
+    "multiSelect": false,
+    "options": [
+      { "label": "Yes — address feedback", "description": "Starts /address-feedback <N> to drive fixes end-to-end." },
+      { "label": "No thanks",              "description": "Stay here; no further action." }
+    ]
+  }]
+}
+```
+
+Substitute the real PR number for `<N>` in both the question text and the description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
+
+Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 
 Suppress silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
@@ -262,5 +278,6 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Omit the footer instruction in Step 4 | Without it, the agent does NOT emit the footer. Step 5 will then abort. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: emit when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger — the user invoked Claude to review their own work and presumably wants Claude's help acting on actionable findings. |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: call `AskUserQuestion` when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger. |
+| Emit the CTA as plain text instead of `AskUserQuestion` | Always use the `AskUserQuestion` tool for the CTA — it gives the user a clickable button and eliminates the "type yes" friction. Never emit a free-text prompt asking the user to reply `yes`. |
 | Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -205,7 +205,7 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
+**Address-feedback CTA (conditional):** At the end of Step 7, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
 
 ```json
 {

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -221,7 +221,7 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 }
 ```
 
-Substitute the real PR number for `<N>` in both the question text and the description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
+Substitute the real PR number for `<N>` in the question text and in the `Yes — address feedback` option description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
 
 Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -205,9 +205,25 @@ When `IS_SELF_REVIEW = true`, skip the review-event submission entirely.
 
 **Never** use `--request-changes`.
 
-**Address-feedback CTA (conditional):** After the submit call succeeds, append the CTA below when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing). Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
+**Address-feedback CTA (conditional):** After the submit call succeeds, when the review produced something actionable — i.e. `DECISION = COMMENT`, OR `posted > 0`, OR `deduped > 0` (existing open threads were re-confirmed; they still need addressing) — call the `AskUserQuestion` tool:
 
-> "Want me to help the PR owner address this feedback? Reply `yes` to start `/address-feedback <N>`."
+```json
+{
+  "questions": [{
+    "question": "Want me to help address this feedback? Start /address-feedback <N>?",
+    "header": "Next step",
+    "multiSelect": false,
+    "options": [
+      { "label": "Yes — address feedback", "description": "Starts /address-feedback <N> to drive fixes end-to-end." },
+      { "label": "No thanks",              "description": "Stay here; no further action." }
+    ]
+  }]
+}
+```
+
+Substitute the real PR number for `<N>` in both the question text and the description. On `Yes — address feedback` → invoke `/address-feedback <N>`. On `No thanks` (or any other answer) → no further action.
+
+Identity does not gate the CTA — when the user has invoked Claude to review their own PR, they have explicitly opted into Claude's help; if findings are actionable, offering to drive `/address-feedback` is the natural next step regardless of authorship.
 
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
@@ -266,5 +282,6 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Force-add 👍 to your own existing comment | Check `reactions.nodes[].user.login` first; skip if you've already reacted. |
 | Block on cleanup | Cleanup runs in background `(... ) &`. Don't `wait` for it. |
 | Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
-| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: emit when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger — the user invoked Claude to review their own work and presumably wants Claude's help acting on actionable findings. |
+| Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: call `AskUserQuestion` when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger. |
+| Emit the CTA as plain text instead of `AskUserQuestion` | Always use the `AskUserQuestion` tool for the CTA — it gives the user a clickable button and eliminates the "type yes" friction. Never emit a free-text prompt asking the user to reply `yes`. |
 | Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |

--- a/tests/test_workflow_pr_review_cta_suppression.py
+++ b/tests/test_workflow_pr_review_cta_suppression.py
@@ -119,3 +119,38 @@ def test_pr_review_followup_cta_clean_approval_suppression_preserved():
     assert "APPROVE" in block, "CTA block (followup) must still suppress on clean APPROVE"
     assert "posted = 0" in block, "CTA block (followup) must still reference posted = 0"
     assert "deduped = 0" in block, "CTA block (followup) must still reference deduped = 0"
+
+
+# ── AskUserQuestion contract ──────────────────────────────────────────────────
+
+
+def test_pr_review_cta_uses_ask_user_question():
+    """The CTA section must call AskUserQuestion with a valid schema, not free-text prose."""
+    import json as _json
+    text = PR_REVIEW_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "AskUserQuestion" in block, (
+        "CTA section must reference the AskUserQuestion tool — not a free-text 'reply yes' prompt."
+    )
+    json_match = re.search(r"```json\s*(\{.*?\})\s*```", block, re.DOTALL)
+    assert json_match, "CTA section must contain a fenced JSON block for AskUserQuestion"
+    parsed = _json.loads(json_match.group(1))
+    assert "questions" in parsed and parsed["questions"], (
+        "AskUserQuestion JSON block must have a non-empty 'questions' array"
+    )
+
+
+def test_pr_review_followup_cta_uses_ask_user_question():
+    """The CTA section (followup) must call AskUserQuestion with a valid schema."""
+    import json as _json
+    text = PR_REVIEW_FOLLOWUP_SKILL.read_text()
+    block = _suppression_block(text)
+    assert "AskUserQuestion" in block, (
+        "CTA section (followup) must reference AskUserQuestion — not a free-text prompt."
+    )
+    json_match = re.search(r"```json\s*(\{.*?\})\s*```", block, re.DOTALL)
+    assert json_match, "CTA section (followup) must contain a fenced JSON block for AskUserQuestion"
+    parsed = _json.loads(json_match.group(1))
+    assert "questions" in parsed and parsed["questions"], (
+        "AskUserQuestion JSON block (followup) must have a non-empty 'questions' array"
+    )


### PR DESCRIPTION
## Summary
- Replace the free-text `"Reply yes to start /address-feedback N"` CTA in `workflow-pr-review` and `workflow-pr-review-followup` with an `AskUserQuestion` call.
- The user now gets a clickable `Yes — address feedback` / `No thanks` button pair instead of having to type manually.
- `AskUserQuestion` is already used for the draft-vs-ready prompt in `workflow-commit-and-pr`; this change brings the address-feedback handoff in line with that UX pattern.
- Common Mistakes table updated with a new row: "Emit the CTA as plain text instead of AskUserQuestion" to guard against future regression.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -k workflow_pr_review` — 14/14 pass (no regressions)

### Type-tailored checks ([polish])
- [x] `AskUserQuestion` JSON block appears in both SKILL.md files
- [x] `<N>` placeholder is consistently documented (substitute real PR number)
- [x] `Yes — address feedback` option invokes `/address-feedback <N>`
- [x] `No thanks` option performs no further action
- [x] Old free-text `"Reply yes"` pattern is absent from both files
- [x] Common Mistakes table addition accurately describes the failure mode

Depends on: #264 (must merge first — this branch is based on it)

Issue: N/A — UX improvement; no issue filed
