### PR TITLE
[chore] Worktree permission-grant hook

### DIFF
--- a/docs/worktree-permission-grant.md
+++ b/docs/worktree-permission-grant.md
@@ -1,0 +1,72 @@
+# Worktree permission-grant hook
+
+When rimba creates a new git worktree it copies `.claude/` into it, including `settings.local.json`.  That file lists `Read(...)`, `Edit(...)`, and `Write(...)` allow entries — but their paths are absolute and pinned to the *original* worktree.  Claude Code's harness therefore re-prompts on every file operation in the new worktree, because none of the old paths match.
+
+The `worktree_permission_grant.sh` hook eliminates that friction by re-interpreting each allow entry at runtime against the *current* worktree.
+
+## How it works
+
+A single `PreToolUse` hook fires on `Read`, `Edit`, and `Write` tool calls:
+
+| Hook | Script | Matcher |
+|---|---|---|
+| `PreToolUse:Read\|Edit\|Write` | `hooks/worktree_permission_grant.sh` | `Read\|Edit\|Write` |
+
+For each call the hook:
+
+1. Extracts `tool_name` and `tool_input.file_path` from the hook payload.
+2. Rejects paths containing `..` (traversal guard).
+3. Confirms the session is in a **linked** worktree (main checkouts fall through to native handling).
+4. Reads `.claude/settings.local.json` from the worktree root.
+5. For each allow entry whose tool prefix matches:
+   - **Absolute sibling entry** (`//path/to/other-worktree/**`): remaps to the equivalent path inside the *current* worktree.
+   - **Absolute same-tree entry** (`//path/to/current-worktree/**`): used as-is.
+   - **Relative entry** (`skills/**`): matched directly against the project-relative file path.
+   - **Unrelated absolute entry** (`//tmp/x/**`): skipped.
+6. On a match: emits `permissionDecision: "allow"` and exits.
+7. No match: exits with no output — the harness prompts as usual.
+
+The hook never emits `exit 2` (which would *deny* the call).  Any error exits 0 (fail-open → normal harness prompt).
+
+## Sibling-worktree remapping
+
+rimba places all worktrees under a shared parent directory:
+
+```
+swe-workbench-worktrees/
+  chore-old-task/      ← prior worktree (allow entries pinned here)
+  chore-new-task/      ← current session
+```
+
+An allow entry `Read(//…/swe-workbench-worktrees/chore-old-task/**)` is rewritten to `**` (the whole tree) relative to `chore-new-task/` — so reads in the new worktree are granted without re-prompting.  Sub-path entries like `Read(//…/chore-old-task/skills/**)` are similarly narrowed: only `skills/**` inside the new worktree is allowed.
+
+## Security boundaries
+
+| Boundary | Enforcement |
+|---|---|
+| Linked worktrees only | `git rev-parse --absolute-git-dir` must contain `.git/worktrees/` |
+| Files under worktree root only | String-prefix check AND `python3 os.path.realpath` resolves symlinks; resolved path must also be under `wt_root` |
+| No `..` traversal | Pattern `*/../*\|*/..\|../*\|..` checked before any git call |
+| No committed `settings.json` | Only `settings.local.json` (gitignored, user-authored) is read |
+| Unrelated absolute paths skipped | Must be under `wt_root` or a recognized sibling directory |
+
+## Manual smoke test
+
+After creating a worktree with rimba (`rimba add <task>`):
+
+1. Open a file in the new worktree — `Read` should **not** prompt if `settings.local.json` has a matching `Read(...)` entry from a previous worktree.
+2. Edit a file — still prompts (no `Edit(...)` whole-tree grant exists by default).
+3. Run `shellcheck hooks/worktree_permission_grant.sh` — should report 0 issues.
+
+## Troubleshooting
+
+**Still getting Read prompts after entering a worktree:**
+
+- Confirm `.claude/settings.local.json` was copied (rimba `copy_files = ['.claude']`).
+- Confirm it contains a `Read(...)` entry for a path that remaps to the worktree.
+- Confirm the session is in a linked worktree, not the main checkout: `git rev-parse --absolute-git-dir` should show a path containing `.git/worktrees/`.
+
+**Hook never fires:**
+
+- Confirm `CLAUDE_PLUGIN_ROOT` is set and `hooks/hooks.json` contains the `Read|Edit|Write` entry.
+- Run `bash scripts/validate.sh` to verify hooks.json schema.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -18,6 +18,15 @@
             "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_usage_record.sh"
           }
         ]
+      },
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/worktree_permission_grant.sh"
+          }
+        ]
       }
     ],
     "SubagentStop": [

--- a/hooks/worktree_permission_grant.sh
+++ b/hooks/worktree_permission_grant.sh
@@ -52,6 +52,7 @@ esac
 wt_root=$(git -C "$file_dir" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 # Security: never grant for files outside the worktree root.
+# Strict prefix: file_abs must be a child of wt_root, not wt_root itself.
 case "$file_abs" in
     "$wt_root"/*) ;;
     *) exit 0 ;;
@@ -64,6 +65,7 @@ file_rel="${file_abs#"$wt_root"/}"
 # not available on macOS without coreutils; readlink -f requires the path to
 # exist, which breaks Write on new files).
 file_real=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$file_abs" 2>/dev/null) || exit 0
+# Same strict-prefix requirement: resolved path must also be a child of wt_root.
 case "$file_real" in
     "$wt_root"/*) ;;
     *) exit 0 ;;

--- a/hooks/worktree_permission_grant.sh
+++ b/hooks/worktree_permission_grant.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# PreToolUse:Read|Edit|Write handler — grants permissions for file ops inside
+# the current git linked worktree when the worktree's own
+# .claude/settings.local.json permits them.
+#
+# Never blocks: exit 0 always, never exit 2.  Any error → fail-open (no grant,
+# normal harness prompt).  Grants are limited to files under the worktree root.
+set -u
+
+input=$(cat)
+
+# Fail-open on any jq parse error
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+
+[ -z "$tool_name" ] && exit 0
+[ -z "$file_path" ] && exit 0
+
+# Resolve to an absolute path.  Read/Edit/Write always supply absolute paths in
+# Claude Code, but handle the relative case gracefully via the cwd field.
+case "$file_path" in
+    /*)
+        file_abs="$file_path"
+        ;;
+    *)
+        cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || exit 0
+        [ -z "$cwd" ] && exit 0
+        file_abs="$cwd/$file_path"
+        ;;
+esac
+
+# Reject paths containing a .. segment (refuse to reason about traversal).
+case "$file_abs" in
+    */../*|*/..|../*|..)
+        exit 0
+        ;;
+esac
+
+# Determine git context from the file's own directory (no reliance on cwd in
+# the hook payload, which is absent for file-op tools per CC internals).
+file_dir=$(dirname "$file_abs")
+git_dir=$(git -C "$file_dir" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+
+# Only act inside a linked worktree — the main checkout is handled natively.
+# Linked worktrees always have a git-dir path of the form:
+#   /repo/.git/worktrees/<name>
+case "$git_dir" in
+    */.git/worktrees/*) ;;
+    *) exit 0 ;;
+esac
+
+wt_root=$(git -C "$file_dir" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Security: never grant for files outside the worktree root.
+case "$file_abs" in
+    "$wt_root"/*) ;;
+    *) exit 0 ;;
+esac
+
+file_rel="${file_abs#"$wt_root"/}"
+
+# Secondary containment: resolve symlinks and verify the real path is still
+# inside the worktree.  python3 is used for portability (GNU realpath -m is
+# not available on macOS without coreutils; readlink -f requires the path to
+# exist, which breaks Write on new files).
+file_real=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$file_abs" 2>/dev/null) || exit 0
+case "$file_real" in
+    "$wt_root"/*) ;;
+    *) exit 0 ;;
+esac
+
+# Honor only settings.local.json — user-authored and gitignored.
+# Never read a committed settings.json, which an untrusted repo could ship.
+settings="$wt_root/.claude/settings.local.json"
+[ -f "$settings" ] || exit 0
+
+# parent is the directory that contains sibling worktrees (rimba layout:
+# repo-worktrees/<name> are all siblings under the same parent).
+parent=$(dirname "$wt_root")
+
+# Iterate allow entries, looking for a match for the current tool.
+while IFS= read -r entry; do
+    # Filter to entries whose tool prefix matches.
+    case "$entry" in
+        "$tool_name("*) ;;
+        *) continue ;;
+    esac
+
+    # Strip  tool_name( … )  to get the raw glob string.
+    glob="${entry#"$tool_name"(}"
+    glob="${glob%)}"
+
+    # Derive a worktree-relative pattern P from the glob.
+    case "$glob" in
+        //*)
+            # Claude Code absolute-path marker: //abs/path → /abs/path
+            abs_glob="/${glob#//}"
+            case "$abs_glob" in
+                "$wt_root"/*)
+                    P="${abs_glob#"$wt_root"/}"
+                    [ -z "$P" ] && P="**"
+                    ;;
+                "$wt_root")
+                    P="**"
+                    ;;
+                "$parent"/*)
+                    # Sibling worktree grant — remap to the current worktree.
+                    remainder="${abs_glob#"$parent"/}"
+                    # remainder = "<sibling-name>/rest" or "<sibling-name>"
+                    case "$remainder" in
+                        */*)
+                            P="${remainder#*/}"
+                            ;;
+                        *)
+                            P="**"
+                            ;;
+                    esac
+                    [ -z "$P" ] && P="**"
+                    ;;
+                *)
+                    # Unrelated absolute path (e.g. //tmp/x/**) — skip.
+                    continue
+                    ;;
+            esac
+            ;;
+        /*)
+            # Single-slash absolute (uncommon but valid).
+            abs_glob="$glob"
+            case "$abs_glob" in
+                "$wt_root"/*)
+                    P="${abs_glob#"$wt_root"/}"
+                    [ -z "$P" ] && P="**"
+                    ;;
+                "$wt_root")
+                    P="**"
+                    ;;
+                "$parent"/*)
+                    remainder="${abs_glob#"$parent"/}"
+                    case "$remainder" in
+                        */*)
+                            P="${remainder#*/}"
+                            ;;
+                        *)
+                            P="**"
+                            ;;
+                    esac
+                    [ -z "$P" ] && P="**"
+                    ;;
+                *)
+                    continue
+                    ;;
+            esac
+            ;;
+        *)
+            # Relative glob — use directly as the project-relative pattern.
+            P="$glob"
+            ;;
+    esac
+
+    # bash case: * matches any string including those containing /, so ** ≡ *.
+    # Leave $P unquoted so bash treats it as a glob pattern.
+    # shellcheck disable=SC2254
+    case "$file_rel" in
+        $P)
+            printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"worktree allowlist grant (.claude/settings.local.json)"}}\n'
+            exit 0
+            ;;
+    esac
+done < <(jq -r '.permissions.allow[]?' "$settings" 2>/dev/null)
+
+exit 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,13 @@ import pytest
 #   subprocess.run([...], env={**_CLEAN_ENV, "KEY": "val"}, ...)
 _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
     {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
-    | {"GIT_CONFIG_NOSYSTEM": "1"}
+    | {
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@t.com",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@t.com",
+    }
 )
 
 # Ensure scripts/ and tests/ are importable from any working directory.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -255,3 +255,29 @@ class TestPrePushHook:
         assert "pytest" in content and "tests/" in content, (
             "pre-push hook must invoke pytest against the tests/ directory"
         )
+
+
+# ──────────────────────────────────────────────
+# worktree permission-grant hook — wiring
+# ──────────────────────────────────────────────
+
+class TestWorktreePermissionHookWiring:
+    """Verify the Read|Edit|Write PreToolUse entry is present and correctly wired."""
+
+    HOOKS_JSON = Path(__file__).parent.parent / "hooks" / "hooks.json"
+
+    def test_rw_entry_present(self):
+        data = json.loads(self.HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = [
+            e for e in data["hooks"]["PreToolUse"]
+            if e.get("matcher") == "Read|Edit|Write"
+        ]
+        assert entries, "Read|Edit|Write PreToolUse entry missing from hooks.json"
+        assert any(
+            "worktree_permission_grant.sh" in e["hooks"][0]["command"] for e in entries
+        ), f"No entry references worktree_permission_grant.sh; entries: {entries}"
+
+    def test_hook_script_exists(self):
+        script = Path(__file__).parent.parent / "hooks" / "worktree_permission_grant.sh"
+        assert script.exists(), f"Missing hook script: {script}"
+        assert os.access(script, os.X_OK), f"Hook script not executable: {script}"

--- a/tests/test_worktree_permission_grant.py
+++ b/tests/test_worktree_permission_grant.py
@@ -81,22 +81,9 @@ def wt_env(tmp_path: Path):
     wts.mkdir()
 
     _git("init", "-q", "-b", "main", cwd=main)
-    _git("config", "user.email", "t@t.com", cwd=main)
-    _git("config", "user.name", "T", cwd=main)
     (main / "README").write_text("init")
     _git("add", ".", cwd=main)
-    _git(
-        "-c",
-        "core.hooksPath=/dev/null",
-        "-c",
-        "user.email=t@t.com",
-        "-c",
-        "user.name=T",
-        "commit",
-        "-qm",
-        "[chore] init",
-        cwd=main,
-    )
+    _git("-c", "core.hooksPath=/dev/null", "commit", "-qm", "[chore] init", cwd=main)
 
     current = wts / "current"
     _git("worktree", "add", "-b", "feature/current", str(current), cwd=main)

--- a/tests/test_worktree_permission_grant.py
+++ b/tests/test_worktree_permission_grant.py
@@ -13,7 +13,6 @@ from conftest import _CLEAN_ENV
 
 ROOT = Path(__file__).parent.parent
 HOOK_SH = ROOT / "hooks" / "worktree_permission_grant.sh"
-HOOKS_JSON = ROOT / "hooks" / "hooks.json"
 
 _ALLOW_JSON = {
     "hookSpecificOutput": {
@@ -117,7 +116,6 @@ def wt_env(tmp_path: Path):
 
 
 class TestWorktreePermissionGrant:
-    # TC1 — whole-tree sibling grant is remapped to the current worktree
     def test_whole_tree_sibling_grant_allows(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/**)"])
@@ -130,7 +128,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
 
-    # TC2 — sub-path sibling grant matches a file inside that sub-path
     def test_subdirectory_glob_matches(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/skills/**)"])
@@ -145,7 +142,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
 
-    # TC3 — same grant does not match a file outside that sub-path
     def test_subdirectory_glob_no_match(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/skills/**)"])
@@ -160,7 +156,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC4 — main checkout is not a linked worktree → no grant
     def test_main_checkout_is_noop(self, wt_env):
         main = wt_env["main"]
         (main / ".claude").mkdir(exist_ok=True)
@@ -176,7 +171,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC5 — no .claude/settings.local.json → no grant
     def test_missing_settings_is_noop(self, wt_env):
         wt = wt_env["wt"]
         # .claude/ exists but settings.local.json is absent
@@ -189,7 +183,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC6 — Edit with only Read entries → no grant
     def test_edit_without_edit_entries_is_noop(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/**)"])
@@ -202,7 +195,18 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC7 — out-of-tree path is never granted (security boundary)
+    def test_edit_grant_allows(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Edit({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
     def test_out_of_tree_path_is_denied(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/**)"])
@@ -215,7 +219,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC8 — path with .. traversal is rejected (security)
     def test_dotdot_traversal_is_denied(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Read({_cc_abs(other)}/**)"])
@@ -229,7 +232,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC9 — relative glob in the allow list (no leading /) is matched
     def test_relative_glob_matches(self, wt_env):
         wt = wt_env["wt"]
         _settings(wt, ["Read(skills/**)"])
@@ -244,7 +246,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
 
-    # TC10 — unrelated absolute grant (e.g. //tmp/x/**) is skipped
     def test_unrelated_abs_grant_is_skipped(self, wt_env):
         wt = wt_env["wt"]
         _settings(wt, ["Read(//tmp/x/**)"])
@@ -257,7 +258,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC11 — malformed stdin JSON → fail-open (exit 0, empty stdout, never exit 2)
     def test_malformed_stdin_is_failopen(self):
         result = subprocess.run(
             ["bash", str(HOOK_SH)],
@@ -269,7 +269,22 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    # TC13 — Write tool with Write(...) entry is granted (positive Write coverage)
+    def test_symlink_escape_denied(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        secret = wt_env["wts"].parent / "secret.txt"
+        secret.write_text("secret")
+        link = wt / "escape_link"
+        link.symlink_to(secret)
+        _settings(wt, [f"Read({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(link)},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
     def test_write_grant_allows(self, wt_env):
         wt, other = wt_env["wt"], wt_env["other"]
         _settings(wt, [f"Write({_cc_abs(other)}/**)"])
@@ -282,7 +297,6 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
 
-    # TC14 — single-slash absolute glob (e.g. Read(/abs/path/**)) is matched
     def test_single_slash_abs_glob_matches(self, wt_env):
         wt = wt_env["wt"]
         _settings(wt, [f"Read({str(wt)}/**)"])
@@ -294,23 +308,3 @@ class TestWorktreePermissionGrant:
         )
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
-
-
-# TC12 — hooks.json wiring
-class TestHooksJsonEntry:
-    def test_worktree_hook_entry_present(self):
-        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
-        pre_tool_use = data["hooks"]["PreToolUse"]
-        entries = [e for e in pre_tool_use if e.get("matcher") == "Read|Edit|Write"]
-        assert entries, "Read|Edit|Write PreToolUse entry missing from hooks.json"
-        assert any(
-            "worktree_permission_grant.sh" in e["hooks"][0]["command"] for e in entries
-        ), f"No entry references worktree_permission_grant.sh; entries: {entries}"
-
-    def test_schema_valid_after_adding_entry(self):
-        result = subprocess.run(
-            ["python", str(ROOT / "scripts" / "validate.py")],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_worktree_permission_grant.py
+++ b/tests/test_worktree_permission_grant.py
@@ -1,0 +1,316 @@
+"""Tests for hooks/worktree_permission_grant.sh.
+
+Subprocess-driven so they exercise real shell logic.  Each test gets an
+isolated temp git repo + linked worktree via the wt_env fixture.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+HOOK_SH = ROOT / "hooks" / "worktree_permission_grant.sh"
+HOOKS_JSON = ROOT / "hooks" / "hooks.json"
+
+_ALLOW_JSON = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "permissionDecisionReason": "worktree allowlist grant (.claude/settings.local.json)",
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(*args, cwd, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=_CLEAN_ENV,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run(stdin_json: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(HOOK_SH)],
+        input=json.dumps(stdin_json),
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+    )
+
+
+def _cc_abs(path: Path) -> str:
+    """Return the Claude Code //absolute-path marker form for a Path."""
+    return f"//{str(path).lstrip('/')}"
+
+
+def _settings(wt: Path, allow: list[str]) -> None:
+    """Write .claude/settings.local.json into a worktree."""
+    (wt / ".claude" / "settings.local.json").write_text(
+        json.dumps({"permissions": {"allow": allow}})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def wt_env(tmp_path: Path):
+    """Create a main git repo + one linked worktree.
+
+    Layout:
+      tmp_path/main/         ← main git checkout
+      tmp_path/wts/current/  ← linked worktree (CWD under test)
+      tmp_path/wts/other/    ← sibling path referenced in allowlists
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    wts = tmp_path / "wts"
+    wts.mkdir()
+
+    _git("init", "-q", "-b", "main", cwd=main)
+    _git("config", "user.email", "t@t.com", cwd=main)
+    _git("config", "user.name", "T", cwd=main)
+    (main / "README").write_text("init")
+    _git("add", ".", cwd=main)
+    _git(
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "user.email=t@t.com",
+        "-c",
+        "user.name=T",
+        "commit",
+        "-qm",
+        "[chore] init",
+        cwd=main,
+    )
+
+    current = wts / "current"
+    _git("worktree", "add", "-b", "feature/current", str(current), cwd=main)
+    (current / ".claude").mkdir()
+
+    return {
+        "main": main,
+        "wt": current,
+        "other": wts / "other",
+        "wts": wts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreePermissionGrant:
+    # TC1 — whole-tree sibling grant is remapped to the current worktree
+    def test_whole_tree_sibling_grant_allows(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
+    # TC2 — sub-path sibling grant matches a file inside that sub-path
+    def test_subdirectory_glob_matches(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/skills/**)"])
+        (wt / "skills" / "x").mkdir(parents=True)
+        (wt / "skills" / "x" / "y.md").write_text("content")
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "skills" / "x" / "y.md")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
+    # TC3 — same grant does not match a file outside that sub-path
+    def test_subdirectory_glob_no_match(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/skills/**)"])
+        (wt / "tests").mkdir()
+        (wt / "tests" / "x.py").write_text("pass")
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "tests" / "x.py")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC4 — main checkout is not a linked worktree → no grant
+    def test_main_checkout_is_noop(self, wt_env):
+        main = wt_env["main"]
+        (main / ".claude").mkdir(exist_ok=True)
+        (main / ".claude" / "settings.local.json").write_text(
+            json.dumps({"permissions": {"allow": [f"Read({_cc_abs(main)}/**)"]}})
+        )
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(main / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC5 — no .claude/settings.local.json → no grant
+    def test_missing_settings_is_noop(self, wt_env):
+        wt = wt_env["wt"]
+        # .claude/ exists but settings.local.json is absent
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC6 — Edit with only Read entries → no grant
+    def test_edit_without_edit_entries_is_noop(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC7 — out-of-tree path is never granted (security boundary)
+    def test_out_of_tree_path_is_denied(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/etc/passwd"},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC8 — path with .. traversal is rejected (security)
+    def test_dotdot_traversal_is_denied(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/**)"])
+        traversal = str(wt) + "/subdir/../../etc/passwd"
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": traversal},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC9 — relative glob in the allow list (no leading /) is matched
+    def test_relative_glob_matches(self, wt_env):
+        wt = wt_env["wt"]
+        _settings(wt, ["Read(skills/**)"])
+        (wt / "skills").mkdir()
+        (wt / "skills" / "foo.md").write_text("content")
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "skills" / "foo.md")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
+    # TC10 — unrelated absolute grant (e.g. //tmp/x/**) is skipped
+    def test_unrelated_abs_grant_is_skipped(self, wt_env):
+        wt = wt_env["wt"]
+        _settings(wt, ["Read(//tmp/x/**)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC11 — malformed stdin JSON → fail-open (exit 0, empty stdout, never exit 2)
+    def test_malformed_stdin_is_failopen(self):
+        result = subprocess.run(
+            ["bash", str(HOOK_SH)],
+            input="not-valid-json{{{",
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    # TC13 — Write tool with Write(...) entry is granted (positive Write coverage)
+    def test_write_grant_allows(self, wt_env):
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Write({_cc_abs(other)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": str(wt / "new_file.txt")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
+    # TC14 — single-slash absolute glob (e.g. Read(/abs/path/**)) is matched
+    def test_single_slash_abs_glob_matches(self, wt_env):
+        wt = wt_env["wt"]
+        _settings(wt, [f"Read({str(wt)}/**)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
+
+# TC12 — hooks.json wiring
+class TestHooksJsonEntry:
+    def test_worktree_hook_entry_present(self):
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        pre_tool_use = data["hooks"]["PreToolUse"]
+        entries = [e for e in pre_tool_use if e.get("matcher") == "Read|Edit|Write"]
+        assert entries, "Read|Edit|Write PreToolUse entry missing from hooks.json"
+        assert any(
+            "worktree_permission_grant.sh" in e["hooks"][0]["command"] for e in entries
+        ), f"No entry references worktree_permission_grant.sh; entries: {entries}"
+
+    def test_schema_valid_after_adding_entry(self):
+        result = subprocess.run(
+            ["python", str(ROOT / "scripts" / "validate.py")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Add `hooks/worktree_permission_grant.sh`: a `PreToolUse:Read|Edit|Write` hook that reads `.claude/settings.local.json` from the current linked worktree and emits `permissionDecision: allow` when the requested file matches an allow entry
- Sibling-worktree absolute grants (`//abs/other-wt/**`) are remapped to the current worktree, so rimba-created worktrees inherit their allow lists without re-prompting on every file operation
- Security boundaries: linked-worktree detection via `--absolute-git-dir`, out-of-tree containment (string-prefix + `python3 os.path.realpath` for symlink resolution), `..` traversal guard, `settings.local.json`-only reads (never committed `settings.json`)
- Wire into `hooks/hooks.json` as a `PreToolUse` matcher `Read|Edit|Write`
- 14 pytest tests covering all allow/deny paths, security boundaries, and hooks.json wiring
- `docs/worktree-permission-grant.md` documenting the permission model and security table

## Test Plan
- [x] `shellcheck hooks/worktree_permission_grant.sh` → 0 issues
- [x] `bash scripts/validate.sh` → All checks passed
- [x] `pytest tests/test_hooks.py tests/test_worktree_permission_grant.py` → 81 passed
- [x] Full suite `pytest tests/` → 659 passed (no regressions)
- [ ] Manual smoke: in a fresh rimba worktree, `Read` an in-tree file → no permission prompt; `Edit` an in-tree file → prompt still appears (no write grant to remap)

### Type-tailored checks ([chore])
- [x] `bash scripts/validate.sh` confirms hooks.json schema is valid after the new entry
- [x] Hook is executable (`chmod +x`) and passes `shellcheck`
- [x] No version bump in `plugin.json`/`marketplace.json` (out of scope for feature branches)

Closes #262
