### PR TITLE
[feat] Add C# language skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "swe-workbench",
-      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
       "version": "0.1.15",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
   "version": "0.1.15",
-  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
     "email": "11341007+lugassawan@users.noreply.github.com",
@@ -20,6 +20,8 @@
     "tdd",
     "solid",
     "bash",
+    "csharp",
+    "dotnet",
     "golang",
     "java",
     "kotlin",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What it is
 
-`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
+`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
 
 ## Install
 
@@ -29,7 +29,7 @@ cd swe-workbench
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge`, `/swe-workbench:doctor` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `code-impl`, `contributor-auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
-- **Languages** — Bash, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript — auto-load by file extension.
+- **Languages** — Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-load by file extension.
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
 

--- a/agents/shared/languages.md
+++ b/agents/shared/languages.md
@@ -3,6 +3,7 @@
 All `swe-workbench` language skills available in this plugin. Use the `Skill` tool to invoke any of these.
 
 - `swe-workbench:language-bash` — Bash idioms: strict mode, quoting, parameter expansion, arrays, pipefail, trap cleanup, idempotency, heredocs, and POSIX portability.
+- `swe-workbench:language-csharp` — C#/.NET idioms: .NET 8 LTS, nullable reference types, records, pattern matching, async/await, dependency injection, options, LINQ, and performance.
 - `swe-workbench:language-go` — Go idioms: error handling, goroutines, channels, interfaces, context, standard library.
 - `swe-workbench:language-java` — Java idioms: records, sealed types, virtual threads, streams, JDK 21+ patterns.
 - `swe-workbench:language-kotlin` — Kotlin idioms: null safety, coroutines, sealed interfaces, scope functions, Flow.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -75,12 +75,13 @@
 
 | Skill | Triggers |
 |---|---|
-| `language-sql` | `.sql` files, migration files; keywords: SQL, SELECT, JOIN, EXPLAIN, CTE, window function, transaction isolation, deadlock, pagination. |
+| `language-csharp` | `.cs` files, `.csproj`, `.sln`, `Directory.Build.props`, keywords: C#, .NET, dotnet, nullable reference types, records, pattern matching, async/await, cancellation tokens, ConfigureAwait, IOptions, LINQ. |
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-java` | `.java` files, `pom.xml`, `build.gradle`, keywords: Java, JVM, Spring, Maven, Gradle, records, sealed classes, virtual threads. |
 | `language-kotlin` | `.kt` files, `build.gradle.kts`, keywords: Kotlin, coroutines, suspend, StateFlow, sealed interface, Kotlin DSL. |
 | `language-ruby` | `.rb` files, `Gemfile`, `Rakefile`, gemspecs, keywords: Ruby, Bundler, RSpec, minitest, blocks, procs, lambdas, pattern matching. |
 | `language-rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
+| `language-sql` | `.sql` files, migration files; keywords: SQL, SELECT, JOIN, EXPLAIN, CTE, window function, transaction isolation, deadlock, pagination. |
 | `language-swift` | `.swift` files, `Package.swift`, keywords: Swift, SwiftUI, actors, async/await, Sendable, Result builders, Swift Package Manager. |
 | `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
 | `language-python` | `.py` files, `pyproject.toml`, `requirements.txt`, keywords: Python, pytest, asyncio, dataclass, type hints, virtualenv. |

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -79,12 +79,12 @@
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-java` | `.java` files, `pom.xml`, `build.gradle`, keywords: Java, JVM, Spring, Maven, Gradle, records, sealed classes, virtual threads. |
 | `language-kotlin` | `.kt` files, `build.gradle.kts`, keywords: Kotlin, coroutines, suspend, StateFlow, sealed interface, Kotlin DSL. |
+| `language-python` | `.py` files, `pyproject.toml`, `requirements.txt`, keywords: Python, pytest, asyncio, dataclass, type hints, virtualenv. |
 | `language-ruby` | `.rb` files, `Gemfile`, `Rakefile`, gemspecs, keywords: Ruby, Bundler, RSpec, minitest, blocks, procs, lambdas, pattern matching. |
 | `language-rust` | `.rs` files, `Cargo.toml`, keywords: Rust, cargo, ownership, borrow checker, trait, lifetime. |
 | `language-sql` | `.sql` files, migration files; keywords: SQL, SELECT, JOIN, EXPLAIN, CTE, window function, transaction isolation, deadlock, pagination. |
 | `language-swift` | `.swift` files, `Package.swift`, keywords: Swift, SwiftUI, actors, async/await, Sendable, Result builders, Swift Package Manager. |
 | `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
-| `language-python` | `.py` files, `pyproject.toml`, `requirements.txt`, keywords: Python, pytest, asyncio, dataclass, type hints, virtualenv. |
 
 ### Workflows — auto-load during implementation
 

--- a/skills/language-csharp/SKILL.md
+++ b/skills/language-csharp/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: language-csharp
+description: C# and .NET idioms — .NET 8 LTS, csproj, C# NRT, records in C#, value semantics in C#, switch expressions in C#, async/await in C#, Task, ValueTask, CancellationToken, ConfigureAwait, dependency injection, IOptions<T>, LINQ, and performance. Auto-load when working with .cs files, .csproj, .sln, Directory.Build.props, or when the user mentions C#, dotnet, .NET 8, C# NRT, NRT, records in C#, value semantics in C#, switch expressions in C#, Task, ValueTask, CancellationToken, ConfigureAwait, IOptions, or LINQ.
+---
+
+# C# / .NET
+
+## .NET 8 project shape
+- Prefer SDK-style projects with explicit `TargetFramework` (`net8.0`) and shared defaults in `Directory.Build.props`.
+- Keep nullable reference types enabled for new code: `<Nullable>enable</Nullable>`.
+- Use `ImplicitUsings` when the repository already does; avoid hand-maintaining noisy common imports.
+- Keep application, domain, infrastructure, and test projects separate when boundaries are real, not just for ceremony.
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  <Nullable>enable</Nullable>
+  <ImplicitUsings>enable</ImplicitUsings>
+</PropertyGroup>
+```
+
+## Nullable reference types
+- Treat warnings as design feedback, not noise. Model absence with `T?`, `required`, or a domain type.
+- Validate nullable inputs at boundaries; keep internals non-null where possible.
+- Use `ArgumentNullException.ThrowIfNull(value)` for guard clauses.
+- Avoid `!` except when bridging a framework or serializer limitation; leave a short reason.
+
+```csharp
+public sealed class User
+{
+    public required string Email { get; init; }
+    public string? DisplayName { get; init; }
+}
+```
+
+## Records and value semantics
+- Use `record` or `readonly record struct` for immutable value-like data.
+- Use classes for identity, lifecycle, mutation, or behavior-heavy objects.
+- Be deliberate with `with`: it is copy-with-change, not validation unless constructors enforce invariants.
+
+```csharp
+public sealed record Money(decimal Amount, string Currency);
+
+var discounted = price with { Amount = price.Amount * 0.9m };
+```
+
+## Pattern matching
+- Use patterns for shape-based branching, parsing, and closed domain states.
+- Prefer switch expressions when every case returns a value.
+- Keep guards (`when`) simple; complex decisions deserve named methods.
+
+```csharp
+return command switch
+{
+    CreateUser(var email) when email.Contains('@') => Create(email),
+    DeleteUser(var id) => Delete(id),
+    _ => throw new InvalidOperationException("unsupported command")
+};
+```
+
+## Async and cancellation
+- Use `async`/`await` all the way. Avoid `.Result`, `.Wait()`, and blocking over async work.
+- Accept and pass `CancellationToken` through I/O, database, and long-running operations.
+- In libraries, use `ConfigureAwait(false)` when code does not need a captured context; in modern app code, follow the repo's convention.
+- Prefer `Task.WhenAll` for independent work; avoid unobserved fire-and-forget tasks.
+
+```csharp
+public async Task<User> GetUserAsync(string id, CancellationToken cancellationToken)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(id);
+    return await repository.FindAsync(id, cancellationToken).ConfigureAwait(false)
+        ?? throw new UserNotFoundException(id);
+}
+```
+
+## Dependency injection and options
+- Depend on abstractions at boundaries, but do not create interfaces for every class by habit.
+- Use constructor injection for required collaborators; avoid service locator patterns.
+- Bind configuration to option records and consume `IOptions<T>`, `IOptionsSnapshot<T>`, or `IOptionsMonitor<T>` based on lifetime needs.
+- Validate options at startup when invalid configuration should fail fast.
+
+```csharp
+public sealed record RetryOptions
+{
+    public int MaxAttempts { get; init; } = 3;
+}
+
+public sealed class Worker(IOptions<RetryOptions> options)
+{
+    private readonly RetryOptions retry = options.Value;
+}
+```
+
+## LINQ and performance
+- Use LINQ for clear transformations, filtering, grouping, and projections.
+- Prefer `Any()` over `Count() > 0`, and avoid repeated enumeration of deferred queries.
+- In hot paths, benchmark before replacing readable LINQ with loops.
+- Use `Span<T>`, pooling, and allocation-aware APIs only when profiling shows they matter.
+
+```csharp
+var activeEmails = users
+    .Where(user => user.IsActive)
+    .Select(user => user.Email)
+    .ToArray();
+```
+
+## Testing
+- xUnit, NUnit, and MSTest are all fine; follow the repository's existing framework.
+- Use fluent assertions when already present, and keep tests behavior-focused.
+- Mock external boundaries, not records, value objects, or simple domain behavior.
+
+## Avoid
+- Disabling nullable warnings instead of fixing the contract.
+- Blocking on tasks with `.Result`, `.Wait()`, or `GetAwaiter().GetResult()`.
+- Treating dependency injection as a reason to hide every constructor behind an interface.
+- Rewriting clear LINQ into loops without a measured performance reason.
+- Making ASP.NET conventions the default for non-web .NET code.

--- a/skills/language-csharp/SKILL.md
+++ b/skills/language-csharp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: language-csharp
-description: C# and .NET idioms — .NET 8 LTS, csproj, C# NRT, records in C#, value semantics in C#, switch expressions in C#, async/await in C#, Task, ValueTask, CancellationToken, ConfigureAwait, dependency injection, IOptions<T>, LINQ, and performance. Auto-load when working with .cs files, .csproj, .sln, Directory.Build.props, or when the user mentions C#, dotnet, .NET 8, C# NRT, NRT, records in C#, value semantics in C#, switch expressions in C#, Task, ValueTask, CancellationToken, ConfigureAwait, IOptions, or LINQ.
+description: C# and .NET idioms — .NET 8 LTS, csproj, C# NRT, records, value semantics, switch expressions, async/await, Task, ValueTask, CancellationToken, ConfigureAwait, dependency injection, IOptions<T>, LINQ, and performance. Auto-load when working with .cs files, .csproj, .sln, Directory.Build.props, or when the user mentions C#, dotnet, .NET 8, C# NRT, NRT, records, value semantics, switch expressions, Task, ValueTask, CancellationToken, ConfigureAwait, IOptions, or LINQ.
 ---
 
 # C# / .NET

--- a/skills/language-csharp/triggers.txt
+++ b/skills/language-csharp/triggers.txt
@@ -1,0 +1,5 @@
+# Representative trigger prompts for language-csharp
+how should I structure a modern C# .NET 8 project with nullable reference types enabled
+review this C# async method for .Result ConfigureAwait and CancellationToken usage
+when should I use records pattern matching and value semantics in C#
+should this hot path use LINQ or a for loop in .NET after profiling allocations


### PR DESCRIPTION
## Summary
- Add `language-csharp` skill covering modern C# and .NET idioms.
- Cover .NET 8 project structure, C# NRT, records, value semantics, switch expressions, async/await, `CancellationToken`, `ConfigureAwait`, dependency injection, `IOptions<T>`, LINQ, and performance tradeoffs.
- Add trigger prompts and register the skill in language catalogs, README, and plugin manifest discovery metadata.

## Test Plan
- [x] Changed skills/commands/agents load without errors: `python scripts/validate.py`
- [x] Skill trigger ranking checks: `python -m pytest tests/test_skill_triggers.py -q`
- [ ] Examples in the diff were exercised manually

Closes #93