### PR TITLE
[feat] Skip already-clarified threads on address-feedback re-runs

### DIFF
--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -145,7 +145,21 @@ This worktree is **disposable** — fixes are committed and pushed to the PR bra
 
 ### Phase 3 — Triage digest
 
-Render outstanding unresolved threads, one by one. Skip any thread where `isResolved == true` — only present threads where `isResolved == false`. For each remaining thread:
+Render outstanding threads, one by one. **Filter out two kinds of thread before presenting:**
+
+1. **Resolved threads** — skip any thread where `isResolved == true`.
+2. **Already-clarified threads** — skip any *unresolved* thread where at least one *reply* comment (`comments.nodes[1:]` onwards — not the thread root at `nodes[0]`, which is always the reviewer's opening comment) has `author.login` equal to `$CURRENT_USER`. This means the owner replied in a prior pass (e.g. a CLARIFIED reply) but left the thread unresolved. It applies whether that reply was posted by this skill or manually by the user. Detecting via reply comments only prevents false-positive skipping when the current user also authored review threads.
+
+If any threads were skipped under rule 2, print a one-line transparency note before the digest:
+> "(N thread(s) skipped — already clarified.)"
+
+If no threads remain after filtering:
+- When N ≥ 1 (threads were skipped under rule 2): print "No new threads to triage — N already clarified."
+- When N = 0 (only resolved threads filtered): print "No new threads to triage."
+
+Then run **Phase 6 — Cleanup** and exit cleanly.
+
+For each remaining thread:
 
 ```
 ─────────────────────────────────────────────────
@@ -259,3 +273,4 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |
 | Resolve a CLARIFIED thread | Only resolve ADDRESSED threads. CLARIFIED = reply only, no resolve. |
 | Try to resolve via REST | Thread resolution is GraphQL-only (`resolveReviewThread` mutation). REST has no equivalent endpoint. |
+| Re-present a thread the owner already clarified | On re-runs, skip *unresolved* threads that already have a comment authored by `$CURRENT_USER`. Detect via `comments.nodes[*].author.login`. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -148,7 +148,7 @@ This worktree is **disposable** — fixes are committed and pushed to the PR bra
 Render outstanding threads, one by one. **Filter out two kinds of thread before presenting:**
 
 1. **Resolved threads** — skip any thread where `isResolved == true`.
-2. **Already-clarified threads** — skip any *unresolved* thread where at least one *reply* comment (`comments.nodes[1:]` onwards — not the thread root at `nodes[0]`, which is always the reviewer's opening comment) has `author.login` equal to `$CURRENT_USER`. This means the owner replied in a prior pass (e.g. a CLARIFIED reply) but left the thread unresolved. It applies whether that reply was posted by this skill or manually by the user. Detecting via reply comments only prevents false-positive skipping when the current user also authored review threads.
+2. **Already-clarified threads** — skip any *unresolved* thread where at least one *reply* comment (`comments.nodes[1:]` onwards — `nodes[0]` is the thread-opening comment, which in the typical reviewer-opened case belongs to the reviewer, not the PR owner) has `author.login` equal to `$CURRENT_USER`. This means the owner replied in a prior pass (e.g. a CLARIFIED reply) but left the thread unresolved. It applies whether that reply was posted by this skill or manually by the user. Detecting via reply comments only prevents false-positive skipping when the current user also authored review threads.
 
 If any threads were skipped under rule 2, print a one-line transparency note before the digest:
 > "(N thread(s) skipped — already clarified.)"

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -270,14 +270,20 @@ def test_address_feedback_skill_skips_already_clarified_threads():
         "comments.nodes[*].author.login against $CURRENT_USER"
     )
     # The skip must be described as 'already clarified' within the Phase 3 section.
-    phase3_match = re.search(r"### Phase 3.*?(?=###)", text, re.DOTALL)
+    phase3_match = re.search(r"### Phase 3.*?(?=###|^##)", text, re.DOTALL | re.MULTILINE)
     assert phase3_match, "Phase 3 section must exist for this check"
     phase3_text = phase3_match.group(0)
     assert "already clarified" in phase3_text.lower(), (
         "SKILL.md Phase 3 must describe skipping threads the owner already clarified on re-runs"
     )
-    # The transparency note format must be explicitly stated.
-    assert re.search(r"thread\(s\) skipped", text), (
-        "SKILL.md must include the transparency note format: "
+    # The transparency note format must appear before the triage digest within Phase 3.
+    idx_skipped = phase3_text.lower().find("thread(s) skipped")
+    idx_digest = phase3_text.find("For each remaining thread")
+    assert idx_skipped != -1, (
+        "SKILL.md Phase 3 must include the transparency note format: "
         "'(N thread(s) skipped — already clarified.)'"
+    )
+    assert idx_digest != -1, "Phase 3 must contain 'For each remaining thread'"
+    assert idx_skipped < idx_digest, (
+        "SKILL.md Phase 3 transparency note must appear before 'For each remaining thread'"
     )

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -259,3 +259,25 @@ def test_address_feedback_skill_reuses_existing_worktree_on_main():
         "SKILL.md Phase 2 must set REUSED_WT=1 when an existing worktree is found via "
         "git worktree list, so Phase 6 skips the destructive cleanup"
     )
+
+
+def test_address_feedback_skill_skips_already_clarified_threads():
+    """Phase 3 must skip unresolved threads already replied to by $CURRENT_USER (closes #296)."""
+    text = SKILL_MD.read_text()
+    # Detection must compare comment authorship against the current user.
+    assert re.search(r"author\.login.*CURRENT_USER|CURRENT_USER.*author\.login", text), (
+        "SKILL.md Phase 3 must detect already-clarified threads by comparing "
+        "comments.nodes[*].author.login against $CURRENT_USER"
+    )
+    # The skip must be described as 'already clarified' within the Phase 3 section.
+    phase3_match = re.search(r"### Phase 3.*?(?=###)", text, re.DOTALL)
+    assert phase3_match, "Phase 3 section must exist for this check"
+    phase3_text = phase3_match.group(0)
+    assert "already clarified" in phase3_text.lower(), (
+        "SKILL.md Phase 3 must describe skipping threads the owner already clarified on re-runs"
+    )
+    # The transparency note format must be explicitly stated.
+    assert re.search(r"thread\(s\) skipped", text), (
+        "SKILL.md must include the transparency note format: "
+        "'(N thread(s) skipped — already clarified.)'"
+    )


### PR DESCRIPTION
## Summary
- Phase 3 of `workflow-address-feedback` now applies a **two-rule filter** before presenting threads:
  1. **Resolved threads** — skip any thread where `isResolved == true` (existing rule).
  2. **Already-clarified threads** — skip unresolved threads where a *reply* comment (`comments.nodes[1:]`) authored by `$CURRENT_USER` already exists from a prior pass (e.g. a CLARIFIED reply left intentionally unresolved).
- Detects via `author.login` on reply comments only (not the thread root), preventing false-positive skipping when the current user also authored review threads.
- Prints a one-line transparency note `(N thread(s) skipped — already clarified.)` before the digest; gives an unambiguous empty-state message when N ≥ 1.
- Adds a matching **Common-mistakes** row to `SKILL.md`.
- Adds a **content-assertion test** (`test_address_feedback_skill_skips_already_clarified_threads`) covering detection logic, Phase 3 section scoping, and the transparency note format.

## Test Plan
- [x] Changed skills load without errors (`bash scripts/validate.sh` — 0 issues)
- [x] New test added (TDD red → green cycle confirmed)
- [x] Full test suite passes (`pytest tests/ -v` — 766/766)
- [x] Diff read-through confirms two-rule filter, transparency note, Common-mistakes row, and all five acceptance criteria from #296

Closes #296
