### PR TITLE
[fix] Drive language/principle skill selection deterministically

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What it is
 
-`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principles auto-load when you are designing or writing code; language skills auto-load by file extension; commands and subagents are there when you want explicit help.
+`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principle and language skills auto-hint by trigger (a non-blocking hint fires when a matching file is touched); commands and subagents are there when you want explicit help.
 
 ## Install
 
@@ -28,8 +28,8 @@ cd swe-workbench
 
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge`, `/swe-workbench:doctor` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `code-impl`, `contributor-auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
-- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-load by trigger keyword.
-- **Languages** — Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-load by file extension.
+- **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security — auto-hint by trigger keyword.
+- **Languages** — Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-hint by file extension (subagents load deterministically via catalog injection).
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle.
 

--- a/agents/accessibility-auditor.md
+++ b/agents/accessibility-auditor.md
@@ -167,6 +167,8 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 
 See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-typescript` for `.tsx` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
+
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 
 - `swe-workbench:principle-accessibility` — semantic HTML, ARIA, keyboard navigation, focus management, contrast, screen-reader patterns

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -55,7 +55,9 @@ See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -83,7 +83,9 @@ Every finding must include all 11 fields. **Omit any finding you cannot fill all
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when a finding surfaces a concern in their domain:
 

--- a/agents/code-impl.md
+++ b/agents/code-impl.md
@@ -51,7 +51,9 @@ blockers: <required for NEEDS_CONTEXT and BLOCKED — what is missing or blockin
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when relevant:
 

--- a/agents/contributor-auditor.md
+++ b/agents/contributor-auditor.md
@@ -141,7 +141,9 @@ See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -54,6 +54,8 @@ Call this out even when the minimal fix does not address it. Silence signals the
 
 ## Principle consultation
 
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
+
 Invoke these skills via the Skill tool when the diagnosis surfaces a concern in their domain:
 
 - `swe-workbench:principle-solid` — responsibility, substitutability, dependency direction
@@ -64,7 +66,7 @@ Invoke these skills via the Skill tool when the diagnosis surfaces a concern in 
 
 ## Available skills
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
 ## Absolute rules
 - No fix without a failing test first.

--- a/agents/dependency-auditor.md
+++ b/agents/dependency-auditor.md
@@ -161,6 +161,8 @@ See @./shared/external-repo-reading.md.
 
 See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
+
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 
 - `swe-workbench:principle-security` — when a license or lockfile finding has security implications

--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -117,6 +117,8 @@ Gate to advance: ...
 
 ## Principle consultation
 
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
+
 Invoke these skills via the Skill tool when the migration surfaces a concern in their domain:
 
 - `swe-workbench:principle-data-modeling` — schema evolution, indexing the new column, hot-key avoidance, retention policy during dual-write window
@@ -130,4 +132,4 @@ Invoke these skills via the Skill tool when the migration surfaces a concern in 
 
 ## Available skills
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.

--- a/agents/performance-tuner.md
+++ b/agents/performance-tuner.md
@@ -129,7 +129,9 @@ Every recommendation must carry a verification step. Refuse to declare an optimi
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the analysis surfaces a concern in their domain:
 

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -30,7 +30,9 @@ You are a refactoring specialist. You improve structure without changing observa
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the refactoring touches their domain:
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -93,7 +93,9 @@ Do **not** repeat per-finding detail in this section — that belongs in the sev
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the review surfaces a concern in their domain:
 

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -110,7 +110,9 @@ If asked to apply a fix, refuse and re-emit the suggested fix as text in the fin
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the audit surfaces a concern in their domain:
 

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -43,7 +43,9 @@ See @./shared/external-repo-reading.md.
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool when the question directly concerns their domain — before forming your recommendation:
 

--- a/agents/tech-writer.md
+++ b/agents/tech-writer.md
@@ -70,7 +70,9 @@ For each invocation, emit:
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke `swe-workbench:principle-clean-code` via the Skill tool when writing inline comments — it enforces naming clarity, DRY, and the same "no-obvious-WHAT" discipline this agent applies.
 

--- a/agents/test-reviewer.md
+++ b/agents/test-reviewer.md
@@ -11,7 +11,9 @@ You are a test reviewer. Your job is to audit existing tests and report concrete
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke these skills via the Skill tool before auditing:
 

--- a/agents/test-writer.md
+++ b/agents/test-writer.md
@@ -22,7 +22,9 @@ Read at least one existing test file before writing — match the repo's style, 
 
 ## Principle consultation
 
-See @./shared/principles.md for the skill catalog.
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
 
 Invoke `swe-workbench:principle-tdd` via the Skill tool before writing any test for the full red-green-refactor discipline and "What to test" checklist.
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -71,7 +71,7 @@
 | `principle-release-engineering` | "release", "tag", "semver", "rollout", "rollback", "kill-switch", "expand-contract", "feature flag", "release notes". |
 | `principle-security` | "auth", "authn", "authz", "trust boundary", "input validation", "SSRF", "CSRF", "session", "JWT", "TLS", "secret", "encrypt". |
 
-### Languages — auto-load by file type
+### Languages — auto-hint by file type (subagents load deterministically)
 
 | Skill | Triggers |
 |---|---|
@@ -86,7 +86,7 @@
 | `language-swift` | `.swift` files, `Package.swift`, keywords: Swift, SwiftUI, actors, async/await, Sendable, Result builders, Swift Package Manager. |
 | `language-typescript` | `.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, keywords: TypeScript, Node, tsconfig. |
 
-### Workflows — auto-load during implementation
+### Workflows — auto-hint during implementation
 
 | Skill | Triggers | Delegation model |
 |---|---|---|
@@ -102,7 +102,7 @@
 
 This skill is an orchestrator — it coordinates other skills rather than restating their content.
 
-### Integrations — auto-load on ticket references
+### Integrations — auto-hint on ticket references
 
 | Skill | Triggers | Delegation model |
 |---|---|---|

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -38,6 +38,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_autoload_hint.sh"
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "hooks": [

--- a/hooks/skill_autoload_hint.sh
+++ b/hooks/skill_autoload_hint.sh
@@ -62,7 +62,7 @@ main() {
 
     # Already hinted this session for this skill → silent no-op
     [ -f "$sentinel" ] && exit 0
-    touch "$sentinel" 2>/dev/null || true
+    touch "$sentinel" 2>/dev/null || exit 0
 
     # Emit hint via hookSpecificOutput
     local hint="Consider \`swe-workbench:${skill}\` for .${ext} work — invoke it via the Skill tool to apply language-specific idioms."

--- a/hooks/skill_autoload_hint.sh
+++ b/hooks/skill_autoload_hint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PostToolUse:Read|Edit|Write handler — emits a non-blocking hint when the
+# touched file's extension maps to a known language-* skill.
+#
+# Behaviour:
+#   • De-duplicates: emits at most once per (session, skill) pair.
+#   • Never blocks: exit 0 always.  A broken hook must never gate a tool call.
+set -u
+
+# ── extension → skill map ────────────────────────────────────────────────────
+ext_to_skill() {
+    local ext="$1"
+    case "$ext" in
+        py)                   echo "language-python" ;;
+        ts|tsx|js|jsx|mjs|cjs) echo "language-typescript" ;;
+        go)                   echo "language-go" ;;
+        rs)                   echo "language-rust" ;;
+        java)                 echo "language-java" ;;
+        kt|kts)               echo "language-kotlin" ;;
+        rb)                   echo "language-ruby" ;;
+        swift)                echo "language-swift" ;;
+        sh|bash)              echo "language-bash" ;;
+        sql)                  echo "language-sql" ;;
+        cs)                   echo "language-csharp" ;;
+        *)                    echo "" ;;
+    esac
+}
+
+main() {
+    local input file_path session_id ext skill safe_session safe_skill sentinel dir today
+
+    input=$(cat)
+
+    # Extract file path (Read/Edit supply file_path; Write also supplies it)
+    file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+    [ -n "$file_path" ] || exit 0
+
+    # Derive extension (lowercase, POSIX tr for Bash 3 compat).
+    # Guard: if ext equals the bare filename there was no dot → not an extension.
+    ext="${file_path##*.}"
+    ext=$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')
+    [ "$ext" = "${file_path##*/}" ] && exit 0   # no dot in filename → no extension
+
+    skill=$(ext_to_skill "$ext")
+    [ -n "$skill" ] || exit 0             # unmapped extension → no hint
+
+    # Session-scoped de-dup sentinel.
+    # Use || true so a jq-absent environment still falls through to the PID fallback.
+    session_id=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || true
+    [ -n "$session_id" ] || session_id="$$"   # fallback: PID (coarse but safe)
+
+    # Sanitize both components: only alphanumeric + dash + underscore
+    safe_session="${session_id//[^A-Za-z0-9_-]/_}"
+    safe_skill="${skill//[^A-Za-z0-9_-]/_}"
+
+    # Date-scoped subdir provides a coarse TTL: yesterday's sentinels are invisible
+    # today, preventing cross-session suppression on long-running machines.
+    today=$(date +%Y%m%d 2>/dev/null) || today="default"
+    dir="${TMPDIR:-/tmp}/swe_wb_skill_hints/${today}"
+    mkdir -p "$dir" 2>/dev/null || exit 0
+    sentinel="${dir}/${safe_session}_${safe_skill}"
+
+    # Already hinted this session for this skill → silent no-op
+    [ -f "$sentinel" ] && exit 0
+    touch "$sentinel" 2>/dev/null || true
+
+    # Emit hint via hookSpecificOutput
+    local hint="Consider \`swe-workbench:${skill}\` for .${ext} work — invoke it via the Skill tool to apply language-specific idioms."
+    jq -cn --arg ctx "$hint" \
+        '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}' \
+        2>/dev/null || true
+}
+
+main
+exit 0

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -443,7 +443,7 @@ def check_catalog_completeness(cache=None):
                  "code-touching agent includes '@./shared/principles.md' but is missing"
                  " '@./shared/languages.md' — add it so language-* skills are in scope."
                  " If this agent never touches source code, add its stem to"
-                 " _NON_CODE_AGENTS in check_catalog_completeness().")
+                 " _NON_CODE_AGENTS at the top of validate.py.")
 
 
 _BLOCKQUOTED_SHARED_RE = re.compile(r'^\s*>.*@\./shared/')

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -406,7 +406,16 @@ def check_catalog_completeness(cache=None):
                 fail(slice_path.relative_to(ROOT),
                      f"entry 'swe-workbench:{sid}' belongs in {_expected_slice(sid)}, not {slice_file}")
 
-    # Every agent must reference at least one slice catalog
+    # Agents that reference @./shared/principles.md but are not code-touching
+    # (e.g. product-manager files GitHub issues and never reads source).
+    # These are explicitly exempt from the languages.md co-requirement below.
+    _NON_CODE_AGENTS = frozenset({
+        "product-manager",
+    })
+
+    # Every agent must reference at least one slice catalog, and every
+    # code-touching agent (one that includes principles.md) must ALSO include
+    # languages.md so language-specific skills are always in scope.
     for agent_md in sorted(agents_dir.glob("*.md")):
         if agents_cache is not None and agent_md in agents_cache:
             agent_text = agents_cache[agent_md]
@@ -424,6 +433,16 @@ def check_catalog_completeness(cache=None):
                  "missing required slice catalog reference"
                  " — add at least one of: '@./shared/principles.md',"
                  " '@./shared/languages.md', '@./shared/workflows.md'")
+            continue
+        # Code-touching agents must include both catalogs.
+        if (agent_md.stem not in _NON_CODE_AGENTS
+                and "@./shared/principles.md" in agent_text
+                and "@./shared/languages.md" not in agent_text):
+            fail(agent_md.relative_to(ROOT),
+                 "code-touching agent includes '@./shared/principles.md' but is missing"
+                 " '@./shared/languages.md' — add it so language-* skills are in scope."
+                 " If this agent never touches source code, add its stem to"
+                 " _NON_CODE_AGENTS in check_catalog_completeness().")
 
 
 _BLOCKQUOTED_SHARED_RE = re.compile(r'^\s*>.*@\./shared/')

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -15,6 +15,14 @@ FAILURES = []
 # must carry a "matcher" field. Only true lifecycle events belong in this set.
 _LIFECYCLE_HOOK_EVENTS = frozenset({"SubagentStop", "PreCompact", "Stop", "Notification"})
 
+# Agents that reference @./shared/principles.md but are NOT code-touching and
+# are therefore exempt from the languages.md co-requirement enforced by
+# check_catalog_completeness(). Add an agent's stem here when it genuinely
+# never reads or writes source code (e.g. it only files GitHub issues).
+_NON_CODE_AGENTS = frozenset({
+    "product-manager",
+})
+
 
 def fail(path, reason):
     FAILURES.append(f"  {path}: {reason}")
@@ -405,13 +413,6 @@ def check_catalog_completeness(cache=None):
             if _expected_slice(sid) != slice_file:
                 fail(slice_path.relative_to(ROOT),
                      f"entry 'swe-workbench:{sid}' belongs in {_expected_slice(sid)}, not {slice_file}")
-
-    # Agents that reference @./shared/principles.md but are not code-touching
-    # (e.g. product-manager files GitHub issues and never reads source).
-    # These are explicitly exempt from the languages.md co-requirement below.
-    _NON_CODE_AGENTS = frozenset({
-        "product-manager",
-    })
 
     # Every agent must reference at least one slice catalog, and every
     # code-touching agent (one that includes principles.md) must ALSO include

--- a/skills/principle-communication/SKILL.md
+++ b/skills/principle-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-communication
-description: Caveman output mode — ultra-terse brief replies with fewer tokens. Strips filler, hedging, pleasantries. Three levels — caveman lite (default), caveman full, ultra caveman / max caveman (maximum compression). Persists until normal mode. Activate with: caveman mode, /caveman, be brief, less tokens, use fewer tokens, talk like caveman, full caveman, ultra caveman, /caveman ultra.
+description: Caveman output mode — ultra-terse brief replies with fewer tokens. Strips filler, hedging, pleasantries. Three levels — caveman lite (default), caveman full, ultra caveman / max caveman (maximum compression). Persists until normal mode. Auto-load when the user requests terser output, says "be brief", "less tokens", "caveman mode", "use fewer tokens", or invokes `/caveman`.
 ---
 
 ## When to invoke

--- a/skills/principle-data-modeling/SKILL.md
+++ b/skills/principle-data-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-data-modeling
-description: Data modeling: relational vs document vs KV vs graph selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution via expand–contract, query-first design, retention and archival.
+description: Data modeling: relational vs document vs KV vs graph selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution via expand–contract, query-first design, retention and archival. Auto-load when designing schemas, choosing a storage paradigm, discussing normalization or denormalization, schema evolution, indexing strategy, hot-key avoidance, query-first design, or data retention.
 ---
 
 # Data Modeling

--- a/tests/test_agent_language_catalog.py
+++ b/tests/test_agent_language_catalog.py
@@ -97,14 +97,19 @@ def _skill_dirs_with_prefix(prefix: str):
     ids=lambda p: p.name,
 )
 def test_skill_description_has_autoload_clause(skill_dir):
-    """T4: every principle-*/language-* SKILL.md description must contain 'Auto-load when'."""
+    """T4: every principle-*/language-* SKILL.md frontmatter description must contain 'Auto-load when'.
+
+    Scans only the YAML frontmatter (between the first two '---' delimiters) so
+    that a body-only occurrence does not produce a false pass — the harness reads
+    the `description:` field, not the body, for auto-triggering.
+    """
     skill_md = skill_dir / "SKILL.md"
     assert skill_md.exists(), f"{skill_dir.name}/SKILL.md does not exist"
     text = skill_md.read_text(encoding="utf-8")
-    # The 'Auto-load when' clause lives in the YAML frontmatter description field.
-    # Match it case-insensitively to tolerate minor capitalisation variation.
-    assert re.search(r"auto-load when", text, re.IGNORECASE), (
-        f"skills/{skill_dir.name}/SKILL.md description is missing an "
-        "'Auto-load when ...' clause. Add it to the description: field in the "
-        "YAML frontmatter so users and agents know when the skill activates."
+    parts = text.split("---", 2)
+    frontmatter = parts[1] if len(parts) >= 3 else ""
+    assert re.search(r"auto-load when", frontmatter, re.IGNORECASE), (
+        f"skills/{skill_dir.name}/SKILL.md description: field is missing an "
+        "'Auto-load when ...' clause. Add it to the YAML frontmatter description "
+        "field (not just the body) so the harness can discover the skill."
     )

--- a/tests/test_agent_language_catalog.py
+++ b/tests/test_agent_language_catalog.py
@@ -88,6 +88,8 @@ def test_agent_has_mandatory_language_gate(agent_name):
 
 
 def _skill_dirs_with_prefix(prefix: str):
+    if not SKILLS_DIR.is_dir():
+        return []
     return [p for p in SKILLS_DIR.iterdir() if p.is_dir() and p.name.startswith(prefix)]
 
 

--- a/tests/test_agent_language_catalog.py
+++ b/tests/test_agent_language_catalog.py
@@ -1,0 +1,110 @@
+"""Structural tests — language-skill under-selection fix.
+
+T1: Every code-touching agent body contains @./shared/languages.md.
+T2: Every code-touching agent body directly contains a mandatory language-skill
+    gate marker (`language-*`) in its consultation section, signalling required
+    (not optional) language-skill loading.
+T4: Every principle-*/language-* SKILL.md description field contains
+    'Auto-load when'.
+
+Tests T1 and T2 fail today (before implementation). T4 fails for
+principle-communication and principle-data-modeling.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+AGENTS_DIR = ROOT / "agents"
+SKILLS_DIR = ROOT / "skills"
+
+# Agents that review, write, or diagnose code — must consult language skills.
+# product-manager is excluded (files GitHub issues; never touches source).
+CODE_TOUCHING_AGENTS = [
+    "accessibility-auditor",
+    "architect",
+    "auditor",
+    "code-impl",
+    "contributor-auditor",
+    "debugger",
+    "dependency-auditor",
+    "migrator",
+    "performance-tuner",
+    "refactorer",
+    "reviewer",
+    "security-auditor",
+    "senior-engineer",
+    "tech-writer",
+    "test-reviewer",
+    "test-writer",
+]
+
+
+def _agent_text(name: str) -> str:
+    path = AGENTS_DIR / f"{name}.md"
+    assert path.exists(), f"agents/{name}.md does not exist"
+    return path.read_text(encoding="utf-8")
+
+
+# ──────────────────────────────────────────────────────────────
+# T1 — @./shared/languages.md present in every code-touching agent
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("agent_name", CODE_TOUCHING_AGENTS)
+def test_agent_has_languages_catalog_include(agent_name):
+    """T1: code-touching agent body must contain @./shared/languages.md."""
+    text = _agent_text(agent_name)
+    assert "@./shared/languages.md" in text, (
+        f"agents/{agent_name}.md is missing '@./shared/languages.md'. "
+        "All code-touching agents must include the language-skill catalog."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# T2 — mandatory language-skill gate present in consultation section
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("agent_name", CODE_TOUCHING_AGENTS)
+def test_agent_has_mandatory_language_gate(agent_name):
+    """T2: consultation section must gate on language-* (required, not optional)."""
+    text = _agent_text(agent_name)
+    # The mandatory gate paragraph uses `language-*` (with the asterisk) to
+    # indicate the required invocation pattern. This is the specific signal
+    # added by the fix; it is NOT present in the @./shared/languages.md include.
+    assert "language-*" in text, (
+        f"agents/{agent_name}.md is missing a mandatory language-skill gate "
+        "('language-*'). Add a required consultation paragraph that instructs "
+        "the agent to detect the language and invoke the matching language-* skill."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# T4 — 'Auto-load when' present in every principle-*/language-* SKILL.md
+# ──────────────────────────────────────────────────────────────
+
+
+def _skill_dirs_with_prefix(prefix: str):
+    return [p for p in SKILLS_DIR.iterdir() if p.is_dir() and p.name.startswith(prefix)]
+
+
+@pytest.mark.parametrize(
+    "skill_dir",
+    _skill_dirs_with_prefix("principle-") + _skill_dirs_with_prefix("language-"),
+    ids=lambda p: p.name,
+)
+def test_skill_description_has_autoload_clause(skill_dir):
+    """T4: every principle-*/language-* SKILL.md description must contain 'Auto-load when'."""
+    skill_md = skill_dir / "SKILL.md"
+    assert skill_md.exists(), f"{skill_dir.name}/SKILL.md does not exist"
+    text = skill_md.read_text(encoding="utf-8")
+    # The 'Auto-load when' clause lives in the YAML frontmatter description field.
+    # Match it case-insensitively to tolerate minor capitalisation variation.
+    assert re.search(r"auto-load when", text, re.IGNORECASE), (
+        f"skills/{skill_dir.name}/SKILL.md description is missing an "
+        "'Auto-load when ...' clause. Add it to the description: field in the "
+        "YAML frontmatter so users and agents know when the skill activates."
+    )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -281,3 +281,124 @@ class TestWorktreePermissionHookWiring:
         script = Path(__file__).parent.parent / "hooks" / "worktree_permission_grant.sh"
         assert script.exists(), f"Missing hook script: {script}"
         assert os.access(script, os.X_OK), f"Hook script not executable: {script}"
+
+
+# ──────────────────────────────────────────────
+# skill autoload hint hook — wiring (T3)
+# ──────────────────────────────────────────────
+
+
+class TestSkillAutoloadHookWiring:
+    """T3 — PostToolUse Read|Edit|Write skill-autoload hint hook is registered
+    and non-blocking (always exit 0).
+    """
+
+    HOOKS_JSON = Path(__file__).parent.parent / "hooks" / "hooks.json"
+    SCRIPT = Path(__file__).parent.parent / "hooks" / "skill_autoload_hint.sh"
+
+    def test_posttooluse_entry_present(self):
+        data = json.loads(self.HOOKS_JSON.read_text(encoding="utf-8"))
+        post_entries = data["hooks"].get("PostToolUse", [])
+        entries = [
+            e for e in post_entries
+            if e.get("matcher") == "Read|Edit|Write"
+        ]
+        assert entries, (
+            "PostToolUse Read|Edit|Write entry missing from hooks.json — "
+            "skill_autoload_hint.sh must be registered there."
+        )
+        assert any(
+            "skill_autoload_hint.sh" in e["hooks"][0]["command"] for e in entries
+        ), f"No entry references skill_autoload_hint.sh; entries: {entries}"
+
+    def test_hook_script_exists_and_executable(self):
+        assert self.SCRIPT.exists(), f"Missing hook script: {self.SCRIPT}"
+        assert os.access(self.SCRIPT, os.X_OK), (
+            f"Hook script not executable: {self.SCRIPT}"
+        )
+
+    def test_hook_is_nonblocking(self):
+        """Script must exit 0 for well-formed input with a session_id."""
+        import subprocess
+        from conftest import _CLEAN_ENV
+
+        result = subprocess.run(
+            [str(self.SCRIPT)],
+            input='{"session_id": "test-session-abc-123", "tool_input": {"file_path": "/tmp/foo.py"}}',
+            text=True,
+            capture_output=True,
+            env=dict(_CLEAN_ENV),
+        )
+        assert result.returncode == 0, (
+            f"skill_autoload_hint.sh exited {result.returncode} — must be "
+            f"non-blocking (exit 0 always). stderr: {result.stderr!r}"
+        )
+
+    @pytest.mark.parametrize("payload", [
+        "",                                                # empty stdin
+        "not json at all",                                 # malformed JSON
+        '{"tool_input": {}}',                              # missing file_path
+        '{"tool_input": {"file_path": "/tmp/noext"}}',     # no extension
+        '{"tool_input": {"file_path": "/tmp/.hidden"}}',   # dotfile (no real ext)
+    ])
+    def test_hook_is_nonblocking_adversarial(self, payload):
+        """Script must exit 0 for any malformed or edge-case input."""
+        import subprocess
+        from conftest import _CLEAN_ENV
+
+        result = subprocess.run(
+            [str(self.SCRIPT)],
+            input=payload,
+            text=True,
+            capture_output=True,
+            env=dict(_CLEAN_ENV),
+        )
+        assert result.returncode == 0, (
+            f"skill_autoload_hint.sh exited {result.returncode} for payload "
+            f"{payload!r}. stderr: {result.stderr!r}"
+        )
+
+    def test_hook_deduplicates_within_session(self, tmp_path):
+        """Same session+extension emits output on first call, silent on second."""
+        import subprocess
+        from conftest import _CLEAN_ENV
+
+        env = dict(_CLEAN_ENV)
+        env["TMPDIR"] = str(tmp_path)  # isolate sentinel dir to this test run
+        payload = '{"session_id": "dedup-test-session", "tool_input": {"file_path": "/src/app.py"}}'
+
+        first = subprocess.run(
+            [str(self.SCRIPT)], input=payload, text=True, capture_output=True, env=env,
+        )
+        second = subprocess.run(
+            [str(self.SCRIPT)], input=payload, text=True, capture_output=True, env=env,
+        )
+        assert first.returncode == 0, f"First call failed: {first.stderr!r}"
+        assert second.returncode == 0, f"Second call failed: {second.stderr!r}"
+        assert first.stdout.strip(), "First call should emit a hint but produced no output"
+        assert not second.stdout.strip(), (
+            "Second call for the same session+skill should be a silent no-op, "
+            f"but produced: {second.stdout!r}"
+        )
+
+    def test_hook_different_skills_both_emit(self, tmp_path):
+        """Different extensions in the same session each get one hint."""
+        import subprocess
+        from conftest import _CLEAN_ENV
+
+        env = dict(_CLEAN_ENV)
+        env["TMPDIR"] = str(tmp_path)
+        py_payload = '{"session_id": "multi-skill-session", "tool_input": {"file_path": "/src/app.py"}}'
+        go_payload = '{"session_id": "multi-skill-session", "tool_input": {"file_path": "/src/main.go"}}'
+
+        py_result = subprocess.run(
+            [str(self.SCRIPT)], input=py_payload, text=True, capture_output=True, env=env,
+        )
+        go_result = subprocess.run(
+            [str(self.SCRIPT)], input=go_payload, text=True, capture_output=True, env=env,
+        )
+        assert py_result.returncode == 0 and go_result.returncode == 0
+        assert py_result.stdout.strip(), "Python hint should have been emitted"
+        assert go_result.stdout.strip(), "Go hint should have been emitted"
+        assert "language-python" in py_result.stdout
+        assert "language-go" in go_result.stdout

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -317,17 +317,19 @@ class TestSkillAutoloadHookWiring:
             f"Hook script not executable: {self.SCRIPT}"
         )
 
-    def test_hook_is_nonblocking(self):
+    def test_hook_is_nonblocking(self, tmp_path):
         """Script must exit 0 for well-formed input with a session_id."""
         import subprocess
         from conftest import _CLEAN_ENV
 
+        env = dict(_CLEAN_ENV)
+        env["TMPDIR"] = str(tmp_path)  # isolate sentinel to this test run
         result = subprocess.run(
             [str(self.SCRIPT)],
             input='{"session_id": "test-session-abc-123", "tool_input": {"file_path": "/tmp/foo.py"}}',
             text=True,
             capture_output=True,
-            env=dict(_CLEAN_ENV),
+            env=env,
         )
         assert result.returncode == 0, (
             f"skill_autoload_hint.sh exited {result.returncode} — must be "

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -775,9 +775,10 @@ class TestTestReviewerAgent:
 
 class TestCheckCatalogCompleteness:
     def _agent_body(self, name="my-agent"):
+        # Code-touching agents must reference both catalogs (new invariant).
         return (
             f"---\nname: {name}\ndescription: d\ntools: Read\n---\n"
-            "\nSee @./shared/principles.md for the skill catalog.\n"
+            "\nSee @./shared/principles.md and @./shared/languages.md for the skill catalog.\n"
         )
 
     def test_full_match_passes(self, reset_validate):
@@ -837,7 +838,21 @@ class TestCheckCatalogCompleteness:
 
     # O3 — slice-specific tests (issue #235)
 
-    def test_agent_with_principles_only_passes(self, reset_validate):
+    def test_non_code_agent_with_principles_only_passes(self, reset_validate):
+        # Non-code agents (product-manager) are whitelisted — principles-only is valid.
+        root = reset_validate
+        make_plugin_tree(root, skills={"principle-foo": "---\nname: principle-foo\ndescription: d\n---\n"})
+        agents_dir = root / "agents"
+        (agents_dir / "product-manager.md").write_text(
+            "---\nname: product-manager\ndescription: d\ntools: Read\n---\n"
+            "\nSee @./shared/principles.md for the skill catalog.\n",
+            encoding="utf-8",
+        )
+        validate.check_catalog_completeness()
+        assert len(validate.FAILURES) == 0
+
+    def test_code_touching_agent_with_principles_only_fails(self, reset_validate):
+        # Code-touching agents must reference @./shared/languages.md alongside principles.md.
         root = reset_validate
         make_plugin_tree(root, skills={"principle-foo": "---\nname: principle-foo\ndescription: d\n---\n"})
         agents_dir = root / "agents"
@@ -847,7 +862,10 @@ class TestCheckCatalogCompleteness:
             encoding="utf-8",
         )
         validate.check_catalog_completeness()
-        assert len(validate.FAILURES) == 0
+        assert any("languages.md" in f for f in validate.FAILURES), (
+            "Expected a failure about missing @./shared/languages.md "
+            "for a code-touching agent that only includes principles.md"
+        )
 
     def test_agent_with_principles_and_languages_passes(self, reset_validate):
         root = reset_validate


### PR DESCRIPTION
## Summary
- **Root cause:** Only 2 of 17 subagents included `@./shared/languages.md`; the rest never loaded language-specific idioms. The docs advertised auto-loading as automatic, but no mechanism ever built that capability.
- **Subagents (deterministic):** Added `@./shared/languages.md` to all 16 code-touching agents and a mandatory `language-*` gate paragraph that requires agents to identify the language in scope and invoke the matching skill — not "when relevant" but required.
- **Main session (non-blocking hint):** New `PostToolUse:Read|Edit|Write` hook emits a hint when a code file is opened, mapping the extension to the correct `language-*` skill. De-duped per session/skill via a date-scoped sentinel dir. Always exits 0.
- **Structural gate:** `validate.py` now requires code-touching agents (those with `@./shared/principles.md`) to also include `@./shared/languages.md`. The `product-manager` agent is whitelisted. Error message names `_NON_CODE_AGENTS` for discoverability.
- **Docs:** `auto-load` → `auto-hint` in README.md and docs/catalog.md to stop advertising a capability that wasn't built.
- **Bonus:** Added `Auto-load when` clause to `principle-communication` and `principle-data-modeling` SKILL.md descriptions.

## Test Plan
- [x] Changed skills/commands/agents load without errors (`python scripts/validate.py` — 0 issues)
- [x] 1029/1029 pytest tests pass after rebase on main
- [x] T1 (languages.md in all 16 agents), T2 (language-* gate in all 16), T3 (hook wired, non-blocking, de-duplication, adversarial inputs), T4 (Auto-load when in all principle-*/language-* SKILL.md) all green
- [x] Hook tested manually: emits JSON hint on first call, silent on second (same session+skill)

### Type-tailored checks ([fix])
- [x] Reproduce: before patch, `python -m pytest tests/test_agent_language_catalog.py --tb=no -q` shows 35 failures; after patch, 0 failures
- [x] Verify: `hooks/skill_autoload_hint.sh` exits 0 for all adversarial payloads (empty stdin, malformed JSON, missing file_path, no extension)

Issue: N/A — addresses user-reported language/principle skill under-selection; no filed issue exists yet
