### PR TITLE
[fix] Clean up address-feedback worktree on exit

### DIFF
--- a/commands/address-feedback.md
+++ b/commands/address-feedback.md
@@ -21,4 +21,4 @@ Inspect `$ARGUMENTS` plus `git rev-parse --abbrev-ref HEAD` and `git log --oneli
 
 Invoke `swe-workbench:workflow-address-feedback` with the resolved PR number and any ticket-context prelude from Step 2.
 
-The skill owns: pre-flight (`gh auth`, `gh pr view`), owner-identity check, durable worktree setup via `rimba add pr:$PR --task "address-feedback-$PR"`, thread fetch via GraphQL `reviewThreads`, per-thread A/C/D triage, Edit-tool fix application, `swe-workbench:workflow-commit-and-pr` for committing, REST reply posting, and GraphQL `resolveReviewThread` for resolved threads.
+The skill owns: pre-flight (`gh auth`, `gh pr view`), owner-identity check, worktree setup via `rimba add pr:$PR --task "address-feedback-$PR"` (cleaned up on exit via Phase 6), thread fetch via GraphQL `reviewThreads`, per-thread A/C/D triage, Edit-tool fix application, `swe-workbench:workflow-commit-and-pr` for committing, REST reply posting, and GraphQL `resolveReviewThread` for resolved threads.

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -95,7 +95,7 @@ If a prior triage save exists at `/tmp/swe-workbench-address-feedback/${PR}-tria
 
 ### Phase 2 — Worktree
 
-**When rimba is available** (preferred — durable, owner commits land here):
+**When rimba is available** (preferred):
 
 ```bash
 RIMBA_OUT=$(rimba add "pr:$PR" --task "address-feedback-$PR" --skip-deps --skip-hooks 2>&1)
@@ -103,7 +103,7 @@ WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 [ -d "$WT" ] || { echo "rimba add failed: $RIMBA_OUT"; exit 1; }
 ```
 
-**When rimba is absent** (durable fallback):
+**When rimba is absent** (fallback):
 
 ```bash
 WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
@@ -112,7 +112,7 @@ git fetch origin "${PR_BRANCH}"
 git worktree add "$WT" "${PR_BRANCH}"
 ```
 
-**This is a durable worktree** — no auto-cleanup. The owner's commits persist here until merged. After merge, run `swe-workbench:workflow-cleanup-merged` to remove it.
+This worktree is **disposable** — fixes are committed and pushed to the PR branch in Phase 4, so the work lives on the remote, not the worktree. Phase 6 removes it on every exit (success, Q-quit, or error). If removal fails, a fallback is attempted; see Phase 6 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 6 before stopping.
 
 ### Phase 3 — Triage digest
 
@@ -134,7 +134,7 @@ Parse severity from `Severity: <level>` prefix in comment body if present; other
 
 Capture: `triage[<thread_id>] = A|C|D`.
 
-If the owner replies `Q`, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json` and exit. Re-invocation resumes from this file.
+If the owner replies `Q`, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, then run **Phase 6 — Cleanup**, and exit. Re-invocation resumes from this file (Phase 2 re-creates the worktree).
 
 ### Phase 4 — Implement + commit
 
@@ -183,6 +183,25 @@ After all replies and resolutions land, emit the follow-up CTA:
 
 > "Want me to ping the reviewer to re-check? Reply `yes` to run `/review --check-followup <N>`."
 
+Then run **Phase 6 — Cleanup**.
+
+### Phase 6 — Cleanup (always)
+
+Run on every exit that occurs after a worktree was created in Phase 2 (success, Q-quit, or error). Skip only on Phase 1 early-exits (before any worktree exists).
+
+```bash
+# positional arg matches the --task label set in Phase 2 ("address-feedback-$PR")
+if rimba remove "address-feedback-$PR" --force 2>/dev/null; then
+  echo "Cleaned up worktree address-feedback-$PR."
+else
+  WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
+  git worktree remove --force "$WT" 2>/dev/null && rm -rf "$WT" 2>/dev/null
+  echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback."
+fi
+```
+
+Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a warning and do not block completion. The fallback removes only the worktree directory — never delete `$PR_BRANCH` directly (e.g. via `git branch -D`), which would destroy the owner's actual PR head branch.
+
 ## Failure modes
 
 | Failure | Signal | Action |
@@ -191,7 +210,8 @@ After all replies and resolutions land, emit the follow-up CTA:
 | PR not found | `gh pr view` fails | Abort. |
 | `CURRENT_USER != AUTHOR_LOGIN` | JSON mismatch | Warn + ask to continue. |
 | No outstanding threads | GraphQL returns 0 unresolved | Print "No open threads — nothing to address." Exit. |
-| Owner picks Q mid-triage | Loop exit | Save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`. Exit cleanly. |
+| Owner picks Q mid-triage | Loop exit | Save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, run Phase 6 cleanup, then exit. |
+| Worktree removal fails (rimba absent or busy) | `rimba remove` non-zero | Attempt `git worktree remove --force` fallback; log warning; do not block. |
 | Reply REST fails (404 — comment deleted) | HTTP 404 | Skip that thread, log "skipped (comment deleted)". |
 | Resolve mutation fails | GraphQL error | Reply already posted — log "reply posted but resolve failed". Continue. Do not roll back the reply. |
 
@@ -200,7 +220,8 @@ After all replies and resolutions land, emit the follow-up CTA:
 | Mistake | Fix |
 |---|---|
 | Omit `--skip-deps --skip-hooks` on the rimba call | Always pass both flags — same as other worktree-creating skills. Deps can be installed manually in the worktree if needed. |
-| Auto-cleanup the worktree after Phase 5 | This is a durable worktree — commits land here. Clean up post-merge via `swe-workbench:workflow-cleanup-merged`. |
+| Leave the worktree behind after skill exits | Phase 6 always removes it — skip Phase 6 only when exiting before Phase 2 (no worktree created yet). |
+| Deleting `$PR_BRANCH` directly in Phase 6 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |
 | Resolve a CLARIFIED thread | Only resolve ADDRESSED threads. CLARIFIED = reply only, no resolve. |
 | Try to resolve via REST | Thread resolution is GraphQL-only (`resolveReviewThread` mutation). REST has no equivalent endpoint. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -194,9 +194,9 @@ Run on every exit that occurs after a worktree was created in Phase 2 (success, 
 if rimba remove "address-feedback-$PR" --force 2>/dev/null; then
   echo "Cleaned up worktree address-feedback-$PR."
 else
-  WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
+  # $WT is set in Phase 2 (both rimba and fallback paths); do not re-assign here
   git worktree remove --force "$WT" 2>/dev/null && rm -rf "$WT" 2>/dev/null
-  echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback."
+  echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback on $WT."
 fi
 ```
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -195,3 +195,15 @@ def test_address_feedback_skill_has_cleanup_phase():
         "SKILL.md must include a Phase 6 (Cleanup) section — "
         "it must run on success, Q-exit, and error paths after a worktree has been created (AC#3)"
     )
+
+
+def test_address_feedback_skill_cleanup_uses_existing_wt():
+    """Phase 6 fallback must use $WT from Phase 2 — must not re-assign WT= in the else branch."""
+    text = SKILL_MD.read_text()
+    phase6_match = re.search(r"### Phase 6.*", text, re.DOTALL)
+    assert phase6_match, "Phase 6 section must exist for this check"
+    phase6_text = phase6_match.group(0)
+    assert not re.search(r'\bWT\s*=\s*["\'\$]', phase6_text), (
+        "Phase 6 must not re-assign $WT — use the value set in Phase 2 so the fallback "
+        "targets the correct worktree directory regardless of which Phase 2 branch (rimba vs. git) ran"
+    )

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -142,3 +142,56 @@ def test_address_feedback_skill_clarified_no_resolve():
         "SKILL.md must state that CLARIFIED threads get a reply but are NOT resolved "
         "(only ADDRESSED threads trigger resolveReviewThread)"
     )
+
+
+# --- Cleanup (Phase 6) tests — AC#1, AC#2, AC#3 from issue #291 ---
+
+def test_address_feedback_skill_cleans_up_worktree():
+    """Phase 6 must include rimba remove "address-feedback-$PR" --force (AC#1)."""
+    text = SKILL_MD.read_text()
+    assert re.search(r'rimba remove ["\']?address-feedback-\$PR["\']? --force', text), (
+        'SKILL.md Phase 6 must include: rimba remove "address-feedback-$PR" --force — '
+        "the worktree is disposable; fixes are on the remote branch after Phase 4"
+    )
+
+
+def test_address_feedback_skill_cleanup_failure_tolerant():
+    """Phase 6 cleanup must include a git-worktree fallback and must not block on failure (AC#2)."""
+    text = SKILL_MD.read_text()
+    assert "git worktree remove" in text, (
+        "SKILL.md Phase 6 must include a 'git worktree remove' fallback for when rimba is absent"
+    )
+    assert re.search(
+        r"warn|do not block|never block|not block|continue|non.blocking|emit.*notice",
+        text, re.IGNORECASE
+    ), (
+        "SKILL.md Phase 6 must state that cleanup failure is non-blocking (warn, do not block, continue)"
+    )
+
+
+def test_address_feedback_skill_cleanup_preserves_pr_branch():
+    """Phase 6 fallback must NEVER contain git branch -D \"$PR_BRANCH\" — that deletes the real PR head branch."""
+    text = SKILL_MD.read_text()
+    assert not re.search(r'branch\s+-D\s+["\']?\$PR_BRANCH', text), (
+        'SKILL.md must NOT contain: git branch -D "$PR_BRANCH" — '
+        "the git-worktree fallback in Phase 6 only removes the worktree dir; "
+        "deleting $PR_BRANCH would destroy the owner's actual PR head branch"
+    )
+
+
+def test_address_feedback_skill_drops_durable_no_cleanup_claim():
+    """SKILL.md must NOT contain the old 'no auto-cleanup' claim (stance reversal for issue #291)."""
+    text = SKILL_MD.read_text()
+    assert "no auto-cleanup" not in text, (
+        "SKILL.md must not claim 'no auto-cleanup' — issue #291 reversed this stance; "
+        "Phase 6 always removes the worktree on exit"
+    )
+
+
+def test_address_feedback_skill_has_cleanup_phase():
+    """SKILL.md must have a Phase 6 / Cleanup section that runs on every post-Phase-2 exit (AC#3)."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"Phase 6|## Phase 6|### Phase 6", text), (
+        "SKILL.md must include a Phase 6 (Cleanup) section — "
+        "it must run on success, Q-exit, and error paths after a worktree has been created (AC#3)"
+    )


### PR DESCRIPTION
## Summary
- Add **Phase 6 — Cleanup (always)** to `workflow-address-feedback`: runs `rimba remove "address-feedback-$PR" --force` on every post-Phase-2 exit (success, Q-quit, or unrecoverable error).
- Fallback to `git worktree remove --force` when rimba is absent; never deletes `$PR_BRANCH` (the real PR head branch).
- Failure-tolerant: if both paths fail, log a warning and continue — cleanup never blocks completion.
- Reverses the prior "durable / no auto-cleanup" design stance (issue #291).
- Updates `commands/address-feedback.md` to drop "durable" wording.
- Adds 5 TDD markdown-assertion tests verifying AC#1, AC#2, AC#3, the correctness guard, and the stance reversal.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `pytest tests/test_workflow_address_feedback_skill.py tests/test_address_feedback_command.py -v` → 23 passed
- [x] `pytest tests/ -v` → 764 passed (full suite green, no cross-skill regressions)
- [x] Verified no `branch -D "$PR_BRANCH"` in final SKILL.md (correctness guard)
- [x] Verified no "durable" / "no auto-cleanup" claims remain in SKILL.md or command file

### Type-tailored checks ([fix])
- [x] Reproduces the reported symptom: stale worktree in `rimba list` after every skill invocation
- [x] Verifies fix: Phase 6 block is present and wired to Q-exit (Phase 3), Phase 5 end, and error exits

Closes #291
