### PR TITLE
[docs] Complete principle-clean-architecture examples — add C#, Ruby, Swift

### DIFF
--- a/skills/principle-clean-architecture/SKILL.md
+++ b/skills/principle-clean-architecture/SKILL.md
@@ -61,7 +61,7 @@ Layers don't require separate modules. A directory per layer suffices: `domain/`
 ## Decision aid
 Ask: "If we swapped the database / web framework / message bus, which files change?" Only the adapters should.
 
-> See `examples/` for worked MVC implementations in Go, Java, Kotlin, Python, Rust, and TypeScript (read on demand — not auto-loaded).
+> See `examples/` for worked MVC implementations in C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).
 
 ## Common Excuses — and Why They're Wrong
 

--- a/skills/principle-clean-architecture/examples/mvc.cs.md
+++ b/skills/principle-clean-architecture/examples/mvc.cs.md
@@ -1,0 +1,76 @@
+# MVC — C# — Product Catalog
+
+## Problem
+Display a filtered list of products. C# records are concise immutable value types with
+compiler-generated equality. Explicit access modifiers and LINQ make layer intent clear;
+primary constructors (C# 12) eliminate boilerplate for simple injection.
+
+## Implementation
+
+```cs
+// file: Product.cs
+public sealed record Product(int Id, string Name, string Category, double Price);
+```
+
+```cs
+// file: ProductModel.cs
+using System.Collections.Generic;
+using System.Linq;
+
+public class ProductModel(IReadOnlyList<Product> products)
+{
+    private readonly IReadOnlyList<Product> _products = products;
+
+    public IReadOnlyList<Product> ByCategory(string category) =>
+        _products.Where(p => p.Category == category).ToList().AsReadOnly();
+}
+```
+
+```cs
+// file: ProductView.cs
+using System.Collections.Generic;
+
+public class ProductView
+{
+    public void Render(IReadOnlyList<Product> products)
+    {
+        foreach (var p in products)
+            Console.WriteLine($"[{p.Id}] {p.Name} — ${p.Price:F2}");
+    }
+
+    public void RenderEmpty(string category) =>
+        Console.WriteLine($"No products in category \"{category}\".");
+}
+```
+
+```cs
+// file: ProductController.cs
+using System.Collections.Generic;
+
+public class ProductController(ProductModel model, ProductView view)
+{
+    public void ShowByCategory(string category)
+    {
+        IReadOnlyList<Product> products = model.ByCategory(category);
+        if (products.Count == 0)
+            view.RenderEmpty(category);
+        else
+            view.Render(products);
+    }
+}
+```
+
+## Common Mistake
+Exposing the internal collection as a mutable `List<Product>`, letting callers alter model state.
+
+```cs
+// ✗ Public List<T> leaks mutability — callers can add, remove, or clear items
+public class BadProductModel
+{
+    public List<Product> Products { get; } = new();  // ✗ List<T> exposes mutation methods
+
+    // Callers can do:
+    // model.Products.Add(ghost);   // ✗ state mutated from outside the model
+    // model.Products.Clear();      // ✗ collection emptied unintentionally
+}
+```

--- a/skills/principle-clean-architecture/examples/mvc.cs.md
+++ b/skills/principle-clean-architecture/examples/mvc.cs.md
@@ -9,7 +9,7 @@ primary constructors (C# 12) eliminate boilerplate for simple injection.
 
 ```cs
 // file: Product.cs
-public sealed record Product(int Id, string Name, string Category, double Price);
+public sealed record Product(int Id, string Name, string Category, decimal Price);
 ```
 
 ```cs
@@ -19,10 +19,8 @@ using System.Linq;
 
 public class ProductModel(IReadOnlyList<Product> products)
 {
-    private readonly IReadOnlyList<Product> _products = products;
-
     public IReadOnlyList<Product> ByCategory(string category) =>
-        _products.Where(p => p.Category == category).ToList().AsReadOnly();
+        products.Where(p => p.Category == category).ToList().AsReadOnly();
 }
 ```
 

--- a/skills/principle-clean-architecture/examples/mvc.rb.md
+++ b/skills/principle-clean-architecture/examples/mvc.rb.md
@@ -1,0 +1,80 @@
+# MVC — Ruby — Product Catalog
+
+## Problem
+Display a filtered list of products. Ruby enforces visibility through conventions:
+`private` restricts methods; instance variables are inaccessible without an explicit
+reader. No Rails — PORO style, where the convention IS the contract.
+
+## Implementation
+
+```ruby
+# frozen_string_literal: true
+# file: model.rb
+
+Product = Data.define(:id, :name, :category, :price)
+
+class ProductModel
+  def initialize(products)
+    @products = products.dup.freeze
+  end
+
+  def by_category(category)
+    @products.select { |p| p.category == category }
+  end
+end
+```
+
+```ruby
+# frozen_string_literal: true
+# file: view.rb
+
+class ProductView
+  def render(products)
+    products.each { |p| puts "[#{p.id}] #{p.name} — $#{format('%.2f', p.price)}" }
+  end
+
+  def render_empty(category)
+    puts "No products in category \"#{category}\"."
+  end
+end
+```
+
+```ruby
+# frozen_string_literal: true
+# file: controller.rb
+
+class ProductController
+  def initialize(model, view)
+    @model = model
+    @view  = view
+  end
+
+  def show_by_category(category)
+    products = @model.by_category(category)
+    if products.empty?
+      @view.render_empty(category)
+    else
+      @view.render(products)
+    end
+  end
+end
+```
+
+## Common Mistake
+Using `attr_accessor :products` instead of omitting the accessor — the generated writer
+lets callers replace or mutate the model's collection.
+
+```ruby
+# ✗ attr_accessor generates a writer — callers can swap the entire collection
+class BadProductModel
+  attr_accessor :products  # ✗ .products= is now public
+
+  def initialize(products)
+    @products = products
+  end
+end
+
+# Callers can now do:
+# model.products = []           # ✗ wipes model state
+# model.products.push(ghost)    # ✗ mutates the live array
+```

--- a/skills/principle-clean-architecture/examples/mvc.swift.md
+++ b/skills/principle-clean-architecture/examples/mvc.swift.md
@@ -1,0 +1,93 @@
+# MVC — Swift — Product Catalog
+
+## Problem
+Display a filtered list of products. Swift structs are value types — the model's array
+is a copy, not a shared reference. `private let` bindings and access control make layer
+ownership explicit and enforce immutability without runtime overhead.
+
+## Implementation
+
+```swift
+// file: Product.swift
+struct Product {
+    let id: Int
+    let name: String
+    let category: String
+    let price: Double
+}
+```
+
+```swift
+// file: ProductModel.swift
+struct ProductModel {
+    private let products: [Product]
+
+    init(products: [Product]) {
+        self.products = products
+    }
+
+    func byCategory(_ category: String) -> [Product] {
+        products.filter { $0.category == category }
+    }
+}
+```
+
+```swift
+// file: ProductView.swift
+struct ProductView {
+    func render(_ products: [Product]) {
+        for p in products {
+            print("[\(p.id)] \(p.name) — $\(String(format: "%.2f", p.price))")
+        }
+    }
+
+    func renderEmpty(_ category: String) {
+        print("No products in category \"\(category)\".")
+    }
+}
+```
+
+```swift
+// file: ProductController.swift
+struct ProductController {
+    private let model: ProductModel
+    private let view: ProductView
+
+    init(model: ProductModel, view: ProductView) {
+        self.model = model
+        self.view  = view
+    }
+
+    func showByCategory(_ category: String) {
+        let products = model.byCategory(category)
+        if products.isEmpty {
+            view.renderEmpty(category)
+        } else {
+            view.render(products)
+        }
+    }
+}
+```
+
+## Common Mistake
+Declaring `Product` as a `class` instead of a `struct` — class instances are reference
+types, so the model's array stores a shared pointer; a caller holding the same instance
+can mutate fields that the model thinks it owns.
+
+```swift
+// ✗ class Product shares references — callers can mutate the item after insertion
+final class Product {       // ✗ reference type: array stores a pointer, not a copy
+    var id: Int             // ✗ var fields enable post-insertion mutation
+    var name: String
+    var category: String
+    var price: Double
+
+    init(id: Int, name: String, category: String, price: Double) {
+        self.id = id; self.name = name; self.category = category; self.price = price
+    }
+}
+
+// let p = Product(id: 1, name: "Lens", category: "photo", price: 299)
+// let model = ProductModel(products: [p])
+// p.price = 0  // ✗ mutates the object already stored inside the model
+```

--- a/skills/principle-clean-architecture/examples/mvc.swift.md
+++ b/skills/principle-clean-architecture/examples/mvc.swift.md
@@ -13,7 +13,7 @@ struct Product {
     let id: Int
     let name: String
     let category: String
-    let price: Double
+    let price: Double  // Double used for simplicity; production money values prefer Decimal
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add `mvc.cs.md`, `mvc.rb.md`, and `mvc.swift.md` — Product Catalog MVC examples for the three OO languages that had language skills but no architecture example.
- Each file follows the existing scenario contract (Problem / Implementation / Common Mistake, `# file:` headers, ≤120 lines). C# uses `sealed record` + `IReadOnlyList<T>` + primary constructors; Ruby uses `Data.define` + PORO; Swift uses `struct` value semantics throughout.
- Update SKILL.md pointer at line 64 to list all 9 languages: C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually

### Type-tailored checks (docs)
- [ ] `bash scripts/validate.sh` exits 0
- [ ] `wc -l skills/principle-clean-architecture/examples/mvc.{cs,rb,swift}.md` — all ≤120 lines
- [ ] `grep -n 'C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript' skills/principle-clean-architecture/SKILL.md` returns line 64
- [ ] Section order, `# file:` headers, and `[id] name — $price` render format match siblings visually

Closes #374
