### PR TITLE
[fix] Drop blockquote on @./shared includes so the shared catalog resolves

### DIFF
--- a/agents/accessibility-auditor.md
+++ b/agents/accessibility-auditor.md
@@ -92,7 +92,7 @@ Flag, don't compute contrast ratios manually. Recommend these as follow-ups:
 
 ## Severity scheme
 
-> Base format, sort order, and silence rule: @./shared/severity-output-contract.md
+Base format, sort order, and silence rule: @./shared/severity-output-contract.md
 
 Domain-specific severity criteria (extends the base ladder with a11y examples):
 
@@ -165,7 +165,7 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 
 ## Principle consultation
 
-> See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -51,11 +51,11 @@ You are an architect. You produce formal artifacts — ADRs, RFCs, contract spec
 
 ## Reading external repos
 
-> See @./shared/external-repo-reading.md.
+See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -83,7 +83,7 @@ Every finding must include all 11 fields. **Omit any finding you cannot fill all
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when a finding surfaces a concern in their domain:
 

--- a/agents/code-impl.md
+++ b/agents/code-impl.md
@@ -51,7 +51,7 @@ blockers: <required for NEEDS_CONTEXT and BLOCKED — what is missing or blockin
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when relevant:
 

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -137,11 +137,11 @@ Output is markdown only. Never comment on the PR, apply labels, request changes 
 
 ## Reading external repos
 
-> See @./shared/external-repo-reading.md.
+See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/dependency-auditor.md
+++ b/agents/dependency-auditor.md
@@ -155,11 +155,11 @@ If asked to apply a fix, refuse and re-emit the recommended action as text in th
 
 ## Reading external repos
 
-> See @./shared/external-repo-reading.md.
+See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-> See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -130,4 +130,4 @@ Invoke these skills via the Skill tool when the migration surfaces a concern in 
 
 ## Available skills
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.

--- a/agents/performance-tuner.md
+++ b/agents/performance-tuner.md
@@ -81,8 +81,8 @@ When the user requests optimization without a profile, respond:
 
 ## Severity scheme
 
-> Sort order and silence rule: @./shared/severity-output-contract.md
-> **Deliberate divergence:** quantitative thresholds and 8-column output table below override the base format for performance triage.
+Sort order and silence rule: @./shared/severity-output-contract.md
+**Deliberate divergence:** quantitative thresholds and 8-column output table below override the base format for performance triage.
 
 | Severity | Definition |
 |---|---|
@@ -129,7 +129,7 @@ Every recommendation must carry a verification step. Refuse to declare an optimi
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the analysis surfaces a concern in their domain:
 

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -93,7 +93,7 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -30,7 +30,7 @@ You are a refactoring specialist. You improve structure without changing observa
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the refactoring touches their domain:
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -93,7 +93,7 @@ Do **not** repeat per-finding detail in this section — that belongs in the sev
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the review surfaces a concern in their domain:
 

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -72,7 +72,7 @@ Every finding must include:
 
 ## Severity scheme
 
-> Base format, sort order, and silence rule: @./shared/severity-output-contract.md
+Base format, sort order, and silence rule: @./shared/severity-output-contract.md
 
 Domain-specific severity criteria (extends the base ladder with security examples):
 
@@ -110,7 +110,7 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -39,11 +39,11 @@ Be honest. If the existing code is fine, say so and stop.
 
 ## Reading external repos
 
-> See @./shared/external-repo-reading.md.
+See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 

--- a/agents/tech-writer.md
+++ b/agents/tech-writer.md
@@ -70,6 +70,6 @@ For each invocation, emit:
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke `swe-workbench:principle-clean-code` via the Skill tool when writing inline comments — it enforces naming clarity, DRY, and the same "no-obvious-WHAT" discipline this agent applies.

--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -11,7 +11,7 @@ You are a test reviewer. Your job is to audit existing tests and report concrete
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke these skills via the Skill tool before auditing:
 
@@ -42,8 +42,8 @@ If the suite is clean, say so explicitly: "No high-confidence findings in this s
 
 ## Output contract
 
-> Base format, sort order, and silence rule: @./shared/severity-output-contract.md
-> **Extension:** a `Category` column is added between `File:Line` and `Issue` to classify test failure modes.
+Base format, sort order, and silence rule: @./shared/severity-output-contract.md
+**Extension:** a `Category` column is added between `File:Line` and `Issue` to classify test failure modes.
 
 Group findings by severity, highest first (Critical → High → Medium → Low). Use this extended pipe format:
 

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -22,7 +22,7 @@ Read at least one existing test file before writing — match the repo's style, 
 
 ## Principle consultation
 
-> See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md for the skill catalog.
 
 Invoke `swe-workbench:principle-tdd` via the Skill tool before writing any test for the full red-green-refactor discipline and "What to test" checklist.
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -426,6 +426,39 @@ def check_catalog_completeness(cache=None):
                  " '@./shared/languages.md', '@./shared/workflows.md'")
 
 
+_BLOCKQUOTED_SHARED_RE = re.compile(r'^\s*>.*@\./shared/')
+
+
+def check_shared_includes_not_blockquoted(cache=None):
+    """`@./shared/*.md` includes must be plain paragraphs, not blockquotes.
+
+    A leading '> ' suppresses include resolution so the shared catalog/contract
+    is never injected into the agent (issue #309). Convergent plain form:
+    `See @./shared/principles.md for the skill catalog.`
+    """
+    agents_dir = ROOT / "agents"
+    agents_cache = cache[0] if cache is not None else None
+    for agent_md in sorted(agents_dir.glob("*.md")):
+        if agents_cache is not None and agent_md in agents_cache:
+            text = agents_cache[agent_md]
+            if text is None:
+                fail(agent_md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            try:
+                text = agent_md.read_text(encoding="utf-8")
+            except OSError as e:
+                fail(agent_md.relative_to(ROOT), f"could not read file: {e}")
+                continue
+        for i, line in enumerate(text.splitlines(), 1):
+            if _BLOCKQUOTED_SHARED_RE.match(line):
+                fail(
+                    agent_md.relative_to(ROOT),
+                    f"line {i}: '@./shared/' include is blockquoted — drop the leading "
+                    f"'> ' so the include resolves (issue #309): {line.strip()[:60]!r}",
+                )
+
+
 def check_examples():
     """Example files in skills/*/examples/**/*.md must not exceed 120 lines."""
     skills_dir = ROOT / "skills"
@@ -514,6 +547,7 @@ def main():
     check_agent_skill_refs(cache=cache)
     check_command_skill_refs()
     check_catalog_completeness(cache=cache)
+    check_shared_includes_not_blockquoted(cache=cache)
     check_template_placeholders(cache=cache)
     check_unwired_principle_skills(cache=cache)
     check_examples()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,7 +99,7 @@ def make_plugin_tree(
         for agent in agents:
             name = agent["name"]
             fm_lines = "\n".join(f"{k}: {v}" for k, v in agent.items())
-            body = f"---\n{fm_lines}\n---\n\n> See @./shared/principles.md for the skill catalog.\n"
+            body = f"---\n{fm_lines}\n---\n\nSee @./shared/principles.md for the skill catalog.\n"
             (agents_dir / f"{name}.md").write_text(body, encoding="utf-8")
 
     # commands/

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -777,7 +777,7 @@ class TestCheckCatalogCompleteness:
     def _agent_body(self, name="my-agent"):
         return (
             f"---\nname: {name}\ndescription: d\ntools: Read\n---\n"
-            "\n> See @./shared/principles.md for the skill catalog.\n"
+            "\nSee @./shared/principles.md for the skill catalog.\n"
         )
 
     def test_full_match_passes(self, reset_validate):
@@ -843,7 +843,7 @@ class TestCheckCatalogCompleteness:
         agents_dir = root / "agents"
         (agents_dir / "my-agent.md").write_text(
             "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
-            "\n> See @./shared/principles.md for the skill catalog.\n",
+            "\nSee @./shared/principles.md for the skill catalog.\n",
             encoding="utf-8",
         )
         validate.check_catalog_completeness()
@@ -861,7 +861,7 @@ class TestCheckCatalogCompleteness:
         agents_dir = root / "agents"
         (agents_dir / "my-agent.md").write_text(
             "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
-            "\n> See @./shared/principles.md and @./shared/languages.md for the skill catalog.\n",
+            "\nSee @./shared/principles.md and @./shared/languages.md for the skill catalog.\n",
             encoding="utf-8",
         )
         validate.check_catalog_completeness()
@@ -888,7 +888,7 @@ class TestCheckCatalogCompleteness:
         agents_dir = root / "agents"
         (agents_dir / "my-agent.md").write_text(
             "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
-            "\n> See @./shared/workflows.md for the skill catalog.\n",
+            "\nSee @./shared/workflows.md for the skill catalog.\n",
             encoding="utf-8",
         )
         validate.check_catalog_completeness()
@@ -914,12 +914,60 @@ class TestCheckCatalogCompleteness:
         (shared_dir / "languages.md").write_text("\n", encoding="utf-8")
         (agents_dir / "my-agent.md").write_text(
             "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
-            "\n> See @./shared/principles.md\n",
+            "\nSee @./shared/principles.md\n",
             encoding="utf-8",
         )
         validate.check_catalog_completeness()
         # principles.md has language-python (wrong slice) → "belongs in languages.md"
         assert any("belongs in" in f for f in validate.FAILURES)
+
+
+# ──────────────────────────────────────────────
+# check_shared_includes_not_blockquoted
+# ──────────────────────────────────────────────
+
+class TestCheckSharedIncludesNotBlockquoted:
+    def test_blockquoted_principles_include_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "agents" / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
+            "\n> See @./shared/principles.md for the skill catalog.\n",
+            encoding="utf-8",
+        )
+        validate.check_shared_includes_not_blockquoted()
+        assert any("my-agent.md" in f and "blockquoted" in f for f in validate.FAILURES)
+
+    def test_blockquoted_severity_contract_include_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "agents" / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read\n---\n"
+            "\n> Base format, sort order, and silence rule: @./shared/severity-output-contract.md\n",
+            encoding="utf-8",
+        )
+        validate.check_shared_includes_not_blockquoted()
+        assert any("my-agent.md" in f and "blockquoted" in f for f in validate.FAILURES)
+
+    def test_plain_include_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, agents=[{"name": "my-agent", "description": "d"}])
+        validate.check_shared_includes_not_blockquoted()
+        assert len(validate.FAILURES) == 0
+
+    def test_shared_catalog_files_not_scanned(self, reset_validate):
+        """agents/shared/*.md catalog slices use glob("*.md") — not rglob — so they are excluded."""
+        root = reset_validate
+        # An agent with a plain include ensures the check actually runs (non-vacuous).
+        make_plugin_tree(root, agents=[{"name": "my-agent", "description": "d"}])
+        # Overwrite principles.md with a hypothetical blockquoted line; check must not flag it.
+        (root / "agents" / "shared" / "principles.md").write_text(
+            "- `swe-workbench:foo` — foo skill\n"
+            "> Hypothetical blockquoted @./shared/principles.md reference\n",
+            encoding="utf-8",
+        )
+        validate.check_shared_includes_not_blockquoted()
+        assert len(validate.FAILURES) == 0
 
 
 # ──────────────────────────────────────────────
@@ -1091,7 +1139,7 @@ class TestCheckUnwiredPrincipleSkills:
     def _agent_body(self, extra=""):
         return (
             "---\nname: my-agent\ndescription: d\ntools: Read, Skill\n---\n"
-            "\n> See @./shared/principles.md for the skill catalog.\n"
+            "\nSee @./shared/principles.md for the skill catalog.\n"
             + extra
         )
 


### PR DESCRIPTION
## Summary
- Remove the leading `> ` from 24 `@./shared/*.md` include lines + 2 callout-continuation lines across 16 agents — the blockquote was suppressing include resolution so the shared principle catalog and severity-output contract were never injected
- Add `check_shared_includes_not_blockquoted` to `scripts/validate.py` to enforce the plain form going forward (wired into `main()`)
- Fix `tests/helpers.py` synthetic-agent generator and existing test helper methods to use the plain form consistently

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -q` → 880/880 passed (incl. 4 new `TestCheckSharedIncludesNotBlockquoted` tests)
- [x] `python scripts/validate.py` → "All checks passed."
- [x] `grep -rn '^>.*@\./shared/' agents/` → 0 matches (AC#1)
- [x] All converted lines use the plain form matching `debugger.md:67` (AC#2)

### Type-tailored checks ([fix])
- [x] Reproduction confirmed: before the fix, blockquoted includes do not resolve; after, they match the plain form already proven to resolve
- [x] No agent content was changed — only the `> ` prefix was removed

Closes #309
