### PR TITLE
[feat] address-feedback: reuse current worktree when on the PR branch

### DIFF
--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -108,7 +108,21 @@ if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
 fi
 ```
 
-If `$WT` is set by the check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty, a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree:
+If `$WT` is not yet set, check whether a worktree for `$PR_BRANCH` already exists elsewhere on disk (e.g. the session is on `main` but the branch was checked out previously):
+
+```bash
+if [ -z "$WT" ]; then
+  EXISTING_WT=$(git worktree list --porcelain \
+    | awk 'BEGIN{wt=""} /^worktree /{wt=$2} /^branch refs\/heads\/'"$PR_BRANCH"'/{print wt; exit}')
+  if [ -n "$EXISTING_WT" ] && [ -d "$EXISTING_WT" ]; then
+    WT="$EXISTING_WT"
+    REUSED_WT=1
+    echo "Found existing worktree for '$PR_BRANCH' at $WT (skipping rimba add)."
+  fi
+fi
+```
+
+If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree:
 
 **When rimba is available** (preferred):
 
@@ -238,7 +252,7 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 
 | Mistake | Fix |
 |---|---|
-| Create a new worktree when already on the PR branch | Phase 2 first compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH`; on a match it reuses `$(pwd)` and skips `rimba add`. Only fall through to creation when the branches differ. |
+| Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
 | Omit `--skip-deps --skip-hooks` on the rimba call | Always pass both flags — same as other worktree-creating skills. Deps can be installed manually in the worktree if needed. |
 | Leave the worktree behind after skill exits | Phase 6 always removes it — skip Phase 6 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
 | Deleting `$PR_BRANCH` directly in Phase 6 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -104,11 +104,11 @@ if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
   REUSED_WT=1
   echo "Already on PR branch '$PR_BRANCH' — reusing the current worktree at $WT (skipping rimba add)."
   DIRTY=$(git status --porcelain)
-  [ -n "$DIRTY" ] && echo "Note: working tree has uncommitted changes; confirm before fixes are committed so unrelated edits aren't swept into the feedback commit."
+  [ -n "$DIRTY" ] && echo "Note: working tree has uncommitted changes; the user may stash before Phase 4 commits to avoid sweeping unrelated edits into the feedback commit."
 fi
 ```
 
-If `$WT` is set by the check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty, a non-blocking warning was already emitted; the user can intervene before Phase 4 commits. Otherwise create a new durable worktree:
+If `$WT` is set by the check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty, a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree:
 
 **When rimba is available** (preferred):
 

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -95,6 +95,21 @@ If a prior triage save exists at `/tmp/swe-workbench-address-feedback/${PR}-tria
 
 ### Phase 2 — Worktree
 
+First, check whether the current branch already matches the PR head — if so, reuse the current worktree instead of creating a new one:
+
+```bash
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
+  WT=$(pwd)
+  REUSED_WT=1
+  echo "Already on PR branch '$PR_BRANCH' — reusing the current worktree at $WT (skipping rimba add)."
+  DIRTY=$(git status --porcelain)
+  [ -n "$DIRTY" ] && echo "Note: working tree has uncommitted changes; confirm before fixes are committed so unrelated edits aren't swept into the feedback commit."
+fi
+```
+
+If `$WT` is set by the check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty, a non-blocking warning was already emitted; the user can intervene before Phase 4 commits. Otherwise create a new durable worktree:
+
 **When rimba is available** (preferred):
 
 ```bash
@@ -187,16 +202,20 @@ Then run **Phase 6 — Cleanup**.
 
 ### Phase 6 — Cleanup (always)
 
-Run on every exit that occurs after a worktree was created in Phase 2 (success, Q-quit, or error). Skip only on Phase 1 early-exits (before any worktree exists).
+Run on every exit that occurs after a worktree was **created** in Phase 2 (success, Q-quit, or error). Skip on Phase 1 early-exits (before any worktree exists) and when the reuse-guard fired (`REUSED_WT=1`) — the reuse path sets `$WT` to an existing checkout, never creates a worktree, so there is nothing to remove.
 
 ```bash
-# positional arg matches the --task label set in Phase 2 ("address-feedback-$PR")
-if rimba remove "address-feedback-$PR" --force 2>/dev/null; then
-  echo "Cleaned up worktree address-feedback-$PR."
+if [ "${REUSED_WT:-0}" = "1" ]; then
+  echo "Reused existing worktree at $WT — skipping cleanup (nothing was created)."
 else
-  # $WT is set in Phase 2 (both rimba and fallback paths); do not re-assign here
-  git worktree remove --force "$WT" 2>/dev/null && rm -rf "$WT" 2>/dev/null
-  echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback on $WT."
+  # positional arg matches the --task label set in Phase 2 ("address-feedback-$PR")
+  if rimba remove "address-feedback-$PR" --force 2>/dev/null; then
+    echo "Cleaned up worktree address-feedback-$PR."
+  else
+    # $WT is set in Phase 2 (both rimba and fallback paths); do not re-assign here
+    git worktree remove --force "$WT" 2>/dev/null && rm -rf "$WT" 2>/dev/null
+    echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback on $WT."
+  fi
 fi
 ```
 
@@ -219,8 +238,9 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 
 | Mistake | Fix |
 |---|---|
+| Create a new worktree when already on the PR branch | Phase 2 first compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH`; on a match it reuses `$(pwd)` and skips `rimba add`. Only fall through to creation when the branches differ. |
 | Omit `--skip-deps --skip-hooks` on the rimba call | Always pass both flags — same as other worktree-creating skills. Deps can be installed manually in the worktree if needed. |
-| Leave the worktree behind after skill exits | Phase 6 always removes it — skip Phase 6 only when exiting before Phase 2 (no worktree created yet). |
+| Leave the worktree behind after skill exits | Phase 6 always removes it — skip Phase 6 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
 | Deleting `$PR_BRANCH` directly in Phase 6 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |
 | Resolve a CLARIFIED thread | Only resolve ADDRESSED threads. CLARIFIED = reply only, no resolve. |

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -207,3 +207,36 @@ def test_address_feedback_skill_cleanup_uses_existing_wt():
         "Phase 6 must not re-assign $WT — use the value set in Phase 2 so the fallback "
         "targets the correct worktree directory regardless of which Phase 2 branch (rimba vs. git) ran"
     )
+
+
+def test_address_feedback_skill_reuses_worktree_when_on_pr_branch():
+    """Phase 2 must reuse the current worktree when the branch matches the PR head (closes #295)."""
+    text = SKILL_MD.read_text()
+    # Detection: compare current branch against $PR_BRANCH on one guard line.
+    guard_lines = [
+        ln for ln in text.splitlines()
+        if "rev-parse --abbrev-ref HEAD" in ln and "PR_BRANCH" in ln
+    ]
+    assert guard_lines, (
+        "SKILL.md Phase 2 must compare 'git rev-parse --abbrev-ref HEAD' against "
+        "$PR_BRANCH to detect when the user is already on the PR branch"
+    )
+    # Skip path: reuse the current directory instead of creating a worktree.
+    assert "WT=$(pwd)" in text, (
+        "SKILL.md Phase 2 must set WT=$(pwd) to reuse the current worktree when "
+        "already on the PR branch, skipping 'rimba add'"
+    )
+
+
+def test_address_feedback_skill_phase6_skips_cleanup_on_reuse():
+    """Phase 6 must not run git worktree remove / rm -rf when the worktree was reused (closes #295)."""
+    text = SKILL_MD.read_text()
+    phase6_idx = text.find("### Phase 6")
+    assert phase6_idx != -1, "Phase 6 section must exist"
+    phase6_text = text[phase6_idx:]
+    # Phase 6 must reference REUSED_WT so the cleanup is skipped for the reuse path.
+    assert "REUSED_WT" in phase6_text, (
+        "SKILL.md Phase 6 must guard cleanup with REUSED_WT — when the reuse-guard "
+        "fires (WT=$(pwd)), rimba remove will fail for an unregistered task, causing "
+        "git worktree remove --force / rm -rf to run against the user's live checkout"
+    )

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -212,14 +212,13 @@ def test_address_feedback_skill_cleanup_uses_existing_wt():
 def test_address_feedback_skill_reuses_worktree_when_on_pr_branch():
     """Phase 2 must reuse the current worktree when the branch matches the PR head (closes #295)."""
     text = SKILL_MD.read_text()
-    # Detection: compare current branch against $PR_BRANCH on one guard line.
-    guard_lines = [
-        ln for ln in text.splitlines()
-        if "rev-parse --abbrev-ref HEAD" in ln and "PR_BRANCH" in ln
-    ]
-    assert guard_lines, (
-        "SKILL.md Phase 2 must compare 'git rev-parse --abbrev-ref HEAD' against "
-        "$PR_BRANCH to detect when the user is already on the PR branch"
+    # Assignment line must exist in the code block.
+    assert "CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" in text, (
+        "SKILL.md Phase 2 must assign: CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+    )
+    # Comparison must test $CURRENT_BRANCH against $PR_BRANCH in the if-condition.
+    assert re.search(r'"\$CURRENT_BRANCH"\s*=\s*"\$PR_BRANCH"', text), (
+        "SKILL.md Phase 2 must compare $CURRENT_BRANCH against $PR_BRANCH in the if-condition"
     )
     # Skip path: reuse the current directory instead of creating a worktree.
     assert "WT=$(pwd)" in text, (

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -239,3 +239,23 @@ def test_address_feedback_skill_phase6_skips_cleanup_on_reuse():
         "fires (WT=$(pwd)), rimba remove will fail for an unregistered task, causing "
         "git worktree remove --force / rm -rf to run against the user's live checkout"
     )
+
+
+def test_address_feedback_skill_reuses_existing_worktree_on_main():
+    """Phase 2 must find and reuse an existing worktree for PR_BRANCH when session is not on that branch."""
+    text = SKILL_MD.read_text()
+    # Must use git worktree list --porcelain to locate an existing worktree for the branch.
+    assert "git worktree list --porcelain" in text, (
+        "SKILL.md Phase 2 must scan 'git worktree list --porcelain' to find an existing "
+        "worktree for $PR_BRANCH when the current branch does not match (e.g. session on main)"
+    )
+    # Must look up the branch ref inside the porcelain output (awk escapes the slashes).
+    assert r"refs\/heads\/" in text, (
+        r"SKILL.md Phase 2 must match 'refs\/heads\/$PR_BRANCH' in the awk pattern "
+        "to locate the correct registered worktree in porcelain output"
+    )
+    # Must set REUSED_WT=1 on a match, same as the first guard.
+    assert re.search(r"EXISTING_WT.*\n.*REUSED_WT=1|REUSED_WT=1.*EXISTING_WT", text, re.DOTALL), (
+        "SKILL.md Phase 2 must set REUSED_WT=1 when an existing worktree is found via "
+        "git worktree list, so Phase 6 skips the destructive cleanup"
+    )


### PR DESCRIPTION
## Summary

- Phase 2 of `workflow-address-feedback` now opens with a reuse-guard: if `git rev-parse --abbrev-ref HEAD` already equals `$PR_BRANCH` (and is not a detached HEAD), the skill sets `WT=$(pwd)` and `REUSED_WT=1`, skipping `rimba add` entirely.
- A dirty-tree check emits a non-blocking warning so the user can catch unrelated edits before Phase 4 commits them.
- Phase 6 now checks `REUSED_WT` before running cleanup: when `1`, it skips `rimba remove` and the `git worktree remove --force`/`rm -rf` fallback — preventing destruction of the user's live checkout.
- Two regression tests added (21 total in the address-feedback suite).

## Test Plan

- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `pytest tests/test_workflow_address_feedback_skill.py -v` — all 21 pass
- [ ] `pytest tests/ -v` — all 767 pass (no regressions)
- [ ] `bash scripts/validate.sh` — all checks passed

### Type-tailored checks ([feat])

- [ ] When the current branch matches `$PR_BRANCH`, the reuse-guard fires: `WT=$(pwd)` is set, `REUSED_WT=1` is set, and `rimba add` is not called.
- [ ] Phase 6 emits "Reused existing worktree … skipping cleanup" and does not run `rimba remove` or `git worktree remove --force` when `REUSED_WT=1`.
- [ ] When the current branch does NOT match `$PR_BRANCH`, the guard does not fire and both the rimba-path and fallback-path remain reachable.
- [ ] In detached HEAD state (`git rev-parse --abbrev-ref HEAD` returns `HEAD`), the guard does not fire.

Closes #295
