### PR TITLE
[chore] Advertise SQL in plugin.json/marketplace.json keywords and description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "swe-workbench",
-      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
       "version": "0.1.15",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
   "version": "0.1.15",
-  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript), and pragmatic workflows.",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
     "email": "11341007+lugassawan@users.noreply.github.com",
@@ -28,6 +28,7 @@
     "python",
     "ruby",
     "rust",
+    "sql",
     "swift",
     "typescript"
   ]


### PR DESCRIPTION
## Summary

- Added `"sql"` to `plugin.json` keywords array (alongside existing language entries like `"rust"`, `"swift"`)
- Added `SQL` to the language expertise parenthetical in `plugin.json` description (between Rust and Swift)
- Mirrored the same description change in `marketplace.json` so both manifests stay identical
- `README.md:32` Languages bullet already listed SQL (added in a prior commit) — no README change needed

## Test Plan

- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `plugin.json` and `marketplace.json` descriptions are identical (both now list SQL)

### Type-tailored checks ([chore])
- [ ] `grep '"sql"' .claude-plugin/plugin.json` returns a match in the keywords array
- [ ] `grep 'SQL' .claude-plugin/plugin.json .claude-plugin/marketplace.json` returns matches in both description fields
- [ ] `python3 -c "import json; p=json.load(open('.claude-plugin/plugin.json')); m=json.load(open('.claude-plugin/marketplace.json')); assert p['description'] == m['plugins'][0]['description'], 'descriptions diverged'"` exits 0

Closes #330
