### PR TITLE
[fix] Suppress stderr in sync-and-verify.sh pull block

### DIFF
--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -117,7 +117,7 @@ cd "$eval_cwd" && eval "$(bash script.sh arg 2>&1)"
 # Correct — capture first, then move, then eval:
 output="$(bash script.sh arg 2>&1)"; cd "$eval_cwd"; eval "$output"
 ```
-  Under `set -e`, check `$?` after the capture step before eval-ing — a non-zero exit from the subshell leaves `$output` empty or partial and `eval "$output"` silently no-ops.
+  Under `set -e`, use `output=$(…) || handle_error` — `$?` is unreachable because the parent script aborts at the failed assignment before the next line executes. The `||` forms a conditional context that suppresses `set -e` and runs the handler on non-zero exit.
 
 ## Avoid
 - Backtick substitution `` `cmd` `` — use `$(cmd)`.

--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -109,6 +109,14 @@ fi
 assert_eq() { [[ "$1" == "$2" ]] || { echo "FAIL: expected '$2', got '$1'" >&2; exit 1; }; }
 ```
 - Mock external commands by prepending a temp dir containing stub scripts to `PATH`.
+- **eval/cwd trap**: when testing `eval "$(script 2>&1)"` patterns, capture the script output FIRST from a valid cwd, THEN `cd` to the eval directory, THEN eval. `$(...)` launches a subshell that inherits the cwd at expansion time — `cd eval_cwd && eval "$(script)"` means the script runs FROM `eval_cwd`, not the original directory, and may exit early.
+```bash
+# Wrong — script inherits eval_cwd as cwd, may exit early if it's not a git repo:
+cd "$eval_cwd" && eval "$(bash script.sh arg 2>&1)"
+
+# Correct — capture first, then move, then eval:
+output="$(bash script.sh arg 2>&1)"; cd "$eval_cwd"; eval "$output"
+```
 
 ## Avoid
 - Backtick substitution `` `cmd` `` — use `$(cmd)`.

--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -117,6 +117,7 @@ cd "$eval_cwd" && eval "$(bash script.sh arg 2>&1)"
 # Correct — capture first, then move, then eval:
 output="$(bash script.sh arg 2>&1)"; cd "$eval_cwd"; eval "$output"
 ```
+  Under `set -e`, check `$?` after the capture step before eval-ing — a non-zero exit from the subshell leaves `$output` empty or partial and `eval "$output"` silently no-ops.
 
 ## Avoid
 - Backtick substitution `` `cmd` `` — use `$(cmd)`.

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -15,7 +15,7 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 cd "$MAIN_REPO"
 
 # Block B: sync local default branch (best-effort — failure warns, does not abort)
-(git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH") >/dev/null \
+(git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH") >/dev/null 2>&1 \
   || echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually" >&2
 
 # Block C: verification gate — check whether hook already cleaned up

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -16,7 +16,7 @@ cd "$MAIN_REPO"
 
 # Block B: sync local default branch (best-effort — failure warns, does not abort)
 (git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH") >/dev/null 2>&1 \
-  || echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually" >&2
+  || echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually (run git pull to see the underlying error)" >&2
 
 # Block C: verification gate — check whether hook already cleaned up
 # Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -183,7 +183,9 @@ class TestSyncAndVerifyEvalSafety:
         no_hooks.mkdir(exist_ok=True)  # don't rely on git_repo fixture side-effect
 
         subprocess.run(
-            ["git", "clone", str(tmp_path / "origin.git"), str(clone)],
+            # --branch main: force HEAD checkout regardless of bare repo's default branch
+            # (CI runners may have a bare repo whose HEAD defaults to 'master').
+            ["git", "clone", "--branch", "main", str(tmp_path / "origin.git"), str(clone)],
             check=True,
             capture_output=True,
             env=_CLEAN_ENV,

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -218,7 +218,10 @@ class TestSyncAndVerifyEvalSafety:
             env=_CLEAN_ENV,
         )
         subprocess.run(
-            ["git", "push", "origin", "main"],
+            # HEAD:main — robust to CI runners where the bare repo's HEAD
+            # defaults to `master`, leaving the clone without a local `main`
+            # branch; this pushes whatever is checked out to origin/main.
+            ["git", "push", "origin", "HEAD:main"],
             cwd=str(clone),
             check=True,
             capture_output=True,
@@ -240,13 +243,18 @@ class TestSyncAndVerifyEvalSafety:
         # are already in sync, the test would be vacuous.
         # Note: we use ls-remote (not rev-list HEAD..origin/main) because we
         # haven't fetched yet — origin/main tracking ref is stale locally.
-        origin_sha = subprocess.run(
+        ls_remote_out = subprocess.run(
             ["git", "ls-remote", "origin", "refs/heads/main"],
             cwd=str(git_repo),
             capture_output=True,
             text=True,
             env=_CLEAN_ENV,
-        ).stdout.split()[0]
+        ).stdout.split()
+        assert ls_remote_out, (
+            "ls-remote returned no output for refs/heads/main — "
+            "origin has no main branch; fixture setup failed."
+        )
+        origin_sha = ls_remote_out[0]
         local_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=str(git_repo),
@@ -258,6 +266,13 @@ class TestSyncAndVerifyEvalSafety:
             f"Pre-condition: origin/main ({origin_sha}) must be ahead of "
             f"local HEAD ({local_sha}). git pull won't fetch — the "
             f"'-> FETCH_HEAD' tracking line won't appear and the test is vacuous."
+        )
+
+        # Guard: eval_cwd and SCRIPT paths must not contain double-quotes,
+        # which would break the inline bash string we build below.
+        assert '"' not in str(eval_cwd) and '"' not in str(SCRIPT), (
+            f"Path contains double-quote — inline bash string will break.\n"
+            f"eval_cwd={eval_cwd}, SCRIPT={SCRIPT}"
         )
 
         # Capture BEFORE cd-ing to eval_cwd: the script needs a valid git cwd

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -16,7 +16,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from conftest import _CLEAN_ENV
 
 SCRIPT = (
@@ -207,7 +206,9 @@ class TestSyncAndVerifyEvalSafety:
             env=_CLEAN_ENV,
         )
         (clone / "new.txt").write_text("new\n")
-        subprocess.run(["git", "add", "new.txt"], cwd=str(clone), check=True, env=_CLEAN_ENV)
+        subprocess.run(
+            ["git", "add", "new.txt"], cwd=str(clone), check=True, env=_CLEAN_ENV
+        )
         subprocess.run(
             ["git", "commit", "-m", "trigger fetch output"],
             cwd=str(clone),

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -167,3 +167,90 @@ class TestSyncAndVerifyNonMainDefaultBranch:
         )
         result = _run_script(git_repo_trunk, BRANCH, default_branch="trunk")
         _assert_contract(result, "1")
+
+
+class TestSyncAndVerifyEvalSafety:
+    """Regression: caller adding `2>&1` to $(...) must not let git output
+    poison eval. Specifically, git's '* branch main -> FETCH_HEAD' tracking
+    line must not parse as a `> FETCH_HEAD` redirect inside eval."""
+
+    def test_eval_with_merged_stderr_does_not_create_stray_files(
+        self, tmp_path, git_repo
+    ):
+        # Push a new commit to origin so the next `git pull --ff-only origin main`
+        # actually transfers refs and prints the `From ... -> FETCH_HEAD` line.
+        clone = tmp_path / "second_clone"
+        no_hooks = tmp_path / ".nohooks"  # created by _build_repo via git_repo fixture
+
+        subprocess.run(
+            ["git", "clone", str(tmp_path / "origin.git"), str(clone)],
+            check=True,
+            capture_output=True,
+            env=_CLEAN_ENV,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "ci@example.com"],
+            cwd=str(clone),
+            check=True,
+            env=_CLEAN_ENV,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "CI"],
+            cwd=str(clone),
+            check=True,
+            env=_CLEAN_ENV,
+        )
+        subprocess.run(
+            ["git", "config", "core.hooksPath", str(no_hooks)],
+            cwd=str(clone),
+            check=True,
+            env=_CLEAN_ENV,
+        )
+        (clone / "new.txt").write_text("new\n")
+        subprocess.run(["git", "add", "new.txt"], cwd=str(clone), check=True, env=_CLEAN_ENV)
+        subprocess.run(
+            ["git", "commit", "-m", "trigger fetch output"],
+            cwd=str(clone),
+            check=True,
+            capture_output=True,
+            env=_CLEAN_ENV,
+        )
+        subprocess.run(
+            ["git", "push", "origin", "main"],
+            cwd=str(clone),
+            check=True,
+            capture_output=True,
+            env=_CLEAN_ENV,
+        )
+
+        # Reproduce the caller-side bug: eval "$(... 2>&1)".
+        # Run inside a clean tempdir so any stray redirect lands somewhere
+        # observable (and out of the test runner's cwd).
+        eval_cwd = tmp_path / "eval_cwd"
+        eval_cwd.mkdir()
+        # Glob target: ensure `*` expands to something so the eval'd `*` token
+        # behaves the same way as in the bug repro (where cwd contained files).
+        (eval_cwd / "decoy").write_text("")
+
+        # Capture the script's output first (from git_repo, a valid git cwd),
+        # THEN cd to eval_cwd before eval-ing it. If we cd first and then run
+        # the script, the script exits early ("could not resolve main repo path")
+        # because eval_cwd is not a git repository — and the bug never triggers.
+        runner = (
+            f'output="$(bash "{SCRIPT}" "{BRANCH}" main 2>&1)"; '
+            f'cd "{eval_cwd}"; '
+            f'eval "$output" 2>/dev/null || true'
+        )
+        subprocess.run(
+            ["bash", "-c", runner],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+
+        assert not (eval_cwd / "FETCH_HEAD").exists(), (
+            f"Stray FETCH_HEAD created in {eval_cwd} — the script's "
+            f"stdout-after-2>&1 still contains a git tracking line that "
+            f"eval parsed as a redirect."
+        )

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -270,9 +270,11 @@ class TestSyncAndVerifyEvalSafety:
 
         # Guard: eval_cwd and SCRIPT paths must not contain double-quotes,
         # which would break the inline bash string we build below.
-        assert '"' not in str(eval_cwd) and '"' not in str(SCRIPT), (
-            f"Path contains double-quote — inline bash string will break.\n"
-            f"eval_cwd={eval_cwd}, SCRIPT={SCRIPT}"
+        assert (
+            '"' not in str(eval_cwd) and '"' not in str(SCRIPT) and '"' not in BRANCH
+        ), (
+            f"Path or branch contains double-quote — inline bash string will break.\n"
+            f"eval_cwd={eval_cwd}, SCRIPT={SCRIPT}, BRANCH={BRANCH}"
         )
 
         # Capture BEFORE cd-ing to eval_cwd: the script needs a valid git cwd
@@ -282,12 +284,15 @@ class TestSyncAndVerifyEvalSafety:
             f'cd "{eval_cwd}"; '
             f'eval "$output" 2>/dev/null || true'
         )
-        subprocess.run(
+        result = subprocess.run(
             ["bash", "-c", runner],
             cwd=str(git_repo),
             capture_output=True,
             text=True,
             env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, (
+            f"bash runner failed (rc={result.returncode}):\n{result.stderr}"
         )
 
         assert not (eval_cwd / "FETCH_HEAD").exists(), (

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -179,7 +179,8 @@ class TestSyncAndVerifyEvalSafety:
         # Push a new commit to origin so the next `git pull --ff-only origin main`
         # actually transfers refs and prints the `From ... -> FETCH_HEAD` line.
         clone = tmp_path / "second_clone"
-        no_hooks = tmp_path / ".nohooks"  # created by _build_repo via git_repo fixture
+        no_hooks = tmp_path / ".nohooks"
+        no_hooks.mkdir(exist_ok=True)  # don't rely on git_repo fixture side-effect
 
         subprocess.run(
             ["git", "clone", str(tmp_path / "origin.git"), str(clone)],
@@ -233,10 +234,34 @@ class TestSyncAndVerifyEvalSafety:
         # behaves the same way as in the bug repro (where cwd contained files).
         (eval_cwd / "decoy").write_text("")
 
-        # Capture the script's output first (from git_repo, a valid git cwd),
-        # THEN cd to eval_cwd before eval-ing it. If we cd first and then run
-        # the script, the script exits early ("could not resolve main repo path")
-        # because eval_cwd is not a git repository — and the bug never triggers.
+        # Pre-condition: origin must be ahead of local so git pull actually
+        # fetches new refs. The `* branch main -> FETCH_HEAD` tracking line
+        # only appears when git pull fetches something new. If origin and local
+        # are already in sync, the test would be vacuous.
+        # Note: we use ls-remote (not rev-list HEAD..origin/main) because we
+        # haven't fetched yet — origin/main tracking ref is stale locally.
+        origin_sha = subprocess.run(
+            ["git", "ls-remote", "origin", "refs/heads/main"],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        ).stdout.split()[0]
+        local_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        ).stdout.strip()
+        assert origin_sha != local_sha, (
+            f"Pre-condition: origin/main ({origin_sha}) must be ahead of "
+            f"local HEAD ({local_sha}). git pull won't fetch — the "
+            f"'-> FETCH_HEAD' tracking line won't appear and the test is vacuous."
+        )
+
+        # Capture BEFORE cd-ing to eval_cwd: the script needs a valid git cwd
+        # to resolve MAIN_REPO. If we cd first, the script exits early.
         runner = (
             f'output="$(bash "{SCRIPT}" "{BRANCH}" main 2>&1)"; '
             f'cd "{eval_cwd}"; '
@@ -252,6 +277,6 @@ class TestSyncAndVerifyEvalSafety:
 
         assert not (eval_cwd / "FETCH_HEAD").exists(), (
             f"Stray FETCH_HEAD created in {eval_cwd} — the script's "
-            f"stdout-after-2>&1 still contains a git tracking line that "
-            f"eval parsed as a redirect."
+            f"combined stdout+stderr still contains a git tracking line that "
+            f"eval parsed as a `> FETCH_HEAD` redirect."
         )


### PR DESCRIPTION
## Summary

- `scripts/sync-and-verify.sh` Block B (the `git checkout && git pull --ff-only` step) redirected only stdout to `/dev/null`, leaving git's fetch progress messages on stderr. A caller using `eval "$(... 2>&1)"` merged that stderr into the captured stdout; bash then eval'd `* branch main -> FETCH_HEAD` as a shell redirect, creating an empty `FETCH_HEAD` file in the working tree.
- Fix: add `2>&1` after `>/dev/null` on the pull line so all git progress output is discarded on the happy path. The `|| echo "sync-main: best-effort failed …" >&2` fallback is preserved.
- Regression test (`TestSyncAndVerifyEvalSafety`): pushes a real commit to a fixture origin, runs the script with merged stderr, eval's the output from a clean temp directory, and asserts no stray `FETCH_HEAD` file is created.

## Test Plan

- [x] New regression test fails against unfixed script (red commit `b2cb6bd`)
- [x] New regression test passes after one-line fix (green commit `1bd36e5`)
- [x] `shellcheck scripts/sync-and-verify.sh` — clean
- [x] Full test suite: 627 tests pass (`pytest tests/`)
- [x] `ruff check` / `ruff format` — no issues on modified files
- [ ] Manual smoke: `eval "$(bash skills/workflow-cleanup-merged/scripts/sync-and-verify.sh main main 2>&1)"` from a temp dir with a decoy file — verify no `FETCH_HEAD` created

Issue: N/A — stray empty FETCH_HEAD file found on main after /cleanup-merged for PR #282; root cause is unsafe eval of git output containing git's fetch tracking line
