### PR TITLE
[ci] Auto-assign repo owner as reviewer on contributor PRs

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,31 @@
+name: Auto-assign reviewer
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+# Least privilege: only what's needed to request a reviewer.
+permissions:
+  contents: none
+  pull-requests: write
+
+# Avoid duplicate assignment runs on rapid re-triggers.
+concurrency:
+  group: auto-assign-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # GitHub rejects requesting a review from the PR author. Skip owner-authored
+    # PRs so this is a clean no-op rather than a failing job.
+    if: ${{ github.event.pull_request.user.login != github.repository_owner }}
+    steps:
+      - name: Request review from repo owner
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: gh pr edit "$PR" --repo "$REPO" --add-reviewer "$OWNER"

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -2,7 +2,7 @@ name: Auto-assign reviewer
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, reopened]
 
 # Least privilege: only what's needed to request a reviewer.
 permissions:
@@ -12,7 +12,7 @@ permissions:
 # Avoid duplicate assignment runs on rapid re-triggers.
 concurrency:
   group: auto-assign-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/auto-assign-reviewer.yml` to auto-request a review from the repo owner on contributor PRs
- Uses `pull_request_target` so fork PRs receive a write-capable token; the job never checks out or executes PR code
- Skips owner-authored PRs cleanly (GitHub API rejects self-review) via a job-level `if:` guard
- Scopes permissions to `contents: none` + `pull-requests: write` only
- Resolves to the repo owner dynamically via `github.repository_owner` — no hardcoded username

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `actionlint .github/workflows/auto-assign-reviewer.yml` — 0 issues
- [ ] Owner-authored PR: `assign` job shows **Skipped** in Actions (the `if:` guard short-circuits before the runner spins up)
- [ ] Contributor PR (from a fork): `assign` job runs and `@lugassawan` appears as reviewer on the PR

Issue: N/A — repo configuration, no tracking issue
