### PR TITLE
[feat] Document dependency flow and enforce no-cycles check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ It checks:
 - `skills/*/templates/*.md` — every `[[detect:KEY]]` marker is documented in the adjacent `SKILL.md`'s `## Project Detection` section.
 - `skills/*/triggers.txt` — every skill must have a sibling `triggers.txt` with ≥2 non-empty non-comment lines (each ≤200 chars).
 - `skills/*/examples/**/*.md` — companion example files must be ≤120 lines each. See `docs/extending.md` for the full `examples/` convention (multi-fence `// file:` header rule, visibility ordering).
+- Dependency-flow graph (`check_no_cycles`) — action-cued `` `swe-workbench:<id>` `` activations must not form cycles across commands, skills, and agents. See `docs/extending.md` (`## Dependency flow`) for the allowed layering rules that this check enforces.
 
 The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`).
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -22,7 +22,7 @@ Orchestrator skills that compose many sub-skills (see the `development` workflow
 Three artifact kinds — commands, skills, and agents — form a strict layering:
 
 ```
-command ──► skill
+command ──► skill ──► skill
    │         │
    │         ▼
    └───────► agent ──► skill

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -17,6 +17,29 @@ Skills are intentionally small — each under 150 lines. A sharp, well-triggered
 
 Orchestrator skills that compose many sub-skills (see the `development` workflow) may exceed 150 lines. When they do, extract conditional content (mode templates, rarely-loaded sub-flows) into companion files inside the skill's directory rather than padding the always-loaded `SKILL.md`.
 
+## Dependency flow
+
+Three artifact kinds — commands, skills, and agents — form a strict layering:
+
+```
+command ──► skill
+   │         │
+   │         ▼
+   └───────► agent ──► skill
+```
+
+**Commands** are orchestrators (top layer). A command pulls in whatever skills and subagents a workflow needs. Commands may activate skills and agents.
+
+**Skills** may activate other skills. Composing a workflow from smaller skills is encouraged; it keeps any single skill under the 150-line cap (see `## Philosophy`). Skills must not activate commands.
+
+**Agents** may activate skills. An agent is a leaf worker dispatched *by* a command, never the reverse. Naming the entry command in a `**Reachable via:**` breadcrumb is documentation, not a dependency, and does not count as an activation.
+
+**Async handoffs:** a skill may suggest running a command as a human-driven next step (e.g. "run `/swe-workbench:review` next"). This is an asynchronous handoff — the user decides whether to follow up — not a synchronous activation, and does not form a loading cycle.
+
+**No back-edges:** nothing that a command activates may synchronously activate that command (or its skills) in turn. Cycles in the activation graph break Claude Code's loading behavior and are forbidden at all layers.
+
+`scripts/validate.py` (`check_no_cycles`) machine-enforces the no-cycle rule by scanning action-cued `` `swe-workbench:<id>` `` activations. Slash-command handoffs (`/swe-workbench:cmd`) and prose cross-references (`` See `swe-workbench:X` ``) are intentionally excluded from the graph — they are pointers, not activations.
+
 ## Adding worked examples to a skill
 
 For skills that describe patterns (e.g. `principle-*`), add language-specific implementations as companion files in an `examples/` subdirectory inside the skill's directory:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -627,14 +627,16 @@ def _build_dep_graph(cache):
             # Skip @-include lines — pure file composition, not activations.
             if line.lstrip().startswith('@'):
                 continue
-            # Skip lines with slash-command refs — async handoffs, not activations.
-            if _SLASH_CMD_RE.search(line):
+            # Strip slash-command tokens (async handoffs) before checking for
+            # action cues and swe-workbench refs. Stripping rather than skipping
+            # the whole line preserves real activation edges that co-occur with
+            # a slash hint (e.g. "invoke `swe-workbench:x` (then run `/review`)").
+            clean = _SLASH_CMD_RE.sub('', line)
+            if not _ACTION_RE.search(clean):
                 continue
-            if not _ACTION_RE.search(line):
+            if _POINTER_RE.search(clean):
                 continue
-            if _POINTER_RE.search(line):
-                continue
-            for mid in _CYCLE_MENTION_RE.findall(line):
+            for mid in _CYCLE_MENTION_RE.findall(clean):
                 dst_node = resolvable.get(mid)
                 if dst_node is None or dst_node == src_node:
                     continue

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -581,6 +581,136 @@ def check_hook_scripts():
 
 
 # ──────────────────────────────────────────────
+# Dependency-flow cycle checker
+# ──────────────────────────────────────────────
+
+_CYCLE_MENTION_RE = re.compile(r'`swe-workbench:([\w-]+)`')
+# Backtick-delimited slash-command refs are async handoffs, not activations.
+# Both backticks are required to avoid matching Unix paths (e.g. scripts/validate.py).
+_SLASH_CMD_RE = re.compile(r'`/(?:swe-workbench:)?[\w-]+`')
+# Action words that signal an activation (case-insensitive).
+_ACTION_RE = re.compile(
+    r'\b(invoke|activate|apply|execute via|dispatch|delegate|compose|consult|run)\b',
+    re.IGNORECASE,
+)
+# Pointer/reference words that exclude a line from being an edge.
+_POINTER_RE = re.compile(
+    r'\b(see|defer to|recommend|like|per |unlike|e\.g\.|cf\.|analogous|mirror|'
+    r'follows the|precedent|such as|similar to|counterpart|note them)\b',
+    re.IGNORECASE,
+)
+
+
+def _build_dep_graph(cache):
+    """Return adjacency dict: {(kind, id): set of (kind, id)} for action-cued activations."""
+    root = ROOT
+    agents_cache, skills_cache = cache[0], cache[1]
+
+    skills_dir = root / "skills"
+    agents_dir = root / "agents"
+    commands_dir = root / "commands"
+
+    # Pre-build resolution index: id -> (kind, id)
+    resolvable = {}
+    for p in skills_dir.glob("*/SKILL.md"):
+        resolvable[p.parent.name] = ("skill", p.parent.name)
+    for p in agents_dir.glob("*.md"):
+        if p.parent.name == "shared":
+            continue
+        if p.stem not in resolvable:
+            resolvable[p.stem] = ("agent", p.stem)
+
+    graph = {}
+
+    def _scan(src_node, text):
+        for line in text.splitlines():
+            # Skip @-include lines — pure file composition, not activations.
+            if line.lstrip().startswith('@'):
+                continue
+            # Skip lines with slash-command refs — async handoffs, not activations.
+            if _SLASH_CMD_RE.search(line):
+                continue
+            if not _ACTION_RE.search(line):
+                continue
+            if _POINTER_RE.search(line):
+                continue
+            for mid in _CYCLE_MENTION_RE.findall(line):
+                dst_node = resolvable.get(mid)
+                if dst_node is None or dst_node == src_node:
+                    continue
+                graph.setdefault(src_node, set()).add(dst_node)
+
+    # Commands
+    for cmd_md in sorted(commands_dir.glob("*.md")):
+        src = ("command", cmd_md.stem)
+        try:
+            text = cmd_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        _scan(src, text)
+
+    # Skills
+    for skill_md, text in skills_cache.items():
+        if skill_md.parent.parent != skills_dir:
+            continue
+        if text is None:
+            continue
+        src = ("skill", skill_md.parent.name)
+        _scan(src, text)
+
+    # Agents (non-shared)
+    for agent_md, text in agents_cache.items():
+        if agent_md.parent.name == "shared":
+            continue
+        if text is None:
+            continue
+        src = ("agent", agent_md.stem)
+        _scan(src, text)
+
+    return graph
+
+
+def check_no_cycles(cache=None):
+    """Fail if the action-cued activation graph contains a cycle."""
+    if cache is None:
+        cache = _build_cache()
+    graph = _build_dep_graph(cache)
+
+    # DFS with white/gray/black coloring.
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {}
+    stack = []
+    reported = set()
+
+    def dfs(node):
+        color[node] = GRAY
+        stack.append(node)
+        for neighbor in sorted(graph.get(node, set())):
+            if color.get(neighbor) == GRAY:
+                # Back-edge found — extract cycle from stack.
+                cycle_start = stack.index(neighbor)
+                cycle = stack[cycle_start:] + [neighbor]
+                key = tuple(cycle)
+                if key not in reported:
+                    reported.add(key)
+                    path = " -> ".join(f"{k}:{i}" for k, i in cycle)
+                    fail(
+                        Path("(dependency graph)"),
+                        f"dependency cycle: {path} — break the back-edge "
+                        f"(an activated artifact must not activate its activator)",
+                    )
+            elif color.get(neighbor, WHITE) == WHITE:
+                dfs(neighbor)
+        stack.pop()
+        color[node] = BLACK
+
+    all_nodes = set(graph.keys()) | {n for nbrs in graph.values() for n in nbrs}
+    for node in sorted(all_nodes):
+        if color.get(node, WHITE) == WHITE:
+            dfs(node)
+
+
+# ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────
 
@@ -606,6 +736,7 @@ def main():
     check_examples()
     check_hook_scripts()
     check_test_subprocess_env()
+    check_no_cycles(cache=cache)
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1650,3 +1650,114 @@ class TestCheckTestSubprocessEnv:
         )
         validate.check_test_subprocess_env()
         assert len(validate.FAILURES) == 0
+
+
+# ──────────────────────────────────────────────
+# check_no_cycles
+# ──────────────────────────────────────────────
+
+def _make_cycle_tree(root):
+    """Create the minimum required directories for check_no_cycles tests."""
+    (root / "agents" / "shared").mkdir(parents=True, exist_ok=True)
+    (root / "commands").mkdir(exist_ok=True)
+    (root / "skills").mkdir(exist_ok=True)
+
+
+class TestCheckNoCycles:
+    """Dependency-flow cycle detection (issue #371)."""
+
+    REAL_ROOT = Path(__file__).parent.parent
+
+    def test_green_baseline_live_repo(self, reset_validate, monkeypatch):
+        """Live repo activation graph must have zero cycles."""
+        monkeypatch.setattr(validate, "ROOT", self.REAL_ROOT)
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert validate.FAILURES == []
+
+    def test_skill_to_skill_cycle_detected(self, reset_validate):
+        """skill A action-invokes skill B and B action-invokes A → cycle reported."""
+        root = reset_validate
+        _make_cycle_tree(root)
+        (root / "skills" / "a").mkdir()
+        (root / "skills" / "a" / "SKILL.md").write_text(
+            "---\nname: a\ndescription: d\n---\ninvoke `swe-workbench:b`\n",
+            encoding="utf-8",
+        )
+        (root / "skills" / "b").mkdir()
+        (root / "skills" / "b" / "SKILL.md").write_text(
+            "---\nname: b\ndescription: d\n---\ninvoke `swe-workbench:a`\n",
+            encoding="utf-8",
+        )
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert len(validate.FAILURES) >= 1
+        combined = " ".join(validate.FAILURES)
+        assert "a" in combined and "b" in combined
+
+    def test_prose_cross_ref_no_cycle(self, reset_validate):
+        """See `swe-workbench:X` lines are pointer cues, not activations — no edge emitted."""
+        root = reset_validate
+        _make_cycle_tree(root)
+        (root / "skills" / "a").mkdir()
+        (root / "skills" / "a" / "SKILL.md").write_text(
+            "---\nname: a\ndescription: d\n---\nSee `swe-workbench:b` for details.\n",
+            encoding="utf-8",
+        )
+        (root / "skills" / "b").mkdir()
+        (root / "skills" / "b" / "SKILL.md").write_text(
+            "---\nname: b\ndescription: d\n---\nSee `swe-workbench:a` for details.\n",
+            encoding="utf-8",
+        )
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert validate.FAILURES == []
+
+    def test_slash_handoff_no_cycle(self, reset_validate):
+        """Slash-command handoffs in skills are excluded; command→skill edge alone is not a cycle."""
+        root = reset_validate
+        _make_cycle_tree(root)
+        (root / "skills" / "a").mkdir()
+        (root / "skills" / "a" / "SKILL.md").write_text(
+            "---\nname: a\ndescription: d\n---\nWhen done, run `/review` next.\n",
+            encoding="utf-8",
+        )
+        (root / "commands" / "review.md").write_text(
+            "---\ndescription: review\n---\ninvoke `swe-workbench:a`\n",
+            encoding="utf-8",
+        )
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert validate.FAILURES == []
+
+    def test_self_mention_no_edge(self, reset_validate):
+        """A skill action-invoking its own id must not produce a self-edge or cycle."""
+        root = reset_validate
+        _make_cycle_tree(root)
+        (root / "skills" / "a").mkdir()
+        (root / "skills" / "a" / "SKILL.md").write_text(
+            "---\nname: a\ndescription: d\n---\ninvoke `swe-workbench:a` directly.\n",
+            encoding="utf-8",
+        )
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert validate.FAILURES == []
+
+    def test_agent_mediated_cycle_detected(self, reset_validate):
+        """skill A → agent X → skill A is a cycle and must be reported."""
+        root = reset_validate
+        _make_cycle_tree(root)
+        (root / "skills" / "a").mkdir()
+        (root / "skills" / "a" / "SKILL.md").write_text(
+            "---\nname: a\ndescription: d\n---\ninvoke `swe-workbench:x`\n",
+            encoding="utf-8",
+        )
+        (root / "agents" / "x.md").write_text(
+            "---\nname: x\ndescription: d\n---\ninvoke `swe-workbench:a`\n",
+            encoding="utf-8",
+        )
+        cache = validate._build_cache()
+        validate.check_no_cycles(cache=cache)
+        assert len(validate.FAILURES) >= 1
+        combined = " ".join(validate.FAILURES)
+        assert "a" in combined and "x" in combined


### PR DESCRIPTION
## Summary
- Add `## Dependency flow` section to `docs/extending.md` documenting the allowed command→skill/agent→skill layering, the async-handoff exemption, and the no-back-edges rule
- Add a `check_no_cycles` bullet to `CONTRIBUTING.md` → `## Validator` cross-referencing the new section
- Implement `check_no_cycles(cache)` in `scripts/validate.py`: DFS white/gray/black cycle detection on action-cued `` `swe-workbench:<id>` `` activations; excludes slash-command handoffs, `@`-include lines, and pointer-cue prose; registered in `main()`
- Add `TestCheckNoCycles` to `tests/test_validate.py`: 6 tests (green live-repo baseline + positive cycle + 4 negative exclusion cases)

## Test Plan
- [x] `python3 scripts/validate.py` → `All checks passed.` on the live repo (new check is green)
- [x] `pytest tests/test_validate.py::TestCheckNoCycles` → 6/6 passed
- [x] Full `pytest tests/test_validate.py` → 169/169 passed
- [x] Pre-push hook: full test suite (1065 tests) passed on push

### Type-tailored checks (feat)
- [x] New behaviour: `check_no_cycles` detects a synthetic skill A→skill B→skill A cycle and reports both ids in the failure message
- [x] New behaviour: prose `See \`swe-workbench:X\`` cross-refs produce no edge (pointer-cue exclusion works)
- [x] New behaviour: `` `/review` `` slash handoffs produce no edge (slash exclusion works, backticks required)
- [x] New behaviour: action-cued self-reference (`invoke \`swe-workbench:a\`` inside skill `a`) produces no self-edge (dst==src guard works)
- [x] New behaviour: skill→agent→skill mediated cycle is detected correctly
- [x] Green-baseline test: live repo has zero activation cycles

Closes #371
