### PR TITLE
[docs] Add principle-release-engineering skill

### DIFF
--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -122,6 +122,7 @@ Invoke these skills via the Skill tool when the migration surfaces a concern in 
 - `swe-workbench:principle-data-modeling` — schema evolution, indexing the new column, hot-key avoidance, retention policy during dual-write window
 - `swe-workbench:principle-resiliency` — phased migration as blast-radius reduction; kill-switch flag at Switch phase as graceful-degradation mechanism
 - `swe-workbench:principle-version-control` — atomic per-phase commits ("Phase 2/5: backfill user_email_v2"); conflict resolution on long-running dual-write branches diverging from main
+- `swe-workbench:principle-release-engineering` — semver bump for migrations that cross a compatibility boundary; expand-contract as the per-phase release discipline; rollback path documented before each phase ships
 - `swe-workbench:principle-event-driven` — compatible serializers, parallel consumer groups, DLQ strategy at Switch, idempotent event handlers during Dual-write
 - `swe-workbench:principle-observability` — every advance gate must cite a metric; no metric = blind gate = blocked; structured logs per phase transition
 - `swe-workbench:principle-performance` — backfill cost on a representative replica before production; bounded `ACCESS EXCLUSIVE` lock duration; chunk size tuning

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -59,3 +59,4 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-distributed-systems` — CAP/PACELC, consistency models, consensus and quorum, replication, exactly-once effects
 - `swe-workbench:principle-observability` — SLI/SLO selection, what to instrument at boundaries, alerting on symptoms vs causes
 - `swe-workbench:principle-cost-awareness` — cost-per-request mental model, scale-to-zero vs cold-start, storage tier selection
+- `swe-workbench:principle-release-engineering` — semver-bump risk, expand-contract sequencing for breaking changes, rollback-vs-rollforward trade-offs, tag-identity invariants

--- a/agents/shared/principles.md
+++ b/agents/shared/principles.md
@@ -19,6 +19,7 @@ All `swe-workbench` principle skills available in this plugin. Use the `Skill` t
 - `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
 - `swe-workbench:principle-performance` — Performance: latency vs throughput, profile-before-optimize, Big-O, allocation pressure, data locality, N+1 queries.
 - `swe-workbench:principle-refactoring` — Refactoring discipline: Fowler's catalog, smell→move mapping, rule of three, characterization-tests-first, small behavior-preserving steps with green between.
+- `swe-workbench:principle-release-engineering` — Release engineering: semver discipline, expand-contract for breaking changes, idempotent release automation, post-release verification, rollback planning, release-notes audience.
 - `swe-workbench:principle-resiliency` — Resiliency: failure domains, bulkheads, graceful degradation, fail-fast vs fail-soft, health checks, blast radius containment.
 - `swe-workbench:principle-security` — Security: trust boundaries, input validation, secrets handling, secure defaults, threat modeling.
 - `swe-workbench:principle-solid` — SOLID principles: SRP, OCP, LSP, ISP, DIP — responsibility, coupling, abstractions.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -65,6 +65,7 @@
 | `principle-concurrency` | "race condition", "deadlock", "livelock", "structured concurrency", "cancellation", "backpressure", "mutex vs channel", "actor model", "atomics", "memory model". |
 | `principle-cost-awareness` | "cloud cost", "FinOps", "egress", "right-sizing", "scale-to-zero", "cost-per-request", "storage tier", "log volume", "cardinality cost". |
 | `principle-data-modeling` | "schema design", "data model", "normalization", "denormalization", "indexing", "hot key", "hot partition", "schema evolution", "expand contract", "query-first", "storage paradigm", "relational vs document", "TTL", "archival". |
+| `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "canary", "kill-switch", "expand-contract", "feature flag", "release notes". |
 | `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
 ### Languages — auto-load by file type

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -65,7 +65,7 @@
 | `principle-concurrency` | "race condition", "deadlock", "livelock", "structured concurrency", "cancellation", "backpressure", "mutex vs channel", "actor model", "atomics", "memory model". |
 | `principle-cost-awareness` | "cloud cost", "FinOps", "egress", "right-sizing", "scale-to-zero", "cost-per-request", "storage tier", "log volume", "cardinality cost". |
 | `principle-data-modeling` | "schema design", "data model", "normalization", "denormalization", "indexing", "hot key", "hot partition", "schema evolution", "expand contract", "query-first", "storage paradigm", "relational vs document", "TTL", "archival". |
-| `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "canary", "kill-switch", "expand-contract", "feature flag", "release notes". |
+| `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "kill-switch", "expand-contract", "feature flag", "release notes". |
 | `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
 ### Languages — auto-load by file type

--- a/skills/principle-release-engineering/SKILL.md
+++ b/skills/principle-release-engineering/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: principle-release-engineering
+description: Release engineering: semver discipline, tag identity, rollout strategy, rollback planning, expand-contract for breaking changes, canary deployments, kill-switch, feature flag, release notes audience, idempotent release automation, post-release verification. Auto-load when cutting a release, planning a breaking API change, writing release notes, choosing a version bump, designing a rollback plan, or building release automation scripts.
+---
+
+# Release Engineering
+
+A release is a promise: a specific artifact, at a specific version, reachable at a specific address, forever. Every discipline here protects that promise.
+
+## Semver discipline
+
+`MAJOR.MINOR.PATCH` — each level communicates an intent to callers.
+
+| Bump | Meaning | Example |
+|------|---------|---------|
+| PATCH | Backward-compatible bug fix only | `1.2.3 → 1.2.4` |
+| MINOR | New capability, backward-compatible | `1.2.3 → 1.3.0` |
+| MAJOR | Breaking change — callers must adapt | `1.2.3 → 2.0.0` |
+
+Never skip levels to signal "importance" (`1.0.0 → 3.0.0`). Pre-1.0 (`0.x.y`) still communicates intent: MINOR adds capability, PATCH fixes bugs, and a MAJOR bump to `1.0.0` signals API stability. If you're unsure between MINOR and MAJOR, default to MAJOR — over-caution is safe, under-caution breaks callers.
+
+## Expand-contract for breaking changes
+
+Never atomically break a public contract. Ship in three independent deployments:
+
+1. **Expand** — add the new interface alongside the old one. Both work.
+2. **Migrate** — update all callers to the new interface. Old interface idle.
+3. **Contract** — remove the old interface once callers are migrated.
+
+Each phase ships and bakes before the next begins. A rollback at any phase is safe because the old path still exists. For *schema* expand-contract mechanics — column backfills, dual-write windows, index swaps — defer to `swe-workbench:principle-data-modeling` and the `swe-workbench:migrator` agent.
+
+## Idempotent automation
+
+Release scripts must detect-and-resume rather than fail-fast. Re-running after a partial failure must not double-tag, double-publish, or double-bump.
+
+- Check whether the tag already exists before creating it.
+- Check whether the version is already in the registry before publishing.
+- Check whether the changelog entry is already present before inserting.
+- Each step is independently re-entrant: fix the failure, re-run, the completed steps are skipped.
+
+A script that requires manual surgery to re-run has shifted the failure cost from automation to humans, at the worst possible moment.
+
+## Pre-release gate
+
+Every release must clear all gates before the tag is created:
+
+- [ ] Changelog / release notes written and reviewed
+- [ ] Version bumped in all manifests (`package.json`, `Cargo.toml`, `pyproject.toml`, …)
+- [ ] All tests green on the release commit
+- [ ] Working tree clean (no uncommitted changes)
+- [ ] Tag is signed or carries provenance
+- [ ] No draft state — release is explicitly published
+
+Automate what you can. Gate what you cannot. A partial release (tag exists, package not published) is worse than no release.
+
+## Post-release verification
+
+CI green ≠ release successful. Confirm the artifact is actually reachable after publishing:
+
+- Pull the published package from the registry in a clean environment.
+- Smoke-test the published artifact (not the local build).
+- Verify the tag points to the expected commit (`git show <tag>`).
+- Confirm the release page / changelog is visible to external users.
+
+If verification fails, yank or retract before users hit the broken artifact. A broken release discovered via user report is a support incident; one caught in verification is a near-miss.
+
+## Rollback planning
+
+Every release must have a documented rollback path *before* shipping — not discovered at incident time.
+
+| Scenario | Rollback mechanism |
+|----------|--------------------|
+| Bug in new version | Hotfix release (PATCH bump) or yank + re-publish previous |
+| Breaking change escaped | Revert via expand-contract Phase 1 (old interface was never removed) |
+| Infrastructure regression | Feature-flag disable or blue-green flip to previous slot |
+| Data corruption | Point-in-time restore + dual-write replay (see `migrator` agent) |
+
+"We'll figure it out" is not a rollback plan. Write the rollback steps in the release PR before merging.
+
+## Release notes audience
+
+Release notes are for users, not maintainers. Write for someone who has never seen your commit log.
+
+- **No**: "Various improvements and bug fixes." **Yes**: "Fixed a crash when the config file is missing on first launch."
+- **No**: "Merged PR #247 (sha: d4f3a1c)." **Yes**: "API responses now include a `request-id` header for correlation."
+- **No**: Internal jargon, team nicknames, sprint references.
+- **Yes**: What changed for the user, why it matters, and any action required on their side (migration steps, deprecation timeline).
+
+Group by impact: breaking changes first (with migration guidance), then new features, then bug fixes.
+
+## When release ceremony is overkill
+
+- Solo experimental repos with no downstream consumers.
+- Internal tools with a single operator who deploys from HEAD.
+- Libraries in active spike (`0.0.x`) before the first stable API.
+
+Even then: **tag identity** costs nothing and must never be skipped. One tag = one immutable commit. Re-pointing a published tag to a different commit silently changes what every consumer gets on a clean fetch — it is the highest-severity release mistake.
+
+## Red Flags
+
+| Flag | Problem |
+|------|---------|
+| Re-pointing a published tag | Silently changes the artifact for all consumers; breaks reproducibility |
+| Force-pushing a release branch | Rewrites history others have pulled; breaks bisect on the release line |
+| "fix bump version" follow-up commit after a tag | Tag and published artifact now diverge; `v1.2.3` is a lie |
+| Rollback plan discovered at incident time | Means time-to-restore measured in hours, not minutes |
+| Changelog written from `git log` without translation | User-facing notes become commit-message archaeology |
+| Partial-failure script requiring manual surgery to re-run | Automation defeats itself; re-entry cost borne by humans under pressure |
+| "CI is green, we're good" without artifact verification | Published package could be missing, corrupt, or pointing to the wrong build |

--- a/skills/principle-release-engineering/SKILL.md
+++ b/skills/principle-release-engineering/SKILL.md
@@ -101,7 +101,7 @@ Even then: **tag identity** costs nothing and must never be skipped. One tag = o
 | Flag | Problem |
 |------|---------|
 | Re-pointing a published tag | Silently changes the artifact for all consumers; breaks reproducibility |
-| Force-pushing a release branch | Rewrites history others have pulled; breaks bisect on the release line |
+| Force-pushing a release branch | Consumers who pinned the pre-push SHA now reference a phantom commit; a release tag may point to a ghost commit — for general branch force-push discipline see `swe-workbench:principle-version-control` |
 | "fix bump version" follow-up commit after a tag | Tag and published artifact now diverge; `v1.2.3` is a lie |
 | Rollback plan discovered at incident time | Means time-to-restore measured in hours, not minutes |
 | Changelog written from `git log` without translation | User-facing notes become commit-message archaeology |

--- a/skills/principle-release-engineering/SKILL.md
+++ b/skills/principle-release-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-release-engineering
-description: Release engineering: semver discipline, tag identity, rollout strategy, rollback planning, expand-contract for breaking changes, canary deployments, kill-switch, feature flag, release notes audience, idempotent release automation, post-release verification. Auto-load when cutting a release, planning a breaking API change, writing release notes, choosing a version bump, designing a rollback plan, or building release automation scripts.
+description: Release engineering: semver discipline, tag identity, rollout strategy, rollback planning, expand-contract for breaking changes, kill-switch, feature flag, release notes audience, idempotent release automation, post-release verification. Auto-load when cutting a release, planning a breaking API change, writing release notes, choosing a version bump, designing a rollback plan, using a feature flag as a kill-switch, or building release automation scripts.
 ---
 
 # Release Engineering
@@ -74,6 +74,8 @@ Every release must have a documented rollback path *before* shipping — not dis
 | Breaking change escaped | Revert via expand-contract Phase 1 (old interface was never removed) |
 | Infrastructure regression | Feature-flag disable or blue-green flip to previous slot |
 | Data corruption | Point-in-time restore + dual-write replay (see `migrator` agent) |
+
+A **kill-switch** is a feature flag that disables a feature in production without a redeploy. Gate high-risk features behind a flag before release so the rollback is a config change, not a hotfix deploy. Plan the flag's removal cadence upfront — a kill-switch left in permanently becomes an untested code path and an operational liability.
 
 "We'll figure it out" is not a rollback plan. Write the rollback steps in the release PR before merging.
 

--- a/skills/principle-release-engineering/triggers.txt
+++ b/skills/principle-release-engineering/triggers.txt
@@ -3,3 +3,4 @@ what's the safest way to ship a breaking API change without breaking callers in 
 should this be a major bump or a minor bump and what does semver actually mean for a pre-1.0 library
 we need a rollback plan before we tag this release — what should it actually contain
 how do I verify the release actually landed in the registry and not just that CI was green
+how do I use a feature flag as a kill-switch to roll back a release without redeploying

--- a/skills/principle-release-engineering/triggers.txt
+++ b/skills/principle-release-engineering/triggers.txt
@@ -1,0 +1,5 @@
+how do I cut a release that I can safely re-run if it fails halfway through
+what's the safest way to ship a breaking API change without breaking callers in flight
+should this be a major bump or a minor bump and what does semver actually mean for a pre-1.0 library
+we need a rollback plan before we tag this release — what should it actually contain
+how do I verify the release actually landed in the registry and not just that CI was green

--- a/tests/skill_sibling_sets.txt
+++ b/tests/skill_sibling_sets.txt
@@ -20,3 +20,12 @@ principle-clean-architecture, principle-ddd, principle-event-driven
 # belongs to either skill — the distinction (first-pass vs re-check) is determined
 # by context the BM25 ranker cannot resolve.
 workflow-pr-review, workflow-pr-review-followup
+
+# principle-data-modeling and principle-release-engineering both cover the
+# expand-contract pattern, but from different angles: principle-data-modeling owns
+# schema mechanics (column backfills, dual-write windows, index swaps), while
+# principle-release-engineering owns API/code-contract discipline (ship new interface
+# alongside old, migrate callers, remove old). A prompt like "how do I evolve a
+# database schema without breaking existing clients using an expand-contract migration"
+# legitimately belongs to either skill.
+principle-data-modeling, principle-release-engineering

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -459,6 +459,63 @@ class TestPrincipleCodeReviewSkill:
 
 
 # ──────────────────────────────────────────────
+# principle-release-engineering skill structural assertions
+# ──────────────────────────────────────────────
+
+class TestPrincipleReleaseEngineeringSkill:
+    """Integration tests: assert the real skills/principle-release-engineering/SKILL.md satisfies
+    all acceptance criteria from issue #175 without relying on a synthetic fixture."""
+
+    SKILL_PATH = Path(__file__).parent.parent / "skills" / "principle-release-engineering" / "SKILL.md"
+    TRIGGERS_PATH = Path(__file__).parent.parent / "skills" / "principle-release-engineering" / "triggers.txt"
+
+    def test_file_exists(self):
+        assert self.SKILL_PATH.exists(), "skills/principle-release-engineering/SKILL.md must exist"
+
+    def test_frontmatter_name(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "name: principle-release-engineering" in text
+
+    def test_semver_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Semver" in text
+
+    def test_expand_contract_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Expand-contract" in text or "## Expand-Contract" in text
+
+    def test_idempotent_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Idempotent" in text
+
+    def test_post_release_verification_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Post-release verification" in text or "## Post-Release Verification" in text
+
+    def test_rollback_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Rollback" in text
+
+    def test_triggers_has_two_or_more_non_empty_lines(self):
+        assert self.TRIGGERS_PATH.exists(), "triggers.txt must exist"
+        lines = [
+            ln for ln in self.TRIGGERS_PATH.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        assert len(lines) >= 2, f"triggers.txt must have ≥2 non-empty lines, got {len(lines)}"
+
+    def test_skill_passes_validate(self, reset_validate, monkeypatch):
+        """The real skill must pass check_skills() and check_unwired_principle_skills()
+        against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.SKILL_PATH.parent.parent.parent)
+        val.FAILURES.clear()
+        val.check_skills()
+        val.check_unwired_principle_skills()
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
 # check_commands
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `principle-release-engineering` skill covering semver discipline, expand-contract for breaking changes, idempotent release automation, pre/post-release gates, rollback planning, and release-notes audience
- Wire skill into `agents/migrator.md` and `agents/senior-engineer.md` to satisfy `check_unwired_principle_skills` validator
- Add skill to `agents/shared/principles.md` catalog and `docs/catalog.md` table
- Add `TestPrincipleReleaseEngineeringSkill` integration test class (9 assertions) covering all acceptance criteria

## Test Plan
- [x] Changed skills/commands/agents load without errors (`python3 scripts/validate.py` → "All checks passed")
- [x] Examples in the diff were exercised manually (`pytest tests/ -v` → 641 passed, 0 failed)
- [x] `wc -l skills/principle-release-engineering/SKILL.md` → 109 lines (≤ 145 budget)
- [x] `grep -c '## ' skills/principle-release-engineering/SKILL.md` → 9 H2 sections
- [x] New `TestPrincipleReleaseEngineeringSkill` class: 9/9 tests green including live-tree `validate.py` pass
- [x] `check_unwired_principle_skills` passes via wiring in `migrator.md` + `senior-engineer.md`

### Type-tailored checks ([docs])
- [x] All modified `.md` skill/agent files parse correctly (YAML frontmatter validated by `validate.py`)
- [x] Skill description front-loads BM25 keywords: release, tag, semver, rollout, rollback, canary, kill-switch, expand-contract, feature flag, release notes
- [x] `triggers.txt` has ≥ 2 non-empty lines (5 provided)

Closes #175
