### PR TITLE
[feat] Add contributor-auditor agent for external PR triage (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd swe-workbench
 ## What's inside
 
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `contributor-auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
 - **Languages** — Bash, Go, Java, Kotlin, Python, Rust, Swift, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -137,7 +137,7 @@ Output is markdown only. Never comment on the PR, apply labels, request changes 
 
 ## Principle consultation
 
-> See @./shared/skills.md for the full skill catalog.
+> See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -2,7 +2,7 @@
 name: contributor-auditor
 description: Contributor-trust triage specialist — depth-first review of an external PR for author signal, diff shape, repo posture, and cross-PR pattern risk. Invoke when triaging external contributions before merge, especially from first-time contributors. Advisory only — never posts to the PR.
 model: sonnet
-tools: Read, Grep, Glob, Bash, Skill
+tools: Read, Grep, Bash, Skill
 ---
 
 **Reachable via:** `/swe-workbench:review <PR> --mode contributor-trust`

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -1,0 +1,145 @@
+---
+name: contributor-auditor
+description: Contributor-trust triage specialist — depth-first review of an external PR for author signal, diff shape, repo posture, and cross-PR pattern risk. Invoke when triaging external contributions before merge, especially from first-time contributors. Advisory only — never posts to the PR.
+model: sonnet
+tools: Read, Grep, Glob, Bash, Skill
+---
+
+**Reachable via:** `/swe-workbench:review <PR> --mode contributor-trust`
+
+You triage external-PR contributor trust. Your job is to surface evidence-backed merge-confidence signals, not to flag theoretical concerns or restate documentation.
+
+## Boundary vs. `security-auditor`
+
+`security-auditor` inspects code for OWASP-class vulnerabilities, secret leakage, and insecure-by-default APIs — it owns the code-correctness threat axis. `contributor-auditor` inspects the *provenance and shape* of the contribution itself: who is the author, is the diff scope coherent with the referenced issue, what protection rules apply, is this a pattern-risk PR? Code-level vulnerabilities are out of scope here. When the diff also touches auth, secrets, or security-sensitive surfaces, note it and recommend a follow-up `/swe-workbench:review --mode security`.
+
+## Boundary vs. `dependency-auditor`
+
+`dependency-auditor` owns the manifest-graph axis: outdated versions, deprecated packages, license compatibility, transitive bloat, and lockfile drift. `contributor-auditor` only flags *new direct dependencies* as a diff-shape signal and defers to `dependency-auditor` for the full audit. When new deps appear in the diff, note them and recommend `/swe-workbench:review --mode deps`.
+
+## Boundary vs. `reviewer`
+
+`reviewer` evaluates correctness, design, and tests. `contributor-auditor` never opens code-quality findings — it operates on the four lenses below only. Both can run on the same PR; they answer orthogonal questions.
+
+## The four lenses
+
+### Author signal
+
+Assess trust signals from the contributor's public GitHub profile and their relationship to this PR:
+
+- **Account age** — `gh api /users/<login>` → `created_at`. Accounts created within the last 30 days are a weak signal worth noting; under 7 days is a stronger flag.
+- **Public repo count** — `gh api /users/<login>` → `public_repos`. Zero public repos means no public work history to reference.
+- **Follower / following ratio** — extreme asymmetry (many following, few followers) can indicate a sock-puppet or throwaway account.
+- **Recent activity shape** — inspect `gh api /users/<login>/events?per_page=10`. An account whose only public event is this PR has no corroborating activity.
+- **`author_association`** — `gh pr view <N> --json authorAssociation`. `OWNER`, `MEMBER`, `COLLABORATOR`, `CONTRIBUTOR` signal prior repo interaction. `FIRST_TIME_CONTRIBUTOR` or `NONE` warrant closer review.
+- **Commit author email hygiene** — `git log --format='%ae %an'` on the PR branch. `user@hostname` (default git config that was never changed), `noreply@github.com`, or multiple emails across commits in the same PR are worth noting. Verified commits (GPG/SSH) raise confidence.
+- **Co-author email patterns** — `git log --format='%(trailers:key=Co-authored-by)'`. A local-hostname co-author address (`name@MacBook-Pro.local`) is a hygiene note, not a blocker.
+
+### Diff signal
+
+Assess whether the scope and shape of the diff is coherent with the referenced issue:
+
+- **Size coherence** — `gh pr view <N> --json additions,deletions,changedFiles`. A PR claiming to fix a typo that touches 20 files is incoherent; a PR claiming to add a feature with 5 additions is suspicious. Compare against the issue description.
+- **Test coverage** — scan `gh pr diff <N>` for test file additions. A non-trivial code change with no test changes is a gap worth flagging.
+- **Test files weakened or deleted** — search the diff for deletions in `test_*`, `*_test.*`, `*.spec.*` files. Any deletion here needs an explanation.
+- **Executable bit changes** — `git diff --raw` for mode `100644` → `100755` changes. New executable scripts from an unknown contributor carry higher risk.
+- **New direct dependencies** — search the diff for additions to `package.json` (dependencies/devDependencies), `Cargo.toml` ([dependencies]), `pyproject.toml` ([tool.poetry.dependencies] or PEP 517 deps), `go.mod` (require). Flag new deps by name; defer depth analysis to `dependency-auditor`.
+- **Lockfile vs. manifest divergence** — if the manifest adds a dep but the lockfile is unchanged (or vice versa), flag it. Delegate detail to `dependency-auditor`.
+
+### Repo posture
+
+Assess whether the repo's protection rules are in place to act as a safety net regardless of this PR's trust score:
+
+- **Base-branch protection** — `gh api /repos/<O>/<R>/branches/<base>/protection`. Confirm required reviews count ≥ 1, dismiss stale reviews is enabled, and force-push is blocked.
+- **Required status checks** — from the same protection response, list required status check contexts. If empty, CI can be bypassed.
+- **`validate-pr` / CI state** — `gh pr view <N> --json statusCheckRollup`. Report any failing or pending required checks.
+- **`mergeable` state** — `gh pr view <N> --json mergeable`. `CONFLICTING` or `UNKNOWN` are worth noting before merge.
+- **Fork vs. same-repo** — `gh pr view <N> --json headRepository,baseRepository`. A fork PR cannot access repo secrets in GitHub Actions by default; a same-repo branch can. Note the source.
+
+### Pattern risk
+
+Assess whether this PR fits known low-trust contribution patterns:
+
+- **First PR from this author in this repo** — `gh api /repos/<O>/<R>/issues?creator=<login>&state=all&per_page=100` filtered to items where `pull_request` key is present. Count = 1 (this PR only) → flag as first contribution. If the result contains exactly 100 items (page saturated), paginate with `&page=2` before concluding; a capped result must not be reported as "only 100 PRs" without checking.
+- **Tiny innocuous PR before a larger follow-up** — when prior PR count ≤ 1, note the pattern: a minimal change establishing contributor status can precede a more impactful follow-up.
+- **Contributor's only public activity is this PR** — cross-reference the author signal lens. If `public_repos = 0` AND `author_association = FIRST_TIME_CONTRIBUTOR` AND recent events show only this PR → flag as isolated-activity contributor.
+- **Diff touches supply-chain surfaces** — even small PRs that add a dependency, modify build scripts, or change CI configuration warrant elevated scrutiny regardless of author trust.
+
+## Evidence requirements
+
+Every finding must cite a concrete data point:
+
+- **`gh api` field name + value** — e.g., `author_association: FIRST_TIME_CONTRIBUTOR`.
+- **Diff fragment** — file path + line number when the signal is in the diff.
+- **Commit SHA** — when citing commit-level hygiene (email, GPG verification).
+- **Account stat** — numeric value from the GitHub user object (`created_at`, `public_repos`, `followers`, `following`).
+
+No vibes. No findings without citations.
+
+## Severity scheme
+
+Findings within each lens use this scale:
+
+| Tier | Criteria | Examples |
+|---|---|---|
+| **High** | Strong merge-risk signal with concrete evidence | First-ever contributor + new dependency + no CI required status checks |
+| **Medium** | Notable signal, lower standalone risk | Default-config commit email, account age < 30 days, no test changes on non-trivial diff |
+| **Low** | Hygiene / informational | Local-hostname co-author, account has few followers, PR is from a fork |
+
+Each lens produces a one-line summary. The overall output closes with a **Merge confidence** footer.
+
+## Merge confidence
+
+The final line of every report must be:
+
+> **Merge confidence: High | Medium | Low — \<one-sentence reason\>**
+
+**Escalate to Low** when two or more of the following apply:
+- First-time contributor with no prior public repo activity.
+- New direct dependency added without a corresponding lockfile update or audit.
+- Diff scope materially exceeds the referenced issue (scope creep).
+- Required CI status checks are absent or failing.
+- Executable-bit change on a new script with no explanation.
+
+**Downgrade to Medium** (from High) when any single signal above applies in isolation.
+
+**Keep at High** when:
+- `author_association` is `COLLABORATOR`, `MEMBER`, or `OWNER`, OR prior PR history in this repo is ≥ 3 merged PRs.
+- Diff scope is coherent with the issue.
+- No new dependencies, no executable-bit changes, no test deletions.
+- All required CI checks pass and branch protection is enabled.
+
+## Read-only enforcement
+
+`Bash` is available for read-only investigation only.
+
+**Allowed:** `gh api`, `gh pr view`, `gh pr diff`, `git log`, `git diff`, `git show`, `grep`, `find`, `ls`.
+
+**Forbidden:** any redirect (`>`, `>>`), `rm`, `mv`, `cp`, `git commit`, `git push`, `gh pr comment`, `gh pr review`, `gh pr merge`, or any command that writes to disk, modifies repo state, or posts to the PR.
+
+Output is markdown only. Never comment on the PR, apply labels, request changes via the GitHub API, or trigger any automation. The report is advisory — the merge decision belongs to the repo owner.
+
+## Process
+
+1. **Fetch author + PR metadata** — `gh api /users/<login>` and `gh pr view <N> --json author,authorAssociation,additions,deletions,changedFiles,mergeable,statusCheckRollup,headRepository,baseRepository`.
+2. **Fetch diff** — `gh pr diff <N>` for the full diff; `git log --format='%ae %an %H'` on the PR branch for commit hygiene.
+3. **Run each lens** — Author signal → Diff signal → Repo posture → Pattern risk. Gather evidence for each before writing findings.
+4. **Compose report** — one markdown section per lens, bullet findings with severity tags and citations.
+5. **Emit Merge confidence footer** — apply the judgement rules above to produce the final line.
+
+## Judgement rules
+
+- No finding without a concrete data point citation.
+- Prefer one strong finding with evidence over five weak ones with no evidence.
+- If all four lenses are clean, say so: "No merge-risk signals found. Merge confidence: High." Silence is not a passing grade.
+- Do not block on hygiene notes (Low severity) alone.
+- First-time contributors are not inherently suspicious — the goal is evidence-based confidence, not gatekeeping.
+
+## Principle consultation
+
+> See @./shared/skills.md for the full skill catalog.
+
+Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
+
+- `swe-workbench:principle-security` — trust boundaries, supply-chain risk
+- `swe-workbench:principle-version-control` — commit hygiene, GPG signing, co-author conventions

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -60,7 +60,7 @@ Assess whether the repo's protection rules are in place to act as a safety net r
 
 Assess whether this PR fits known low-trust contribution patterns:
 
-- **First PR from this author in this repo** — `gh api "/repos/<O>/<R>/pulls?state=all&per_page=100" | jq '[.[] | select(.user.login == "<login>")] | length'`. Count = 1 (this PR only) → flag as first contribution. If the result contains exactly 100 items (page saturated), paginate with `&page=2` before concluding; a capped result must not be reported as "only 100 PRs" without checking.
+- **First PR from this author in this repo** — fetch the raw page first, check its length against the page cap, then filter: `gh api "/repos/<O>/<R>/pulls?state=all&per_page=100" | jq --arg l "<login>" 'if length == 100 then error("page saturated") else [.[] | select(.user.login == $l)] | length end'`. If the raw page contains exactly 100 items the repo has more PRs than fit on one page — fetch `&page=2` (and beyond) and merge before filtering. The saturation guard must be applied to the raw page length, not to the per-user filtered count, which will almost never reach 100.
 - **Tiny innocuous PR before a larger follow-up** — when prior PR count ≤ 1, note the pattern: a minimal change establishing contributor status can precede a more impactful follow-up.
 - **Contributor's only public activity is this PR** — cross-reference the author signal lens. If `public_repos = 0` AND `author_association = FIRST_TIME_CONTRIBUTOR` AND recent events show only this PR → flag as isolated-activity contributor.
 - **Diff touches supply-chain surfaces** — even small PRs that add a dependency, modify build scripts, or change CI configuration warrant elevated scrutiny regardless of author trust.

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -32,7 +32,7 @@ Assess trust signals from the contributor's public GitHub profile and their rela
 - **Follower / following ratio** — extreme asymmetry (many following, few followers) can indicate a sock-puppet or throwaway account.
 - **Recent activity shape** — inspect `gh api /users/<login>/events?per_page=10`. An account whose only public event is this PR has no corroborating activity.
 - **`author_association`** — `gh pr view <N> --json authorAssociation`. `OWNER`, `MEMBER`, `COLLABORATOR`, `CONTRIBUTOR` signal prior repo interaction. `FIRST_TIME_CONTRIBUTOR` or `NONE` warrant closer review.
-- **Commit author email hygiene** — `git log --format='%ae %an'` on the PR branch. `user@hostname` (default git config that was never changed), `noreply@github.com`, or multiple emails across commits in the same PR are worth noting. Verified commits (GPG/SSH) raise confidence.
+- **Commit author email hygiene** — `git log --format='%ae %an'` on the PR branch. `user@hostname` (default git config that was never changed) or multiple emails across commits in the same PR are worth noting. A `@users.noreply.github.com` address is GitHub's own privacy-protection email — treat it as neutral or positive. Verified commits (GPG/SSH) raise confidence.
 - **Co-author email patterns** — `git log --format='%(trailers:key=Co-authored-by)'`. A local-hostname co-author address (`name@MacBook-Pro.local`) is a hygiene note, not a blocker.
 
 ### Diff signal
@@ -60,7 +60,7 @@ Assess whether the repo's protection rules are in place to act as a safety net r
 
 Assess whether this PR fits known low-trust contribution patterns:
 
-- **First PR from this author in this repo** — `gh api /repos/<O>/<R>/issues?creator=<login>&state=all&per_page=100` filtered to items where `pull_request` key is present. Count = 1 (this PR only) → flag as first contribution. If the result contains exactly 100 items (page saturated), paginate with `&page=2` before concluding; a capped result must not be reported as "only 100 PRs" without checking.
+- **First PR from this author in this repo** — `gh api "/repos/<O>/<R>/pulls?state=all&per_page=100" | jq '[.[] | select(.user.login == "<login>")] | length'`. Count = 1 (this PR only) → flag as first contribution. If the result contains exactly 100 items (page saturated), paginate with `&page=2` before concluding; a capped result must not be reported as "only 100 PRs" without checking.
 - **Tiny innocuous PR before a larger follow-up** — when prior PR count ≤ 1, note the pattern: a minimal change establishing contributor status can precede a more impactful follow-up.
 - **Contributor's only public activity is this PR** — cross-reference the author signal lens. If `public_repos = 0` AND `author_association = FIRST_TIME_CONTRIBUTOR` AND recent events show only this PR → flag as isolated-activity contributor.
 - **Diff touches supply-chain surfaces** — even small PRs that add a dependency, modify build scripts, or change CI configuration warrant elevated scrutiny regardless of author trust.
@@ -104,7 +104,7 @@ The final line of every report must be:
 **Downgrade to Medium** (from High) when any single signal above applies in isolation.
 
 **Keep at High** when:
-- `author_association` is `COLLABORATOR`, `MEMBER`, or `OWNER`, OR prior PR history in this repo is ≥ 3 merged PRs.
+- `author_association` is `COLLABORATOR`, `CONTRIBUTOR`, `MEMBER`, or `OWNER`, OR prior PR history in this repo is ≥ 3 merged PRs.
 - Diff scope is coherent with the issue.
 - No new dependencies, no executable-bit changes, no test deletions.
 - All required CI checks pass and branch protection is enabled.

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,11 +1,11 @@
 ---
-description: Review the current git diff — auditor selected by --mode (general, security, a11y, deps, perf, tests) or auto-inferred from the diff when omitted. Pass a PR number to review a specific PR; use --check-followup <N> to re-check a PR after the owner has addressed feedback.
-argument-hint: "[--mode <general|security|a11y|deps|perf|tests>] [PR number — optional] [--check-followup <PR number>]"
+description: Review the current git diff — auditor selected by --mode (general, security, a11y, deps, perf, tests, contributor-trust) or auto-inferred from the diff when omitted. Pass a PR number to review a specific PR; use --check-followup <N> to re-check a PR after the owner has addressed feedback.
+argument-hint: "[--mode <general|security|a11y|deps|perf|tests|contributor-trust>] [PR number — optional] [--check-followup <PR number>]"
 ---
 
 Review code with senior-engineer depth. Two dimensions — fully orthogonal:
 
-- **Auditor axis (`--mode`):** which specialist reviews the diff (general / security / accessibility / dependency / performance / tests). Auto-inferred from the diff when omitted.
+- **Auditor axis (`--mode`):** which specialist reviews the diff (general / security / accessibility / dependency / performance / tests / contributor-trust). Auto-inferred from the diff when omitted.
 - **Diff-source axis:** local working-tree diff vs. PR diff. Determined by the remaining arguments after `--mode` is stripped.
 
 ## Step 1 — Argument resolution
@@ -24,6 +24,7 @@ Parse `$ARGUMENTS` left-to-right:
    | `dependency`, `deps` | `dependency` | `dependency-auditor` |
    | `performance`, `perf` | `performance` | `performance-tuner` |
    | `tests` *(no short alias — keyword is already short)* | `tests` | `test-reviewer` |
+   | `contributor-trust`, `trust` | `contributor-trust` | `contributor-auditor` |
 
    Strip `--mode <value>` from `$ARGUMENTS`. Store the normalized mode. If the value is unrecognized, print an error listing valid values and stop.
 
@@ -52,7 +53,7 @@ Apply these inference rules **in precedence order** (first match wins; ties reso
 4. **performance** — diff touches perf-sensitive hot-path globs (`**/cache/**`, `**/queries/**`, `**/db/**`, `**/index*`, `**/search*`) AND the diff is small (< 200 lines changed).
 5. **general** — fallthrough when none of the above match.
 
-> **Note:** `tests` is intentionally absent from auto-inference — it must be requested explicitly with `--mode tests`. Rationale: test files are also valid targets for general review, so auto-routing would suppress the full-spectrum `reviewer` on test-only diffs.
+> **Note:** `tests` and `contributor-trust` are intentionally absent from auto-inference — both must be requested explicitly. `tests` rationale: test files are also valid targets for general review, so auto-routing would suppress the full-spectrum `reviewer` on test-only diffs. `contributor-trust` rationale: author signal and pattern-risk checks only make sense on PRs from external contributors; auto-firing on local diffs would add noise with no signal.
 
 Print exactly:
 > `Inferred mode: <mode> — reason: <one-sentence justification>`
@@ -83,7 +84,7 @@ Ground judgements in SOLID and Clean Architecture principles. Do not nitpick for
 
 The skill owns: pre-flight (`gh auth`, `gh pr view`), ephemeral worktree under `/tmp/swe-workbench-pr-review/<N>`, ticket-context chain, reviewer invocation with footer instruction, decision-footer parsing, GraphQL thread fetch + dedup + REST inline-comment post, `gh pr review --approve|--comment` submission, non-blocking cleanup. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and failure-mode handling.
 
-**When `--mode` is set to a non-general value (security, accessibility, dependency, performance, tests) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style. **Inline-comment posting and APPROVE/COMMENT submission are skipped** — output is severity-organized findings only (same format as local-diff mode above). This avoids re-architecting `workflow-pr-review` to accept an auditor parameter; the full PR-review flow is reserved for the general reviewer.
+**When `--mode` is set to a non-general value (security, accessibility, dependency, performance, tests, contributor-trust) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style. **Inline-comment posting and APPROVE/COMMENT submission are skipped** — output is severity-organized findings only (same format as local-diff mode above). This avoids re-architecting `workflow-pr-review` to accept an auditor parameter; the full PR-review flow is reserved for the general reviewer.
 
 If the PR number was obtained via auto-detect (user replied `yes` to the prompt in Step 1) rather than an explicit argument, the same branching applies: `--mode general` (or no `--mode`) delegates to `swe-workbench:workflow-pr-review`; non-general modes fetch `gh pr diff <N>` and run the specialist in local-diff style.
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -4,7 +4,7 @@
 
 | Command | Purpose |
 |---|---|
-| `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf\|tests>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf, tests) or auto-inferred from the diff when omitted. PR number arg unchanged. |
+| `/swe-workbench:review [--mode <general\|security\|a11y\|deps\|perf\|tests\|contributor-trust>]` | Review the current git diff — auditor selected by `--mode` (general, security, a11y, deps, perf, tests, contributor-trust) or auto-inferred from the diff when omitted. PR number arg unchanged. |
 | `/swe-workbench:security-review` | Depth-first security audit of the current diff — OWASP Top 10, secrets, insecure APIs, dependency CVEs. Pass a PR number to audit a specific PR. |
 | `/swe-workbench:design <question>` | Consult the senior-engineer subagent for an architectural decision. |
 | `/swe-workbench:architect <decision>` | Author an ADR, RFC, or cross-service contract via the architect subagent. Use when the output must be a written decision record — service decomposition, multi-system tech selection, cross-team contract — not advice about existing code. |
@@ -29,6 +29,7 @@
 | `accessibility-auditor` | Depth-first WCAG 2.2 AA review of frontend diffs — ARIA misuse, keyboard traps, focus mismanagement, color contrast. Invoked by `/swe-workbench:review --mode a11y`. |
 | `architect` | Authoring ADRs, RFCs, and cross-service contracts for decisions that predate any codebase — service decomposition, multi-system tech selection, cross-team contract. Prefer over `senior-engineer` when the output must be a durable written artifact, not advice about existing code. Invoked by `/swe-workbench:architect`. |
 | `auditor` | Cold-start, time-boxed, multi-domain audit sweep — security, performance, reliability, tooling, testing. Invoked by `/swe-workbench:audit-codebase`. |
+| `contributor-auditor` | Triaging external PRs for author signal, diff-shape coherence, repo posture, and pattern-risk signals before merge. Advisory only — never posts to the PR. Invoked by `/swe-workbench:review --mode contributor-trust`. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `dependency-auditor` | Supply-chain hygiene audit — outdated versions, license conflicts, transitive bloat, lockfile drift. Invoked by `/swe-workbench:review --mode deps`. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |

--- a/tests/test_review_routing.py
+++ b/tests/test_review_routing.py
@@ -21,18 +21,20 @@ class TestReviewModeRouting:
 
     def test_all_modes_present(self):
         text = REVIEW_PATH.read_text(encoding="utf-8")
-        for mode in ("general", "security", "accessibility", "dependency", "performance", "tests"):
+        for mode in ("general", "security", "accessibility", "dependency", "performance", "tests",
+                     "contributor-trust"):
             assert mode in text, f"--mode {mode} must be documented"
 
     def test_short_aliases_present(self):
         text = REVIEW_PATH.read_text(encoding="utf-8")
-        for alias in ("a11y", "deps", "perf", "sec"):
+        for alias in ("a11y", "deps", "perf", "sec", "trust"):
             assert alias in text, f"alias '{alias}' must be documented"
 
     def test_all_auditors_referenced(self):
         text = REVIEW_PATH.read_text(encoding="utf-8")
         for agent in ("reviewer", "security-auditor", "accessibility-auditor",
-                      "dependency-auditor", "performance-tuner", "test-reviewer"):
+                      "dependency-auditor", "performance-tuner", "test-reviewer",
+                      "contributor-auditor"):
             assert agent in text, f"auditor '{agent}' must be referenced"
 
     def test_auto_inference_output_format(self):
@@ -126,6 +128,87 @@ class TestCommandOutputStanzas:
     def test_short_command_has_output_stanza(self, cmd):
         text = (COMMANDS_DIR / cmd).read_text(encoding="utf-8")
         assert "## Output" in text, f"{cmd} must have an ## Output stanza"
+
+
+class TestContributorTrustMode:
+    """Assert /review.md and agents/contributor-auditor.md satisfy issue #243 requirements."""
+
+    CONTRIBUTOR_AUDITOR_PATH = AGENTS_DIR / "contributor-auditor.md"
+
+    def test_contributor_trust_in_routing_table(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "contributor-trust" in text, \
+            "commands/review.md routing table must include contributor-trust mode"
+
+    def test_trust_alias_in_routing_table(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "`trust`" in text, \
+            "commands/review.md must document 'trust' as a backtick-formatted alias in the routing table"
+
+    def test_contributor_auditor_agent_referenced(self):
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        assert "contributor-auditor" in text, \
+            "commands/review.md must reference the contributor-auditor agent"
+
+    def test_contributor_trust_not_in_auto_inference(self):
+        """contributor-trust is explicit-only — same posture as tests mode.
+
+        The auto-inference numbered rules (1-5) must not include contributor-trust.
+        It may appear in the explanatory note that follows the rules.
+        """
+        text = REVIEW_PATH.read_text(encoding="utf-8")
+        rules_start = text.find("Apply these inference rules")
+        rules_end = text.find("> **Note:**")
+        assert rules_start != -1, "inference rules block not found"
+        assert rules_end != -1, "> **Note:** block not found"
+        inference_rules = text[rules_start:rules_end]
+        assert "contributor-trust" not in inference_rules, \
+            "contributor-trust must not appear in the numbered auto-inference rules (explicit-only mode)"
+
+    def test_contributor_auditor_agent_file_exists(self):
+        assert self.CONTRIBUTOR_AUDITOR_PATH.exists(), \
+            "agents/contributor-auditor.md must exist"
+
+    @pytest.mark.parametrize("field,value", [
+        ("name", "contributor-auditor"),
+        ("model", "sonnet"),
+    ])
+    def test_contributor_auditor_frontmatter(self, field, value):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "agents/contributor-auditor.md must have frontmatter"
+        assert f"{field}: {value}" in match.group(1), \
+            f"frontmatter must contain '{field}: {value}'"
+
+    def test_contributor_auditor_reachable_via(self):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        assert "**Reachable via:**" in text, \
+            "contributor-auditor.md must declare **Reachable via:**"
+        assert "contributor-trust" in text, \
+            "contributor-auditor.md Reachable via must reference --mode contributor-trust"
+
+    def test_contributor_auditor_four_lenses(self):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        for lens in ("Author signal", "Diff signal", "Repo posture", "Pattern risk"):
+            assert lens in text, \
+                f"contributor-auditor.md must document the '{lens}' lens"
+
+    def test_contributor_auditor_merge_confidence_footer(self):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        assert "Merge confidence" in text, \
+            "contributor-auditor.md must describe the Merge confidence footer"
+
+    def test_contributor_auditor_read_only_enforcement(self):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        assert "Read-only" in text or "read-only" in text, \
+            "contributor-auditor.md must have a read-only enforcement section"
+
+    def test_contributor_auditor_advisory_only(self):
+        text = self.CONTRIBUTOR_AUDITOR_PATH.read_text(encoding="utf-8")
+        lower = text.lower()
+        assert "no comment" in lower or "advisory" in lower or "never post" in lower or \
+               "does not post" in lower or "never comments" in lower, \
+            "contributor-auditor.md must state it never posts to the PR"
 
 
 class TestAgentReachableVia:


### PR DESCRIPTION
## Summary

- Adds `contributor-auditor` subagent reachable via `/swe-workbench:review <PR> --mode contributor-trust` (closes #243)
- Formalises the four-lens manual triage the owner was doing from memory: Author signal, Diff signal, Repo posture, Pattern risk
- Read-only enforcement — advisory output only; never posts to the PR, never applies labels, never auto-merges
- `trust` is the short alias; explicit-only mode (same posture as `--mode tests` — no auto-inference)
- Pattern-risk uses live `gh api /repos/.../issues?creator=<login>` query; no persistent state to maintain

## Test plan

### Type-tailored checks ([feat])
- [ ] `python scripts/validate.py` — all checks pass
- [ ] `pytest tests/test_review_routing.py -v -k contributor` — all 12 contributor-trust tests pass, 0 failed
- [ ] `pytest tests/ -q` — 568 tests pass, 0 failed
- [ ] Live: `/swe-workbench:review 199 --mode=contributor-trust` — produces 4-lens structured report with Merge confidence footer and first-PR flag on `cromanenslow`'s #199
- [ ] Negative: `/swe-workbench:review <recent maintainer PR> --mode=contributor-trust` — Merge confidence: High, minimal findings

Closes #243
