### PR TITLE
[fix] Use baseRepository for OWNER/REPO in workflow PR review skills

### DIFF
--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -34,20 +34,28 @@ This skill orchestrates:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-address-feedback
-gh pr view "$PR" --json number,title,body,headRefName,baseRefName,author,reviewDecision,headRepository,state \
+gh pr view "$PR" --json number,title,body,headRefName,baseRefName,author,reviewDecision,baseRepository,state \
   > "/tmp/swe-workbench-address-feedback/${PR}.json"
 [ -s "/tmp/swe-workbench-address-feedback/${PR}.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
 
 Extract fields from the JSON:
-- `AUTHOR_LOGIN` from `author.login`
-- `OWNER` from `headRepository.nameWithOwner | split("/")[0]`
-- `REPO` from `headRepository.name`
-- `STATE` from `state`
+
+```bash
+JSON="/tmp/swe-workbench-address-feedback/${PR}.json"
+AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
+PR_BRANCH=$(jq -r .headRefName "$JSON")
+OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
+REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
+  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  exit 1
+fi
+```
 
 Check that the PR is open before proceeding:
 ```bash
-STATE=$(jq -r .state "/tmp/swe-workbench-address-feedback/${PR}.json")
+STATE=$(jq -r .state "$JSON")
 [ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — address-feedback only applies to open PRs."; exit 1; }
 ```
 
@@ -98,7 +106,7 @@ WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 **When rimba is absent** (durable fallback):
 
 ```bash
-PR_BRANCH=$(jq -r .headRefName "/tmp/swe-workbench-address-feedback/${PR}.json")
+PR_BRANCH=$(jq -r .headRefName "$JSON")
 WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
 mkdir -p "$(dirname "$WT")"
 git fetch origin "${PR_BRANCH}"

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -106,7 +106,6 @@ WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 **When rimba is absent** (durable fallback):
 
 ```bash
-PR_BRANCH=$(jq -r .headRefName "$JSON")
 WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
 mkdir -p "$(dirname "$WT")"
 git fetch origin "${PR_BRANCH}"

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -34,7 +34,7 @@ This skill orchestrates:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-address-feedback
-gh pr view "$PR" --json number,title,body,headRefName,baseRefName,author,reviewDecision,baseRepository,state \
+gh pr view "$PR" --json number,title,body,headRefName,baseRefName,author,reviewDecision,state \
   > "/tmp/swe-workbench-address-feedback/${PR}.json"
 [ -s "/tmp/swe-workbench-address-feedback/${PR}.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
@@ -45,10 +45,10 @@ Extract fields from the JSON:
 JSON="/tmp/swe-workbench-address-feedback/${PR}.json"
 AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
 PR_BRANCH=$(jq -r .headRefName "$JSON")
-OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
-REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+OWNER=$(gh repo view --json owner -q .owner.login)
+REPO=$(gh repo view --json name   -q .name)
 if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
   exit 1
 fi
 ```

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -34,7 +34,7 @@ This skill orchestrates; analysis is delegated to:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-pr-review
-gh pr view "$PR" --json state,number,headRefName,baseRefName,baseRepository,headRefOid,title,body,author \
+gh pr view "$PR" --json state,number,headRefName,baseRefName,headRefOid,title,body,author \
   > "/tmp/swe-workbench-pr-review/${PR}-followup.json"
 [ -s "/tmp/swe-workbench-pr-review/${PR}-followup.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
@@ -46,10 +46,10 @@ JSON="/tmp/swe-workbench-pr-review/${PR}-followup.json"
 BASE=$(jq -r .baseRefName "$JSON")
 HEAD_SHA=$(jq -r .headRefOid "$JSON")
 AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
-OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
-REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+OWNER=$(gh repo view --json owner -q .owner.login)
+REPO=$(gh repo view --json name   -q .name)
 if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
   exit 1
 fi
 ```

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -34,16 +34,29 @@ This skill orchestrates; analysis is delegated to:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-pr-review
-gh pr view "$PR" --json state,number,headRefName,baseRefName,headRepository,headRefOid,title,body,author \
+gh pr view "$PR" --json state,number,headRefName,baseRefName,baseRepository,headRefOid,title,body,author \
   > "/tmp/swe-workbench-pr-review/${PR}-followup.json"
 [ -s "/tmp/swe-workbench-pr-review/${PR}-followup.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
 
-Extract `BASE`, `HEAD_SHA`, `OWNER`, `REPO`, and `AUTHOR_LOGIN` (from `author.login`) from the JSON. The state file is stored under `${PR}-followup.json` (distinct from `${PR}.json` used by the primary review) to allow both to coexist.
+Extract fields from the JSON. The state file is stored under `${PR}-followup.json` (distinct from `${PR}.json` used by the primary review) to allow both to coexist.
+
+```bash
+JSON="/tmp/swe-workbench-pr-review/${PR}-followup.json"
+BASE=$(jq -r .baseRefName "$JSON")
+HEAD_SHA=$(jq -r .headRefOid "$JSON")
+AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
+OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
+REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
+  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  exit 1
+fi
+```
 
 Check that the PR is open before proceeding:
 ```bash
-STATE=$(jq -r .state "/tmp/swe-workbench-pr-review/${PR}-followup.json")
+STATE=$(jq -r .state "$JSON")
 [ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — follow-up review only applies to open PRs."; exit 1; }
 ```
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -37,7 +37,7 @@ This skill orchestrates; analysis is delegated to:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-pr-review
-gh pr view "$PR" --json state,number,headRefName,baseRefName,baseRepository,headRefOid,title,body,author \
+gh pr view "$PR" --json state,number,headRefName,baseRefName,headRefOid,title,body,author \
   > "/tmp/swe-workbench-pr-review/${PR}.json"
 [ -s "/tmp/swe-workbench-pr-review/${PR}.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
@@ -49,10 +49,10 @@ JSON="/tmp/swe-workbench-pr-review/${PR}.json"
 BASE=$(jq -r .baseRefName "$JSON")
 HEAD_SHA=$(jq -r .headRefOid "$JSON")
 AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
-OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
-REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+OWNER=$(gh repo view --json owner -q .owner.login)
+REPO=$(gh repo view --json name   -q .name)
 if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
   exit 1
 fi
 ```

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -37,12 +37,25 @@ This skill orchestrates; analysis is delegated to:
 gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 mkdir -p /tmp/swe-workbench-pr-review
-gh pr view "$PR" --json state,number,headRefName,baseRefName,headRepository,headRefOid,title,body,author \
+gh pr view "$PR" --json state,number,headRefName,baseRefName,baseRepository,headRefOid,title,body,author \
   > "/tmp/swe-workbench-pr-review/${PR}.json"
 [ -s "/tmp/swe-workbench-pr-review/${PR}.json" ] || { echo "PR #$PR not found or not accessible."; exit 1; }
 ```
 
-Extract `BASE`, `HEAD_SHA`, `OWNER`, `REPO`, and `AUTHOR_LOGIN` (from `author.login`) from the JSON for downstream steps.
+Extract fields from the JSON:
+
+```bash
+JSON="/tmp/swe-workbench-pr-review/${PR}.json"
+BASE=$(jq -r .baseRefName "$JSON")
+HEAD_SHA=$(jq -r .headRefOid "$JSON")
+AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
+OWNER=$(jq -r '.baseRepository.owner.login // (.baseRepository.nameWithOwner // "" | split("/")[0])' "$JSON")
+REPO=$(jq  -r '.baseRepository.name      // (.baseRepository.nameWithOwner // "" | split("/")[1])' "$JSON")
+if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
+  echo "Could not determine base repo owner/name from PR #$PR metadata. Inspect with: gh pr view $PR --json baseRepository" >&2
+  exit 1
+fi
+```
 
 ### Step 2 — Ephemeral worktree
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -64,12 +64,48 @@ def test_address_feedback_skill_uses_three_way_triage():
     assert "DEFERRED" in text, "SKILL.md must reference DEFERRED triage state"
 
 
-def test_address_feedback_skill_fetches_head_repository():
-    """Phase 1 gh pr view must include headRepository so OWNER/REPO can be extracted."""
+def test_address_feedback_skill_fetches_base_repository():
+    """Phase 1 gh pr view must include baseRepository so OWNER/REPO target the base repo."""
     text = SKILL_MD.read_text()
-    assert "headRepository" in text, (
-        "SKILL.md Phase 1 gh pr view must include headRepository in --json fields "
-        "so that $OWNER and $REPO are populated for the GraphQL thread fetch and REST reply endpoint"
+    assert "baseRepository" in text, (
+        "SKILL.md Phase 1 gh pr view must include baseRepository in --json fields "
+        "so that $OWNER and $REPO are populated from the base (receiving) repo, "
+        "not the fork's headRepository"
+    )
+
+
+def test_address_feedback_skill_owner_repo_from_base_jq():
+    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract OWNER from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or headRepository"
+    )
+    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract REPO from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.name // ...'), not prose or headRepository"
+    )
+
+
+def test_address_feedback_skill_no_fragile_owner_extraction():
+    """SKILL.md must not contain fragile Python-dict or headRepository-owner extraction patterns."""
+    text = SKILL_MD.read_text()
+    assert "['owner']['login']" not in text, (
+        "SKILL.md must not contain Python-dict extraction ['owner']['login'] — "
+        "this pattern threw KeyError on fork PRs where headRepository lacks an owner key"
+    )
+    assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
+        "SKILL.md must not derive OWNER from headRepository.owner.login — "
+        "use baseRepository.owner.login instead"
+    )
+
+
+def test_address_feedback_skill_has_owner_repo_guard_clause():
+    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"Could not determine base repo owner", text), (
+        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
     )
 
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -64,26 +64,25 @@ def test_address_feedback_skill_uses_three_way_triage():
     assert "DEFERRED" in text, "SKILL.md must reference DEFERRED triage state"
 
 
-def test_address_feedback_skill_fetches_base_repository():
-    """Phase 1 gh pr view must include baseRepository so OWNER/REPO target the base repo."""
+def test_address_feedback_skill_owner_repo_from_gh_repo_view():
+    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
     text = SKILL_MD.read_text()
-    assert "baseRepository" in text, (
-        "SKILL.md Phase 1 gh pr view must include baseRepository in --json fields "
-        "so that $OWNER and $REPO are populated from the base (receiving) repo, "
-        "not the fork's headRepository"
+    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
+        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
+    )
+    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
+        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
 
-def test_address_feedback_skill_owner_repo_from_base_jq():
-    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+def test_address_feedback_skill_no_invalid_json_field():
+    """Phase 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""
     text = SKILL_MD.read_text()
-    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract OWNER from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or headRepository"
-    )
-    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract REPO from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.name // ...'), not prose or headRepository"
+    assert not re.search(r"gh pr view[^\n]*--json[^\n]*baseRepository", text), (
+        "SKILL.md must not use baseRepository in gh pr view --json — "
+        "that field is unsupported and causes gh to exit with 'Unknown JSON field'"
     )
 
 
@@ -96,7 +95,7 @@ def test_address_feedback_skill_no_fragile_owner_extraction():
     )
     assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
         "SKILL.md must not derive OWNER from headRepository.owner.login — "
-        "use baseRepository.owner.login instead"
+        "use gh repo view instead"
     )
 
 
@@ -105,7 +104,7 @@ def test_address_feedback_skill_has_owner_repo_guard_clause():
     text = SKILL_MD.read_text()
     assert re.search(r"Could not determine base repo owner", text), (
         "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
-        "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
+        "so failures produce an actionable error rather than silently misrouting API calls"
     )
 
 

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -77,25 +77,25 @@ def test_followup_skill_documents_stale_commit_retry():
     )
 
 
-def test_followup_skill_uses_base_repository_in_json_fields():
-    """Step 1 gh pr view --json must include baseRepository (not headRepository) for OWNER/REPO."""
+def test_followup_skill_owner_repo_from_gh_repo_view():
+    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
     text = SKILL_MD.read_text()
-    assert "baseRepository" in text, (
-        "SKILL.md Step 1 gh pr view --json field list must include baseRepository "
-        "so that $OWNER and $REPO target the base (receiving) repo, not the fork"
+    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
+        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
+    )
+    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
+        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
 
-def test_followup_skill_owner_repo_extracted_via_jq_from_base():
-    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+def test_followup_skill_no_invalid_json_field():
+    """Step 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""
     text = SKILL_MD.read_text()
-    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract OWNER from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or Python"
-    )
-    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract REPO from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.name // ...'), not prose or Python"
+    assert not re.search(r"gh pr view[^\n]*--json[^\n]*baseRepository", text), (
+        "SKILL.md must not use baseRepository in gh pr view --json — "
+        "that field is unsupported and causes gh to exit with 'Unknown JSON field'"
     )
 
 
@@ -108,7 +108,7 @@ def test_followup_skill_no_fragile_owner_extraction():
     )
     assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
         "SKILL.md must not reference headRepository.owner.login — "
-        "use baseRepository.owner.login instead"
+        "use gh repo view instead"
     )
 
 

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -75,3 +75,47 @@ def test_followup_skill_documents_stale_commit_retry():
         "SKILL.md failure modes must document the stale commit_id retry: "
         "re-fetch HEAD_SHA via headRefOid when all POSTs return 422"
     )
+
+
+def test_followup_skill_uses_base_repository_in_json_fields():
+    """Step 1 gh pr view --json must include baseRepository (not headRepository) for OWNER/REPO."""
+    text = SKILL_MD.read_text()
+    assert "baseRepository" in text, (
+        "SKILL.md Step 1 gh pr view --json field list must include baseRepository "
+        "so that $OWNER and $REPO target the base (receiving) repo, not the fork"
+    )
+
+
+def test_followup_skill_owner_repo_extracted_via_jq_from_base():
+    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract OWNER from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or Python"
+    )
+    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract REPO from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.name // ...'), not prose or Python"
+    )
+
+
+def test_followup_skill_no_fragile_owner_extraction():
+    """SKILL.md must not contain fragile Python-dict or headRepository-owner extraction patterns."""
+    text = SKILL_MD.read_text()
+    assert "['owner']['login']" not in text, (
+        "SKILL.md must not contain Python-dict extraction ['owner']['login'] — "
+        "this pattern threw KeyError on fork PRs where headRepository lacks an owner key"
+    )
+    assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
+        "SKILL.md must not reference headRepository.owner.login — "
+        "use baseRepository.owner.login instead"
+    )
+
+
+def test_followup_skill_has_owner_repo_guard_clause():
+    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"Could not determine base repo owner", text), (
+        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
+    )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -1,0 +1,69 @@
+# tests/test_workflow_pr_review_skill.py
+
+"""Tests for the workflow-pr-review skill — base-repo extraction (issue #289)."""
+
+import re
+from pathlib import Path
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+SKILL_DIR = ROOT / "skills" / "workflow-pr-review"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def test_pr_review_skill_file_exists():
+    """skills/workflow-pr-review/SKILL.md must exist with valid frontmatter."""
+    assert SKILL_MD.exists(), "skills/workflow-pr-review/SKILL.md must exist"
+    text = SKILL_MD.read_text()
+    fm = validate.parse_frontmatter(SKILL_MD, text=text)
+    assert fm is not None, "SKILL.md must have valid frontmatter"
+    assert "name" in fm, "SKILL.md frontmatter must have a name field"
+    assert "description" in fm, "SKILL.md frontmatter must have a description field"
+    assert fm.get("orchestrator") == "true", (
+        "SKILL.md frontmatter must have orchestrator: true"
+    )
+
+
+def test_pr_review_skill_uses_base_repository_in_json_fields():
+    """Step 1 gh pr view --json must include baseRepository (not headRepository) for OWNER/REPO."""
+    text = SKILL_MD.read_text()
+    assert "baseRepository" in text, (
+        "SKILL.md Step 1 gh pr view --json field list must include baseRepository "
+        "so that $OWNER and $REPO target the base (receiving) repo, not the fork"
+    )
+
+
+def test_pr_review_skill_owner_repo_extracted_via_jq_from_base():
+    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract OWNER from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or Python"
+    )
+    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
+        "SKILL.md must extract REPO from baseRepository via jq "
+        "(e.g. jq -r '.baseRepository.name // ...'), not prose or Python"
+    )
+
+
+def test_pr_review_skill_no_fragile_owner_extraction():
+    """SKILL.md must not contain fragile Python-dict or headRepository-owner extraction patterns."""
+    text = SKILL_MD.read_text()
+    assert "['owner']['login']" not in text, (
+        "SKILL.md must not contain Python-dict extraction ['owner']['login'] — "
+        "this pattern threw KeyError on fork PRs where headRepository lacks an owner key"
+    )
+    assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
+        "SKILL.md must not reference headRepository.owner.login — "
+        "use baseRepository.owner.login instead"
+    )
+
+
+def test_pr_review_skill_has_owner_repo_guard_clause():
+    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"Could not determine base repo owner", text), (
+        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
+    )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -25,25 +25,25 @@ def test_pr_review_skill_file_exists():
     )
 
 
-def test_pr_review_skill_uses_base_repository_in_json_fields():
-    """Step 1 gh pr view --json must include baseRepository (not headRepository) for OWNER/REPO."""
+def test_pr_review_skill_owner_repo_from_gh_repo_view():
+    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
     text = SKILL_MD.read_text()
-    assert "baseRepository" in text, (
-        "SKILL.md Step 1 gh pr view --json field list must include baseRepository "
-        "so that $OWNER and $REPO target the base (receiving) repo, not the fork"
+    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
+        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
+    )
+    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
+        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
 
-def test_pr_review_skill_owner_repo_extracted_via_jq_from_base():
-    """OWNER and REPO must be extracted from baseRepository via a jq expression."""
+def test_pr_review_skill_no_invalid_json_field():
+    """Step 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""
     text = SKILL_MD.read_text()
-    assert re.search(r"OWNER\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract OWNER from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.owner.login // ...'), not prose or Python"
-    )
-    assert re.search(r"REPO\s*=.*\$\(jq[^\n]*baseRepository", text), (
-        "SKILL.md must extract REPO from baseRepository via jq "
-        "(e.g. jq -r '.baseRepository.name // ...'), not prose or Python"
+    assert not re.search(r"gh pr view[^\n]*--json[^\n]*baseRepository", text), (
+        "SKILL.md must not use baseRepository in gh pr view --json — "
+        "that field is unsupported and causes gh to exit with 'Unknown JSON field'"
     )
 
 
@@ -56,7 +56,7 @@ def test_pr_review_skill_no_fragile_owner_extraction():
     )
     assert not re.search(r"headRepository[^`\n]*owner[^`\n]*login", text), (
         "SKILL.md must not reference headRepository.owner.login — "
-        "use baseRepository.owner.login instead"
+        "use gh repo view instead"
     )
 
 
@@ -65,5 +65,5 @@ def test_pr_review_skill_has_owner_repo_guard_clause():
     text = SKILL_MD.read_text()
     assert re.search(r"Could not determine base repo owner", text), (
         "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
-        "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
+        "so failures produce an actionable error rather than silently misrouting API calls"
     )


### PR DESCRIPTION
## Summary

- Replace `headRepository` with `baseRepository` in the `gh pr view --json` field list across all three workflow PR skills (`workflow-pr-review`, `workflow-pr-review-followup`, `workflow-address-feedback`)
- Replace prose OWNER/REPO extraction (which the runtime LLM could implement as fragile Python `['owner']['login']`) with an explicit null-safe jq block: primary `.baseRepository.owner.login`, fallback `.nameWithOwner | split("/")[0]`, guard clause that `exit 1` with an actionable error
- Fix latent fork-PR mis-targeting: OWNER/REPO now resolve to the base (receiving) repo where review threads and inline comments live, not the fork's headRepository
- Add `tests/test_workflow_pr_review_skill.py` (new file); extend followup and address-feedback test files with baseRepository, jq, guard-clause, and negative-pattern assertions
- Head-side fields (`headRefOid`/`HEAD_SHA`, `headRefName`/`PR_BRANCH`, `baseRefName`/`BASE`) untouched

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` → 757 passed (0 failures)
- [x] `grep -rnE "['owner']['login']|headRepository.*owner.*login" skills/` → 0 matches
- [x] `grep -n baseRepository` in all three skills → 12 matches across 3 files
- [x] `scripts/validate.sh` → "All checks passed"
- [x] TDD red-green cycle confirmed per skill: tests failed before fix, passed after

### Type-tailored checks ([fix])

- [x] Original symptom reproduced mentally: `headRepository = {"id": "...", "name": "rimba"}` (no `owner` key) → new extraction never reads `headRepository` for OWNER/REPO, so the `KeyError` class cannot recur
- [x] Guard clause fires on truly-missing base owner/repo and emits actionable `gh pr view $PR --json baseRepository` hint

Closes #289
