### PR TITLE
[feat] Persist workflow state across auto-compaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scripts/__pycache__/
 *.pyc
 .venv/
 .rimba/settings.local.toml
+.claude/cache/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ line number, and file. Use `# nosecret` on a line to suppress intentional
 fixtures. See [docs/secret-detection.md](docs/secret-detection.md) for the
 full pattern list, suppression options, and security notes.
 
+## Workflow state persistence
+
+When Claude Code auto-compacts a long conversation, any in-progress `workflow-development`,
+`workflow-bug-triage`, or `workflow-pr-review` state is saved to a sidecar JSON file under
+`.claude/cache/workflow-state/`. A `SessionStart` hook detects this file after compaction
+and injects a resume preamble so the workflow continues at the correct phase — no manual
+restart needed. See [docs/workflow-state.md](docs/workflow-state.md) for the schema,
+lifecycle table, and a manual smoke test.
+
 ## Skill-usage telemetry
 
 When the orchestrator dispatches a subagent, the skills that subagent invokes are surfaced in the transcript:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@
 - [cost-audit.md](cost-audit.md) — point-in-time model-tier audit (snapshot at #160).
 - [cost-tiers.md](cost-tiers.md) — forward-looking convention for assigning model tiers to new agents.
 - [secret-detection.md](secret-detection.md) — PreToolUse hook that blocks hardcoded secrets before Write/Edit writes the file.
+- [workflow-state.md](workflow-state.md) — SessionStart hook that persists workflow phase state across auto-compaction and injects a resume preamble.

--- a/docs/workflow-state.md
+++ b/docs/workflow-state.md
@@ -54,7 +54,7 @@ but different branches never share a checkpoint file.
 - `mode` — optional mode letter (A/B/C for workflow-development; absent for single-mode skills).
 - `phase` / `phase_label` — current phase/step number and human label; `completed_phases` lists all finished phases.
 - `context` — flat free-form bag; `context.branch` is the resume-validation key. Skills pack skill-specific values here (`pr`, `head_sha`, `decision` for pr-review; project-detection values for workflow-development).
-- `updated_at` — ISO-8601 timestamp; the hook uses filesystem mtime for staleness, not this field.
+- `updated_at` — ISO-8601 timestamp (informational — not used for staleness; the hook uses filesystem mtime instead).
 
 ### Lifecycle
 

--- a/docs/workflow-state.md
+++ b/docs/workflow-state.md
@@ -1,0 +1,160 @@
+# Workflow state persistence
+
+When Claude Code auto-compacts a long conversation, any in-progress swe-workbench
+workflow state lives only in the model's working context and is silently dropped.
+Auto-compaction happens precisely on large, complex tasks — exactly where these workflows
+matter most — leaving the user mid-flight with no clean way to resume.
+
+Workflow state persistence externalizes that state to a sidecar JSON file written by the
+model at each phase/step boundary, and re-injects a resume preamble after compaction so
+the workflow continues at the correct step.
+
+## How it works
+
+### State file
+
+| Property | Value |
+|---|---|
+| **Path** | `<git-toplevel>/.claude/cache/workflow-state/<branch-with-slashes-as-dashes>.json` |
+| **Example** | `.claude/cache/workflow-state/feature-286-workflow-state-persistence.json` |
+| **Directory** | `.claude/cache/` — the plugin's ephemeral-state home; gitignored |
+
+Both the model (writer) and the hook (reader) resolve the git toplevel via
+`git rev-parse --show-toplevel` from the session's cwd. This means the path agreement
+holds whether the session runs in the main checkout or a linked worktree.
+
+Per-branch filenames give worktree isolation for free: two worktrees on the same repo
+but different branches never share a checkpoint file.
+
+### Schema
+
+```json
+{
+  "version": 1,
+  "skill": "swe-workbench:workflow-development",
+  "mode": "B",
+  "phase": "3",
+  "phase_label": "Verify",
+  "completed_phases": ["1", "2"],
+  "context": {
+    "branch": "feature/286-workflow-state-persistence",
+    "worktree_root": "/abs/path/to/worktree",
+    "pr": null,
+    "base": null,
+    "head_sha": null,
+    "decision": null,
+    "notes": "free-form key decisions / identifiers"
+  },
+  "updated_at": "2026-05-21T10:30:00Z"
+}
+```
+
+- `version` — schema version; the hook ignores files with unknown versions (fail-soft).
+- `skill` — fully-qualified skill name driving the workflow.
+- `mode` — optional mode letter (A/B/C for workflow-development; absent for single-mode skills).
+- `phase` / `phase_label` — current phase/step number and human label; `completed_phases` lists all finished phases.
+- `context` — flat free-form bag; `context.branch` is the resume-validation key. Skills pack skill-specific values here (`pr`, `head_sha`, `decision` for pr-review; project-detection values for workflow-development).
+- `updated_at` — ISO-8601 timestamp; the hook uses filesystem mtime for staleness, not this field.
+
+### Lifecycle
+
+| Actor | Event | Action |
+|---|---|---|
+| **Model** | Phase/step transition | Write (overwrite) the state file with the new phase |
+| **Model** | Terminal phase success | Delete the state file |
+| **Hook** | SessionStart(compact) | Read the file; inject resume preamble if fresh + valid |
+| **Hook** | SessionStart(compact), file >24h old | Delete the file; no injection (staleness sweep) |
+| **Hook** | SessionStart(compact), branch mismatch or version ≠ 1 | No injection (fail-open, file untouched) |
+
+The state file is a **fail-soft cache, not a source of truth**. The model owns the semantic
+lifecycle (write/delete at phase boundaries). The hook owns the mechanical lifecycle
+(detect-and-inject, age-sweep). The hook never reconstructs state — any ambiguity degrades
+to "ask", because a wrong resume is worse than no resume.
+
+### Hook registration
+
+| Event | Matcher | Script |
+|---|---|---|
+| `SessionStart` | `"compact"` | `hooks/workflow_resume_hint.sh` |
+
+`SessionStart` requires a `matcher` string (not a lifecycle event in `validate.py`); the
+`"compact"` matcher targets only compaction-triggered session starts.
+
+The hook always exits 0 — it never blocks session startup.
+
+## What survives compaction and what doesn't
+
+| Information | Survives? | Why |
+|---|---|---|
+| Current phase and phase label | ✓ | Written to state file at each transition |
+| Completed phases list | ✓ | Written to state file at each transition |
+| Skill name and mode | ✓ | Written to state file on entry |
+| PR number, base, HEAD SHA, decision | ✓ | Packed into `context` by pr-review skill |
+| Free-form notes and key decisions | ✓ | Model writes to `context.notes` |
+| Full conversation history | ✗ | Compaction by design; the preamble is not a replay |
+| Uncommitted code changes | ✗ | Live in the worktree filesystem — unaffected by compaction |
+| Sub-skill internal state | ✗ | Each sub-skill manages its own context |
+
+## Manual smoke test
+
+```bash
+# 1. Create a minimal state file for the current branch
+BRANCH=$(git branch --show-current)
+SAFE="${BRANCH//\//-}"
+STATEDIR="$(git rev-parse --show-toplevel)/.claude/cache/workflow-state"
+mkdir -p "$STATEDIR"
+python3 -c "
+import json, sys
+s = json.loads(sys.stdin.read())
+s['context']['branch'] = sys.argv[1]
+print(json.dumps(s))
+" "$BRANCH" <<'EOF' > "$STATEDIR/${SAFE}.json"
+{
+  "version": 1,
+  "skill": "swe-workbench:workflow-development",
+  "mode": "B",
+  "phase": "2",
+  "phase_label": "Implement",
+  "completed_phases": ["1"],
+  "context": { "branch": "BRANCH_PLACEHOLDER", "worktree_root": ".", "notes": "smoke test" },
+  "updated_at": "2026-05-21T00:00:00Z"
+}
+EOF
+
+# 2. Run the hook with a simulated SessionStart payload
+echo '{"cwd":"'"$(git rev-parse --show-toplevel)"'"}' \
+  | bash hooks/workflow_resume_hint.sh
+
+# Expected: JSON with hookSpecificOutput.additionalContext containing the skill name and phase.
+
+# 3. Test the no-op path (no file)
+rm "$STATEDIR/${SAFE}.json"
+echo '{"cwd":"'"$(git rev-parse --show-toplevel)"'"}' \
+  | bash hooks/workflow_resume_hint.sh
+
+# Expected: empty output, exit 0.
+```
+
+## Troubleshooting
+
+**Hook fires but no preamble is injected:**
+
+- Confirm the state file exists: `ls .claude/cache/workflow-state/`.
+- Confirm the branch name in `context.branch` matches `git branch --show-current` exactly.
+- Confirm `"version": 1` is present in the file.
+- Confirm the file is not stale: `find .claude/cache/workflow-state -mmin +1440` should be empty.
+
+**State file left behind after a completed workflow:**
+
+The model is responsible for deleting the state file at the terminal phase (Phase 5 for
+workflow-development; Phase 4 for workflow-bug-triage; Step 7 for workflow-pr-review). If
+it was skipped, delete manually:
+```bash
+rm .claude/cache/workflow-state/$(git branch --show-current | tr '/' '-').json
+```
+
+**Hook exits non-zero:**
+
+This should never happen — the hook exits 0 unconditionally. If `bash hooks/workflow_resume_hint.sh`
+exits non-zero when given a valid payload, check for a syntax error in the script:
+`bash -n hooks/workflow_resume_hint.sh`.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -47,6 +47,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/workflow_resume_hint.sh
+++ b/hooks/workflow_resume_hint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# workflow_resume_hint.sh — SessionStart(compact) hook
+#
+# Fires after auto-compaction. Detects a fresh, branch-matching workflow
+# checkpoint and injects a resume preamble so the model re-enters the
+# interrupted workflow at the correct phase.
+#
+# Fail-open: exit 0 unconditionally. A broken hook must never block startup.
+
+main() {
+    local input cwd root branch safe_branch state_dir state_file stale
+    local real_state real_dir version ctx_branch
+    local skill mode phase phase_label completed notes preamble
+
+    input=$(cat)
+    cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || return 0
+    [ -n "$cwd" ] || cwd="$PWD"
+
+    # Resolve git root — absent in non-git directories, which is fine
+    root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || return 0
+
+    # Current branch — absent on detached HEAD, which is fine
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null) || return 0
+    [ -n "$branch" ] || return 0
+
+    # Sanitize branch name: / → - (mirrors the writer contract)
+    safe_branch="${branch//\//-}"
+    state_dir="$root/.claude/cache/workflow-state"
+    state_file="${state_dir}/${safe_branch}.json"
+
+    # Path-containment guard: state_file must resolve inside state_dir.
+    # Uses python3 for portability (GNU realpath -m unavailable on macOS without coreutils).
+    real_state=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" \
+        "$state_file" 2>/dev/null) || return 0
+    real_dir=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" \
+        "$state_dir" 2>/dev/null) || return 0
+    case "$real_state" in "$real_dir/"*) ;; *) return 0 ;; esac
+
+    # No-op gate: no checkpoint for this branch
+    [ -f "$state_file" ] || return 0
+
+    # Staleness gate: file older than 24h is deleted and skipped.
+    # Only the current branch's file is removed; other branches manage their own.
+    stale=$(find "$state_file" -mmin +1440 2>/dev/null)
+    if [ -n "$stale" ]; then
+        rm -f "$state_file"
+        return 0
+    fi
+
+    # Schema version gate — only v1 understood; unknown versions are ignored
+    version=$(jq -r '.version // empty' "$state_file" 2>/dev/null) || return 0
+    [ "$version" = "1" ] || return 0
+
+    # Branch-match gate — reject a checkpoint left by a different branch
+    ctx_branch=$(jq -r '.context.branch // empty' "$state_file" 2>/dev/null) || return 0
+    [ "$ctx_branch" = "$branch" ] || return 0
+
+    # Read resume fields
+    skill=$(jq -r '.skill // ""' "$state_file" 2>/dev/null) || return 0
+    mode=$(jq -r '.mode // ""' "$state_file" 2>/dev/null) || return 0
+    phase=$(jq -r '.phase // ""' "$state_file" 2>/dev/null) || return 0
+    phase_label=$(jq -r '.phase_label // ""' "$state_file" 2>/dev/null) || return 0
+    completed=$(jq -r 'if (.completed_phases | length) > 0 then .completed_phases | join(", ") else "none" end' \
+        "$state_file" 2>/dev/null) || completed="none"
+    notes=$(jq -r '.context.notes // ""' "$state_file" 2>/dev/null) || notes=""
+
+    # Build preamble
+    preamble="[Workflow auto-resume after compaction]
+
+This session was compacted. A workflow checkpoint was found for branch: ${branch}.
+
+Skill:            ${skill}
+Current phase:    Phase ${phase}${phase_label:+ — ${phase_label}}${mode:+ (Mode ${mode})}
+Completed phases: ${completed}
+${notes:+Notes: ${notes}
+}
+Resume from Phase ${phase}${phase_label:+ (${phase_label})} — do NOT restart from Phase 1 or re-run completed phases.
+
+If the recorded state contradicts current repo reality (wrong branch, missing files, unexpected git state), stop and ask the user how to proceed before resuming."
+
+    # Use jq to build the full JSON envelope — avoids any shell format-string risk
+    # from characters in $preamble (%, \n, quotes, etc.).
+    jq -cn --arg ctx "$preamble" \
+        '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$ctx}}' \
+        || return 0
+}
+
+main
+exit 0

--- a/skills/workflow-bug-triage/SKILL.md
+++ b/skills/workflow-bug-triage/SKILL.md
@@ -46,6 +46,10 @@ For the inner investigation loop (read-before-guessing, reproduce-before-theoriz
 
 If `superpowers:systematic-debugging` is unavailable, run the same loop inline — never skip it.
 
+## Checkpoint behavior
+
+After entering each phase, write the workflow state file so the investigation can survive auto-compaction (see `docs/workflow-state.md` for the schema and path). After Phase 4 (issue filed), delete the state file.
+
 ## 4-phase flow
 
 ### Phase 1 — Investigation

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -225,9 +225,10 @@ When writing or finalizing a plan, add a `## Workflow` section using the templat
 ## Implementation-Time Behavior (Mode B)
 
 1. **Announce transitions**: `Phase N complete — <summary>. Moving to Phase N+1: <name>.`
-2. **Delegate to sub-skills**: don't re-implement what a sub-skill already does.
-3. **Track phase state** — sub-skill completed Phases 3 or 4 with evidence → mark them "completed by sub-skill".
-4. **Handle failures and no phase skipping** combined:
+2. **Checkpoint**: after each phase transition, write the workflow state file so the session can survive auto-compaction (see `docs/workflow-state.md` for the schema and path). At Phase 5 success, delete the state file.
+3. **Delegate to sub-skills**: don't re-implement what a sub-skill already does.
+4. **Track phase state** — sub-skill completed Phases 3 or 4 with evidence → mark them "completed by sub-skill".
+5. **Handle failures and no phase skipping** combined:
 
 | Phase | Failure | Skip condition |
 |-------|---------|----------------|

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -28,7 +28,7 @@ This skill orchestrates; analysis is delegated to:
 
 - `swe-workbench:reviewer` subagent — produces `Severity | File:Line | Issue | Why | Fix` findings + a Review Decision footer (when instructed by this skill — see Step 4).
 - `swe-workbench:ticket-context` skill — prepended to the reviewer prompt when the PR body or commit messages reference a ticket key, atlassian/Confluence URL, or `#NNN` GitHub ref.
-
+- **Checkpoint:** write the workflow state file (see `docs/workflow-state.md`) at each step boundary, carrying `$PR`/`$BASE`/`$HEAD_SHA`/`$DECISION` in `context`. Delete the state file after Step 7.
 ## 7-step flow
 
 ### Step 1 — Pre-flight

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -25,10 +25,10 @@ orchestrator: true
 ## Composition
 
 This skill orchestrates; analysis is delegated to:
-
 - `swe-workbench:reviewer` subagent — produces `Severity | File:Line | Issue | Why | Fix` findings + a Review Decision footer (when instructed by this skill — see Step 4).
 - `swe-workbench:ticket-context` skill — prepended to the reviewer prompt when the PR body or commit messages reference a ticket key, atlassian/Confluence URL, or `#NNN` GitHub ref.
 - **Checkpoint:** write the workflow state file (see `docs/workflow-state.md`) at each step boundary, carrying `$PR`/`$BASE`/`$HEAD_SHA`/`$DECISION` in `context`. Delete the state file after Step 7.
+
 ## 7-step flow
 
 ### Step 1 — Pre-flight

--- a/tests/test_workflow_resume_hook.py
+++ b/tests/test_workflow_resume_hook.py
@@ -1,0 +1,277 @@
+"""Tests for hooks/workflow_resume_hint.sh — SessionStart compact hook.
+
+Each test invokes hooks/workflow_resume_hint.sh directly with a JSON payload on
+stdin, mirroring how Claude Code calls the SessionStart hook after auto-compaction.
+Exit 0 always (fail-open). Injection only when a fresh, branch-matching v1 state
+file exists.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+HOOK = Path(__file__).parent.parent / "hooks" / "workflow_resume_hint.sh"
+HOOKS_JSON = Path(__file__).parent.parent / "hooks" / "hooks.json"
+
+_BRANCH = "feature/286-workflow-state-persistence"
+_SAFE_BRANCH = _BRANCH.replace("/", "-")
+
+VALID_STATE: dict = {
+    "version": 1,
+    "skill": "swe-workbench:workflow-development",
+    "mode": "B",
+    "phase": "3",
+    "phase_label": "Verify",
+    "completed_phases": ["1", "2"],
+    "context": {
+        "branch": _BRANCH,
+        "worktree_root": "/abs/path",
+        "pr": None,
+        "base": None,
+        "head_sha": None,
+        "decision": None,
+        "notes": "initial checkpoint",
+    },
+    "updated_at": "2026-05-21T10:30:00Z",
+}
+
+
+@pytest.fixture(scope="module")
+def hook_script():
+    assert HOOK.exists(), f"missing {HOOK}"
+    assert os.access(HOOK, os.X_OK), f"{HOOK} must be executable"
+    return HOOK
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Temp git repo on branch feature/286-workflow-state-persistence."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", _BRANCH],
+        cwd=repo_dir, env=_CLEAN_ENV, check=True,
+    )
+    (repo_dir / "README").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=repo_dir, env=_CLEAN_ENV, check=True)
+    subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null",
+         "-c", "user.email=t@t.com", "-c", "user.name=T",
+         "commit", "-qm", "init"],
+        cwd=repo_dir, env=_CLEAN_ENV, check=True,
+    )
+    return repo_dir
+
+
+def _state_path(repo_dir: Path, branch: str = _BRANCH) -> Path:
+    safe = branch.replace("/", "-")
+    return repo_dir / ".claude" / "cache" / "workflow-state" / f"{safe}.json"
+
+
+def _write_state(repo_dir: Path, state: dict, branch: str = _BRANCH) -> Path:
+    path = _state_path(repo_dir, branch)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state), encoding="utf-8")
+    return path
+
+
+def _run(script, cwd: str) -> subprocess.CompletedProcess:
+    payload = json.dumps({"cwd": cwd})
+    return subprocess.run(
+        [str(script)],
+        input=payload, text=True, capture_output=True,
+        env=_CLEAN_ENV,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+class TestHookWiring:
+    """hooks.json has the right SessionStart entry; script exists and is executable."""
+
+    def test_session_start_entry_present(self):
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = data["hooks"].get("SessionStart", [])
+        assert entries, "SessionStart event missing from hooks.json"
+
+    def test_compact_matcher_present(self):
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = data["hooks"].get("SessionStart", [])
+        compact = [e for e in entries if e.get("matcher") == "compact"]
+        assert compact, "No SessionStart entry with matcher='compact' in hooks.json"
+
+    def test_hook_script_referenced(self):
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = data["hooks"].get("SessionStart", [])
+        compact = [e for e in entries if e.get("matcher") == "compact"]
+        assert any(
+            "workflow_resume_hint.sh" in hook["command"]
+            for e in compact
+            for hook in e.get("hooks", [])
+        ), "workflow_resume_hint.sh not referenced in SessionStart compact entry"
+
+    def test_hook_script_exists_and_executable(self):
+        assert HOOK.exists(), f"Missing hook script: {HOOK}"
+        assert os.access(HOOK, os.X_OK), f"Hook script not executable: {HOOK}"
+
+
+# ---------------------------------------------------------------------------
+# No-op cases — hook must emit nothing and exit 0
+# ---------------------------------------------------------------------------
+
+class TestNoOp:
+    """Hook is silent when there is no state to resume."""
+
+    def test_no_state_file_exits_clean(self, hook_script, git_repo):
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_stale_file_swept_and_no_injection(self, hook_script, git_repo):
+        """State file >24h old is deleted; no preamble injected."""
+        path = _write_state(git_repo, VALID_STATE)
+        old_mtime = os.path.getmtime(path) - 1441 * 60
+        os.utime(path, (old_mtime, old_mtime))
+
+        result = _run(hook_script, str(git_repo))
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert not path.exists(), "Stale state file should be deleted"
+
+
+# ---------------------------------------------------------------------------
+# Fail-open cases — bad / mismatched state must not inject
+# ---------------------------------------------------------------------------
+
+class TestFailOpen:
+    """Hook degrades to no-op rather than injecting a wrong resume."""
+
+    def test_branch_mismatch_no_injection(self, hook_script, git_repo):
+        state = {**VALID_STATE, "context": {**VALID_STATE["context"], "branch": "feature/other"}}
+        _write_state(git_repo, state)
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_version_not_1_no_injection(self, hook_script, git_repo):
+        state = {**VALID_STATE, "version": 2}
+        _write_state(git_repo, state)
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_malformed_json_no_injection(self, hook_script, git_repo):
+        path = _state_path(git_repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not valid json }{", encoding="utf-8")
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_missing_version_field_no_injection(self, hook_script, git_repo):
+        state = {k: v for k, v in VALID_STATE.items() if k != "version"}
+        _write_state(git_repo, state)
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Resume injection — valid fresh branch-matching state must inject
+# ---------------------------------------------------------------------------
+
+class TestResumeInjection:
+    """Hook injects a properly structured preamble for a valid state file."""
+
+    def test_emits_hook_specific_output(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+
+        assert result.returncode == 0
+        assert result.stdout.strip(), "Expected non-empty stdout for valid state"
+        data = json.loads(result.stdout)
+        assert "hookSpecificOutput" in data
+
+    def test_hook_event_name_is_session_start(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        data = json.loads(result.stdout)
+        assert data["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+    def test_additional_context_present(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        data = json.loads(result.stdout)
+        assert "additionalContext" in data["hookSpecificOutput"]
+
+    def test_preamble_contains_skill_name(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "swe-workbench:workflow-development" in ctx
+
+    def test_preamble_contains_phase(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "3" in ctx
+
+    def test_preamble_contains_phase_label(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Verify" in ctx
+
+    def test_preamble_contains_safety_gate(self, hook_script, git_repo):
+        """Preamble must include the 'contradicts current repo reality' safety note."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "contradicts" in ctx or "reality" in ctx
+
+    def test_preamble_contains_completed_phases(self, hook_script, git_repo):
+        """Completed phases list must appear in the preamble (AC#2)."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Completed phases" in ctx or "completed" in ctx.lower()
+        # VALID_STATE.completed_phases = ["1", "2"]
+        assert "1" in ctx and "2" in ctx
+
+    def test_exit_0_on_valid_state(self, hook_script, git_repo):
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        assert result.returncode == 0
+
+    def test_branch_with_percent_character(self, hook_script, tmp_path):
+        """Branch names containing % must not corrupt the JSON envelope."""
+        branch = "feature/100%-done"
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", "-b", branch],
+            cwd=repo_dir, env=_CLEAN_ENV, check=True,
+        )
+        (repo_dir / "README").write_text("init")
+        subprocess.run(["git", "add", "."], cwd=repo_dir, env=_CLEAN_ENV, check=True)
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/dev/null",
+             "-c", "user.email=t@t.com", "-c", "user.name=T",
+             "commit", "-qm", "init"],
+            cwd=repo_dir, env=_CLEAN_ENV, check=True,
+        )
+        state = {**VALID_STATE, "context": {**VALID_STATE["context"], "branch": branch}}
+        _write_state(repo_dir, state, branch)
+        result = _run(hook_script, str(repo_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)  # must be valid JSON — raises if corrupted
+        assert "hookSpecificOutput" in data

--- a/tests/test_workflow_state_skills.py
+++ b/tests/test_workflow_state_skills.py
@@ -1,0 +1,99 @@
+"""Content assertions for workflow-state checkpoint instructions (issue #286).
+
+These tests verify that the three wired workflow skills contain the checkpoint-write
+instruction and the delete-on-terminal instruction, both referencing docs/workflow-state.md.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+
+_SKILLS = {
+    "workflow-development": ROOT / "skills" / "workflow-development" / "SKILL.md",
+    "workflow-bug-triage": ROOT / "skills" / "workflow-bug-triage" / "SKILL.md",
+    "workflow-pr-review": ROOT / "skills" / "workflow-pr-review" / "SKILL.md",
+}
+
+_DOC_PATH = "docs/workflow-state.md"
+
+
+@pytest.mark.parametrize("skill_name,skill_path", list(_SKILLS.items()))
+class TestCheckpointInstructions:
+    """Each wired skill must carry checkpoint-write and delete-on-terminal text."""
+
+    def test_skill_file_exists(self, skill_name, skill_path):
+        assert skill_path.exists(), f"{skill_name}: SKILL.md not found at {skill_path}"
+
+    def test_checkpoint_write_instruction_present(self, skill_name, skill_path):
+        text = skill_path.read_text(encoding="utf-8")
+        assert "workflow-state" in text, (
+            f"{skill_name}: missing checkpoint-write instruction referencing 'workflow-state'"
+        )
+
+    def test_delete_on_terminal_instruction_present(self, skill_name, skill_path):
+        text = skill_path.read_text(encoding="utf-8")
+        # The delete instruction uses "delete" or "remove" near "state file" or "checkpoint"
+        lower = text.lower()
+        has_delete = "delete the" in lower or "remove the" in lower
+        has_target = "state file" in lower or "checkpoint" in lower
+        assert has_delete and has_target, (
+            f"{skill_name}: missing delete-on-terminal instruction for state file/checkpoint"
+        )
+
+    def test_doc_reference_present(self, skill_name, skill_path):
+        text = skill_path.read_text(encoding="utf-8")
+        assert _DOC_PATH in text, (
+            f"{skill_name}: missing reference to {_DOC_PATH!r}"
+        )
+
+
+class TestDocPresence:
+    """The workflow-state doc must exist and contain required sections."""
+
+    DOC = ROOT / "docs" / "workflow-state.md"
+
+    def test_doc_exists(self):
+        assert self.DOC.exists(), f"Missing {self.DOC}"
+
+    def test_doc_has_how_it_works(self):
+        text = self.DOC.read_text(encoding="utf-8")
+        assert "How it works" in text or "how it works" in text.lower(), (
+            "workflow-state.md missing 'How it works' section"
+        )
+
+    def test_doc_has_schema(self):
+        text = self.DOC.read_text(encoding="utf-8")
+        assert '"version"' in text or "version" in text, (
+            "workflow-state.md missing schema documentation"
+        )
+
+    def test_doc_has_lifecycle(self):
+        text = self.DOC.read_text(encoding="utf-8")
+        lower = text.lower()
+        assert "lifecycle" in lower or "survives" in lower, (
+            "workflow-state.md missing lifecycle / what-survives section"
+        )
+
+    def test_doc_has_troubleshooting(self):
+        text = self.DOC.read_text(encoding="utf-8")
+        assert "Troubleshooting" in text or "troubleshooting" in text.lower(), (
+            "workflow-state.md missing Troubleshooting section"
+        )
+
+
+class TestReadmeEntries:
+    """README.md and docs/README.md must reference workflow state persistence."""
+
+    def test_readme_mentions_workflow_state(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        assert "workflow-state" in readme or "workflow state" in readme.lower(), (
+            "README.md missing workflow state persistence section"
+        )
+
+    def test_docs_readme_indexes_workflow_state_doc(self):
+        docs_readme = (ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+        assert "workflow-state" in docs_readme, (
+            "docs/README.md missing index entry for workflow-state.md"
+        )


### PR DESCRIPTION
## Summary

- Add `hooks/workflow_resume_hint.sh` — a `SessionStart(compact)` hook that detects a per-branch checkpoint file and injects a resume preamble so interrupted workflows continue at the correct phase after auto-compaction
- Wire the hook in `hooks/hooks.json` under `SessionStart` with `matcher: "compact"`; path-containment guard and fail-open (exit 0 always) by design
- Add checkpoint-write and delete-on-terminal instructions to `workflow-development` (Mode B), `workflow-bug-triage`, and `workflow-pr-review` skills, all referencing `docs/workflow-state.md` for the schema
- Add `docs/workflow-state.md` covering the state-file path, schema, lifecycle table, what survives compaction, smoke test, and troubleshooting

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` passes (0 issues, all skill line caps respected)
- [x] `python -m pytest tests/` passes (804 tests, 0 failures)
- [x] Smoke test: `echo '{"cwd":"<toplevel>"}' | bash hooks/workflow_resume_hint.sh` emits correct `hookSpecificOutput` JSON for a fresh state file and empty output for no file
- [x] `bash -n hooks/workflow_resume_hint.sh` passes (syntax OK)

### Type-tailored checks ([feat])
- [ ] No-op path: session with no state file → hook emits nothing, exits 0
- [ ] Resume path: valid, fresh, branch-matching file → preamble injected with skill + phase + completed phases
- [ ] Staleness path: file >24h old → deleted, no injection
- [ ] Fail-open path: branch mismatch / version ≠ 1 / malformed JSON → no injection, exit 0
- [ ] Branch with `%` in name → valid JSON output (no printf format-string corruption)

Closes #286
