### PR TITLE
[chore] Add missing language-bash row to catalog and guard test

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -75,6 +75,7 @@
 
 | Skill | Triggers |
 |---|---|
+| `language-bash` | `.sh`, `.bash` files; keywords: bash, shell, sh, shellcheck, set -e, pipefail. |
 | `language-csharp` | `.cs` files, `.csproj`, `.sln`, `Directory.Build.props`, keywords: C#, .NET, dotnet, nullable reference types, records, pattern matching, async/await, cancellation tokens, ConfigureAwait, IOptions, LINQ. |
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-java` | `.java` files, `pom.xml`, `build.gradle`, keywords: Java, JVM, Spring, Maven, Gradle, records, sealed classes, virtual threads. |

--- a/tests/test_agent_language_catalog.py
+++ b/tests/test_agent_language_catalog.py
@@ -115,3 +115,42 @@ def test_skill_description_has_autoload_clause(skill_dir):
         "'Auto-load when ...' clause. Add it to the YAML frontmatter description "
         "field (not just the body) so the harness can discover the skill."
     )
+
+
+# ──────────────────────────────────────────────────────────────
+# T5 — language-* skills registered in catalog.md and skill_autoload_hint.sh
+# ──────────────────────────────────────────────────────────────
+
+CATALOG_MD = ROOT / "docs" / "catalog.md"
+HOOK_SH = ROOT / "hooks" / "skill_autoload_hint.sh"
+
+
+@pytest.mark.parametrize(
+    "skill_dir",
+    _skill_dirs_with_prefix("language-"),
+    ids=lambda p: p.name,
+)
+def test_language_skill_in_catalog(skill_dir):
+    """T5a: every language-* skill must have a row marker in docs/catalog.md."""
+    skill_name = skill_dir.name
+    catalog_text = CATALOG_MD.read_text(encoding="utf-8")
+    row_marker = f"| `{skill_name}` |"
+    assert row_marker in catalog_text, (
+        f"docs/catalog.md is missing a row for '{skill_name}'. "
+        "Add the skill to the Languages table."
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_dir",
+    _skill_dirs_with_prefix("language-"),
+    ids=lambda p: p.name,
+)
+def test_language_skill_in_hook(skill_dir):
+    """T5b: every language-* skill must appear in hooks/skill_autoload_hint.sh."""
+    skill_name = skill_dir.name
+    hook_text = HOOK_SH.read_text(encoding="utf-8")
+    assert skill_name in hook_text, (
+        f"hooks/skill_autoload_hint.sh is missing '{skill_name}'. "
+        "Add the skill to the ext_to_skill() case map."
+    )


### PR DESCRIPTION
## Summary
- Add missing `language-bash` row to `docs/catalog.md` Languages table (`language-bash` was the only language skill absent from the catalog table despite existing in the repo, the hook, and README).
- Add parametrized guard tests T5a/T5b to `tests/test_agent_language_catalog.py` asserting every `language-*` skill is listed in both `docs/catalog.md` and `hooks/skill_autoload_hint.sh` — prevents future drift.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `pytest tests/test_agent_language_catalog.py -v -k "test_language_skill_in_catalog or test_language_skill_in_hook"` — 1 failure (T5a[language-bash]) before catalog row added, 0 failures after (TDD red-green verified)
- [x] Full suite: `pytest tests/ -q` — 1051 passed, 0 failures

### Type-tailored checks (chore)
- [x] No version bump introduced
- [x] `docs/catalog.md` Languages table now lists 11 rows in alphabetical order with `language-bash` first

Closes #306
