### PR TITLE
[fix] skill_usage_flush: encode before rm, guard against jq failure

### DIFF
--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -42,10 +42,11 @@ done
 skills=$(cat "${buffers[@]}" 2>/dev/null | awk '!seen[$0]++ { out = (out ? out ", " : "") $0 } END { print out }')
 [ -z "$skills" ] && { printf '{}'; exit 0; }
 
-# Clean up all matching buffers regardless of whether the emit succeeds below.
-rm -f "${buffers[@]}" 2>/dev/null || true
-
-# Safely JSON-encode the message.
-msg=$(printf 'Skills used by %s: %s' "$agent_type" "$skills" | jq -Rs .)
+# Safely JSON-encode the message. On encode failure emit a clean {} and leave the
+# buffers in place so a later flush can retry — never emit malformed JSON.
+msg=$(printf 'Skills used by %s: %s' "$agent_type" "$skills" | jq -Rs .) || { printf '{}'; exit 0; }
 printf '{"systemMessage": %s, "suppressOutput": true}\n' "$msg"
+
+# Clean up the buffers only after a successful emit.
+rm -f "${buffers[@]}" 2>/dev/null || true
 exit 0

--- a/hooks/skill_usage_flush.sh
+++ b/hooks/skill_usage_flush.sh
@@ -44,7 +44,7 @@ skills=$(cat "${buffers[@]}" 2>/dev/null | awk '!seen[$0]++ { out = (out ? out "
 
 # Safely JSON-encode the message. On encode failure emit a clean {} and leave the
 # buffers in place so a later flush can retry — never emit malformed JSON.
-msg=$(printf 'Skills used by %s: %s' "$agent_type" "$skills" | jq -Rs .) || { printf '{}'; exit 0; }
+msg=$(printf 'Skills used by %s: %s' "$agent_type" "$skills" | jq -Rs .) || { printf '{}\n'; exit 0; }
 printf '{"systemMessage": %s, "suppressOutput": true}\n' "$msg"
 
 # Clean up the buffers only after a successful emit.

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -7,6 +7,7 @@ tree via CLAUDE_PLUGIN_ROOT.
 import datetime
 import json
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -430,6 +431,45 @@ class TestFlushHook:
         assert "skill-bad" not in msg, "non-date-prefixed buffer must be excluded"
         assert not buf_valid.exists(), "valid buffer should be deleted after flush"
         assert buf_bad.exists(), "non-date-prefixed file must survive"
+
+    def test_flush_retains_buffer_and_emits_empty_json_on_encode_failure(
+        self, plugin_root, cache_dir, tmp_path
+    ):
+        """On jq encode failure: emit clean {}, retain buffer for retry."""
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        today = datetime.date.today().strftime("%Y%m%d")
+        buf = skill_cache / f"{today}-abc123.txt"
+        buf.write_text("skill-a\n")
+
+        # Inject a jq shim that exits 1 when called with -Rs (the encode flag).
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        real_jq = shutil.which("jq") or "jq"
+        shim = fake_bin / "jq"
+        shim.write_text(
+            f"#!/usr/bin/env bash\n"
+            f'for arg in "$@"; do [ "$arg" = "-Rs" ] && exit 1; done\n'
+            f'exec {real_jq} "$@"\n'
+        )
+        shim.chmod(0o755)
+
+        env = _env(plugin_root, cache_dir)
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+        result = subprocess.run(
+            ["bash", str(FLUSH_SH)],
+            input=json.dumps({"agent_id": "abc123", "agent_type": "reviewer"}),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {}, (
+            f"Expected clean {{}} on encode failure, got: {result.stdout!r}"
+        )
+        assert buf.exists(), "Buffer must be retained when emit fails"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -445,7 +445,8 @@ class TestFlushHook:
         # Inject a jq shim that exits 1 when called with -Rs (the encode flag).
         fake_bin = tmp_path / "fake-bin"
         fake_bin.mkdir()
-        real_jq = shutil.which("jq") or "jq"
+        real_jq = shutil.which("jq")
+        assert real_jq is not None, "jq must be installed for this test"
         shim = fake_bin / "jq"
         shim.write_text(
             f"#!/usr/bin/env bash\n"


### PR DESCRIPTION
## Summary
- `hooks/skill_usage_flush.sh`: reorder encode → emit → rm ("commit last" discipline)
- Guard the `jq -Rs` command substitution with `|| { printf '{}'; exit 0; }` so a failed encode emits valid `{}` and leaves the buffer intact for retry
- Update stale comment that incorrectly said "regardless of whether the emit succeeds"

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `pytest tests/test_skill_usage_telemetry.py -v` — all TestFlushHook cases green, including new `test_flush_retains_buffer_and_emits_empty_json_on_encode_failure`
- [x] `pytest tests/ -v` — 1059 tests pass, no regressions
- [x] `shellcheck --severity=warning hooks/skill_usage_flush.sh` — clean

### Type-tailored checks (fix)
- [ ] Reproduce: pipe `{"agent_id":"abc123","agent_type":"reviewer"}` into the hook with a failing-`jq` shim on PATH → stdout is `{}`, buffer file retained
- [ ] Success path unchanged: real `jq` path still emits `{"systemMessage": "Skills used by reviewer: …", "suppressOutput": true}` and deletes buffer

Closes #343
