### PR TITLE
[chore] Auto-regenerate pip lockfiles on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress runs when Dependabot pushes a new commit — only the
+# latest lockfile state matters, so stale runs are safe to discard.
+concurrency:
+  group: dependabot-lockfile-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   regen-lockfiles:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,50 @@
+name: Dependabot Lockfile Regen
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+    paths:
+      - tests/requirements.txt
+      - tests/release-requirements.txt
+
+# Default to least-privilege; the one job that writes elevates explicitly.
+permissions:
+  contents: read
+
+jobs:
+  regen-lockfiles:
+    runs-on: ubuntu-latest
+    # Only run for Dependabot PRs. Checking the PR author (user.login) rather than
+    # github.actor ensures the guard holds even when a human pushes a follow-up commit
+    # to a Dependabot branch (as happened manually in #277/#278).
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Checkout the branch tip (not a detached SHA) so git push is a fast-forward.
+          # github.head_ref is safe here: action inputs are not shell-evaluated by the runner.
+          # persist-credentials lets the subsequent git push succeed via GITHUB_TOKEN.
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Regenerate pip lockfiles
+        run: bash scripts/lock-pip-requirements.sh
+
+      - name: Commit and push updated lockfiles if changed
+        run: |
+          if git diff --quiet HEAD -- tests/requirements.lock tests/release-requirements.lock; then
+            echo "Lockfiles are already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/requirements.lock tests/release-requirements.lock
+          git commit -m "[chore] Regenerate lockfiles after dependency bump"
+          git push


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-lockfile.yml` — a new CI workflow that automatically regenerates `tests/requirements.lock` and `tests/release-requirements.lock` when Dependabot bumps `tests/requirements.txt` or `tests/release-requirements.txt`
- Without this, Dependabot only updates the `.txt` input file; the hashed `.lock` outputs (managed by `scripts/lock-pip-requirements.sh` via `pip-compile --generate-hashes`) go stale, causing `lockfile-check` to fail on every Dependabot pip PR (root cause of #277 and #278)
- The workflow is scoped to `dependabot[bot]`-authored PRs via `github.event.pull_request.user.login` (not `github.actor`, which changes when a human pushes to the branch)

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] CI passes on this PR (`validate-pr`, `shellcheck`, `validate-plugin-files`, `lockfile-check`, `pytest`, `Markdown link check`)

### Type-tailored checks (ci)
- [ ] Workflow YAML parses cleanly (confirmed by `validate-plugin-files` / shellcheck)
- [ ] The `if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}` guard uses expression syntax (bare string would always be truthy)
- [ ] `git diff --quiet HEAD -- tests/requirements.lock tests/release-requirements.lock` correctly short-circuits on a no-op run
- [ ] `contents: write` is scoped to the single job; workflow default is `contents: read`
- [ ] No `pull_request_target` trigger (would give untrusted code write access)

Issue: N/A — follow-up to #277 and #278; makes future Dependabot pip bumps self-healing
