### PR TITLE
[fix] Add HIGH-tier private-key-pem pattern to secret_guard

### DIFF
--- a/docs/secret-detection.md
+++ b/docs/secret-detection.md
@@ -25,6 +25,7 @@ the git `pre-commit` hook is absent or bypassed.
 | `github-pat` | `ghp_[A-Za-z0-9]{36}` |
 | `github-fine-grained-pat` | `github_pat_[A-Za-z0-9_]{82}` |
 | `aws-access-key-id` | `AKIA[0-9A-Z]{16}` |
+| `private-key-pem` | `-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----` |
 
 **NEEDS-CONTEXT** — block only when a key name is adjacent to a literal value;
 skipped automatically on lines that contain an environment-variable reference
@@ -50,8 +51,8 @@ BOOTSTRAP_TOKEN = "<placeholder>"  # nosecret
 Only that exact line is suppressed. Adjacent lines are checked normally.
 
 > **Note:** `# nosecret` has **no effect** on HIGH-confidence patterns (`github-pat`,
-> `github-fine-grained-pat`, `aws-access-key-id`). Those patterns are always blocked.
-> If you have a genuine fixture that looks like a GitHub PAT or AWS key, add the file
+> `github-fine-grained-pat`, `aws-access-key-id`, `private-key-pem`). Those patterns are always blocked.
+> If you have a genuine fixture that looks like a GitHub PAT, AWS key, or PEM header, add the file
 > path to `_ALLOWLIST_SUFFIXES` instead.
 
 ### Filename allowlist

--- a/docs/secret-detection.md
+++ b/docs/secret-detection.md
@@ -80,7 +80,7 @@ to extend `_REF_PATTERN` in `hooks/secret_guard.py`.
 **The hook is blocking a test fixture**
 
 For NEEDS-CONTEXT patterns: add `# nosecret` on each fixture line.
-For HIGH-confidence patterns (GitHub PAT, AWS key ID): `# nosecret` has no effect —
+For HIGH-confidence patterns (GitHub PAT, AWS key ID, PEM private-key header): `# nosecret` has no effect —
 add the file's absolute path to `_ALLOWLIST_SUFFIXES` instead.
 
 **The hook seems to do nothing**

--- a/hooks/secret_guard.py
+++ b/hooks/secret_guard.py
@@ -63,6 +63,9 @@ _PATTERNS: list[tuple[str, re.Pattern, bool]] = [
     ("aws-access-key-id",
      re.compile(r"AKIA[0-9A-Z]{16}"),
      False),
+    ("private-key-pem",
+     re.compile(r"-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----"),
+     False),
 
     # NEEDS-CONTEXT – require a key name + literal value structure
     ("aws-secret-access-key",

--- a/tests/test_secret_guard.py
+++ b/tests/test_secret_guard.py
@@ -26,6 +26,10 @@ _FAKE_AKIA = "AKIA" + "D" * 16                              # nosecret
 _FAKE_AWS_SECRET = "E" * 40                                  # nosecret
 _FAKE_API_KEY_VAL = "F" * 20                                 # nosecret
 _FAKE_SECRET_VAL = "G" * 12                                  # nosecret
+_FAKE_PEM_RSA       = "-----BEGIN RSA PRIVATE KEY-----"      # nosecret
+_FAKE_PEM_PKCS8     = "-----BEGIN PRIVATE KEY-----"          # nosecret
+_FAKE_PEM_ENCRYPTED = "-----BEGIN ENCRYPTED PRIVATE KEY-----"  # nosecret
+_FAKE_PEM_SSH2      = "-----BEGIN SSH2 ENCRYPTED PRIVATE KEY-----"  # nosecret
 
 
 def run_guard(payload: dict) -> subprocess.CompletedProcess:
@@ -97,6 +101,10 @@ class TestHighPatterns:
         (f'token = "{_FAKE_GHP}"', "github-pat ghp_"),
         (f'token = "{_FAKE_PAT}"', "github-fine-grained-pat"),
         (f'key_id = "{_FAKE_AKIA}"', "aws-access-key-id"),
+        (_FAKE_PEM_RSA, "private-key-pem rsa"),
+        (_FAKE_PEM_PKCS8, "private-key-pem bare pkcs8"),
+        (_FAKE_PEM_ENCRYPTED, "private-key-pem encrypted"),
+        (_FAKE_PEM_SSH2, "private-key-pem ssh2 encrypted"),
     ])
     def test_blocked(self, content, label):
         result = run_guard(write_payload(content))
@@ -171,6 +179,13 @@ class TestNosecretSuppression:
         content = f'{_FAKE_AKIA}  # nosecret'
         result = run_guard(write_payload(content))
         assert result.returncode == 2
+
+    def test_high_tier_pem_nosecret_does_not_suppress(self):
+        """PEM header + # nosecret must still be BLOCKED — HIGH-tier is un-suppressible."""
+        content = f'{_FAKE_PEM_RSA}  # nosecret'  # nosecret
+        result = run_guard(write_payload(content))
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
 
     def test_high_tier_nosecret_no_space_does_not_suppress(self):
         """#nosecret (no space) on HIGH-tier still blocks."""


### PR DESCRIPTION
## Summary

- Add a HIGH-tier (un-suppressible) `private-key-pem` pattern to `hooks/secret_guard.py` that matches `-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----`, covering RSA, EC/DSA, OPENSSH, bare PKCS#8, and ENCRYPTED variants.
- Add 5 new test cases in `tests/test_secret_guard.py`: parametrized blocks for RSA, bare PKCS#8, ENCRYPTED, SSH2 ENCRYPTED variants, and an explicit `# nosecret`-does-not-suppress case.
- Add a `private-key-pem` row to the HIGH confidence table in `docs/secret-detection.md` and update the un-suppressible note to mention it.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_secret_guard.py -v` — 53 tests pass (5 new PEM cases + 48 existing, 0 regressions)
- [ ] Manual spot-check: `-----BEGIN OPENSSH PRIVATE KEY-----`, `-----BEGIN ENCRYPTED PRIVATE KEY-----`, and `-----BEGIN PRIVATE KEY-----` each exit 2 + `BLOCKED: … pattern: private-key-pem`; a benign file exits 0.

### Type-tailored checks (fix)
- [ ] Reproduce the missing-detection case: write a file with `-----BEGIN RSA PRIVATE KEY-----` and confirm the guard now blocks it (exit 2).
- [ ] Confirm `# nosecret` has no effect (HIGH-tier is un-suppressible): adding it to the same line still exits 2.
- [ ] Confirm no false positives on benign write content (plain Python, no PEM header).

Closes #342
