### PR TITLE
[feat] PreToolUse secret-detection hook on Write/Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ cd swe-workbench
 
 Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide and philosophy → [docs/extending.md](docs/extending.md). Runtime dependencies → [docs/dependencies.md](docs/dependencies.md).
 
+## Secret detection
+
+Every `Write` and `Edit` tool call is scanned for hardcoded secrets (GitHub
+tokens, AWS keys, `.env`-style assignments) before the file is written.
+Detected secrets are blocked with a `BLOCKED:` message naming the pattern,
+line number, and file. Use `# nosecret` on a line to suppress intentional
+fixtures. See [docs/secret-detection.md](docs/secret-detection.md) for the
+full pattern list, suppression options, and security notes.
+
 ## Skill-usage telemetry
 
 When the orchestrator dispatches a subagent, the skills that subagent invokes are surfaced in the transcript:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 - [dependencies.md](dependencies.md) — runtime plugin dependencies.
 - [cost-audit.md](cost-audit.md) — point-in-time model-tier audit (snapshot at #160).
 - [cost-tiers.md](cost-tiers.md) — forward-looking convention for assigning model tiers to new agents.
+- [secret-detection.md](secret-detection.md) — PreToolUse hook that blocks hardcoded secrets before Write/Edit writes the file.

--- a/docs/secret-detection.md
+++ b/docs/secret-detection.md
@@ -1,0 +1,98 @@
+# Secret detection
+
+The `secret_guard.py` hook intercepts every `Write` and `Edit` tool call and
+blocks the operation **before the file is written** when the content contains a
+hardcoded secret. This catches accidental leaks at authoring time, even when
+the git `pre-commit` hook is absent or bypassed.
+
+## How it works
+
+| Layer | Detail |
+|---|---|
+| **Hook event** | `PreToolUse` on matcher `Write\|Edit` |
+| **Script** | `hooks/secret_guard.py` — stdlib only (`re`, `json`), no external deps |
+| **Input** | JSON payload on stdin (Claude Code hook protocol) |
+| **Block** | writes `BLOCKED: …` to stderr, exits 2 |
+| **Allow** | exits 0, empty stderr |
+| **Tool routing** | `Write` → scan `tool_input.content`; `Edit` → scan `tool_input.new_string` only (removing a secret in `old_string` is never blocked) |
+
+### Pattern tiers
+
+**HIGH confidence** — block anywhere in a non-suppressed line:
+
+| Pattern name | Regex |
+|---|---|
+| `github-pat` | `ghp_[A-Za-z0-9]{36}` |
+| `github-fine-grained-pat` | `github_pat_[A-Za-z0-9_]{82}` |
+| `aws-access-key-id` | `AKIA[0-9A-Z]{16}` |
+
+**NEEDS-CONTEXT** — block only when a key name is adjacent to a literal value;
+skipped automatically on lines that contain an environment-variable reference
+(`os.environ`, `os.getenv`, `process.env`, `ENV[`, `getenv`):
+
+| Pattern name | What it matches |
+|---|---|
+| `aws-secret-access-key` | `aws_secret… = "…40-char…"` |
+| `generic-api-key` | `API_KEY = "…≥16 chars…"` |
+| `generic-secret` | `SECRET / PASSWORD / PASSWD / TOKEN = "…≥8 chars…"` |
+| `dotenv-assignment` | `SECRET=…` / `TOKEN=…` etc. at line start (`.env` style) |
+
+## Suppression & allowlist
+
+### Per-line suppression
+
+Add `# nosecret` anywhere on the line to skip all pattern checks for that line:
+
+```python
+BOOTSTRAP_TOKEN = "<placeholder>"  # nosecret
+```
+
+Only that exact line is suppressed. Adjacent lines are checked normally.
+
+### Filename allowlist
+
+Certain files are exempt from all checks (the hook exits 0 immediately):
+
+| Exempted path | Reason |
+|---|---|
+| Any file named `.gitignore` | May reference token formats as ignore patterns |
+| `tests/test_secret_guard.py` | The test corpus contains shaped-but-fake fixture tokens |
+
+Add future fixture files to `_ALLOWLIST_SUFFIXES` in `hooks/secret_guard.py`
+**by explicit absolute suffix**, never by a broad glob — the allowlist is
+intentionally narrow.
+
+## Troubleshooting
+
+**False positive — I'm assigning from an env var, not hardcoding**
+
+The hook already skips NEEDS-CONTEXT patterns when the line contains
+`os.environ`, `os.getenv`, `process.env`, `ENV[`, or `getenv`. If a reference
+form you use is not covered, add a `# nosecret` on that line, or open an issue
+to extend `_REF_PATTERN` in `hooks/secret_guard.py`.
+
+**The hook is blocking a test fixture**
+
+Add `# nosecret` on each fixture line, or add the file's absolute path to
+`_ALLOWLIST_SUFFIXES`.
+
+**The hook seems to do nothing**
+
+The hook activates once the plugin is (re)loaded at the installed version.
+Verify the entry is present in `hooks/hooks.json` and that the script is
+executable (`chmod +x hooks/secret_guard.py`).
+
+## Security note
+
+This hook is a **guardrail against accidental leaks by a cooperative agent**,
+not an adversarial control. An agent or user who controls the write payload
+can trivially evade it (e.g., by encoding the secret or splitting across
+lines). The fail-open posture (exit 0 on parse/interpreter errors) is
+deliberate: a broken guard that blocked every file write would be worse than
+no guard at all.
+
+Defense-in-depth remains important. Combine this hook with:
+
+- The `.githooks/pre-commit` scanner (catches leaks that reach the index)
+- Repository secret scanning (GitHub Advanced Security, etc.)
+- Credential rotation and short-lived tokens where possible

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,15 @@
             "command": "$CLAUDE_PLUGIN_ROOT/hooks/worktree_permission_grant.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/secret_guard.py"
+          }
+        ]
       }
     ],
     "SubagentStop": [

--- a/hooks/secret_guard.py
+++ b/hooks/secret_guard.py
@@ -14,6 +14,8 @@ Block:  write "BLOCKED: …" to stderr, exit 2.
 Allow:  exit 0, empty stderr.
 """
 
+from __future__ import annotations
+
 import json
 import re
 import sys
@@ -43,6 +45,7 @@ _ALLOWLIST_SUFFIXES = frozenset({
 _REF_PATTERN = re.compile(
     r"os\.environ|os\.getenv|process\.env|ENV\[|\bgetenv\b"
 )
+_NOSECRET_PAT = re.compile(r"#\s*nosecret\b")
 
 _PATTERNS: list[tuple[str, re.Pattern, bool]] = [
     # HIGH – prefixed tokens distinctive enough to block without context
@@ -67,7 +70,7 @@ _PATTERNS: list[tuple[str, re.Pattern, bool]] = [
      re.compile(r"(?i)\b(?:SECRET|PASSWORD|PASSWD|TOKEN)\s*=\s*[\"'][^\"']{8,}[\"']"),
      True),
     ("dotenv-assignment",
-     re.compile(r"^(?:SECRET|API_KEY|TOKEN|PASSWORD)=[^\s]{8,}"),
+     re.compile(r"^(?:SECRET|API_KEY|TOKEN|PASSWORD|PASSWD)=[^\s]{8,}"),
      True),
 ]
 
@@ -88,7 +91,7 @@ def _scan(content: str) -> tuple[str, int] | None:
     """Return (pattern_name, 1-based line_number) for the first match, or None."""
     lines = content.splitlines()
     for lineno, line in enumerate(lines, start=1):
-        if "# nosecret" in line:
+        if _NOSECRET_PAT.search(line):
             continue
         is_ref = bool(_REF_PATTERN.search(line))
         for name, pattern, needs_context in _PATTERNS:

--- a/hooks/secret_guard.py
+++ b/hooks/secret_guard.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block Write/Edit when content contains a hardcoded secret.
+
+Failure posture (deliberately opposite of bash_guard.sh):
+  - FAIL OPEN  on parse / interpreter error → exit 0 (no stderr)
+  - FAIL CLOSED only on a confirmed pattern match → exit 2 + "BLOCKED: …"
+
+Rationale: a secret guard that failed closed on a malformed payload would
+block every file edit — a self-inflicted DoS. This is a guardrail against
+*accidental* leaks by a cooperative agent, not an adversarial control.
+
+Input:  JSON on stdin from Claude Code hook runtime.
+Block:  write "BLOCKED: …" to stderr, exit 2.
+Allow:  exit 0, empty stderr.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# ── Filename allowlist ────────────────────────────────────────────────────────
+# Whole-file exemptions. Keep narrow and explicit; never use broad globs.
+_ALLOWLIST_BASENAMES = frozenset({".gitignore"})
+_ALLOWLIST_SUFFIXES = frozenset({
+    str(Path(__file__).resolve().parent.parent / "tests" / "test_secret_guard.py"),
+})
+
+# ── Pattern definitions ───────────────────────────────────────────────────────
+# Each entry: (name, compiled_regex, needs_context: bool)
+# HIGH tier  (needs_context=False): block anywhere in a non-suppressed line.
+# NEEDS-CONTEXT tier (needs_context=True): skip lines that contain an
+#   environment-variable reference (os.environ, os.getenv, process.env, ENV[,
+#   getenv). Checked in _scan rather than embedded in the regex so that the
+#   reference guard operates on the *full* line without lookahead positioning
+#   issues (a mid-pattern lookahead sees only the remaining suffix, not the
+#   part already consumed by earlier alternates).
+#
+# `# nosecret` suppression: checked via plain string containment on each line
+# before pattern matching. Intentional for the cooperative-agent threat model;
+# documented in docs/secret-detection.md.
+
+_REF_PATTERN = re.compile(
+    r"os\.environ|os\.getenv|process\.env|ENV\[|\bgetenv\b"
+)
+
+_PATTERNS: list[tuple[str, re.Pattern, bool]] = [
+    # HIGH – prefixed tokens distinctive enough to block without context
+    ("github-pat",
+     re.compile(r"ghp_[A-Za-z0-9]{36}"),
+     False),
+    ("github-fine-grained-pat",
+     re.compile(r"github_pat_[A-Za-z0-9_]{82}"),
+     False),
+    ("aws-access-key-id",
+     re.compile(r"AKIA[0-9A-Z]{16}"),
+     False),
+
+    # NEEDS-CONTEXT – require a key name + literal value structure
+    ("aws-secret-access-key",
+     re.compile(r"(?i)aws_secret\w*\s*[:=]\s*[\"']?[A-Za-z0-9/+=]{40}[\"']?"),
+     True),
+    ("generic-api-key",
+     re.compile(r"(?i)\bAPI_KEY\s*=\s*[\"'][^\"']{16,}[\"']"),
+     True),
+    ("generic-secret",
+     re.compile(r"(?i)\b(?:SECRET|PASSWORD|PASSWD|TOKEN)\s*=\s*[\"'][^\"']{8,}[\"']"),
+     True),
+    ("dotenv-assignment",
+     re.compile(r"^(?:SECRET|API_KEY|TOKEN|PASSWORD)=[^\s]{8,}"),
+     True),
+]
+
+
+def _is_allowlisted(file_path: str) -> bool:
+    p = Path(file_path)
+    if p.name in _ALLOWLIST_BASENAMES:
+        return True
+    try:
+        if str(p.resolve()) in _ALLOWLIST_SUFFIXES:
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def _scan(content: str) -> tuple[str, int] | None:
+    """Return (pattern_name, 1-based line_number) for the first match, or None."""
+    lines = content.splitlines()
+    for lineno, line in enumerate(lines, start=1):
+        if "# nosecret" in line:
+            continue
+        is_ref = bool(_REF_PATTERN.search(line))
+        for name, pattern, needs_context in _PATTERNS:
+            if needs_context and is_ref:
+                continue
+            if pattern.search(line):
+                return name, lineno
+    return None
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input")
+
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+
+    if tool_name == "Write":
+        content = tool_input.get("content", "")
+        file_path = tool_input.get("file_path", "")
+    elif tool_name == "Edit":
+        content = tool_input.get("new_string", "")
+        file_path = tool_input.get("file_path", "")
+    else:
+        sys.exit(0)
+
+    if not isinstance(content, str) or not content:
+        sys.exit(0)
+
+    if _is_allowlisted(file_path):
+        sys.exit(0)
+
+    match = _scan(content)
+    if match is None:
+        sys.exit(0)
+
+    pattern_name, lineno = match
+    print(
+        f"BLOCKED: hardcoded secret detected (pattern: {pattern_name}, "
+        f"line {lineno}, file: {file_path or '<unknown>'})\n"
+        f"Replace the literal with an environment-variable reference "
+        f"(e.g. os.environ[...]), or add `# nosecret` on that line "
+        f"if this is an intentional fixture/example.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/secret_guard.py
+++ b/hooks/secret_guard.py
@@ -70,7 +70,7 @@ _PATTERNS: list[tuple[str, re.Pattern, bool]] = [
      re.compile(r"(?i)\b(?:SECRET|PASSWORD|PASSWD|TOKEN)\s*=\s*[\"'][^\"']{8,}[\"']"),
      True),
     ("dotenv-assignment",
-     re.compile(r"^(?:SECRET|API_KEY|TOKEN|PASSWORD|PASSWD)=[^\s]{8,}"),
+     re.compile(r"^(?:SECRET|API_KEY|TOKEN|PASSWORD|PASSWD)=[^\s]{8,}"),  # ^ anchors on each split line, not full content
      True),
 ]
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -2,6 +2,7 @@
 """Plugin self-validator. Zero dependencies beyond python3 stdlib."""
 
 import json
+import py_compile
 import re
 import sys
 from pathlib import Path
@@ -481,6 +482,19 @@ def check_unwired_principle_skills(cache=None):
 
 
 # ──────────────────────────────────────────────
+# Python hook syntax check
+# ──────────────────────────────────────────────
+
+def check_hook_scripts():
+    hooks_dir = ROOT / "hooks"
+    for py_file in sorted(hooks_dir.glob("*.py")):
+        try:
+            py_compile.compile(str(py_file), doraise=True)
+        except py_compile.PyCompileError as exc:
+            fail(py_file.relative_to(ROOT), str(exc))
+
+
+# ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────
 
@@ -503,6 +517,7 @@ def main():
     check_template_placeholders(cache=cache)
     check_unwired_principle_skills(cache=cache)
     check_examples()
+    check_hook_scripts()
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ pytest tests/ -v
 |---|---|
 | `test_validate.py` | Every `check_*` function in `scripts/validate.py` (positive + negative) |
 | `test_hooks.py` | All 3 regex blockers in `hooks/hooks.json` (block + allow cases) |
+| `test_secret_guard.py` | `hooks/secret_guard.py` — 7 units: plumbing/fail-open, HIGH patterns, NEEDS-CONTEXT patterns, `# nosecret` suppression, filename allowlist, Edit routing, hooks.json wiring |
 | `test_skill_triggers.py` | BM25 top-1 ranking harness across all 22 skills × their `triggers.txt` fixtures; deliberate-vague acceptance test |
 
 Tests are hermetic: `conftest.py` redirects `validate.ROOT` to a `tmp_path` so

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -127,6 +127,7 @@ class TestNeedsContextPatterns:
         (f'aws_secret_access_key = "{_FAKE_AWS_SECRET}"', "aws-secret-access-key"),
         (f'API_KEY={_FAKE_API_KEY_VAL}', "dotenv-api-key"),
         (f'SECRET={_FAKE_SECRET_VAL}', "dotenv-secret"),
+        (f'PASSWD={_FAKE_SECRET_VAL}', "dotenv-passwd"),
         # getenv as substring should NOT suppress detection (word-boundary fix)
         (f'SECRET = "{_FAKE_SECRET_VAL}"  # see getenv_config.py', "getenv substring in comment"),
     ])
@@ -173,6 +174,16 @@ class TestNosecretSuppression:
         result = run_guard(write_payload(content))
         assert result.returncode == 0
 
+    def test_nosecret_no_space_after_hash_allows(self):
+        content = f'{_FAKE_AKIA}  #nosecret'
+        result = run_guard(write_payload(content))
+        assert result.returncode == 0
+
+    def test_nosecrets_plural_does_not_suppress(self):
+        content = f'TOKEN = "{_FAKE_GHP}"  # nosecrets stored here'
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2
+
 
 # ──────────────────────────────────────────────
 # Unit 5: Filename allowlist
@@ -185,7 +196,7 @@ class TestFilenameAllowlist:
         assert result.returncode == 0
 
     def test_test_corpus_allowed(self):
-        content = f'_FAKE_GHP = "ghp_{"A" * 36}"'  # nosecret
+        content = f'_FAKE_GHP = "{_FAKE_GHP}"'  # nosecret
         corpus_path = str(SCRIPT.parent.parent / "tests" / "test_secret_guard.py")
         result = run_guard(write_payload(content, path=corpus_path))
         assert result.returncode == 0

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -1,0 +1,255 @@
+"""Tests for hooks/secret_guard.py — PreToolUse Write/Edit secret-detection hook.
+
+Each test drives hooks/secret_guard.py via subprocess (shebang, not python3
+directly), mirroring how Claude Code calls the hook.
+
+Exit code 2 + "BLOCKED" in stderr → secret detected, operation blocked.
+Exit code 0, empty stderr             → allowed.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+SCRIPT = Path(__file__).parent.parent / "hooks" / "secret_guard.py"
+
+# ── Fixture tokens (shaped like real secrets but not real credentials) ──
+# These are test fixtures, not real credentials.
+_FAKE_GHP = "ghp_" + "A" * 36                              # nosecret
+_FAKE_PAT = "github_pat_" + "B" * 22 + "_" + "C" * 59     # nosecret
+_FAKE_AKIA = "AKIA" + "D" * 16                              # nosecret
+_FAKE_AWS_SECRET = "E" * 40                                  # nosecret
+_FAKE_API_KEY_VAL = "F" * 20                                 # nosecret
+_FAKE_SECRET_VAL = "G" * 12                                  # nosecret
+
+
+def run_guard(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=dict(_CLEAN_ENV),
+    )
+
+
+def write_payload(content: str, path: str = "/tmp/test.py") -> dict:
+    return {"tool_name": "Write", "tool_input": {"file_path": path, "content": content}}
+
+
+def edit_payload(new_string: str, old_string: str = "", path: str = "/tmp/test.py") -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": path,
+            "old_string": old_string,
+            "new_string": new_string,
+        },
+    }
+
+
+# ──────────────────────────────────────────────
+# Unit 1: Plumbing + fail-open
+# ──────────────────────────────────────────────
+
+class TestPlumbingAndFailOpen:
+    def test_script_exists_and_is_executable(self):
+        assert SCRIPT.exists(), f"missing {SCRIPT}"
+        assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} must be executable"
+
+    def test_malformed_stdin_exits_0(self):
+        result = subprocess.run(
+            [str(SCRIPT)], input="not-json", text=True, capture_output=True,
+            env=dict(_CLEAN_ENV),
+        )
+        assert result.returncode == 0
+        assert result.stderr == ""
+
+    def test_missing_tool_name_exits_0(self):
+        result = run_guard({"tool_input": {"content": "hello"}})
+        assert result.returncode == 0
+
+    def test_missing_tool_input_exits_0(self):
+        result = run_guard({"tool_name": "Write"})
+        assert result.returncode == 0
+
+    def test_non_write_edit_tool_exits_0(self):
+        result = run_guard({"tool_name": "Bash", "tool_input": {"command": "echo hi"}})
+        assert result.returncode == 0
+
+    def test_benign_write_content_exits_0(self):
+        result = run_guard(write_payload("x = 1\nprint(x)\n"))
+        assert result.returncode == 0
+        assert result.stderr == ""
+
+
+# ──────────────────────────────────────────────
+# Unit 2: HIGH-confidence patterns
+# ──────────────────────────────────────────────
+
+class TestHighPatterns:
+    @pytest.mark.parametrize("content,label", [
+        (f'token = "{_FAKE_GHP}"', "github-pat ghp_"),
+        (f'token = "{_FAKE_PAT}"', "github-fine-grained-pat"),
+        (f'key_id = "{_FAKE_AKIA}"', "aws-access-key-id"),
+    ])
+    def test_blocked(self, content, label):
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2, f"Expected BLOCKED for {label}: {result.stderr!r}"
+        assert "BLOCKED" in result.stderr
+
+    def test_blocked_message_includes_line_number(self):
+        content = f"\n\ntoken = '{_FAKE_GHP}'"
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2
+        assert "line 3" in result.stderr
+
+    def test_blocked_message_includes_pattern_name(self):
+        result = run_guard(write_payload(f'x = "{_FAKE_AKIA}"'))
+        assert "aws-access-key-id" in result.stderr
+
+
+# ──────────────────────────────────────────────
+# Unit 3: NEEDS-CONTEXT patterns
+# ──────────────────────────────────────────────
+
+class TestNeedsContextPatterns:
+    @pytest.mark.parametrize("content,label", [
+        (f'API_KEY = "{_FAKE_API_KEY_VAL}"', "generic-api-key assignment"),
+        (f'SECRET = "{_FAKE_SECRET_VAL}"', "generic-secret SECRET"),
+        (f'PASSWORD = "{_FAKE_SECRET_VAL}"', "generic-secret PASSWORD"),
+        (f'TOKEN = "{_FAKE_SECRET_VAL}"', "generic-secret TOKEN"),
+        (f'aws_secret_access_key = "{_FAKE_AWS_SECRET}"', "aws-secret-access-key"),
+        (f'API_KEY={_FAKE_API_KEY_VAL}', "dotenv-api-key"),
+        (f'SECRET={_FAKE_SECRET_VAL}', "dotenv-secret"),
+        # getenv as substring should NOT suppress detection (word-boundary fix)
+        (f'SECRET = "{_FAKE_SECRET_VAL}"  # see getenv_config.py', "getenv substring in comment"),
+    ])
+    def test_blocked(self, content, label):
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2, f"Expected BLOCKED for {label!r}: {result.stderr!r}"
+        assert "BLOCKED" in result.stderr
+
+    @pytest.mark.parametrize("content,label", [
+        ('SECRET = os.environ["SECRET"]', "env reference - os.environ"),
+        ('API_KEY = os.getenv("API_KEY")', "env reference - os.getenv"),
+        ('TOKEN = process.env.TOKEN', "env reference - process.env"),
+        ('PASSWORD = ENV["PASSWORD"]', "env reference - ENV[]"),
+        ('SECRET=os.environ["SECRET"]', "dotenv-style env reference"),
+        ('TOKEN=process.env.TOKEN', "dotenv process.env"),
+        # Boolean / short values must not be blocked (dotenv flags)
+        ('TOKEN=true', "dotenv boolean true"),
+        ('TOKEN=false', "dotenv boolean false"),
+        ('SECRET=1', "dotenv single char"),
+        ('PASSWORD=no', "dotenv short value"),
+    ])
+    def test_allowed_env_reference(self, content, label):
+        result = run_guard(write_payload(content))
+        assert result.returncode == 0, f"Expected ALLOWED for {label!r}: {result.stderr!r}"
+
+
+# ──────────────────────────────────────────────
+# Unit 4: Per-line # nosecret suppression
+# ──────────────────────────────────────────────
+
+class TestNosecretSuppression:
+    def test_nosecret_on_same_line_allows(self):
+        content = f'TOKEN = "{_FAKE_GHP}"  # nosecret'
+        result = run_guard(write_payload(content))
+        assert result.returncode == 0
+
+    def test_secret_on_adjacent_line_still_blocked(self):
+        content = f'x = 1  # nosecret\nTOKEN = "{_FAKE_GHP}"\n'
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2
+
+    def test_nosecret_inline_comment_allows(self):
+        content = f'{_FAKE_AKIA}  # nosecret'
+        result = run_guard(write_payload(content))
+        assert result.returncode == 0
+
+
+# ──────────────────────────────────────────────
+# Unit 5: Filename allowlist
+# ──────────────────────────────────────────────
+
+class TestFilenameAllowlist:
+    def test_gitignore_allowed(self):
+        content = f'TOKEN = "{_FAKE_GHP}"'
+        result = run_guard(write_payload(content, path="/repo/.gitignore"))
+        assert result.returncode == 0
+
+    def test_test_corpus_allowed(self):
+        content = f'_FAKE_GHP = "ghp_{"A" * 36}"'  # nosecret
+        corpus_path = str(SCRIPT.parent.parent / "tests" / "test_secret_guard.py")
+        result = run_guard(write_payload(content, path=corpus_path))
+        assert result.returncode == 0
+
+    def test_arbitrary_test_file_not_in_allowlist(self):
+        content = f'token = "{_FAKE_GHP}"'
+        result = run_guard(write_payload(content, path="/project/tests/other_test.py"))
+        assert result.returncode == 2
+
+
+# ──────────────────────────────────────────────
+# Unit 6: Edit routing
+# ──────────────────────────────────────────────
+
+class TestEditRouting:
+    def test_secret_in_new_string_blocked(self):
+        result = run_guard(edit_payload(
+            new_string=f'token = "{_FAKE_GHP}"',
+            old_string="token = old_value",
+        ))
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_secret_only_in_old_string_allowed(self):
+        result = run_guard(edit_payload(
+            new_string="token = os.environ['TOKEN']",
+            old_string=f'token = "{_FAKE_GHP}"',
+        ))
+        assert result.returncode == 0
+
+    def test_edit_benign_both_strings_allowed(self):
+        result = run_guard(edit_payload(
+            new_string="x = 2",
+            old_string="x = 1",
+        ))
+        assert result.returncode == 0
+
+
+# ──────────────────────────────────────────────
+# Unit 7: Wiring — hooks.json has Write|Edit entry
+# ──────────────────────────────────────────────
+
+class TestHooksJsonWiring:
+    HOOKS_JSON = Path(__file__).parent.parent / "hooks" / "hooks.json"
+
+    def test_write_edit_entry_present(self):
+        data = json.loads(self.HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = [
+            e for e in data["hooks"]["PreToolUse"]
+            if e.get("matcher") == "Write|Edit"
+        ]
+        assert entries, "Write|Edit PreToolUse entry missing from hooks.json"
+
+    def test_secret_guard_referenced(self):
+        data = json.loads(self.HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = [
+            e for e in data["hooks"]["PreToolUse"]
+            if e.get("matcher") == "Write|Edit"
+        ]
+        assert any(
+            "secret_guard.py" in e["hooks"][0]["command"] for e in entries
+        ), f"No entry references secret_guard.py; entries: {entries}"
+
+    def test_hook_script_exists_and_executable(self):
+        script = Path(__file__).parent.parent / "hooks" / "secret_guard.py"
+        assert script.exists(), f"Missing: {script}"
+        assert os.access(script, os.X_OK), f"Not executable: {script}"


### PR DESCRIPTION
## Summary

- Adds `hooks/secret_guard.py` — a `PreToolUse` hook on `Write|Edit` that blocks the operation before the file is written when content contains a hardcoded secret (GitHub tokens, AWS keys, `.env`-style assignments), closing the gap when the git `pre-commit` hook is absent.
- Patterns are two-tiered: HIGH (prefixed tokens like `ghp_`, `AKIA` blocked anywhere) and NEEDS-CONTEXT (key+literal structure required; env-var references exempt). Per-line `# nosecret` suppression and a narrow filename allowlist handle legitimate fixtures.
- Fail-open posture (exit 0 on parse errors) is deliberate — documented in `docs/secret-detection.md` alongside the accidental-leak threat model.
- `scripts/validate.py` gains `check_hook_scripts()` to `py_compile` every `hooks/*.py` at CI time.

## Test Plan

- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `python3 -m py_compile hooks/secret_guard.py` — clean
- [ ] `python3 scripts/validate.py` → `All checks passed.`
- [ ] `pytest tests/test_secret_guard.py tests/test_hooks.py -v` — 107 passed
- [ ] Smoke: `echo '{"tool_name":"Write","tool_input":{"file_path":"/tmp/x.py","content":"TOKEN = \"ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\""}}' | hooks/secret_guard.py` → exit 2 + `BLOCKED`
- [ ] Smoke: benign payload → exit 0, empty stderr

### Type-tailored checks ([feat])

- [ ] New behaviour exercised end-to-end with a shaped-but-fake token in a Write payload
- [ ] `# nosecret` suppression verified: suppressed line allowed, adjacent unsuppressed line still blocked
- [ ] Edit routing verified: secret in `new_string` blocked; secret only in `old_string` allowed
- [ ] Dotenv boolean values (`TOKEN=true`, `SECRET=no`) verified as allowed (no false-positive)

Closes #181
