### PR TITLE
[ci] Route nightly skill-triggers failures to a tracking issue

### DIFF
--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -65,6 +65,7 @@ jobs:
           existing=$(gh issue list \
             --label skill-trigger-drift \
             --state open \
+            --limit 1 \
             --json number \
             --jq '.[0].number // empty')
 

--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -32,7 +32,7 @@ jobs:
           set -euo pipefail
 
           # Ensure the tracking label exists (idempotent; fails loud on real errors)
-          if ! gh label list --json name --jq '.[].name' | grep -qx skill-trigger-drift; then
+          if ! gh label list --limit 200 --json name --jq '.[].name' | grep -qx skill-trigger-drift; then
             gh label create skill-trigger-drift \
               --color fbca04 \
               --description 'Nightly BM25 harness detected description drift'
@@ -75,6 +75,6 @@ jobs:
             echo "Creating new tracking issue"
             gh issue create \
               --title "Nightly skill-trigger harness failing" \
-              --label skill-trigger-drift,ci \
+              --label skill-trigger-drift \
               --body "$body"
           fi

--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -18,4 +19,62 @@ jobs:
           python-version: '3.12'
       - run: pip install -r tests/requirements.txt
       - name: Run skill auto-trigger harness
-        run: pytest tests/test_skill_triggers.py -v
+        run: pytest tests/test_skill_triggers.py -v | tee /tmp/harness.log
+        # pipefail is on by default in GitHub Actions bash; pytest's exit
+        # code is preserved through `tee`.
+
+      - name: Route failure to tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the tracking label exists (idempotent; fails loud on real errors)
+          if ! gh label list --json name --jq '.[].name' | grep -qx skill-trigger-drift; then
+            gh label create skill-trigger-drift \
+              --color fbca04 \
+              --description 'Nightly BM25 harness detected description drift'
+          fi
+
+          # Extract failing test IDs from pytest output
+          failed_tests=$(grep -E '^FAILED ' /tmp/harness.log | awk '{print $2}' || true)
+          if [ -z "$failed_tests" ]; then
+            failed_tests="(could not parse FAILED lines; see run log)"
+          fi
+
+          date_today=$(date -u +%Y-%m-%d)
+          body=$(cat <<EOF
+          ### Nightly skill-trigger harness failed on ${date_today}
+
+          **Failing tests:**
+          \`\`\`
+          ${failed_tests}
+          \`\`\`
+
+          **Run:** ${RUN_URL}
+
+          ---
+
+          Usually means a skill's description has drifted (BM25 ranks a sibling skill above the target). Edit the relevant \`skills/<name>/SKILL.md\` description and re-run via \`workflow_dispatch\`.
+          EOF
+          )
+
+          # Look up open tracking issue
+          existing=$(gh issue list \
+            --label skill-trigger-drift \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Appending to existing tracking issue #${existing}"
+            gh issue comment "$existing" --body "$body"
+          else
+            echo "Creating new tracking issue"
+            gh issue create \
+              --title "Nightly skill-trigger harness failing" \
+              --label skill-trigger-drift,ci \
+              --body "$body"
+          fi


### PR DESCRIPTION
## Summary
- Adds `issues: write` permission to the `smoke` job so the failure step can create labels and issues.
- Pipes `pytest` output through `tee /tmp/harness.log` so the failure step can parse `FAILED` lines; pytest exit code is preserved because `pipefail` is on by default in GitHub Actions bash.
- Adds an `if: failure()` step that ensures the `skill-trigger-drift` label exists (check-then-create, idempotent), looks up the first open issue with that label, and comments on it or files a new one — implementing the rolling tracking-issue strategy so repeated nightly failures from the same drift episode accumulate in one thread rather than spawning duplicates.

## Test Plan
- [ ] YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/skill-triggers.yml'))"` exits 0.
- [ ] Permissions diff confirms only `issues: write` added; no other scope widened.
- [ ] `GH_TOKEN` and `RUN_URL` are passed through `env:` (not inline `${{ }}` in `run:`) — safe against injection.
- [ ] End-to-end dry-run: trigger `workflow_dispatch` on this branch with a deliberate failure → confirm issue filed with label, body contains test IDs and run URL → trigger again → confirm comment appended to existing issue rather than new issue opened.

### Type-tailored checks (ci)
- [ ] Workflow YAML is syntactically valid and parses without warnings.
- [ ] `if: failure()` step is correctly gated — only fires on upstream step failure, not on success.
- [ ] `gh label create` is idempotent: running twice does not error on "already exists".
- [ ] `|| true` is applied only to the `grep` that may legitimately return empty; `set -euo pipefail` is present to fail loud on real errors.

Closes #232
