### PR TITLE
[feat] Add principle-postmortem skill

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -60,6 +60,7 @@ Invoke these skills via the Skill tool when the diagnosis surfaces a concern in 
 - `swe-workbench:principle-clean-architecture` — boundaries, layering, dependency rule
 - `swe-workbench:principle-concurrency` — race conditions, deadlock, missing cancellation propagation, ordering bugs, memory-model surprises
 - `swe-workbench:principle-refactoring` — when the diagnosis surfaces structural debt that the minimal fix should NOT touch (recommend follow-up /refactor)
+- `swe-workbench:principle-postmortem` — when the bug triggered a production incident and the team needs blameless RCA framing, trigger/condition/root-cause decomposition, or action-item structure
 
 ## Available skills
 

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -60,3 +60,4 @@ Invoke these skills via the Skill tool when the question directly concerns their
 - `swe-workbench:principle-observability` — SLI/SLO selection, what to instrument at boundaries, alerting on symptoms vs causes
 - `swe-workbench:principle-cost-awareness` — cost-per-request mental model, scale-to-zero vs cold-start, storage tier selection
 - `swe-workbench:principle-release-engineering` — semver-bump risk, expand-contract sequencing for breaking changes, rollback-vs-rollforward trade-offs, tag-identity invariants
+- `swe-workbench:principle-postmortem` — blameless RCA after incidents, trigger/condition/root-cause decomposition, action-item ownership, MTTD/MTTR trends (completes the prevent→detect→learn triad)

--- a/agents/shared/principles.md
+++ b/agents/shared/principles.md
@@ -18,6 +18,7 @@ All `swe-workbench` principle skills available in this plugin. Use the `Skill` t
 - `swe-workbench:principle-i18n` — Internationalization & localization: locale-aware formatting, time zones, plural rules, message catalogs, RTL layout, ISO 8601, currency.
 - `swe-workbench:principle-observability` — Observability: logs vs metrics vs traces, structured logging, OpenTelemetry, SLI/SLO.
 - `swe-workbench:principle-performance` — Performance: latency vs throughput, profile-before-optimize, Big-O, allocation pressure, data locality, N+1 queries.
+- `swe-workbench:principle-postmortem` — Postmortem principles: blameless culture, root cause analysis (5 Whys, Fishbone/Ishikawa), incident document structure, action-item discipline, MTTD/MTTR metrics.
 - `swe-workbench:principle-refactoring` — Refactoring discipline: Fowler's catalog, smell→move mapping, rule of three, characterization-tests-first, small behavior-preserving steps with green between.
 - `swe-workbench:principle-release-engineering` — Release engineering: semver discipline, expand-contract for breaking changes, idempotent release automation, post-release verification, rollback planning, release-notes audience.
 - `swe-workbench:principle-resiliency` — Resiliency: failure domains, bulkheads, graceful degradation, fail-fast vs fail-soft, health checks, blast radius containment.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -58,6 +58,7 @@
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
 | `principle-code-review` | "code review checklist", "PR review heuristics", "review comment", "review finding", "nitpick filtering", "reviewing a diff". |
+| `principle-postmortem` | "postmortem", "blameless", "root cause analysis", "5 whys", "fishbone", "incident review", "MTTD", "MTTR", "action items", "incident report", "blameless postmortem". |
 | `principle-refactoring` | "refactor", "Fowler", "Extract Function", "Inline Variable", "Move Function", "smell", "Long Method", "Feature Envy", "Data Clumps", "Primitive Obsession", "characterization test", "behavior-preserving". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |
 | `principle-api-design` | "api versioning", "idempotency", "idempotency key", "pagination", "cursor pagination", "error shape", "REST vs RPC", "event-driven", "API deprecation", "API contract". |
@@ -66,7 +67,6 @@
 | `principle-cost-awareness` | "cloud cost", "FinOps", "egress", "right-sizing", "scale-to-zero", "cost-per-request", "storage tier", "log volume", "cardinality cost". |
 | `principle-data-modeling` | "schema design", "data model", "normalization", "denormalization", "indexing", "hot key", "hot partition", "schema evolution", "expand contract", "query-first", "storage paradigm", "relational vs document", "TTL", "archival". |
 | `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "kill-switch", "expand-contract", "feature flag", "release notes". |
-| `principle-postmortem` | "postmortem", "blameless", "root cause analysis", "5 whys", "fishbone", "incident review", "MTTD", "MTTR", "action items", "incident report", "blameless postmortem". |
 | `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
 ### Languages — auto-load by file type

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -66,6 +66,7 @@
 | `principle-cost-awareness` | "cloud cost", "FinOps", "egress", "right-sizing", "scale-to-zero", "cost-per-request", "storage tier", "log volume", "cardinality cost". |
 | `principle-data-modeling` | "schema design", "data model", "normalization", "denormalization", "indexing", "hot key", "hot partition", "schema evolution", "expand contract", "query-first", "storage paradigm", "relational vs document", "TTL", "archival". |
 | `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "kill-switch", "expand-contract", "feature flag", "release notes". |
+| `principle-postmortem` | "postmortem", "blameless", "root cause analysis", "5 whys", "fishbone", "incident review", "MTTD", "MTTR", "action items", "incident report", "blameless postmortem". |
 | `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
 ### Languages — auto-load by file type

--- a/skills/principle-postmortem/SKILL.md
+++ b/skills/principle-postmortem/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: principle-postmortem
+description: Postmortem principles — blameless culture, root cause analysis (5 Whys, Fishbone), incident document structure, action-item discipline, MTTD/MTTR metrics. Auto-load when running a blameless review, structuring an incident report, facilitating RCA, tracking action items after an outage, or improving incident response processes.
+---
+
+# Postmortem
+
+Incidents are inevitable. A postmortem converts failure into systemic learning — the goal is not to assign blame but to close the gap between what the system can do and what the environment demands. The prevent → detect → learn triad is incomplete without this phase.
+
+Cross-references: `principle-resiliency` (prevent), `principle-observability#SLI / SLO / Error Budget` (detect / MTTD-MTTR framing), `principle-release-engineering#Rollback` (remediation action items).
+
+## Blameless Culture
+
+Blame suppresses signal. When individuals fear punishment, they conceal information, underreport near-misses, and avoid risky-but-necessary work. Blameless postmortems operate from the assumption that everyone acted rationally given the information and tools available to them at the time.
+
+Guiding principles:
+
+- **"The system allowed it"** — if a person could cause an outage, the system lacked the guardrails to prevent it. The fix belongs in the system, not the person.
+- **Psychological safety** — participants must feel safe sharing the full sequence of events, including their own mistakes. Facilitation owns this; interrupt any language that assigns personal fault.
+- **Hindsight bias** — it is easy to see the right move after the fact. Explicitly reconstruct the information available at each decision point; do not evaluate decisions using information that only became visible later.
+- **Counterfactual fairness** — "if only they had done X" is only valid if X was a realistic, well-understood option at the time. If X required information no one had, the real gap is in the information architecture.
+- **Separate the review from personnel processes** — postmortems feed the improvement backlog, not performance reviews.
+
+## Root Cause Analysis
+
+A single proximate cause is almost never the full story. Three distinct layers exist:
+
+- **Trigger** — the immediate event that precipitated the incident (a deployment, a traffic spike, a configuration change).
+- **Condition** — the pre-existing state that made the system vulnerable to that trigger (an untested code path, a missing circuit breaker, a stale cache TTL).
+- **Root cause** — the systemic gap that allowed the condition to persist undetected (absent pre-deploy checklist, no SLO alert on the affected path, no load test in CI).
+
+Fixing only the trigger prevents the exact same incident; fixing the root cause prevents a class of incidents.
+
+### 5 Whys
+
+Iteratively ask "why did this happen?" until you reach a controllable, systemic factor. Each answer becomes the premise of the next question.
+
+- Start from the trigger, not the symptom.
+- Stop when the answer is "we had no process / no visibility / no incentive to catch this" — that is a root cause.
+- Document each why-answer pair; the chain is the evidence.
+- Beware shallow stopping: "human error" is almost never a root cause — ask why the error was possible.
+
+### Fishbone (Ishikawa)
+
+Use when the incident has multiple, parallel contributing factors that do not form a clean causal chain. Draw a central "spine" (the effect) with branches for contributing factor categories:
+
+- **People** — training gaps, handoff failures, role ambiguity.
+- **Process** — missing runbooks, inadequate on-call rotations, unclear escalation paths.
+- **Tooling** — alert fatigue, missing dashboards, slow deploy pipelines, inadequate rollback mechanisms.
+- **Environment** — dependency failures, infrastructure limits, third-party SLA violations.
+- **Measurement** — absent or lagging metrics, poorly calibrated SLOs, no baseline data.
+
+Each branch can have sub-branches. Fishbone complements 5 Whys: use 5 Whys to drill into the most critical branch found by the Fishbone diagram.
+
+## Postmortem Document Structure
+
+Time-box the draft to **24–72 hours** after mitigation while memory is fresh.
+
+Required sections, in order:
+
+- **Title + Severity + Status** — descriptive title, severity tier (P0–P3 or equivalent), draft/reviewed/closed.
+- **Timeline** — chronological sequence of events with UTC timestamps: when did the condition begin, when was the incident detected, when were responders paged, when was mitigation applied, when was the incident closed.
+- **Impact** — who was affected, how many users/requests/dollars, duration. Quantify; avoid vague language.
+- **Root cause** — one paragraph. Uses the trigger/condition/root-cause framing from above.
+- **Contributing factors** — list of conditions that compounded the impact or delayed detection.
+- **Lessons learned** — what went well (do not skip this; it anchors future behavior), what went poorly, where there was luck.
+- **Action items** — see Action-Item Discipline below.
+
+## Action-Item Discipline
+
+"Improve monitoring" is not an action item. An action item is a specific, measurable change assigned to a named owner with a due date.
+
+Every action item must answer three questions:
+
+1. **What exactly will change?** — name the alert, the runbook section, the circuit-breaker threshold, the test case.
+2. **Who is the owner?** — one person; committees do not ship.
+3. **When is it done?** — a specific date or sprint, not "soon".
+
+Categorize by impact tier:
+
+- **Prevent** — eliminates the root cause (adds the missing guard, removes the dangerous code path).
+- **Detect** — closes the detection gap (adds the missing SLO alert, reduces MTTD).
+- **Mitigate** — reduces blast radius for the next occurrence (adds a kill-switch, improves rollback speed).
+
+Track in the same system as engineering work (sprint backlog, issue tracker). Postmortem action items that live only in a doc rot and get forgotten.
+
+## Incident Metrics
+
+Track over rolling quarters to surface trends, not just individual incidents:
+
+- **MTTD (Mean Time To Detect)** — gap between incident start and first alert. Feeds `principle-observability` SLO work; high MTTD signals missing or miscalibrated alerts.
+- **MTTR (Mean Time To Recover)** — gap between detection and full mitigation. Feeds `principle-resiliency` rollback and degradation work; high MTTR signals slow deploy pipelines or inadequate runbooks.
+- **Repeat-incident rate** — same root cause recurring within a quarter. The single strongest signal that action items are not being completed or are not addressing the right layer.
+
+Review trends in retros, not just in individual postmortems. A rising MTTD means the observability investment is not keeping pace with system complexity.
+
+## When a Postmortem is Overkill
+
+Not every incident warrants a full postmortem. Reserve the full process for:
+
+- Customer-visible impact lasting more than a few minutes (adjust threshold to your SLO tier).
+- Incidents that required escalation beyond the on-call engineer.
+- Any incident in the same root-cause class as a prior postmortem (repeat signal).
+- Incidents where the responder felt they were close to making a much larger mistake.
+
+For minor incidents below this threshold, a lightweight 5-line "incident note" (what happened, what was done, follow-up if any) is sufficient. The overhead of a full postmortem can discourage reporting if applied indiscriminately.
+
+## Red Flags
+
+| Flag | Problem |
+|---|---|
+| The postmortem names an individual as the root cause | Blame, not analysis. The system allowed the action; the fix belongs in the system. |
+| Action items have no owner | Orphaned tasks. Without an owner, no one ships. |
+| Action items have no due date | Perpetually pending. No due date means no accountability. |
+| The doc was written more than a week after the incident | Memory has decayed; the timeline will be inaccurate and contributing factors will be missed. |
+| "Human error" appears as a root cause | Premature stop. Ask why the error was possible; the answer is the real root cause. |
+| The incident timeline has gaps longer than 30 minutes with no annotation | Responders were working but not communicating; the timeline is incomplete. |
+| Action items are not tracked in the engineering backlog | Postmortem action items that live only in a doc get forgotten. Link every item to a ticket. |
+| No "what went well" section | Anchoring bias — teams that only record failures fail to reinforce behavior worth repeating. |

--- a/skills/principle-postmortem/triggers.txt
+++ b/skills/principle-postmortem/triggers.txt
@@ -1,0 +1,5 @@
+how do I run a blameless postmortem without the team feeling like they're being blamed for the outage
+what sections should a postmortem document include and in what order
+walk me through the 5 whys and fishbone diagram for finding the root cause of this incident
+every action item from our last postmortem needs an owner and a due date — what format should we use
+how do I track MTTD and MTTR trends over multiple quarters to measure whether our blameless postmortem process is improving incident response

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -516,6 +516,66 @@ class TestPrincipleReleaseEngineeringSkill:
 
 
 # ──────────────────────────────────────────────
+# principle-postmortem skill structural assertions
+# ──────────────────────────────────────────────
+
+class TestPrinciplePostmortemSkill:
+    """Integration tests: assert the real skills/principle-postmortem/SKILL.md satisfies
+    all acceptance criteria from issue #178 without relying on a synthetic fixture."""
+
+    SKILL_PATH = Path(__file__).parent.parent / "skills" / "principle-postmortem" / "SKILL.md"
+    TRIGGERS_PATH = Path(__file__).parent.parent / "skills" / "principle-postmortem" / "triggers.txt"
+
+    def test_file_exists(self):
+        assert self.SKILL_PATH.exists(), "skills/principle-postmortem/SKILL.md must exist"
+
+    def test_frontmatter_name(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "name: principle-postmortem" in text
+
+    def test_blameless_culture_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Blameless Culture" in text
+
+    def test_root_cause_analysis_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Root Cause Analysis" in text
+
+    def test_postmortem_document_structure_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Postmortem Document Structure" in text
+
+    def test_action_item_discipline_section_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Action-Item Discipline" in text
+
+    def test_two_rca_frameworks_present(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "5 Whys" in text, "RCA section must cover the 5 Whys framework"
+        assert "Fishbone" in text or "Ishikawa" in text, (
+            "RCA section must cover the Fishbone/Ishikawa framework"
+        )
+
+    def test_triggers_has_two_or_more_non_empty_lines(self):
+        assert self.TRIGGERS_PATH.exists(), "triggers.txt must exist"
+        lines = [
+            ln for ln in self.TRIGGERS_PATH.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        assert len(lines) >= 2, f"triggers.txt must have ≥2 non-empty lines, got {len(lines)}"
+
+    def test_skill_passes_validate(self, reset_validate, monkeypatch):
+        """The real skill must pass check_skills() and check_unwired_principle_skills()
+        against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.SKILL_PATH.parent.parent.parent)
+        val.FAILURES.clear()
+        val.check_skills()
+        val.check_unwired_principle_skills()
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
 # check_commands
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `skills/principle-postmortem/SKILL.md` — blameless culture, 5 Whys + Fishbone RCA frameworks, postmortem document structure, action-item discipline, MTTD/MTTR metrics, Red Flags table.
- Add `skills/principle-postmortem/triggers.txt` — 5 domain-specific trigger prompts (BM25-tested, no sibling collision).
- Wire into `agents/shared/principles.md` catalog (alphabetically between `principle-performance` and `principle-refactoring`).
- Wire into `agents/debugger.md` (RCA framing support) and `agents/senior-engineer.md` (completes the prevent→detect→learn triad alongside `principle-resiliency` and `principle-observability`).
- Add row to `docs/catalog.md` Principles table.
- Add `TestPrinciplePostmortemSkill` to `tests/test_validate.py` mirroring `TestPrincipleReleaseEngineeringSkill` (PR #285 precedent); covers all 5 acceptance criteria from issue #178.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` passes — "All checks passed"
- [x] `pytest tests/test_validate.py -k Postmortem -v` — 9/9 passed
- [x] `pytest tests/test_skill_triggers.py -k postmortem -v` — 5/5 passed (all triggers rank `principle-postmortem` #1)
- [x] `pytest tests/ -v` — 656/656 passed (no regressions)

Closes #178
