### PR TITLE
[fix] invoke doctor.sh via $CLAUDE_PLUGIN_ROOT for plugin-install portability

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -5,7 +5,7 @@ description: Read-only preflight check of runtime dependencies (gh, git, jq, rim
 Run the preflight diagnostic and print the results verbatim:
 
 ```
-bash scripts/doctor.sh
+bash "$CLAUDE_PLUGIN_ROOT/scripts/doctor.sh"
 ```
 
 Print the full stdout output exactly as produced — do not summarise, truncate, or reformat it.

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -70,3 +70,14 @@ def test_doctor_in_readme():
     assert "/swe-workbench:doctor" in commands_line, (
         "README.md '- **Commands**' bullet must include /swe-workbench:doctor"
     )
+
+
+def test_doctor_invokes_script_portably():
+    """doctor.md must invoke the script via $CLAUDE_PLUGIN_ROOT (portable for plugin installs, #328)."""
+    text = DOCTOR_CMD.read_text()
+    assert "$CLAUDE_PLUGIN_ROOT/scripts/doctor.sh" in text, (
+        "doctor.md must invoke the script via $CLAUDE_PLUGIN_ROOT for plugin-install portability"
+    )
+    assert "bash scripts/doctor.sh" not in text, (
+        "doctor.md must not invoke the script via a non-portable bare relative path"
+    )


### PR DESCRIPTION
## Summary
- Fix `commands/doctor.md:8` to invoke `scripts/doctor.sh` via `$CLAUDE_PLUGIN_ROOT` instead of a bare relative path — resolves the "file not found" failure for all plugin-installed users
- Add regression test `test_doctor_invokes_script_portably()` to prevent the bare-path pattern from being reintroduced

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [ ] `pytest tests/test_doctor_command.py -q` — all 6 tests pass (including new `test_doctor_invokes_script_portably`)

### Type-tailored checks (fix)
- [ ] Reproduce: install swe-workbench as a plugin, run `/swe-workbench:doctor` from any project dir — script now runs and prints the dependency table (previously: "file not found")
- [x] `pytest tests/ -q` — 1110/1110 pass, no regressions

Closes #328
