### PR TITLE
[fix] Guard both git checkout main sites in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,6 +51,7 @@ case "$CURRENT_BRANCH" in
     echo "Detected in-progress release branch '${CURRENT_BRANCH}'. Switching to main."
     if ! git checkout main; then
       echo "Error: could not switch to main (checked out in another worktree?)." >&2
+      echo "  Remedy: cd to the main worktree, switch off main, then re-run this script." >&2
       exit 1
     fi
     ;;
@@ -312,6 +313,7 @@ fi
 
 if ! git checkout main; then
   echo "Error: could not switch to main (checked out in another worktree?)." >&2
+  echo "  Remedy: cd to the main worktree, switch off main, then re-run this script." >&2
   exit 1
 fi
 git pull --ff-only origin main

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,7 +49,10 @@ case "$CURRENT_BRANCH" in
   main) ;;
   chore/bump-v*)
     echo "Detected in-progress release branch '${CURRENT_BRANCH}'. Switching to main."
-    git checkout main
+    if ! git checkout main; then
+      echo "Error: could not switch to main (checked out in another worktree?)." >&2
+      exit 1
+    fi
     ;;
   *)
     echo "Error: must run from main or a 'chore/bump-v*' resume branch (currently on '${CURRENT_BRANCH}')." >&2
@@ -307,7 +310,10 @@ fi
 
 # ── Sync main + verify merge SHA ─────────────────────────────
 
-git checkout main
+if ! git checkout main; then
+  echo "Error: could not switch to main (checked out in another worktree?)." >&2
+  exit 1
+fi
 git pull --ff-only origin main
 
 MERGE_SHA=""

--- a/tests/test_release_sh_checkout_main.py
+++ b/tests/test_release_sh_checkout_main.py
@@ -41,7 +41,11 @@ def _guard_indices(lines: list[str]) -> list[int]:
 
 
 def _guard_block(lines: list[str], idx: int) -> list[str]:
-    """Return lines from idx up to and including the closing 'fi'."""
+    """Return lines from idx up to and including the closing 'fi'.
+
+    Assumes the guard body contains no nested if/fi pairs.
+    If guard bodies grow nested conditionals, switch to depth tracking.
+    """
     block = []
     for ln in lines[idx:]:
         block.append(ln)

--- a/tests/test_release_sh_checkout_main.py
+++ b/tests/test_release_sh_checkout_main.py
@@ -40,6 +40,16 @@ def _guard_indices(lines: list[str]) -> list[int]:
     ]
 
 
+def _guard_block(lines: list[str], idx: int) -> list[str]:
+    """Return lines from idx up to and including the closing 'fi'."""
+    block = []
+    for ln in lines[idx:]:
+        block.append(ln)
+        if ln.strip() == "fi":
+            break
+    return block
+
+
 class TestCheckoutMainGuarded:
     """Static: every git checkout main must be wrapped in an if ! guard."""
 
@@ -73,14 +83,13 @@ class TestCheckoutMainGuarded:
 
         for idx in guards:
             lineno = idx + 1
-            # Inspect up to 5 lines after the guard opener
-            block = lines[idx : idx + 5]
+            block = _guard_block(lines, idx)
             has_error = any("Error: could not switch to main" in ln for ln in block)
             has_exit = any(ln.strip() == "exit 1" for ln in block)
             assert has_error, (
                 f"Guard at line {lineno} is missing the 'Error: could not switch to main' "
-                f"echo within the next 5 lines"
+                f"echo in the guard block"
             )
             assert has_exit, (
-                f"Guard at line {lineno} is missing 'exit 1' within the next 5 lines"
+                f"Guard at line {lineno} is missing 'exit 1' in the guard block"
             )

--- a/tests/test_release_sh_checkout_main.py
+++ b/tests/test_release_sh_checkout_main.py
@@ -1,0 +1,86 @@
+"""
+Regression tests for guarded git checkout main in scripts/release.sh.
+
+Guards against bare `git checkout main` failing in rimba multi-worktree layouts
+with 'fatal: main is already used by worktree at ...'.
+
+Both the resume arm (~line 52) and the post-merge sync (~line 310) must be
+wrapped in: if ! git checkout main; then ... exit 1; fi
+"""
+from pathlib import Path
+
+RELEASE_SH = Path(__file__).parent.parent / "scripts" / "release.sh"
+
+
+def _script_lines() -> list[str]:
+    return RELEASE_SH.read_text().splitlines()
+
+
+def _is_shell_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def _bare_checkout_lines(lines: list[str]) -> list[tuple[int, str]]:
+    """Return (1-based lineno, text) for standalone bare `git checkout main` lines."""
+    return [
+        (i + 1, ln)
+        for i, ln in enumerate(lines)
+        if ln.strip() == "git checkout main"
+        and not _is_shell_comment(ln)
+    ]
+
+
+def _guard_indices(lines: list[str]) -> list[int]:
+    """Return 0-based indices of `if ! git checkout main; then` lines."""
+    return [
+        i
+        for i, ln in enumerate(lines)
+        if "if ! git checkout main; then" in ln
+        and not _is_shell_comment(ln)
+    ]
+
+
+class TestCheckoutMainGuarded:
+    """Static: every git checkout main must be wrapped in an if ! guard."""
+
+    def test_no_bare_git_checkout_main(self):
+        lines = _script_lines()
+        bare = _bare_checkout_lines(lines)
+        assert bare == [], (
+            "Found bare 'git checkout main' (unguarded) in release.sh:\n"
+            + "\n".join(f"  line {n}: {text.strip()}" for n, text in bare)
+            + "\nWrap each in:\n"
+            + "  if ! git checkout main; then\n"
+            + '    echo "Error: could not switch to main (checked out in another worktree?)." >&2\n'
+            + "    exit 1\n"
+            + "  fi"
+        )
+
+    def test_at_least_two_guards_present(self):
+        """Both the resume arm and the post-merge sync must be guarded."""
+        lines = _script_lines()
+        guards = _guard_indices(lines)
+        assert len(guards) >= 2, (
+            f"Expected at least 2 guarded 'if ! git checkout main; then' blocks, "
+            f"found {len(guards)}"
+        )
+
+    def test_each_guard_has_error_echo_and_exit(self):
+        """Every guard block must emit 'Error: could not switch to main' to stderr and exit 1."""
+        lines = _script_lines()
+        guards = _guard_indices(lines)
+        assert guards, "No 'if ! git checkout main; then' guards found — expected at least 2"
+
+        for idx in guards:
+            lineno = idx + 1
+            # Inspect up to 5 lines after the guard opener
+            block = lines[idx : idx + 5]
+            has_error = any("Error: could not switch to main" in ln for ln in block)
+            has_exit = any(ln.strip() == "exit 1" for ln in block)
+            assert has_error, (
+                f"Guard at line {lineno} is missing the 'Error: could not switch to main' "
+                f"echo within the next 5 lines"
+            )
+            assert has_exit, (
+                f"Guard at line {lineno} is missing 'exit 1' within the next 5 lines"
+            )


### PR DESCRIPTION
## Summary
- Wraps the bare `git checkout main` at the resume arm (`:52`) in an `if ! git checkout main; then ... exit 1; fi` block — prints a guided `Error: could not switch to main (checked out in another worktree?).` to stderr
- Applies the identical guard to the post-merge sync site (`:310`), both producing the same `Error:` wording to match the script's preflight error contract (`:13`, `:22`, `:31`, `:55`)
- Adds `tests/test_release_sh_checkout_main.py` with 3 static-guard assertions (no bare checkouts, ≥2 guards present, each guard has the `Error:` echo + `exit 1`)

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `pytest tests/test_release_sh_checkout_main.py -v` → 3 tests pass (TDD green)
- [x] `pytest tests/test_release_sh_gh_repo.py tests/test_release_sh_ci_wait.py` → 25 tests pass (no regression)
- [x] `bash -n scripts/release.sh` → syntax OK
- [x] Full suite `pytest -q` → 1073 tests pass

### Type-tailored checks ([fix])
- [ ] Simulate `git checkout main` failure (worktree contention) and confirm guided `Error:` message is printed to stderr with `exit 1` at both sites
- [ ] Confirm `echo "  git checkout main ..."` help-text lines inside double-quoted strings are not incorrectly flagged as bare checkouts

Closes #344
