### PR TITLE
[ci] Add PR concurrency guard and per-job timeouts

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   regen-lockfiles:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only run for Dependabot PRs. Checking the PR author (user.login) rather than
     # github.actor ensures the guard holds even when a human pushes a follow-up commit
     # to a Dependabot branch (as happened manually in #277/#278).

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,9 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -92,6 +97,7 @@ jobs:
 
   validate-plugin-files:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -101,6 +107,7 @@ jobs:
 
   shellcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
@@ -114,6 +121,7 @@ jobs:
 
   pytest:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -126,6 +134,7 @@ jobs:
 
   lockfile-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -139,6 +148,7 @@ jobs:
   markdown-links:
     name: Markdown link check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate-schemas:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -67,6 +68,7 @@ jobs:
   publish-release:
     needs: validate-schemas
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -9,6 +9,7 @@ jobs:
   smoke:
     name: BM25 trigger smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       issues: write

--- a/tests/test_workflow_hardening.py
+++ b/tests/test_workflow_hardening.py
@@ -1,0 +1,72 @@
+"""Guard: every CI job must declare timeout-minutes; pr.yml must have a concurrency guard.
+
+Prevents hung jobs (especially lychee's live network requests in markdown-links) from
+consuming GitHub Actions quota up to the 6-hour default, and ensures stale in-progress
+runs are cancelled when a new push arrives on an open PR.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+
+WORKFLOW_FILES = [
+    "pr.yml",
+    "release.yml",
+    "skill-triggers.yml",
+    "dependabot-lockfile.yml",
+]
+
+# Anchors to the start of the jobs: section; everything else (on:, permissions:) is ignored.
+JOBS_SECTION_RE = re.compile(r"^jobs:\s*$", re.MULTILINE)
+
+# Matches job-name keys at exactly 2-space indent with no inline value, e.g. "  smoke:"
+JOB_KEY_RE = re.compile(r"^  (\S[^:]*):\s*$", re.MULTILINE)
+
+# Matches timeout-minutes at exactly 4-space indent (direct job property), e.g. "    timeout-minutes: 15"
+TIMEOUT_RE = re.compile(r"^    timeout-minutes:\s*\d+\s*$", re.MULTILINE)
+
+
+@pytest.mark.parametrize("filename", WORKFLOW_FILES)
+def test_every_job_has_timeout_minutes(filename):
+    text = (ROOT / ".github" / "workflows" / filename).read_text()
+
+    jobs_match = JOBS_SECTION_RE.search(text)
+    assert jobs_match, f"{filename}: no 'jobs:' section found"
+    # Scope all subsequent scanning to the jobs: block only, so trigger keys in
+    # the on: block (pull_request, schedule, etc.) are not mistaken for job names.
+    jobs_section = text[jobs_match.end():]
+
+    job_matches = list(JOB_KEY_RE.finditer(jobs_section))
+    assert job_matches, f"{filename}: no job keys found under 'jobs:' — check indentation regex"
+
+    missing = []
+    for i, match in enumerate(job_matches):
+        job_name = match.group(1)
+        start = match.end()
+        end = job_matches[i + 1].start() if i + 1 < len(job_matches) else len(jobs_section)
+        segment = jobs_section[start:end]
+        if not TIMEOUT_RE.search(segment):
+            missing.append(job_name)
+
+    assert not missing, (
+        f"{filename}: job(s) missing 'timeout-minutes': {missing}"
+    )
+
+
+def test_pr_yml_has_concurrency_guard():
+    text = (ROOT / ".github" / "workflows" / "pr.yml").read_text()
+
+    # Match the top-level concurrency: block and capture its indented body
+    conc_match = re.search(r"^concurrency:\s*\n((?:  .+\n?)+)", text, re.MULTILINE)
+    assert conc_match, "pr.yml: missing top-level 'concurrency:' block"
+
+    conc_body = conc_match.group(1)
+    assert "github.ref" in conc_body, (
+        "pr.yml: concurrency group must reference ${{ github.ref }}"
+    )
+    assert re.search(r"cancel-in-progress:\s*true", conc_body), (
+        "pr.yml: missing 'cancel-in-progress: true' inside concurrency block"
+    )

--- a/tests/test_workflow_hardening.py
+++ b/tests/test_workflow_hardening.py
@@ -5,6 +5,7 @@ consuming GitHub Actions quota up to the 6-hour default, and ensures stale in-pr
 runs are cancelled when a new push arrives on an open PR.
 """
 
+import glob
 import re
 from pathlib import Path
 
@@ -13,10 +14,8 @@ import pytest
 ROOT = Path(__file__).parent.parent
 
 WORKFLOW_FILES = [
-    "pr.yml",
-    "release.yml",
-    "skill-triggers.yml",
-    "dependabot-lockfile.yml",
+    Path(p).name
+    for p in sorted(glob.glob(str(ROOT / ".github" / "workflows" / "*.yml")))
 ]
 
 # Anchors to the start of the jobs: section; everything else (on:, permissions:) is ignored.
@@ -26,7 +25,8 @@ JOBS_SECTION_RE = re.compile(r"^jobs:\s*$", re.MULTILINE)
 JOB_KEY_RE = re.compile(r"^  (\S[^:]*):\s*$", re.MULTILINE)
 
 # Matches timeout-minutes at exactly 4-space indent (direct job property), e.g. "    timeout-minutes: 15"
-TIMEOUT_RE = re.compile(r"^    timeout-minutes:\s*\d+\s*$", re.MULTILINE)
+# [1-9]\d* requires a positive integer — rejects 0 which disables the timeout on GitHub Actions.
+TIMEOUT_RE = re.compile(r"^    timeout-minutes:\s*[1-9]\d*\s*$", re.MULTILINE)
 
 
 @pytest.mark.parametrize("filename", WORKFLOW_FILES)


### PR DESCRIPTION
## Summary
- Add top-level `concurrency` block to `pr.yml` keyed on `github.ref` with `cancel-in-progress: true`, so a second push to an open PR auto-cancels the stale in-progress run.
- Add `timeout-minutes` to every job across all four workflow files (`pr.yml`, `release.yml`, `skill-triggers.yml`, `dependabot-lockfile.yml`) — 10 jobs total — so hung steps (e.g. `lychee` network requests in `markdown-links`) fail fast instead of running to GitHub's 6-hour default.
- Add `tests/test_workflow_hardening.py` — dependency-free TDD regression guard (stdlib only: `re`, `pathlib`, `pytest`) with two functions: `test_every_job_has_timeout_minutes` (parametrized over all four workflow files) and `test_pr_yml_has_concurrency_guard`.

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `pytest tests/test_workflow_hardening.py -v` — 5 tests pass (was red before YAML edits, green after)
- [ ] `pytest tests/ -v` — 891 tests pass, no regressions

### Type-tailored checks ([ci])
- [ ] Workflow YAML parses without errors on push (GitHub Actions runner validates YAML structure on run)
- [ ] `pr.yml` concurrency block is at top-level (0-indent), `cancel-in-progress: true` confirmed
- [ ] All 10 jobs have `timeout-minutes` at 4-space indent (job-level property)
- [ ] A second push to this PR cancels the prior in-progress run (visible in Actions tab as "Cancelled")

Closes #307
