### PR TITLE
[fix] Fix plugin surface-area defects (dead alias, unreachable agent, doc drift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ cd swe-workbench
 
 ## What's inside
 
-- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
+- **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
 - **Languages** — Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.

--- a/agents/accessibility-auditor.md
+++ b/agents/accessibility-auditor.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review --mode a11y`
+
 You audit frontend code for accessibility violations. Your job is to find concrete WCAG 2.2 AA failures and a11y bugs — not to flag theoretical concerns or restate documentation.
 
 ## Boundary vs. `reviewer`

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, WebFetch, Skill
 ---
 
+**Reachable via:** `/swe-workbench:architect`
+
 You are an architect. You produce formal artifacts — ADRs, RFCs, contract specs — that outlive the meeting. You do not write code or produce implementation guides; the deliverable is a written record that survives the meeting and informs the next engineer who faces the same decision.
 
 ## Mental model

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:audit-codebase`
+
 You perform cold-start, time-boxed, multi-domain audits of unfamiliar codebases. Your job is to surface ranked findings with complete reasoning chains — not to patch code.
 
 ## Boundary vs. other agents

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:debug`
+
 You are a debugger. You find the root cause, then make the smallest change that fixes it, then prove the fix with a test.
 
 ## Composition (non-negotiable)

--- a/agents/dependency-auditor.md
+++ b/agents/dependency-auditor.md
@@ -5,6 +5,8 @@ model: haiku
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review --mode deps`
+
 You audit dependency graphs for supply-chain hygiene. Your job is to surface concrete, actionable risks across the manifest-graph axis — outdated versions, deprecated packages, license conflicts, transitive bloat, and lockfile drift — not to find exploitable code vulnerabilities.
 
 ## Boundary vs. `security-auditor`

--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:migrate`
+
 You are a migrator. Every intermediate state in a migration must satisfy three properties: **deployable** (ships without breaking), **functioning** (the system works correctly at that state), and **reversible** (rollback is documented and tested). If any property fails, the plan is wrong — re-design, do not proceed.
 
 ## Boundary vs. `refactorer`

--- a/agents/performance-tuner.md
+++ b/agents/performance-tuner.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review --mode perf`
+
 Depth-first performance triage. This agent's job is to read a profile, rank its hotspots, and recommend targeted optimizations with before/after verification steps. It does not guess at bottlenecks and will not recommend optimizations without profiling evidence. If no profile is supplied, it refuses and explains how to capture one.
 
 ## Composition (non-negotiable)

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -5,6 +5,8 @@ model: haiku
 tools: Read, Write, Grep, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:capture`, `/swe-workbench:report-issue`
+
 You are a product manager working on the user's current repository — whatever its scale, stack, or domain. Your job is not to ship features. Your job is to make sure that when an idea surfaces mid-development, it is captured in a way that future-you (or future-teammate) can actually act on. You ask the questions a good PM would ask before a feature gets built, but you ask them quickly, in plain language, and you stop asking the moment the thought is legible.
 
 You do not assume anything about the repo's templates, taxonomy, or process. You discover those at runtime by reading `.github/ISSUE_TEMPLATE/`. If templates exist, you respect them. If they don't, you fall through to a clean default. You file into whatever repo `gh repo view` reports — never hardcoded.

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:refactor`
+
 You are a refactoring specialist. You improve structure without changing observable behavior.
 
 ## Absolute rules

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review` (general mode); also `swe-workbench:workflow-pr-review`, `swe-workbench:workflow-pr-review-followup`, `swe-workbench:workflow-development` Phase 4
+
 You are a senior code reviewer. Your job is to catch the issues a careful colleague would flag on a Monday-morning PR — not to restate what the code does.
 
 ## Process

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review --mode security`, `/swe-workbench:security-review`
+
 You audit code for security vulnerabilities. Your job is to find concrete, exploitable risks — not to flag theoretical concerns or restate documentation.
 
 ## Boundary vs. `reviewer`

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, WebFetch, Skill
 ---
 
+**Reachable via:** `/swe-workbench:design`; conditional consult in `/swe-workbench:implement`
+
 You are a senior software architect. You help engineers make design decisions they will not regret in six months.
 
 ## Mental model

--- a/agents/tech-writer.md
+++ b/agents/tech-writer.md
@@ -5,6 +5,8 @@ model: haiku
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:document`
+
 You are a technical writer. You write the smallest documentation that pins the right things, in the voice the repo already uses.
 
 ## Boundary

--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:review --mode tests`
+
 You are a test reviewer. Your job is to audit existing tests and report concrete, high-confidence findings — not to rewrite tests or flag theoretical concerns.
 
 ## Principle consultation

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -5,6 +5,8 @@ model: haiku
 tools: Read, Edit, Grep, Glob, Bash, Skill
 ---
 
+**Reachable via:** `/swe-workbench:test`
+
 You are a test author. You write the smallest set of tests that pin behaviour, in the idiom of the target language.
 
 ## Framework selection

--- a/commands/audit-codebase.md
+++ b/commands/audit-codebase.md
@@ -31,3 +31,14 @@ Pass the parsed values as plain prose to `swe-workbench:workflow-codebase-audit`
 Append the ticket-context summary from Step 2 if present.
 
 The skill handles phase orchestration, schema enforcement, fan-out (deep mode), and ranked rendering. This command does not produce Plan-mode output — the audit is read-only by definition.
+
+## Output
+
+The `workflow-codebase-audit` skill (via the `auditor` subagent) produces a ranked findings document. Expect:
+
+- **Summary header** — scope, depth, and time-box used; total finding count by domain.
+- **Ranked findings** — ordered by severity (Critical → High → Medium → Low), each with: domain tag, `File:Line` anchor, concise issue title, root-cause reasoning chain, and counter-evidence note (what was checked that did NOT confirm the finding).
+- **Domain sections** — `security`, `perf`, `reliability`, `tooling`, `testing` (only domains in `--scope` are rendered; `all` renders all five).
+- **Next-action recommendations** — top-N actionable fixes the team should address first, keyed to finding IDs.
+
+In `--depth deep`, the `security-auditor` additionally deep-dives the top-N security findings and the `debugger` attempts to reproduce the top-N reliability findings; their outputs are appended as sub-sections.

--- a/commands/cleanup-merged.md
+++ b/commands/cleanup-merged.md
@@ -10,3 +10,14 @@ Invoke `swe-workbench:workflow-cleanup-merged` to perform the full cleanup.
 Pass the PR number from $ARGUMENTS to the skill if provided. If $ARGUMENTS is empty, the skill will derive the target branch from the current branch.
 
 When the skill completes, print a summary listing each artifact (worktree, local branch, remote branch) and whether it was removed or was already gone, plus whether local main was synced to origin/main.
+
+## Output
+
+The `workflow-cleanup-merged` skill produces a structured artifact summary. Expect one status line per artifact:
+
+- **Worktree** — path and whether it was removed or was already absent.
+- **Local branch** — branch name and whether it was deleted or was already gone.
+- **Remote branch** — remote ref and whether it was deleted, was already gone, or was skipped (no push permission).
+- **Main sync** — whether local `main` was fast-forwarded to `origin/main` or was already up to date.
+
+Total lines: four. No severity tiers — this is a cleanup confirmation, not a findings report.

--- a/commands/review.md
+++ b/commands/review.md
@@ -23,7 +23,7 @@ Parse `$ARGUMENTS` left-to-right:
    | `accessibility`, `a11y` | `accessibility` | `accessibility-auditor` |
    | `dependency`, `deps` | `dependency` | `dependency-auditor` |
    | `performance`, `perf` | `performance` | `performance-tuner` |
-   | `tests` | `tests` | `test-reviewer` |
+   | `tests` *(no short alias — keyword is already short)* | `tests` | `test-reviewer` |
 
    Strip `--mode <value>` from `$ARGUMENTS`. Store the normalized mode. If the value is unrecognized, print an error listing valid values and stop.
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,11 +1,11 @@
 ---
-description: Review the current git diff — auditor selected by --mode (general, security, a11y, deps, perf) or auto-inferred from the diff when omitted. Pass a PR number to review a specific PR; use --check-followup <N> to re-check a PR after the owner has addressed feedback.
-argument-hint: "[--mode <general|security|a11y|deps|perf>] [PR number — optional] [--check-followup <PR number>]"
+description: Review the current git diff — auditor selected by --mode (general, security, a11y, deps, perf, tests) or auto-inferred from the diff when omitted. Pass a PR number to review a specific PR; use --check-followup <N> to re-check a PR after the owner has addressed feedback.
+argument-hint: "[--mode <general|security|a11y|deps|perf|tests>] [PR number — optional] [--check-followup <PR number>]"
 ---
 
 Review code with senior-engineer depth. Two dimensions — fully orthogonal:
 
-- **Auditor axis (`--mode`):** which specialist reviews the diff (general / security / accessibility / dependency / performance). Auto-inferred from the diff when omitted.
+- **Auditor axis (`--mode`):** which specialist reviews the diff (general / security / accessibility / dependency / performance / tests). Auto-inferred from the diff when omitted.
 - **Diff-source axis:** local working-tree diff vs. PR diff. Determined by the remaining arguments after `--mode` is stripped.
 
 ## Step 1 — Argument resolution
@@ -23,6 +23,7 @@ Parse `$ARGUMENTS` left-to-right:
    | `accessibility`, `a11y` | `accessibility` | `accessibility-auditor` |
    | `dependency`, `deps` | `dependency` | `dependency-auditor` |
    | `performance`, `perf` | `performance` | `performance-tuner` |
+   | `tests` | `tests` | `test-reviewer` |
 
    Strip `--mode <value>` from `$ARGUMENTS`. Store the normalized mode. If the value is unrecognized, print an error listing valid values and stop.
 
@@ -50,6 +51,8 @@ Apply these inference rules **in precedence order** (first match wins; ties reso
 3. **accessibility** — ALL changed files are frontend surfaces (`*.jsx`, `*.tsx`, `*.html`, `*.css`, `*.svelte`, `*.vue`) AND the diff content includes interactive markup (`<button`, `<input`, `<a `, `<form`, `<dialog`, `role=`, `aria-`).
 4. **performance** — diff touches perf-sensitive hot-path globs (`**/cache/**`, `**/queries/**`, `**/db/**`, `**/index*`, `**/search*`) AND the diff is small (< 200 lines changed).
 5. **general** — fallthrough when none of the above match.
+
+> **Note:** `tests` is intentionally absent from auto-inference — it must be requested explicitly with `--mode tests`. Rationale: test files are also valid targets for general review, so auto-routing would suppress the full-spectrum `reviewer` on test-only diffs.
 
 Print exactly:
 > `Inferred mode: <mode> — reason: <one-sentence justification>`
@@ -80,7 +83,7 @@ Ground judgements in SOLID and Clean Architecture principles. Do not nitpick for
 
 The skill owns: pre-flight (`gh auth`, `gh pr view`), ephemeral worktree under `/tmp/swe-workbench-pr-review/<N>`, ticket-context chain, reviewer invocation with footer instruction, decision-footer parsing, GraphQL thread fetch + dedup + REST inline-comment post, `gh pr review --approve|--comment` submission, non-blocking cleanup. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and failure-mode handling.
 
-**When `--mode` is set to a non-general value (security, accessibility, dependency, performance) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style. **Inline-comment posting and APPROVE/COMMENT submission are skipped** — output is severity-organized findings only (same format as local-diff mode above). This avoids re-architecting `workflow-pr-review` to accept an auditor parameter; the full PR-review flow is reserved for the general reviewer.
+**When `--mode` is set to a non-general value (security, accessibility, dependency, performance, tests) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style. **Inline-comment posting and APPROVE/COMMENT submission are skipped** — output is severity-organized findings only (same format as local-diff mode above). This avoids re-architecting `workflow-pr-review` to accept an auditor parameter; the full PR-review flow is reserved for the general reviewer.
 
 If the PR number was obtained via auto-detect (user replied `yes` to the prompt in Step 1) rather than an explicit argument, the same branching applies: `--mode general` (or no `--mode`) delegates to `swe-workbench:workflow-pr-review`; non-general modes fetch `gh pr diff <N>` and run the specialist in local-diff style.
 

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,6 +1,21 @@
 ---
-description: Alias for `/review --mode security`. Audit the current git diff for security vulnerabilities — OWASP Top 10, secrets, insecure APIs, dependency CVEs.
+description: Depth-first security audit of the current git diff — OWASP Top 10, secret leakage, insecure-by-default APIs, and language-specific foot-guns. Pass a PR number to audit a specific PR's diff.
 argument-hint: "[PR number — optional; omit to audit local diff]"
 ---
 
-This command is an alias. Delegate to `/review --mode security $ARGUMENTS`.
+Target: $ARGUMENTS
+
+If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its summary to the delegation context. (Trigger patterns are defined in that skill's "When to invoke" section.)
+
+Delegate to the `security-auditor` subagent with the resolved diff (PR diff via `gh pr diff <N>` if $ARGUMENTS is a PR number — stripping a leading `#` if present; otherwise the local-diff cascade: `git diff` → `git diff --staged` → `git diff origin/main...HEAD`). Ask for a prioritized findings report.
+
+## Output
+
+The `security-auditor` subagent produces a severity-organized findings report. Expect:
+
+- **Critical** — data exfiltration, authentication bypass, direct secret exposure, remote code execution risk.
+- **High** — exploitable injection (SQLi, XSS, SSRF, XXE), broken access control, insecure deserialization.
+- **Medium** — missing input validation at trust boundaries, insecure defaults, weak cryptographic choices.
+- **Low** — defence-in-depth gaps, minor information-disclosure risks, dependency CVEs with low exploitability.
+
+Each finding uses: `Severity | File:Line | Issue | Why it matters | Suggested fix`. The report closes with a short summary section (total counts by severity, surface areas touched, recommended next action).

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -4,8 +4,8 @@
 
 | Command | Purpose |
 |---|---|
-| `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf) or auto-inferred from the diff when omitted. PR number arg unchanged. |
-| `/swe-workbench:security-review` | Alias for `/swe-workbench:review --mode security`. Kept for backward compat. |
+| `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf\|tests>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf, tests) or auto-inferred from the diff when omitted. PR number arg unchanged. |
+| `/swe-workbench:security-review` | Depth-first security audit of the current diff — OWASP Top 10, secrets, insecure APIs, dependency CVEs. Pass a PR number to audit a specific PR. |
 | `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
 | `/swe-workbench:architect <decision>` | Author an ADR, RFC, or cross-service contract via the architect subagent. Use when the output must be a written decision record — service decomposition, multi-system tech selection, cross-team contract — not advice about existing code. |
 | `/swe-workbench:refactor <target>` | Behavior-preserving refactor via Fowler's catalog. |
@@ -28,12 +28,15 @@
 |---|---|
 | `reviewer` | PR review, diff audit, post-feature sanity check. |
 | `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |
+| `accessibility-auditor` | Depth-first WCAG 2.2 AA review of frontend diffs — ARIA misuse, keyboard traps, focus mismanagement, color contrast. Invoked by `/swe-workbench:review --mode a11y`. |
+| `auditor` | Cold-start, time-boxed, multi-domain audit sweep — security, performance, reliability, tooling, testing. Invoked by `/swe-workbench:audit-codebase`. |
+| `dependency-auditor` | Supply-chain hygiene audit — outdated versions, license conflicts, transitive bloat, lockfile drift. Invoked by `/swe-workbench:review --mode deps`. |
 | `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
 | `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `test-writer` | Authoring tests for an existing function, module, or change set. |
-| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. |
+| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. Invoked by `/swe-workbench:review --mode tests`. |
 | `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
 | `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. Invoked by `/swe-workbench:document`. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,21 +26,21 @@
 
 | Agent | When to invoke |
 |---|---|
-| `reviewer` | PR review, diff audit, post-feature sanity check. |
-| `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |
 | `accessibility-auditor` | Depth-first WCAG 2.2 AA review of frontend diffs — ARIA misuse, keyboard traps, focus mismanagement, color contrast. Invoked by `/swe-workbench:review --mode a11y`. |
-| `auditor` | Cold-start, time-boxed, multi-domain audit sweep — security, performance, reliability, tooling, testing. Invoked by `/swe-workbench:audit-codebase`. |
-| `dependency-auditor` | Supply-chain hygiene audit — outdated versions, license conflicts, transitive bloat, lockfile drift. Invoked by `/swe-workbench:review --mode deps`. |
-| `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
 | `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
-| `refactorer` | Cleaning up smells before adding a feature. |
+| `auditor` | Cold-start, time-boxed, multi-domain audit sweep — security, performance, reliability, tooling, testing. Invoked by `/swe-workbench:audit-codebase`. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
-| `test-writer` | Authoring tests for an existing function, module, or change set. |
-| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. Invoked by `/swe-workbench:review --mode tests`. |
-| `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
-| `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. Invoked by `/swe-workbench:document`. |
+| `dependency-auditor` | Supply-chain hygiene audit — outdated versions, license conflicts, transitive bloat, lockfile drift. Invoked by `/swe-workbench:review --mode deps`. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |
 | `performance-tuner` | Profile-driven hotspot triage — ranks bottlenecks from a flame graph or benchmark and recommends targeted optimizations. Refuses speculative optimization without profiling evidence. |
+| `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
+| `refactorer` | Cleaning up smells before adding a feature. |
+| `reviewer` | PR review, diff audit, post-feature sanity check. |
+| `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |
+| `senior-engineer` | Architecture decisions, service scoping, tradeoff analysis. |
+| `tech-writer` | Generates README sections, ADRs, ARCHITECTURE/OVERVIEW, and non-obvious inline comments — style-aware, reads existing docs first. Invoked by `/swe-workbench:document`. |
+| `test-reviewer` | Auditing existing tests for flakiness, over-mocking, behaviour-vs-implementation drift, and coverage gaps. Invoked by `/swe-workbench:review --mode tests`. |
+| `test-writer` | Authoring tests for an existing function, module, or change set. |
 
 ## Skills
 

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -108,10 +108,6 @@ class TestSecurityReviewCommand:
         assert "PR number" in text or "PR diff" in text or "gh pr diff" in text, \
             "security-review.md must document PR-number argument support"
 
-    def test_output_stanza_present(self):
-        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
-        assert "## Output" in text, "security-review.md must have an ## Output stanza"
-
     def test_frontmatter_preserved(self):
         text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
         match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -16,9 +16,9 @@ class TestReviewModeRouting:
         assert match
         assert "--mode" in match.group(1)
 
-    def test_all_five_modes_present(self):
+    def test_all_modes_present(self):
         text = REVIEW_PATH.read_text(encoding="utf-8")
-        for mode in ("general", "security", "accessibility", "dependency", "performance"):
+        for mode in ("general", "security", "accessibility", "dependency", "performance", "tests"):
             assert mode in text, f"--mode {mode} must be documented"
 
     def test_short_aliases_present(self):
@@ -26,10 +26,10 @@ class TestReviewModeRouting:
         for alias in ("a11y", "deps", "perf", "sec"):
             assert alias in text, f"alias '{alias}' must be documented"
 
-    def test_all_five_auditors_referenced(self):
+    def test_all_auditors_referenced(self):
         text = REVIEW_PATH.read_text(encoding="utf-8")
         for agent in ("reviewer", "security-auditor", "accessibility-auditor",
-                      "dependency-auditor", "performance-tuner"):
+                      "dependency-auditor", "performance-tuner", "test-reviewer"):
             assert agent in text, f"auditor '{agent}' must be referenced"
 
     def test_auto_inference_output_format(self):
@@ -80,20 +80,34 @@ class TestReviewModeRouting:
         assert "swe-workbench:workflow-pr-review" in text
 
 
-class TestSecurityReviewIsStub:
-    """Assert /security-review.md is a thin alias for /review --mode security."""
+class TestSecurityReviewCommand:
+    """Assert /security-review.md delegates directly to the security-auditor agent.
 
-    def test_delegates_to_review(self):
-        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
-        assert "/review --mode security" in text or "review --mode security" in text
+    The command is no longer a stub alias for /review --mode security. Slash
+    commands cannot chain slash commands — the harness does not expand inner
+    slash references. The command now handles diff resolution itself and
+    delegates to the security-auditor subagent directly (issue #234).
+    """
 
-    def test_does_not_invoke_security_auditor_directly(self):
-        """Prevents stub from silently re-growing the dispatch logic."""
+    def test_delegates_to_security_auditor(self):
         text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
-        # The agent name must not appear — delegation lives in /review
-        assert "security-auditor" not in text, \
-            "security-review.md must not reference security-auditor directly; " \
-            "delegation now lives in /review"
+        assert "security-auditor" in text, \
+            "security-review.md must delegate to the security-auditor subagent directly"
+
+    def test_does_not_chain_slash_command(self):
+        """Slash-command chaining silently no-ops in the Claude Code harness."""
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        assert "Delegate to `/review" not in text and "delegate to `/review" not in text, \
+            "security-review.md must not chain /review — slash commands cannot chain slash commands"
+
+    def test_pr_number_arg_documented(self):
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        assert "PR number" in text or "PR diff" in text or "gh pr diff" in text, \
+            "security-review.md must document PR-number argument support"
+
+    def test_output_stanza_present(self):
+        text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")
+        assert "## Output" in text, "security-review.md must have an ## Output stanza"
 
     def test_frontmatter_preserved(self):
         text = SECURITY_REVIEW_PATH.read_text(encoding="utf-8")

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -1,10 +1,13 @@
 """Structural tests for /review mode-routing (issue #172)."""
 import re
 from pathlib import Path
+import pytest
 
 
 REVIEW_PATH = Path(__file__).parent.parent / "commands" / "review.md"
 SECURITY_REVIEW_PATH = Path(__file__).parent.parent / "commands" / "security-review.md"
+COMMANDS_DIR = Path(__file__).parent.parent / "commands"
+AGENTS_DIR = Path(__file__).parent.parent / "agents"
 
 
 class TestReviewModeRouting:
@@ -114,3 +117,26 @@ class TestSecurityReviewCommand:
         match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
         assert match
         assert "description:" in match.group(1)
+
+
+class TestCommandOutputStanzas:
+    """Assert every short command documented in issue #234 has an ## Output stanza."""
+
+    @pytest.mark.parametrize("cmd", [
+        "security-review.md",
+        "cleanup-merged.md",
+        "audit-codebase.md",
+    ])
+    def test_short_command_has_output_stanza(self, cmd):
+        text = (COMMANDS_DIR / cmd).read_text(encoding="utf-8")
+        assert "## Output" in text, f"{cmd} must have an ## Output stanza"
+
+
+class TestAgentReachableVia:
+    """Assert every agent file declares its entry-point via **Reachable via:** annotation."""
+
+    def test_all_agents_have_reachable_via(self):
+        for agent_file in sorted(AGENTS_DIR.glob("*.md")):
+            text = agent_file.read_text(encoding="utf-8")
+            assert "**Reachable via:**" in text, \
+                f"{agent_file.name} must have a '**Reachable via:**' annotation"


### PR DESCRIPTION
## Summary

- Fix `/security-review` dead alias: rewrite body to delegate directly to `security-auditor` subagent (slash commands cannot chain slash commands — the harness never expands inner slash references)
- Wire `test-reviewer` agent: add `--mode tests` row to `/review` command, update frontmatter/argument-hint/prose, document intentional non-inference with a prose note
- Sync README ↔ catalog ↔ disk: add missing commands (`audit-codebase`, `codebase-knowledge`) and agents (`test-reviewer`, `accessibility-auditor`, `auditor`, `dependency-auditor`) to README and catalog
- Add `## Output` stanzas to `security-review`, `cleanup-merged`, and `audit-codebase` commands
- Add `**Reachable via:**` annotation (first body line after `---`) to all 15 agent files for reverse-indexing
- Update `TestSecurityReviewIsStub` → `TestSecurityReviewCommand` in test suite: old tests enforced the broken stub behavior; new tests assert correct direct-delegation

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Static parity audit: `grep -L "Reachable via:" agents/*.md` → empty; disk/README/catalog counts match (17 commands, 15 agents each)
- [x] Pre-push hook: all 547 tests pass (2 tests updated to reflect correct behavior)
- [x] Reachability spot-check: `tech-writer`→`/document`, `security-auditor`→`/security-review`, `test-reviewer`→`/review --mode tests` — all delegation claims verified against actual command bodies

### Type-tailored checks ([fix])

- [x] Root cause confirmed: slash commands cannot chain slash commands in Claude Code — prose containing `/review --mode security` is never expanded by the harness
- [x] Fix verified: `security-review.md` now references `security-auditor` directly with the same thin-delegation pattern as `/document`, `/refactor`, `/architect`
- [x] Regression check: existing modes (`a11y`, `deps`, `perf`, `security`, `general`) routing unchanged in `review.md`

Closes #234
