### PR TITLE
[fix] Drop redundant PR-review narrative summary from review body

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -79,18 +79,6 @@ flip from `COMMENT → APPROVE` is the orchestrator's responsibility, not yours.
 **When NOT instructed** (e.g. local-diff mode, ad-hoc invocation), do not emit the verdict line —
 this mirrors the footer's opt-in contract.
 
-## Review Summary (when instructed)
-
-When the invoker (e.g. `workflow-pr-review` Step 4) explicitly asks for a Review Summary, begin the review with a `## Review Summary` section — before any severity-grouped findings. Write 2–4 sentences covering:
-
-1. **Overall posture** — APPROVE-lean or COMMENT-lean, and why in one clause.
-2. **Strongest positives** — what the diff does well (architecture, test coverage, clarity).
-3. **Most important concerns** — top 1–2 issues the author should know before reading inline comments.
-
-Do **not** repeat per-finding detail in this section — that belongs in the severity-grouped findings below. The orchestrator extracts these paragraphs verbatim and uses them as the top-level PR review body.
-
-**When NOT instructed** (e.g. local-diff mode, ad-hoc invocation), do not emit this section — keep output to severity-grouped findings only.
-
 ## Principle consultation
 
 See @./shared/principles.md and @./shared/languages.md for the skill catalog.

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -94,7 +94,6 @@ Pass the agent:
 - Repo-relative-path instruction (load-bearing): emit **repo-relative** paths (e.g. `src/foo.ts:42`, NOT `$WT/src/foo.ts:42`). The orchestrator uses these paths to position GitHub comments.
 - Footer instruction (opt-in per `## Decision footer`): end with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**`. Never `REQUEST_CHANGES`.
 - Blocking-scope instruction (opt-in per `## Blocking-scope verdict`): classify each Critical/High as in-diff (`+` lines) or out-of-diff; mark out-of-diff with `**Informational (out-of-diff):** `; emit `**Blocking Scope: NONE|OUT-OF-DIFF-ONLY|IN-DIFF**` before the footer. APPROVE/COMMENT rule unchanged.
-- Narrative instruction (opt-in per `## Review Summary`): begin with `## Review Summary` (2–4 sentences: posture, positives, concerns); used as PR review body for cross-author reviews.
 - Ticket-context prelude (if Step 3 produced one).
 
 ### Step 5 — Parse decision footer + blocking-scope verdict
@@ -188,23 +187,12 @@ if [ "$DECISION" = "COMMENT" ] && [ "$BLOCKING_SCOPE" = "OUT-OF-DIFF-ONLY" ] \
   DECISION=APPROVE
 fi
 
-NARRATIVE=$(awk '
-  /^[[:space:]]*(Critical|High|Medium|Low|Severity)[[:space:]]*\|/ { exit }
-  /^###[[:space:]]+(Critical|High|Medium|Low)\b/ { exit }
-  /^\*\*Blocking Scope:/ { exit }
-  /^\*\*Review Decision:/ { exit }
-  { print }
-' <<< "$REVIEWER_OUTPUT" | sed -e '/^[[:space:]]*$/d' -e '/^## Review Summary[[:space:]]*$/d')
-HAS_NARRATIVE="$([ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ] && echo true || echo false)"
-
 BYLINE="_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted ${posted} inline comments, deduped ${deduped}._"
 INFORMATIONAL_SECTION=""
 [ -n "$DEFERRED_INFORMATIONAL" ] && INFORMATIONAL_SECTION=$(printf '\n\n### Informational (out-of-diff)\n\n%s\n' "$DEFERRED_INFORMATIONAL")
-if [ "$HAS_NARRATIVE" = true ] && [ "$IS_SELF_REVIEW" = false ]; then
-  SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s%s\n' \
-    "$NARRATIVE" "$DECISION" "$BYLINE" "$INFORMATIONAL_SECTION")
-elif [ "$IS_SELF_REVIEW" = false ]; then
-  SUMMARY="$BYLINE"; [ -n "$INFORMATIONAL_SECTION" ] && SUMMARY="${SUMMARY}${INFORMATIONAL_SECTION}"
+if [ "$IS_SELF_REVIEW" = false ]; then
+  SUMMARY=$(printf '**Review Decision: %s**\n\n---\n%s%s\n' \
+    "$DECISION" "$BYLINE" "$INFORMATIONAL_SECTION")
 else
   SUMMARY=""
 fi
@@ -290,10 +278,8 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Use `--task "pr-review-$PR"` for the worktree | Use `--task "pr-followup-$PR"` to avoid colliding with a still-active primary-review worktree. |
 | Omit the footer instruction in Step 4 | Without it, the agent does NOT emit the footer. Step 5 will then abort. |
 | Forget repo-relative-path instruction | GitHub comment positioning requires repo-relative paths. The agent will emit `$WT/...` paths otherwise. |
-| Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
 | Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: call `AskUserQuestion` when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger. |
 | Emit the CTA as plain text instead of `AskUserQuestion` | Always use the `AskUserQuestion` tool for the CTA — it gives the user a clickable button and eliminates the "type yes" friction. Never emit a free-text prompt asking the user to reply `yes`. |
-| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |
 | Apply the diff-scoping flip on self-review | The flip is gated on `IS_SELF_REVIEW = false`. A self-review with out-of-diff-only Critical/High findings stays `COMMENT`. See [Diff-scoping flip contract](#diff-scoping-flip-contract). |
 | Apply the diff-scoping flip when identity is unknown | `IDENTITY_KNOWN = false` when `$CURRENT_USER` or `$AUTHOR_LOGIN` is empty. The flip does NOT fire — stay COMMENT. Never auto-approve when you can't verify the authorship axis. |
 | Fire the CTA after the diff-scoping flip when `DECISION=APPROVE`, `posted=0`, `deduped=0` | CTA suppression is evaluated post-flip. After a flip to `APPROVE`, `posted=0`, `deduped=0` → suppress. The informational findings land in the summary body (not inline threads); there is nothing for `/address-feedback` to act on. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -91,7 +91,6 @@ Pass the agent:
 - Repo-relative-path instruction (load-bearing): emit **repo-relative** paths (e.g. `src/foo.ts:42`, NOT `$WT/src/foo.ts:42`). The orchestrator uses these paths to position GitHub comments.
 - Footer instruction (opt-in per `## Decision footer`): end with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**`. Never `REQUEST_CHANGES`.
 - Blocking-scope instruction (opt-in per `## Blocking-scope verdict`): classify each Critical/High as in-diff (`+` lines) or out-of-diff; mark out-of-diff with `**Informational (out-of-diff):** `; emit `**Blocking Scope: NONE|OUT-OF-DIFF-ONLY|IN-DIFF**` before the footer. APPROVE/COMMENT rule unchanged.
-- Narrative instruction (opt-in per `## Review Summary`): begin with `## Review Summary` (2–4 sentences: posture, positives, concerns); used as PR review body for cross-author reviews.
 - Ticket-context prelude (if Step 3 produced one).
 
 ### Step 5 — Parse decision footer + blocking-scope verdict
@@ -187,23 +186,12 @@ if [ "$DECISION" = "COMMENT" ] && [ "$BLOCKING_SCOPE" = "OUT-OF-DIFF-ONLY" ] \
   DECISION=APPROVE
 fi
 
-NARRATIVE=$(awk '
-  /^[[:space:]]*(Critical|High|Medium|Low|Severity)[[:space:]]*\|/ { exit }
-  /^###[[:space:]]+(Critical|High|Medium|Low)\b/ { exit }
-  /^\*\*Blocking Scope:/ { exit }
-  /^\*\*Review Decision:/ { exit }
-  { print }
-' <<< "$REVIEWER_OUTPUT" | sed -e '/^[[:space:]]*$/d' -e '/^## Review Summary[[:space:]]*$/d')
-HAS_NARRATIVE="$([ -n "$(echo "$NARRATIVE" | tr -d '[:space:]')" ] && echo true || echo false)"
-
 BYLINE="_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench)). Posted ${posted} inline comments, deduped ${deduped}._"
 INFORMATIONAL_SECTION=""
 [ -n "$DEFERRED_INFORMATIONAL" ] && INFORMATIONAL_SECTION=$(printf '\n\n### Informational (out-of-diff)\n\n%s\n' "$DEFERRED_INFORMATIONAL")
-if [ "$HAS_NARRATIVE" = true ] && [ "$IS_SELF_REVIEW" = false ]; then
-  SUMMARY=$(printf '## Review Summary\n\n%s\n\nDetailed feedback in inline comments.\n\n**Review Decision: %s**\n\n---\n%s%s\n' \
-    "$NARRATIVE" "$DECISION" "$BYLINE" "$INFORMATIONAL_SECTION")
-elif [ "$IS_SELF_REVIEW" = false ]; then
-  SUMMARY="$BYLINE"; [ -n "$INFORMATIONAL_SECTION" ] && SUMMARY="${SUMMARY}${INFORMATIONAL_SECTION}"
+if [ "$IS_SELF_REVIEW" = false ]; then
+  SUMMARY=$(printf '**Review Decision: %s**\n\n---\n%s%s\n' \
+    "$DECISION" "$BYLINE" "$INFORMATIONAL_SECTION")
 else
   SUMMARY=""
 fi
@@ -292,9 +280,7 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Parse threads from REST `pulls/{N}/comments` | REST returns review-comment-by-comment; threading is reconstructed by the GraphQL `reviewThreads` shape. Use GraphQL to fetch, REST to post. |
 | Force-add 👍 to your own existing comment | Check `reactions.nodes[].user.login` first; skip if you've already reacted. |
 | Block on cleanup | Cleanup runs in background `(... ) &`. Don't `wait` for it. |
-| Skip the narrative instruction in Step 4 | Without it, the reviewer does NOT emit `## Review Summary` (per its `## Review Summary (when instructed)` block). Step 7 falls back to the BYLINE-only branch silently — body is not wrong but loses the prose narrative for cross-author reviews (self-review intentionally produces BYLINE-only; see "Post `## Review Summary` on self-review" row). |
 | Emit the address-feedback CTA when there is nothing to address | The CTA is gated on outcome only: call `AskUserQuestion` when `DECISION = COMMENT` OR `posted > 0` OR `deduped > 0`. Suppress on clean approvals (APPROVE with `posted = 0` and `deduped = 0`). Self-review is NOT a suppression trigger. |
 | Emit the CTA as plain text instead of `AskUserQuestion` | Always use the `AskUserQuestion` tool for the CTA — it gives the user a clickable button and eliminates the "type yes" friction. Never emit a free-text prompt asking the user to reply `yes`. |
-| Post `## Review Summary` on self-review | Step 7 gates narrative inclusion on `IS_SELF_REVIEW = false`. This is a distinct policy axis from the address-feedback CTA, which is gated on outcome only (not identity). The narrative is still presented in the author's Claude session; only the GitHub-posted body is BYLINE-only. |
 | Apply the diff-scoping flip on self-review | The flip is gated on `IS_SELF_REVIEW = false`. A self-review with out-of-diff-only Critical/High findings stays `COMMENT`. |
 | Fire the CTA after the diff-scoping flip when `DECISION=APPROVE`, `posted=0`, `deduped=0` | CTA suppression is evaluated post-flip. After a flip to `APPROVE`, `posted=0`, `deduped=0` → suppress. The informational findings land in the summary body (not inline threads); there is nothing for `/address-feedback` to act on. |

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -267,9 +267,8 @@ def test_pr_review_byline_and_summary_link_to_tool_repo():
             f"BYLINE must hardcode the tool URL, not interpolate the review-target repo."
         )
 
-        # 4. Fallback SUMMARY must delegate to $BYLINE rather than duplicate the URL string
-        assert 'SUMMARY="$BYLINE"' in body, (
-            f"{skill_name}/SKILL.md fallback SUMMARY does not reuse $BYLINE.\n"
-            f"Expected:  SUMMARY=\"$BYLINE\"\n"
-            f"This keeps the two branches in sync automatically — the URL lives in one place."
+        # 4. SUMMARY construction must reference "$BYLINE" (not duplicate the URL string)
+        assert re.search(r'SUMMARY=\$\(printf .+"\$BYLINE"', body, re.DOTALL), (
+            f"{skill_name}/SKILL.md SUMMARY construction does not reference \"$BYLINE\" in a printf call.\n"
+            f"Expected: SUMMARY=$(printf '...' ... \"$BYLINE\" ...) so the URL lives in one place."
         )

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -228,13 +228,30 @@ def test_step7_deferred_informational_appended_to_summary(skill_path):
 
 
 @pytest.mark.parametrize("skill_path", SKILLS, ids=[p.parent.name for p in SKILLS])
-def test_step7_awk_excludes_blocking_scope_line_from_narrative(skill_path):
-    """The awk narrative-extraction block must exclude the Blocking Scope verdict line."""
+def test_step7_lean_body_no_narrative(skill_path):
+    """Step 7 non-self-review body must use the lean form: no ## Review Summary, no
+    'Detailed feedback in inline comments.', no NARRATIVE extraction variables."""
     text = skill_path.read_text()
-    assert re.search(r"\*\*Blocking Scope:", text), (
-        f"{skill_path.parent.name}: the awk block that extracts $NARRATIVE must contain "
-        "a guard like '/^\\*\\*Blocking Scope:/ {{ exit }}' so the verdict line is "
-        "never captured into the posted review summary"
+    assert "## Review Summary" not in text, (
+        f"{skill_path.parent.name}: '## Review Summary' must not appear — the narrative "
+        "is fully removed; the review body carries only the decision + byline + informational notes."
+    )
+    assert "Detailed feedback in inline comments." not in text, (
+        f"{skill_path.parent.name}: 'Detailed feedback in inline comments.' must not appear — "
+        "this phrase belonged to the removed narrative branch."
+    )
+    assert "HAS_NARRATIVE" not in text, (
+        f"{skill_path.parent.name}: HAS_NARRATIVE variable must be removed along with the "
+        "NARRATIVE extraction block."
+    )
+
+
+def test_reviewer_no_review_summary_section():
+    """agents/reviewer.md must no longer contain the ## Review Summary (when instructed) section."""
+    text = REVIEWER_MD.read_text()
+    assert "## Review Summary" not in text, (
+        "agents/reviewer.md still contains '## Review Summary' — delete the entire "
+        "'## Review Summary (when instructed)' block; the orchestrator no longer requests it."
     )
 
 

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -244,6 +244,10 @@ def test_step7_lean_body_no_narrative(skill_path):
         f"{skill_path.parent.name}: HAS_NARRATIVE variable must be removed along with the "
         "NARRATIVE extraction block."
     )
+    assert "Narrative instruction" not in text, (
+        f"{skill_path.parent.name}: 'Narrative instruction' Step-4 bullet must be removed — "
+        "the reviewer is no longer instructed to emit a narrative section."
+    )
 
 
 def test_reviewer_no_review_summary_section():
@@ -252,6 +256,11 @@ def test_reviewer_no_review_summary_section():
     assert "## Review Summary" not in text, (
         "agents/reviewer.md still contains '## Review Summary' — delete the entire "
         "'## Review Summary (when instructed)' block; the orchestrator no longer requests it."
+    )
+    assert "orchestrator extracts these paragraphs" not in text, (
+        "agents/reviewer.md still contains explanatory prose from the deleted "
+        "'## Review Summary (when instructed)' block — the full section must be removed, "
+        "not just the heading."
     )
 
 


### PR DESCRIPTION
## Summary
- Remove the `## Review Summary` narrative from the GitHub-posted PR review body — the body now carries only **decision + byline + out-of-diff informational notes**
- Delete the `NARRATIVE` extraction awk block and `HAS_NARRATIVE` variable from both `workflow-pr-review` and `workflow-pr-review-followup` SKILL.md files
- Collapse the 3-branch body-assembly `if` to 2 branches (only `IS_SELF_REVIEW` axis remains)
- Remove the Step-4 narrative instruction bullet from both SKILLs
- Delete two stale common-mistakes table rows referencing the removed narrative feature
- Remove the `## Review Summary (when instructed)` section from `agents/reviewer.md`
- Update tests: remove stale `test_step7_awk_excludes_blocking_scope_line_from_narrative`, add lean-body and reviewer.md regression assertions, fix `test_pr_review_byline_and_summary_link_to_tool_repo` to match the new printf-based SUMMARY form

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_workflow_pr_review_diff_scoping.py tests/test_skill_repo_ambiguity.py tests/test_workflow_pr_review_skill.py tests/test_workflow_pr_review_followup_skill.py tests/test_workflow_pr_review_cta_suppression.py -v` — 65 passed
- [x] `pytest tests/ -v` — 1110 passed (confirmed by pre-push hook)
- [x] `grep -rn "Review Summary|HAS_NARRATIVE|NARRATIVE|Detailed feedback in inline" skills/ agents/` — no matches

### Type-tailored checks (fix)
- [x] Non-self-review COMMENT body: `**Review Decision: COMMENT**\n\n---\n_Reviewed by..._` shape confirmed in SKILL.md Step 7
- [x] Self-review still produces empty SUMMARY (two-branch if preserved)
- [x] Informational section still appended when `DEFERRED_INFORMATIONAL` is non-empty (existing test kept)

Closes #327
