### PR TITLE
[feat] Add principle-communication skill (caveman ultra-terse output mode)

### DIFF
--- a/agents/shared/principles.md
+++ b/agents/shared/principles.md
@@ -7,6 +7,7 @@ All `swe-workbench` principle skills available in this plugin. Use the `Skill` t
 - `swe-workbench:principle-clean-architecture` — Clean Architecture: dependency rule, ports and adapters, domain-centric layering.
 - `swe-workbench:principle-clean-code` — Clean code: DRY, KISS, YAGNI, naming, function length, abstraction level.
 - `swe-workbench:principle-code-review` — Code review: four-axis lens (correctness, security, design, tests), confidence-based filtering, comment tone, nitpick filtering.
+- `swe-workbench:principle-communication` — Communication & output discipline: terse "caveman" output mode (lite/full/ultra), drop filler/hedging, preserve code symbols and error strings verbatim, auto-clarity carve-out.
 - `swe-workbench:principle-concurrency` — Concurrency: race conditions, deadlock, structured concurrency, cancellation, backpressure.
 - `swe-workbench:principle-cost-awareness` — Cost awareness: FinOps mindset, egress, right-sizing, scale-to-zero, cost-per-request, storage tiers, observability cost.
 - `swe-workbench:principle-data-modeling` — Data modeling: storage paradigm selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution, query-first design, retention.

--- a/agents/tech-writer.md
+++ b/agents/tech-writer.md
@@ -73,3 +73,5 @@ For each invocation, emit:
 See @./shared/principles.md for the skill catalog.
 
 Invoke `swe-workbench:principle-clean-code` via the Skill tool when writing inline comments — it enforces naming clarity, DRY, and the same "no-obvious-WHAT" discipline this agent applies.
+
+Invoke `swe-workbench:principle-communication` via the Skill tool when the user requests terser or denser output — it governs the caveman output-discipline mode (lite/full/ultra) and the auto-clarity carve-out rules.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -59,6 +59,7 @@
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
 | `principle-code-review` | "code review checklist", "PR review heuristics", "review comment", "review finding", "nitpick filtering", "reviewing a diff". |
+| `principle-communication` | "caveman mode", "be brief", "less tokens", "use fewer tokens", "talk like caveman", "full caveman", "ultra caveman", `/caveman`, `/caveman ultra`. |
 | `principle-postmortem` | "postmortem", "blameless", "root cause analysis", "5 whys", "fishbone", "incident review", "MTTD", "MTTR", "action items", "incident report", "blameless postmortem". |
 | `principle-refactoring` | "refactor", "Fowler", "Extract Function", "Inline Variable", "Move Function", "smell", "Long Method", "Feature Envy", "Data Clumps", "Primitive Obsession", "characterization test", "behavior-preserving". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -59,7 +59,7 @@
 | `principle-design-patterns` | "design pattern", "strategy", "factory", "observer", "decorator", "adapter". |
 | `principle-clean-code` | "clean code", "function length", "naming", "DRY", "KISS", "YAGNI", "abstraction level", "error handling". |
 | `principle-code-review` | "code review checklist", "PR review heuristics", "review comment", "review finding", "nitpick filtering", "reviewing a diff". |
-| `principle-communication` | "caveman mode", "be brief", "less tokens", "use fewer tokens", "talk like caveman", "full caveman", "ultra caveman", `/caveman`, `/caveman ultra`. |
+| `principle-communication` | "caveman mode", "be brief", "less tokens", "use fewer tokens", "talk like caveman", "use caveman", "full caveman", "ultra caveman", "max caveman", `/caveman`, `/caveman ultra`. |
 | `principle-postmortem` | "postmortem", "blameless", "root cause analysis", "5 whys", "fishbone", "incident review", "MTTD", "MTTR", "action items", "incident report", "blameless postmortem". |
 | `principle-refactoring` | "refactor", "Fowler", "Extract Function", "Inline Variable", "Move Function", "smell", "Long Method", "Feature Envy", "Data Clumps", "Primitive Obsession", "characterization test", "behavior-preserving". |
 | `principle-observability` | "structured logs", "application metrics", "distributed traces", "span", "OpenTelemetry", "SLO", "SLI", "RED method", "USE method", "cardinality", "structured logging". |

--- a/skills/principle-communication/SKILL.md
+++ b/skills/principle-communication/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: principle-communication
+description: Caveman output mode — ultra-terse brief replies with fewer tokens. Strips filler, hedging, pleasantries. Three levels — caveman lite (default), caveman full, ultra caveman / max caveman (maximum compression). Persists until normal mode. Activate with: caveman mode, /caveman, be brief, less tokens, use fewer tokens, talk like caveman, full caveman, ultra caveman, /caveman ultra.
+---
+
+## When to invoke
+
+Activate when the user says any of the following (case-insensitive):
+
+| Phrase | Level activated |
+|---|---|
+| "caveman mode" / "talk like caveman" / "use caveman" / `/caveman` | **lite** (default) |
+| "be brief" / "less tokens" / "use fewer tokens" | **lite** |
+| "full caveman" | **full** |
+| "ultra caveman" / "max caveman" / `/caveman ultra` | **ultra** |
+| "stop caveman" / "normal mode" | off |
+
+## Intensity ladder
+
+### lite (default)
+Drop filler and hedging. Keep articles and full sentences. Professional but tight.
+
+Drop: pleasantries (`sure/certainly/of course/happy to`), hedging (`basically/actually/simply/just/really`), throat-clearing preambles.
+
+Keep: `a/an/the`, complete sentences, all technical terms verbatim.
+
+**Example — "Why does this React component re-render?"**
+> Your component re-renders because you create a new object reference each render. Wrap the object in `useMemo`.
+
+### full
+Drop articles. Fragments OK. Short synonyms over verbose ones.
+
+Drop: `a/an/the`, conjunctions where meaning holds, filler phrases. Use short synonyms: `big` not `extensive`, `fix` not `"implement a solution for"`, `use` not `utilize`.
+
+**Example — "Why does this React component re-render?"**
+> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+
+### ultra
+Abbreviate common prose words. Strip conjunctions. Arrows for causality. One word when one word suffices.
+
+Abbreviate: `DB`, `auth`, `config`, `req`, `res`, `fn`, `impl`, `arg`, `msg`, `ctx`. Use `→` for causality. Drop all conjunctions and prepositions where meaning is clear.
+
+**Example — "Why does this React component re-render?"**
+> Inline obj prop → new ref → re-render. `useMemo`.
+
+## Rules at every level
+
+- Code symbols, function names, API names, code blocks, and error strings are **never** abbreviated or altered.
+- Maintain chosen level across all turns — no drift back to verbose prose over time.
+- Level persists until the user explicitly turns it off with "stop caveman" or "normal mode".
+
+## Persistence
+
+Once activated, caveman mode is **active every response**. It does not revert after many turns. It remains active if you are unsure whether it still applies. It is off only when the user says "stop caveman" or "normal mode".
+
+## Auto-clarity carve-out
+
+Temporarily drop caveman and render full prose for:
+
+- Security warnings
+- Irreversible or destructive action confirmations (e.g. `DROP TABLE`, force-push, `rm -rf`)
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Cases where compression itself creates technical ambiguity (e.g. omitting a step from an ordered procedure)
+- User asks to clarify or repeats a question
+
+Extend this to swe-workbench destructive workflows: `swe-workbench:migrate`, `workflow-cleanup-merged`, `workflow-address-feedback` — render confirmation steps in full prose.
+
+Resume the chosen caveman level immediately after the clear part is done.
+
+**Example — destructive operation at any level:**
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+
+_(Auto-clarity ends here — caveman level resumes.)_
+
+Backup verified? Run it.
+
+## Subagent scope
+
+Caveman governs the orchestrator's user-facing output only. Subagents keep their own output style. When relaying subagent results to the user, the orchestrator renders the relay at the active caveman level.
+
+---
+
+Adapted from [`mattpocock/skills` caveman](https://github.com/mattpocock/skills/blob/main/skills/productivity/caveman/SKILL.md).

--- a/skills/principle-communication/SKILL.md
+++ b/skills/principle-communication/SKILL.md
@@ -38,7 +38,7 @@ Drop: `a/an/the`, conjunctions where meaning holds, filler phrases. Use short sy
 ### ultra
 Abbreviate common prose words. Strip conjunctions. Arrows for causality. One word when one word suffices.
 
-Abbreviate: `DB`, `auth`, `config`, `req`, `res`, `fn`, `impl`, `arg`, `msg`, `ctx`. Use `→` for causality. Drop all conjunctions and prepositions where meaning is clear.
+Abbreviate in prose: `DB`, `auth`, `config`, `req`, `res`, `fn`, `impl`, `arg`, `msg`, `ctx`. Use `→` for causality. Drop all conjunctions and prepositions where meaning is clear. Never abbreviate identifiers inside code blocks or inline backtick spans.
 
 **Example — "Why does this React component re-render?"**
 > Inline obj prop → new ref → re-render. `useMemo`.

--- a/skills/principle-communication/triggers.txt
+++ b/skills/principle-communication/triggers.txt
@@ -1,0 +1,7 @@
+# Representative trigger prompts for principle-communication
+caveman mode
+be brief from now on
+use fewer tokens in your replies
+full caveman please
+ultra caveman, max compression
+stop using filler words and hedging


### PR DESCRIPTION
## Summary

- Add `skills/principle-communication/SKILL.md` — caveman ultra-terse output mode with three intensity levels (lite/full/ultra), persistence across turns, and an auto-clarity carve-out for security warnings, destructive confirmations, and order-sensitive sequences.
- Add `skills/principle-communication/triggers.txt` — 6 representative BM25 trigger prompts; all 6 rank `principle-communication` #1 in the skill-trigger harness.
- Add catalog entry to `agents/shared/principles.md` (machine-enforced; em-dash format).
- Wire `swe-workbench:principle-communication` into `agents/tech-writer.md` principle-consultation list (required by `check_unwired_principle_skills`).
- Add row to `docs/catalog.md` Principles table.

## Test Plan

- [x] Changed skills/commands/agents load without errors (`scripts/validate.py` → "All checks passed")
- [x] Examples in the diff were exercised manually (SKILL.md intensity ladder reviewed against ACs)
- [x] `pytest tests/ -v` → 886/886 passed, no regressions
- [x] `pytest tests/test_skill_triggers.py -v -k principle-communication` → 6/6 trigger prompts rank skill #1

### Type-tailored checks ([feat])

- [ ] Activate caveman with "caveman mode" — confirm lite level (no filler/hedging, full sentences kept).
- [ ] Escalate with "full caveman" — confirm articles dropped, fragments OK.
- [ ] Escalate with "ultra caveman" — confirm compression abbreviations (`DB`, `auth`, arrows `→`).
- [ ] Confirm persistence: several turns of questions — caveman level holds without drift.
- [ ] Confirm off: say "normal mode" — prose returns to full verbosity.
- [ ] Trigger auto-clarity: run a destructive swe-workbench workflow step — confirm full-prose confirmation; confirm caveman resumes after.
- [ ] Confirm code symbols and error strings never abbreviated at any level.

Closes #311
