### PR TITLE
[fix] skill_usage_flush: anchor buffer glob to 8-digit date prefix

### DIFF
--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -29,7 +29,9 @@ cache_dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/cache/skill-usage"
 # Buffer may span today's and yesterday's date-stamped file (straddle midnight).
 # The 8-digit bracket prefix is intentional: without it, "*-foo.txt" greedily
 # matches a sibling agent "bar-foo"'s "<date>-bar-foo.txt" (id allows hyphens).
-# Compatible with bash 3.2+ (POSIX bracket classes, no extglob required).
+# The suffix -"$agent_id".txt is an exact match, so a longer id ("bar-foo") never
+# matches a shorter one's glob ("foo") either. Compatible with bash 3.2+ (POSIX
+# bracket classes, no extglob required).
 buffers=()
 for f in "$cache_dir"/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-"$agent_id".txt; do
   [ -f "$f" ] && buffers+=("$f")

--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -27,9 +27,11 @@ fi
 cache_dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/cache/skill-usage"
 
 # Buffer may span today's and yesterday's date-stamped file (straddle midnight).
-# Use a glob loop so paths with spaces are handled correctly (compatible with bash 3.2+).
+# The 8-digit bracket prefix is intentional: without it, "*-foo.txt" greedily
+# matches a sibling agent "bar-foo"'s "<date>-bar-foo.txt" (id allows hyphens).
+# Compatible with bash 3.2+ (POSIX bracket classes, no extglob required).
 buffers=()
-for f in "$cache_dir"/*-"$agent_id".txt; do
+for f in "$cache_dir"/[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-"$agent_id".txt; do
   [ -f "$f" ] && buffers+=("$f")
 done
 [ "${#buffers[@]}" -eq 0 ] && { printf '{}'; exit 0; }

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -4,6 +4,7 @@ Subprocess-driven so they exercise real POSIX sh logic.  Each test gets an
 isolated cache dir via tmp_path + CLAUDE_PROJECT_DIR, and a minimal agents/
 tree via CLAUDE_PLUGIN_ROOT.
 """
+import datetime
 import json
 import os
 import subprocess
@@ -361,8 +362,6 @@ class TestFlushHook:
 
     def test_midnight_straddle(self, plugin_root, cache_dir):
         """Buffers from both today and yesterday contribute to the flush line."""
-        import datetime
-
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         today = datetime.date.today().strftime("%Y%m%d")
@@ -388,8 +387,6 @@ class TestFlushHook:
 
     def test_sibling_agent_buffer_not_flushed(self, plugin_root, cache_dir):
         """agent 'foo' flush must not touch sibling agent 'bar-foo' whose id ends in '-foo'."""
-        import datetime
-
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         today = datetime.date.today().strftime("%Y%m%d")
@@ -413,8 +410,6 @@ class TestFlushHook:
 
     def test_date_anchor_rejects_non_date_prefix(self, plugin_root, cache_dir):
         """Glob must only match <8-digit-date>-<id>.txt; non-date prefix must be ignored."""
-        import datetime
-
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         today = datetime.date.today().strftime("%Y%m%d")

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -386,6 +386,56 @@ class TestFlushHook:
         assert not buf_today.exists()
         assert not buf_yesterday.exists()
 
+    def test_sibling_agent_buffer_not_flushed(self, plugin_root, cache_dir):
+        """agent 'foo' flush must not touch sibling agent 'bar-foo' whose id ends in '-foo'."""
+        import datetime
+
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = datetime.date.today().strftime("%Y%m%d")
+        buf_foo = skill_cache / f"{today}-foo.txt"
+        buf_sibling = skill_cache / f"{today}-bar-foo.txt"
+        buf_foo.write_text("skill-foo\n")
+        buf_sibling.write_text("skill-sibling\n")
+
+        result = _run_flush(
+            {"agent_id": "foo", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        msg = out.get("systemMessage", "")
+        assert "skill-foo" in msg, "foo's own skill must appear in the flush message"
+        assert "skill-sibling" not in msg, "sibling bar-foo's skill must NOT appear"
+        assert not buf_foo.exists(), "foo's buffer should be deleted after flush"
+        assert buf_sibling.exists(), "bar-foo's buffer must survive foo's flush"
+
+    def test_date_anchor_rejects_non_date_prefix(self, plugin_root, cache_dir):
+        """Glob must only match <8-digit-date>-<id>.txt; non-date prefix must be ignored."""
+        import datetime
+
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = datetime.date.today().strftime("%Y%m%d")
+        buf_valid = skill_cache / f"{today}-foo.txt"
+        buf_bad = skill_cache / "notadate-foo.txt"
+        buf_valid.write_text("skill-valid\n")
+        buf_bad.write_text("skill-bad\n")
+
+        result = _run_flush(
+            {"agent_id": "foo", "agent_type": "reviewer"},
+            plugin_root,
+            cache_dir,
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        msg = out.get("systemMessage", "")
+        assert "skill-valid" in msg, "date-prefixed buffer must be included"
+        assert "skill-bad" not in msg, "non-date-prefixed buffer must be excluded"
+        assert not buf_valid.exists(), "valid buffer should be deleted after flush"
+        assert buf_bad.exists(), "non-date-prefixed file must survive"
+
 
 # ---------------------------------------------------------------------------
 # hooks.json schema — tests 12–13


### PR DESCRIPTION
## Summary
- **Bug:** `skill_usage_flush.sh` glob `*-<id>.txt` matched sibling agent buffers whose id is a hyphen-suffix of another (e.g. `bar-foo`'s buffer `<date>-bar-foo.txt` was picked up when flushing agent `foo`), causing skill mis-attribution and silent buffer deletion.
- **Fix:** anchored the glob with `[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-<id>.txt`; the record hook always writes `<YYYYMMDD>-<id>.txt`, so every real buffer still matches.
- **Tests:** two new tests added to `TestFlushHook` — sibling isolation (AC#1) and non-date-prefix rejection (AC#2) — both red before the fix, green after.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_skill_usage_telemetry.py -v` — 23/23 pass (2 new)
- [x] `pytest tests/ -v` — 876/876 pass, no regressions
- [x] `python scripts/validate.py` — all checks passed

### Type-tailored checks ([fix])
- [x] Reproduced the bug with two agents (`foo` and `bar-foo`) before the fix
- [x] Verified `bar-foo`'s buffer survives after flushing `foo` post-fix
- [x] Midnight-straddle (`test_midnight_straddle`) still passes — both date-stamped buffers for the same agent are still matched

Closes #305
