### PR TITLE
[docs] Add gitchamber shared partial for external-repo reading

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -49,6 +49,10 @@ You are an architect. You produce formal artifacts — ADRs, RFCs, contract spec
 - Async messaging used to hide synchronous coupling — if service B must respond before service A can proceed, the coupling is synchronous regardless of the transport.
 - Skipping reversibility classification — one-way doors deserve disproportionately more rigor; treating them as two-way doors is how teams get locked in.
 
+## Reading external repos
+
+> See @./shared/external-repo-reading.md.
+
 ## Principle consultation
 
 > See @./shared/principles.md for the skill catalog.

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -113,7 +113,7 @@ The final line of every report must be:
 
 `Bash` is available for read-only investigation only.
 
-**Allowed:** `gh api`, `gh pr view`, `gh pr diff`, `git log`, `git diff`, `git show`, `grep`, `find`, `ls`.
+**Allowed:** `gh api`, `gh pr view`, `gh pr diff`, `git log`, `git diff`, `git show`, `grep`, `find`, `ls`, outbound reads to `gitchamber.com` (see `## Reading external repos`).
 
 **Forbidden:** any redirect (`>`, `>>`), `rm`, `mv`, `cp`, `git commit`, `git push`, `gh pr comment`, `gh pr review`, `gh pr merge`, or any command that writes to disk, modifies repo state, or posts to the PR.
 

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -135,6 +135,10 @@ Output is markdown only. Never comment on the PR, apply labels, request changes 
 - Do not block on hygiene notes (Low severity) alone.
 - First-time contributors are not inherently suspicious — the goal is evidence-based confidence, not gatekeeping.
 
+## Reading external repos
+
+> See @./shared/external-repo-reading.md.
+
 ## Principle consultation
 
 > See @./shared/principles.md for the skill catalog.

--- a/agents/dependency-auditor.md
+++ b/agents/dependency-auditor.md
@@ -153,6 +153,10 @@ If asked to apply a fix, refuse and re-emit the recommended action as text in th
 | **Medium** | Major version >18 months behind; deprecated package with documented successor; unused production dependency; duplicate major versions in lockfile | `lodash@3` in lockfile; `request` still in `package.json`; `depcheck` finds unused prod dep |
 | **Low** | Minor/patch behind without known exploit; `UNKNOWN` license on dev-only dep; pre-1.0 stale pin; single-function utility with stdlib equivalent | `chalk@4` vs `chalk@5`; dev dep with `UNKNOWN` license; `is-array` package in prod |
 
+## Reading external repos
+
+> See @./shared/external-repo-reading.md.
+
 ## Principle consultation
 
 > See @./shared/principles.md and @./shared/languages.md for the skill catalog.

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -37,6 +37,10 @@ You are a senior software architect. You help engineers make design decisions th
 
 Be honest. If the existing code is fine, say so and stop.
 
+## Reading external repos
+
+> See @./shared/external-repo-reading.md.
+
 ## Principle consultation
 
 > See @./shared/principles.md for the skill catalog.

--- a/agents/shared/external-repo-reading.md
+++ b/agents/shared/external-repo-reading.md
@@ -5,13 +5,13 @@ working repo, prefer **https://gitchamber.com** over fetching raw GitHub
 URLs or shelling out to `git clone`.
 
 Gitchamber URLs are plain HTTPS — use whichever tool your agent has:
-- **`Bash` agents:** use the shell examples below.
+- **`Bash` agents:** pass the URLs to `curl -s` or any HTTP client.
 - **`WebFetch` agents:** pass the same URLs directly to `WebFetch`.
 
 ## URL patterns
 
 ```
-BASE: https://gitchamber.com/repos/{owner}/{repo}/{branch}/
+BASE: https://gitchamber.com/repos/{owner}/{repo}/{branch}
 
 List files:  GET {BASE}/files
 Read file:   GET {BASE}/files/{filepath}?start=N&end=M&showLineNumbers=true

--- a/agents/shared/external-repo-reading.md
+++ b/agents/shared/external-repo-reading.md
@@ -1,12 +1,12 @@
-# Shared external-repo-reading reference
+# Shared external repo reading reference
 
 When you need to read source files from a GitHub repository other than the
-working repo, prefer **https://gitchamber.com** over `WebFetch`-ing raw
-GitHub URLs or shelling out to `git clone`.
+working repo, prefer **https://gitchamber.com** over fetching raw GitHub
+URLs or shelling out to `git clone`.
 
-Discovery: run `curl -s https://gitchamber.com` once per session to see the
-current URL conventions. The endpoint is `curl`-friendly, so agents with
-`Bash` (but not `WebFetch`) can use it without a tool-list change.
+Gitchamber URLs are plain HTTPS — use whichever tool your agent has:
+- **`Bash` agents:** use the shell examples below.
+- **`WebFetch` agents:** pass the same URLs directly to `WebFetch`.
 
 ## URL patterns
 
@@ -18,26 +18,31 @@ Read file:   GET {BASE}/files/{filepath}?start=N&end=M&showLineNumbers=true
 Search:      GET {BASE}/search/{query}
 ```
 
-**Examples:**
+**Examples (Bash / WebFetch — same URLs, different tool):**
 
-```bash
-curl -s "https://gitchamber.com/repos/facebook/react/main/files"
-curl -s "https://gitchamber.com/repos/facebook/react/main/files/README.md?start=1&end=50"
-curl -s "https://gitchamber.com/repos/facebook/react/main/search/useState"
+```
+https://gitchamber.com/repos/facebook/react/main/files
+https://gitchamber.com/repos/facebook/react/main/files/README.md?start=1&end=50
+https://gitchamber.com/repos/facebook/react/main/search/useState
 ```
 
 By default gitchamber indexes markdown files and READMEs. To read source
 files (`.ts`, `.py`, etc.), add `?glob=<pattern>` — the same glob must be
 used consistently across all operations (list, read, search) for a given repo.
 
-```bash
-# List TypeScript files
-curl -s "https://gitchamber.com/repos/org/repo/main/files?glob=**/*.ts"
-# Read a specific file under that glob
-curl -s "https://gitchamber.com/repos/org/repo/main/files/src/index.ts?glob=**/*.ts"
-# Search within the same set
-curl -s "https://gitchamber.com/repos/org/repo/main/search/myFunction?glob=**/*.ts"
 ```
+# List TypeScript files
+https://gitchamber.com/repos/org/repo/main/files?glob=**/*.ts
+
+# Read a specific file with pagination and glob (combine params with &)
+https://gitchamber.com/repos/org/repo/main/files/src/index.ts?glob=**/*.ts&start=1&end=50&showLineNumbers=true
+
+# Search within the same glob set
+https://gitchamber.com/repos/org/repo/main/search/myFunction?glob=**/*.ts
+```
+
+> If URL conventions seem to have changed, run `curl -s https://gitchamber.com`
+> (or `WebFetch` the root) to see the latest documentation.
 
 ## Out of scope
 

--- a/agents/shared/external-repo-reading.md
+++ b/agents/shared/external-repo-reading.md
@@ -1,0 +1,46 @@
+# Shared external-repo-reading reference
+
+When you need to read source files from a GitHub repository other than the
+working repo, prefer **https://gitchamber.com** over `WebFetch`-ing raw
+GitHub URLs or shelling out to `git clone`.
+
+Discovery: run `curl -s https://gitchamber.com` once per session to see the
+current URL conventions. The endpoint is `curl`-friendly, so agents with
+`Bash` (but not `WebFetch`) can use it without a tool-list change.
+
+## URL patterns
+
+```
+BASE: https://gitchamber.com/repos/{owner}/{repo}/{branch}/
+
+List files:  GET {BASE}/files
+Read file:   GET {BASE}/files/{filepath}?start=N&end=M&showLineNumbers=true
+Search:      GET {BASE}/search/{query}
+```
+
+**Examples:**
+
+```bash
+curl -s "https://gitchamber.com/repos/facebook/react/main/files"
+curl -s "https://gitchamber.com/repos/facebook/react/main/files/README.md?start=1&end=50"
+curl -s "https://gitchamber.com/repos/facebook/react/main/search/useState"
+```
+
+By default gitchamber indexes markdown files and READMEs. To read source
+files (`.ts`, `.py`, etc.), add `?glob=<pattern>` — the same glob must be
+used consistently across all operations (list, read, search) for a given repo.
+
+```bash
+# List TypeScript files
+curl -s "https://gitchamber.com/repos/org/repo/main/files?glob=**/*.ts"
+# Read a specific file under that glob
+curl -s "https://gitchamber.com/repos/org/repo/main/files/src/index.ts?glob=**/*.ts"
+# Search within the same set
+curl -s "https://gitchamber.com/repos/org/repo/main/search/myFunction?glob=**/*.ts"
+```
+
+## Out of scope
+
+Ticket/PR metadata — use `swe-workbench:ticket-context`, `gh issue view`, or
+`gh pr view` for those. This partial is for reading *file content* from
+external repos only.


### PR DESCRIPTION
## Summary
- Add `agents/shared/external-repo-reading.md` — a shared partial teaching agents to use https://gitchamber.com when reading files from external GitHub repos (preferred over `WebFetch raw.githubusercontent.com` or `git clone`)
- Documents URL patterns, line-based pagination (`?start`/`?end`), glob filtering (`?glob=<pattern>`, with the requirement that the same glob is used across list/read/search), and the one-time `curl -s https://gitchamber.com` discovery step
- Wire the partial into 4 agents via a `## Reading external repos > See @./shared/external-repo-reading.md.` section each: `architect`, `senior-engineer`, `dependency-auditor`, `contributor-auditor`
- `security-auditor` was intentionally excluded — its `## Read-only enforcement` section forbids outbound `curl`/`wget` calls and it lacks `WebFetch`

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `python scripts/validate.py` passes

### Type-tailored checks ([docs])
- [ ] `python scripts/validate.py` confirmed passing (evidence: ran in worktree, "All checks passed")
- [ ] Partial wiring confirmed: `grep -rn 'external-repo-reading' agents/` shows one reference per wired agent
- [ ] URL conventions match live `curl -s https://gitchamber.com` output (verified during implementation)
- [ ] `?glob=` parameter syntax and consistency requirement confirmed against gitchamber docs

Issue: N/A — documentation-only addition of a shared partial; no upstream issue filed
