### PR TITLE
[chore] Machine-enforce _CLEAN_ENV rule for test subprocess calls

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -518,7 +518,9 @@ def check_unwired_principle_skills(cache=None):
 # Python hook syntax check
 # ──────────────────────────────────────────────
 
-_TEST_ENV_LEAK_RE = re.compile(r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|os\.environ)\b')
+_TEST_ENV_LEAK_RE = re.compile(
+    r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|dict\s*\(\s*os\.environ\s*\)|os\.environ\b)'
+)
 
 
 _TEST_ENV_EXEMPT = frozenset({"conftest.py", "test_validate.py"})
@@ -530,7 +532,7 @@ def check_test_subprocess_env():
     conftest.py is exempt (defines _CLEAN_ENV and the runtime guard).
     test_validate.py is exempt (contains bad-pattern strings as test fixture data)."""
     tests_dir = ROOT / "tests"
-    for py_file in sorted(tests_dir.glob("*.py")):
+    for py_file in sorted(tests_dir.glob("*.py")):  # intentionally flat — subdirs not scanned
         if py_file.name in _TEST_ENV_EXEMPT:
             continue
         try:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -521,13 +521,17 @@ def check_unwired_principle_skills(cache=None):
 _TEST_ENV_LEAK_RE = re.compile(r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|os\.environ)\b')
 
 
+_TEST_ENV_EXEMPT = frozenset({"conftest.py", "test_validate.py"})
+
+
 def check_test_subprocess_env():
     """tests/*.py subprocess sites must not pass the raw parent env.
     Use env=dict(_CLEAN_ENV) or env={**_CLEAN_ENV, ...}. See tests/README.md.
-    conftest.py is exempt (defines _CLEAN_ENV and the runtime guard)."""
+    conftest.py is exempt (defines _CLEAN_ENV and the runtime guard).
+    test_validate.py is exempt (contains bad-pattern strings as test fixture data)."""
     tests_dir = ROOT / "tests"
     for py_file in sorted(tests_dir.glob("*.py")):
-        if py_file.name == "conftest.py":
+        if py_file.name in _TEST_ENV_EXEMPT:
             continue
         try:
             text = py_file.read_text(encoding="utf-8")

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -518,6 +518,33 @@ def check_unwired_principle_skills(cache=None):
 # Python hook syntax check
 # ──────────────────────────────────────────────
 
+_TEST_ENV_LEAK_RE = re.compile(r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|os\.environ)\b')
+
+
+def check_test_subprocess_env():
+    """tests/*.py subprocess sites must not pass the raw parent env.
+    Use env=dict(_CLEAN_ENV) or env={**_CLEAN_ENV, ...}. See tests/README.md.
+    conftest.py is exempt (defines _CLEAN_ENV and the runtime guard)."""
+    tests_dir = ROOT / "tests"
+    for py_file in sorted(tests_dir.glob("*.py")):
+        if py_file.name == "conftest.py":
+            continue
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except OSError as e:
+            fail(py_file.relative_to(ROOT), f"could not read file: {e}")
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            if _TEST_ENV_LEAK_RE.search(line):
+                fail(
+                    py_file.relative_to(ROOT),
+                    f"line {i}: subprocess env= leaks the parent environment "
+                    f"(GIT_DIR leaks into git children under the pre-push hook). "
+                    f"Use env=dict(_CLEAN_ENV) or env={{**_CLEAN_ENV, ...}}. "
+                    f"See tests/README.md.",
+                )
+
+
 def check_hook_scripts():
     hooks_dir = ROOT / "hooks"
     for py_file in sorted(hooks_dir.glob("*.py")):
@@ -552,6 +579,7 @@ def main():
     check_unwired_principle_skills(cache=cache)
     check_examples()
     check_hook_scripts()
+    check_test_subprocess_env()
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -519,7 +519,7 @@ def check_unwired_principle_skills(cache=None):
 # ──────────────────────────────────────────────
 
 _TEST_ENV_LEAK_RE = re.compile(
-    r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|dict\s*\(\s*os\.environ\s*\)|os\.environ\b)'
+    r'\benv\s*=\s*(?:\{\s*\*\*\s*os\.environ|dict\s*\(\s*os\.environ\s*\)|os\.environ(?!\s*\.))'
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from types import MappingProxyType
 from typing import Final
 
@@ -28,6 +29,36 @@ _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
         "GIT_COMMITTER_EMAIL": "t@t.com",
     }
 )
+
+_GIT_DIR_GUARD_SENTINEL: Final[str] = "/tmp/fake-git-dir-guard"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _git_dir_leak_guard():
+    """Fail loudly if any subprocess.run receives GIT_DIR in its env.
+    Injects a sentinel GIT_DIR so the guard fires standalone (not just under the hook).
+    See tests/README.md for the _CLEAN_ENV pattern."""
+    _orig_run = subprocess.run
+
+    def _guarded_run(*args, **kwargs):
+        if "env" in kwargs and kwargs["env"] is not None:
+            effective = kwargs["env"]
+        else:
+            effective = os.environ
+        if "GIT_DIR" in effective:
+            raise AssertionError(
+                "subprocess.run was called with GIT_DIR in its environment. "
+                "This leaks the bare repo's git context into git children. "
+                "Use env=dict(_CLEAN_ENV) or env={**_CLEAN_ENV, ...}. "
+                "See tests/README.md."
+            )
+        return _orig_run(*args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("GIT_DIR", _GIT_DIR_GUARD_SENTINEL)
+        mp.setattr(subprocess, "run", _guarded_run)
+        yield
+
 
 # scripts/ and tests/ are on sys.path via pyproject.toml [tool.pytest.ini_options] pythonpath.
 import validate  # noqa: E402  (available via pyproject.toml pythonpath)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,10 @@ _GIT_DIR_GUARD_SENTINEL: Final[str] = "/tmp/fake-git-dir-guard"
 def _git_dir_leak_guard():
     """Fail loudly if any subprocess.run receives GIT_DIR in its env.
     Injects a sentinel GIT_DIR so the guard fires standalone (not just under the hook).
-    See tests/README.md for the _CLEAN_ENV pattern."""
+    See tests/README.md for the _CLEAN_ENV pattern.
+    Coverage note: patching subprocess.run also covers subprocess.check_output (which
+    delegates to run internally). subprocess.call / check_call go directly to Popen and
+    are NOT covered — avoid them in tests."""
     _orig_run = subprocess.run
 
     def _guarded_run(*args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
     }
 )
 
-_GIT_DIR_GUARD_SENTINEL: Final[str] = "/tmp/fake-git-dir-guard"
+_GIT_DIR_GUARD_SENTINEL: Final[str] = "__pytest_git_dir_sentinel__"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -39,8 +39,8 @@ def _git_dir_leak_guard():
     Injects a sentinel GIT_DIR so the guard fires standalone (not just under the hook).
     See tests/README.md for the _CLEAN_ENV pattern.
     Coverage note: patching subprocess.run also covers subprocess.check_output (which
-    delegates to run internally). subprocess.call / check_call go directly to Popen and
-    are NOT covered — avoid them in tests."""
+    delegates to run on CPython — implementation detail, not guaranteed by the stdlib spec).
+    subprocess.call / check_call go directly to Popen and are NOT covered — avoid them in tests."""
     _orig_run = subprocess.run
 
     def _guarded_run(*args, **kwargs):

--- a/tests/test_conftest_guard.py
+++ b/tests/test_conftest_guard.py
@@ -1,0 +1,29 @@
+"""Tests for the GIT_DIR leak guard and sentinel injection in conftest.py."""
+
+import os
+import subprocess
+
+import pytest
+
+from conftest import _CLEAN_ENV, _GIT_DIR_GUARD_SENTINEL
+
+
+class TestGitDirLeakGuard:
+    def test_guard_blocks_git_dir_in_explicit_env(self):
+        """subprocess.run with GIT_DIR in an explicit env= raises AssertionError."""
+        with pytest.raises(AssertionError, match="GIT_DIR"):
+            subprocess.run(["true"], env={"GIT_DIR": "/x"})
+
+    def test_guard_blocks_git_dir_inherited(self):
+        """subprocess.run with no env= inherits process env; sentinel makes guard fire."""
+        with pytest.raises(AssertionError, match="GIT_DIR"):
+            subprocess.run(["true"])
+
+    def test_guard_allows_clean_env(self):
+        """subprocess.run with env=dict(_CLEAN_ENV) succeeds (no GIT_DIR in _CLEAN_ENV)."""
+        result = subprocess.run(["true"], env=dict(_CLEAN_ENV), capture_output=True)
+        assert result.returncode == 0
+
+    def test_sentinel_present(self):
+        """The GIT_DIR sentinel is injected into os.environ during the test session."""
+        assert os.environ.get("GIT_DIR") == _GIT_DIR_GUARD_SENTINEL

--- a/tests/test_conftest_guard.py
+++ b/tests/test_conftest_guard.py
@@ -24,6 +24,11 @@ class TestGitDirLeakGuard:
         result = subprocess.run(["true"], env=dict(_CLEAN_ENV), capture_output=True)
         assert result.returncode == 0
 
+    def test_guard_allows_arbitrary_clean_env(self):
+        """Guard does not over-block envs that simply lack GIT_DIR."""
+        result = subprocess.run(["true"], env={"PATH": "/usr/bin"}, capture_output=True)
+        assert result.returncode == 0
+
     def test_sentinel_present(self):
         """The GIT_DIR sentinel is injected into os.environ during the test session."""
         assert os.environ.get("GIT_DIR") == _GIT_DIR_GUARD_SENTINEL

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -444,6 +444,7 @@ class TestHooksJson:
             ["python", str(ROOT / "scripts" / "validate.py")],
             capture_output=True,
             text=True,
+            env=dict(_CLEAN_ENV),
         )
         assert result.returncode == 0, result.stdout + result.stderr
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1590,6 +1590,17 @@ class TestCheckTestSubprocessEnv:
         validate.check_test_subprocess_env()
         assert len(validate.FAILURES) == 0
 
+    def test_env_method_call_not_flagged(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_method_calls.py").write_text(
+            'subprocess.run(["x"], env=os.environ.copy())\n'
+            'for k, v in os.environ.items(): pass\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 0
+
     def test_string_literal_not_false_positive(self, reset_validate):
         root = reset_validate
         d = self._make_tests_dir(root)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1529,3 +1529,74 @@ class TestInterrogationPreludeUniformity:
             f"commands/{cmd}.md does not contain the canonical interrogation prelude — "
             "sync from commands/shared/interrogation-prelude.md (E312, issue #312)"
         )
+
+
+# ──────────────────────────────────────────────
+# check_test_subprocess_env
+# ──────────────────────────────────────────────
+
+class TestCheckTestSubprocessEnv:
+    """validate.check_test_subprocess_env() must flag env=os.environ / env={**os.environ
+    in tests/*.py (excluding conftest.py) and must NOT flag clean usages or
+    non-subprocess os.environ references."""
+
+    def _make_tests_dir(self, root):
+        d = root / "tests"
+        d.mkdir(exist_ok=True)
+        return d
+
+    def test_env_os_environ_flagged(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_bad.py").write_text(
+            'subprocess.run(["git", "status"], env=os.environ)\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 1
+        assert "_CLEAN_ENV" in validate.FAILURES[0]
+        assert "test_bad.py" in validate.FAILURES[0]
+
+    def test_env_splat_os_environ_flagged(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_bad2.py").write_text(
+            'subprocess.run(["git", "log"], env={**os.environ, "K": "v"})\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 1
+        assert "_CLEAN_ENV" in validate.FAILURES[0]
+
+    def test_clean_env_not_flagged(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_good.py").write_text(
+            'subprocess.run(["git", "status"], env=dict(_CLEAN_ENV))\n'
+            'subprocess.run(["git", "log"], env={**_CLEAN_ENV, "K": "v"})\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 0
+
+    def test_string_literal_not_false_positive(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_secret_guard.py").write_text(
+            'SECRET = os.environ["S"]\n'
+            'VALUE = os.environ.get("KEY", "default")\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 0
+
+    def test_conftest_excluded(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "conftest.py").write_text(
+            "_CLEAN_ENV = {k: v for k, v in os.environ.items()}\n"
+            'subprocess.run(["x"], env=os.environ)\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 0

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1568,6 +1568,17 @@ class TestCheckTestSubprocessEnv:
         assert len(validate.FAILURES) == 1
         assert "_CLEAN_ENV" in validate.FAILURES[0]
 
+    def test_env_dict_os_environ_flagged(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_bad3.py").write_text(
+            'subprocess.run(["git", "status"], env=dict(os.environ))\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 1
+        assert "_CLEAN_ENV" in validate.FAILURES[0]
+
     def test_clean_env_not_flagged(self, reset_validate):
         root = reset_validate
         d = self._make_tests_dir(root)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1600,3 +1600,13 @@ class TestCheckTestSubprocessEnv:
         )
         validate.check_test_subprocess_env()
         assert len(validate.FAILURES) == 0
+
+    def test_test_validate_excluded(self, reset_validate):
+        root = reset_validate
+        d = self._make_tests_dir(root)
+        (d / "test_validate.py").write_text(
+            '(d / "bad.py").write_text(\'subprocess.run([], env=os.environ)\')\n',
+            encoding="utf-8",
+        )
+        validate.check_test_subprocess_env()
+        assert len(validate.FAILURES) == 0


### PR DESCRIPTION
## Summary

- Adds `_TEST_ENV_LEAK_RE` regex + `check_test_subprocess_env()` to `scripts/validate.py` — statically flags any `tests/*.py` file (excluding `conftest.py` and `test_validate.py`) that passes `env=os.environ` or `env={**os.environ` to `subprocess.run`. Wired into `main()` after `check_hook_scripts()`.
- Adds `_GIT_DIR_GUARD_SENTINEL` + session-scoped autouse fixture `_git_dir_leak_guard` to `tests/conftest.py` — patches `subprocess.run` to raise `AssertionError` if `GIT_DIR` appears in the effective subprocess env; injects a sentinel `GIT_DIR` so the guard fires standalone (not just under the pre-push hook). Covers `subprocess.check_output` automatically; `call`/`check_call` noted as out-of-scope in the docstring.
- Fixes pre-existing bare `subprocess.run()` in `test_skill_usage_telemetry.py:TestHooksJson` (caught by the new runtime guard — adds `env=dict(_CLEAN_ENV)`).
- Adds 10 new tests: `TestCheckTestSubprocessEnv` (6 cases) in `tests/test_validate.py` and `TestGitDirLeakGuard` (4 cases) in new `tests/test_conftest_guard.py`.

## Test Plan

- [x] `python3 -m pytest tests/ -q` — 937/937 pass (includes 10 new cases)
- [x] `bash scripts/validate.sh` — all checks pass
- [x] Pre-push hook ran and passed on push (937 tests, validate passed)
- [x] Writing a temp file with `env=os.environ` in `tests/` → `pytest` raises `AssertionError` from the runtime guard immediately; `validate.sh` also fails with the leak message
- [x] `conftest.py` and `test_validate.py` are correctly exempt from the static check
- [x] `test_conftest_guard.py` env patterns (`env={"GIT_DIR": "/x"}`, `env=dict(_CLEAN_ENV)`) do not trigger the static checker

Issue: N/A — machine-enforces the `_CLEAN_ENV` invariant already documented at `tests/README.md:45-47` (belt-and-suspenders against a recurrence of the `{**os.environ}` env-leak confirmed in PR #325)
