### PR TITLE
[fix] Detect + enforce repo commit and branch conventions

### DIFF
--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -45,7 +45,7 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
    - `type(scope): subject` (Conventional Commits)
    - `JIRA-123: subject` (JIRA-prefix style)
    Apply whichever convention the hook enforces for this host repo.
-2. If no commit-msg hook exists, run `git log --oneline -20` and tally leading prefix shapes: `[type]` → swe-workbench; `type(scope):` / `type:` → Conventional Commits; `TICKET-123:` → JIRA-prefix. Pick the **dominant** shape (plurality wins); note **scope** usage. Default to Conventional Commits only when no shape reaches a plurality.
+2. If no commit-msg hook exists, run `git log --oneline -20` and tally leading prefix shapes: `[type]` → swe-workbench; `type(scope):` / `type:` → Conventional Commits; `TICKET-123:` → JIRA-prefix. Pick the **dominant** shape (plurality wins); note **scope** usage (when >50% of Conventional Commits samples carry a `(scope)`, include a scope in generated commit messages, derived from the changed subsystem or file path). Default to Conventional Commits only when no shape reaches a plurality.
 3. If both fail (new repo, empty history), ask the user which convention to follow.
 
 **When the host repo uses the swe-workbench plugin's `[type] Subject` convention**, the enforcing regex is (load-bearing — quote, do not re-derive):

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -45,7 +45,7 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
    - `type(scope): subject` (Conventional Commits)
    - `JIRA-123: subject` (JIRA-prefix style)
    Apply whichever convention the hook enforces for this host repo.
-2. If no commit-msg hook exists, infer convention from `git log --oneline -10`. Default to Conventional Commits if no pattern dominates.
+2. If no commit-msg hook exists, run `git log --oneline -20` and tally leading prefix shapes: `[type]` → swe-workbench; `type(scope):` / `type:` → Conventional Commits; `TICKET-123:` → JIRA-prefix. Pick the **dominant** shape (plurality wins); note **scope** usage. Default to Conventional Commits only when no shape reaches a plurality.
 3. If both fail (new repo, empty history), ask the user which convention to follow.
 
 **When the host repo uses the swe-workbench plugin's `[type] Subject` convention**, the enforcing regex is (load-bearing — quote, do not re-derive):
@@ -76,14 +76,16 @@ Ambiguous wording: **default to preview-only** and ask the user to escalate.
 **Trailer hygiene.** Never emit a `Co-authored-by`, `Signed-off-by`, or similar trailer in the commit message body or PR body **unless the user explicitly asked for it in this turn**. Do not derive trailers from `git config user.email` / `user.name`, the harness environment, or any auto-detected identity. If the staged work has multiple genuine authors, ask the user whether to attribute them rather than guessing.
 **Sync source:** `.githooks/commit-msg` is canonical. If a commit fails the hook, re-read the hook (don't guess).
 
-## Branch-naming check
+## Branch-convention detection
 
-Convention: `<type>/<kebab-description>` where `<type>` is the same set as commit types.
+Detect the host repo's branch convention via 3-tier probe. **Tier 1:** run `git branch -a`, strip the `remotes/<remote>/` prefix, and tally `<prefix>/` on non-default branches (plurality wins). **Tier 2:** if Tier 1 yielded fewer than 3 non-default branch samples, derive from the commit type-set (e.g. `[feat]` → `feature/`, `[fix]` → `bugfix/`; for unmapped types fall through to Tier 3). **Tier 3 fallback:** default to `<type>/<kebab>`; warn when convention is ambiguous or undetectable.
 
-Behaviour:
-- If current branch is `main` or `master` → **warn** the user (`.githooks/pre-commit` will block the commit anyway): "You're on `main`. Switch to a feature branch first: `git checkout -b feat/<topic>`."
-- If branch doesn't match `<type>/<kebab>` → **warn-only** (don't auto-rename): "Branch `<name>` doesn't match the `<type>/<kebab>` convention. Continue anyway? Reply `yes` or rename first."
-- If branch matches → silent.
+**Current-branch evaluation:**
+- `main`/`master` → warn: "You're on `main`. Switch to a feature branch first."
+- `worktree-*` pattern (EnterWorktree-mangled) → non-conforming; pointer: "Use `rimba add <task> [--bugfix|--hotfix|--docs|--test|--chore]` for canonical prefixes (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`)." Stop evaluation here; do not offer a rename.
+- Mismatch with detected convention → offer rename (see below). Matches → silent.
+
+**Rename offer:** Before `git branch -m`, check safety: `git rev-parse @{upstream} 2>/dev/null` (exit 0 = already pushed / has upstream); `gh pr view --json state` (open PR check). When pushed or open PR → suggest-only (print compliant name, skip rename). Otherwise call `AskUserQuestion` with **Rename** (`git branch -m <current> <compliant>`) / **Keep as-is** options.
 
 ## Pre-commit gate: suspicious staged files
 

--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -34,9 +34,9 @@ wheel==0.47.0 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.1 \
-    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
-    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
+pip==26.1.2 \
+    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
+    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via pip-tools
 setuptools==82.0.1 \
     --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \

--- a/tests/test_workflow_commit_and_pr_convention_detection.py
+++ b/tests/test_workflow_commit_and_pr_convention_detection.py
@@ -1,0 +1,189 @@
+"""Tests for branch-convention detection and concrete commit-format inference (issue #394).
+
+Covers:
+  (a) Branch-convention 3-tier probe: git branch -a, commit type-set, <type>/<kebab> fallback, ambiguous/undetectable warning.
+  (b) Rename offer: AskUserQuestion + git branch -m; suggest-only when upstream/pushed or open PR exists; main/master warning.
+  (c) EnterWorktree-mangled worktree-* pattern recognition; rimba pointer; canonical prefixes.
+  (d) Commit-fallback concreteness: git log --oneline, prefix/leading, dominant/plurality, scope, "only when no shape reaches a plurality".
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SKILL_PATH = ROOT / "skills" / "workflow-commit-and-pr" / "SKILL.md"
+
+BRANCH_SECTION_HEADING = "## Branch-convention detection"
+COMMIT_FORMAT_HEADING = "## Codified commit format"
+
+
+def _section_body(text: str, heading: str) -> str:
+    """Return text from heading to the next ## heading (exclusive)."""
+    start = text.find(heading)
+    if start == -1:
+        return ""
+    end = text.find("\n## ", start + len(heading))
+    return text[start:end] if end != -1 else text[start:]
+
+
+# ---------------------------------------------------------------------------
+# (a) 3-tier branch-convention probe
+# ---------------------------------------------------------------------------
+
+
+def test_branch_section_uses_3tier_detection():
+    """Branch section must describe the 3-tier detection probe.
+
+    Asserts:
+    1. Section heading is 'Branch-convention detection' (not the old 'Branch-naming check').
+    2. Tier 1: infers prefixes from git branch -a.
+    3. Tier 2: derives prefix set from commit type-set.
+    4. Tier 3: <type>/<kebab> fallback retained.
+    5. Warns on ambiguous or undetectable conventions.
+    """
+    body = SKILL_PATH.read_text()
+
+    assert BRANCH_SECTION_HEADING in body, (
+        f"Missing section '{BRANCH_SECTION_HEADING}' — old heading 'Branch-naming check' must be renamed"
+    )
+
+    section = _section_body(body, BRANCH_SECTION_HEADING)
+
+    assert "git branch -a" in section, (
+        "Tier 1 detection must reference 'git branch -a' to infer dominant prefix from history"
+    )
+
+    assert re.search(r"commit type.set|type.set|derived? from.{0,30}commit", section, re.IGNORECASE), (
+        "Tier 2 detection must describe deriving branch prefix from detected commit type-set"
+    )
+
+    assert re.search(r"<type>/<kebab>|type/kebab", section), (
+        "Tier 3 fallback '<type>/<kebab>' must be retained in the branch section"
+    )
+
+    assert re.search(r"ambiguous|undetectable", section, re.IGNORECASE), (
+        "Branch section must warn clearly when convention is ambiguous or undetectable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) Rename offer mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_branch_rename_offer_mechanics():
+    """Branch section must specify the rename offer, suggest-only safety, and main/master warning.
+
+    Asserts:
+    1. AskUserQuestion is called to offer the rename (never silent/auto).
+    2. git branch -m is the rename command.
+    3. Detects pushed/upstream state (checks for upstream or @{upstream}).
+    4. Detects open PR via gh pr view.
+    5. Downgrades to suggest-only when pushed or open PR exists.
+    6. main/master branch warning is retained.
+    """
+    body = SKILL_PATH.read_text()
+    section = _section_body(body, BRANCH_SECTION_HEADING)
+
+    assert section, f"Section '{BRANCH_SECTION_HEADING}' not found in SKILL.md"
+
+    assert "AskUserQuestion" in section, (
+        "Rename must be offered via AskUserQuestion — never silent or auto-renamed"
+    )
+
+    assert "git branch -m" in section, (
+        "The rename command offered to the user must be 'git branch -m'"
+    )
+
+    assert re.search(r"upstream|@\{upstream\}", section), (
+        "Must detect whether branch already has an upstream (pushed state)"
+    )
+
+    assert re.search(r"gh pr view", section), (
+        "Must check for an open PR via 'gh pr view' before offering rename"
+    )
+
+    assert re.search(r"suggest.only", section, re.IGNORECASE), (
+        "Must downgrade to suggest-only (print compliant name, no git branch -m) when pushed or open PR"
+    )
+
+    assert re.search(r"`main`|`master`|main.*warn|master.*warn", section), (
+        "main/master branch warning must be retained in the branch-convention section"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) EnterWorktree-mangled pattern guard
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_mangled_pattern_guard():
+    """Branch section must recognise worktree-* mangled names and point to rimba.
+
+    Asserts:
+    1. 'worktree-' pattern is explicitly mentioned.
+    2. 'rimba' is referenced as the canonical branch-creation tool.
+    3. All six canonical rimba prefixes are listed: feature/, bugfix/, hotfix/, docs/, test/, chore/.
+    """
+    body = SKILL_PATH.read_text()
+    section = _section_body(body, BRANCH_SECTION_HEADING)
+
+    assert re.search(r"worktree-", section), (
+        "Branch section must recognize the 'worktree-*' EnterWorktree-mangled pattern"
+    )
+
+    assert "rimba" in section, (
+        "Branch section must point to rimba as the canonical branch-creation tool"
+    )
+
+    canonical_prefixes = ["feature/", "bugfix/", "hotfix/", "docs/", "test/", "chore/"]
+    for prefix in canonical_prefixes:
+        assert prefix in section, (
+            f"Canonical rimba prefix '{prefix}' must be listed in the branch section"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (d) Concrete commit-format fallback
+# ---------------------------------------------------------------------------
+
+
+def test_commit_format_fallback_is_concrete():
+    """Commit-format fallback (git log inference) must be concrete, not vague.
+
+    Asserts:
+    1. References 'git log --oneline' as the fallback probe command.
+    2. Describes tally/parsing of leading prefix shapes ('prefix' or 'leading').
+    3. Uses 'dominant' or 'plurality' to describe the selection algorithm.
+    4. Mentions 'scope' detection (whether scopes are used).
+    5. Defaults to Conventional Commits "only when no pattern dominates" (not unconditionally).
+    """
+    body = SKILL_PATH.read_text()
+    section = _section_body(body, COMMIT_FORMAT_HEADING)
+
+    assert section, f"Section '{COMMIT_FORMAT_HEADING}' not found in SKILL.md"
+
+    assert "git log --oneline" in section, (
+        "Commit fallback must specify 'git log --oneline' as the inference command"
+    )
+
+    assert re.search(r"prefix|leading", section, re.IGNORECASE), (
+        "Commit fallback must describe parsing leading prefixes from log output"
+    )
+
+    assert re.search(r"dominant|plurality", section, re.IGNORECASE), (
+        "Commit fallback must select the dominant/plurality shape, not just observe"
+    )
+
+    assert re.search(r"note\s+\*{0,2}scope\*{0,2}\s+usage|detect.*scope", section, re.IGNORECASE), (
+        "Commit fallback must instruct to note/detect scope usage, not merely mention "
+        "the word 'scope' in a format example"
+    )
+
+    assert re.search(
+        r"only when no (shape|pattern) (reach|dominates|reaches)|no (shape|pattern) dominates",
+        section,
+        re.IGNORECASE,
+    ), (
+        "Commit fallback must default to Conventional Commits ONLY when no pattern dominates, "
+        "not unconditionally — framing must be conditional"
+    )

--- a/tests/test_workflow_commit_and_pr_convention_detection.py
+++ b/tests/test_workflow_commit_and_pr_convention_detection.py
@@ -52,8 +52,8 @@ def test_branch_section_uses_3tier_detection():
         "Tier 1 detection must reference 'git branch -a' to infer dominant prefix from history"
     )
 
-    assert re.search(r"commit type.set|type.set|derived? from.{0,30}commit", section, re.IGNORECASE), (
-        "Tier 2 detection must describe deriving branch prefix from detected commit type-set"
+    assert "commit type-set" in section or re.search(r"type.set.*commit|commit.*type.set", section, re.IGNORECASE), (
+        "Tier 2 detection must reference the 'commit type-set' concept explicitly"
     )
 
     assert re.search(r"<type>/<kebab>|type/kebab", section), (


### PR DESCRIPTION
## Summary
- Add 3-tier branch-convention detection to `workflow-commit-and-pr`: infer prefix from `git branch -a` history → derive from commit type-set → fall back to `<type>/<kebab>`; strip `remotes/<remote>/` prefix; warn when ambiguous or undetectable
- Concretize the `git log --oneline` commit-format fallback: tally leading prefix shapes across 20 commits, pick dominant/plurality, note scope usage; default to Conventional Commits only when no shape reaches a plurality
- Add `worktree-*` mangled-name guard (EnterWorktree issue) with rimba pointer and canonical-prefix list; offer safe rename via `AskUserQuestion`/`git branch -m`; downgrade to suggest-only when branch is pushed or has open PR

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually

### Type-tailored checks ([fix])
- [x] Reproduce: confirmed RED baseline — all 4 tests failed before SKILL.md edits (heading `## Branch-naming check`, markers absent)
- [x] Verify fix: 4 new tests pass; `pytest tests/ -v` — 1116/1116; `bash scripts/validate.sh` passes (253 lines, cap 260)
- [x] No regressions in `test_workflow_commit_and_pr_secret_scan.py` or `_test_plan_generation.py` (headings and enforcing-regex block untouched)

Closes #394
