### PR TITLE
[fix] Remove dangling $REVIEWER_OUTPUT reference from Step 7 prose

### DIFF
--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -172,7 +172,7 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
 ### Step 7 — Submit + cleanup
 
-Build the lean review body `$SUMMARY` — decision line + byline only. Findings are already posted as inline comments in Step 6; do NOT restate them here:
+Build the lean review body `$SUMMARY` — decision line + byline (+ optional informational notes for out-of-diff findings). Findings already posted as inline comments in Step 6 must NOT be restated here:
 
 ```bash
 if [ -z "$CURRENT_USER" ] || [ -z "$AUTHOR_LOGIN" ]; then

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -172,7 +172,7 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
 ### Step 7 — Submit + cleanup
 
-Build `$SUMMARY` from `$REVIEWER_OUTPUT` (captured in Step 4):
+Build the lean review body `$SUMMARY` — decision line + byline only. Findings are already posted as inline comments in Step 6; do NOT restate them here:
 
 ```bash
 if [ -z "$CURRENT_USER" ] || [ -z "$AUTHOR_LOGIN" ]; then

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -171,7 +171,7 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
 ### Step 7 — Submit + cleanup
 
-Build the lean review body `$SUMMARY` — decision line + byline only. Findings are already posted as inline comments in Step 6; do NOT restate them here:
+Build the lean review body `$SUMMARY` — decision line + byline (+ optional informational notes for out-of-diff findings). Findings already posted as inline comments in Step 6 must NOT be restated here:
 
 ```bash
 if [ -z "$CURRENT_USER" ] || [ -z "$AUTHOR_LOGIN" ]; then

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -171,7 +171,7 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
 ### Step 7 — Submit + cleanup
 
-Build `$SUMMARY` from `$REVIEWER_OUTPUT` (captured in Step 4):
+Build the lean review body `$SUMMARY` — decision line + byline only. Findings are already posted as inline comments in Step 6; do NOT restate them here:
 
 ```bash
 if [ -z "$CURRENT_USER" ] || [ -z "$AUTHOR_LOGIN" ]; then

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -253,6 +253,10 @@ def test_step7_lean_body_no_narrative(skill_path):
         "narrative removal (#391) — the lean body is built from $DECISION/$BYLINE only, not "
         "from reviewer output. Remove the stale Step 7 prose that names it."
     )
+    assert "decision line + byline" in text, (
+        f"{skill_path.parent.name}: Step 7 prose must affirm the lean-body intent — "
+        "'decision line + byline' directive is missing. Findings must not be restated in the body."
+    )
 
 
 def test_reviewer_no_review_summary_section():

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -248,6 +248,11 @@ def test_step7_lean_body_no_narrative(skill_path):
         f"{skill_path.parent.name}: 'Narrative instruction' Step-4 bullet must be removed — "
         "the reviewer is no longer instructed to emit a narrative section."
     )
+    assert "$REVIEWER_OUTPUT" not in text, (
+        f"{skill_path.parent.name}: '$REVIEWER_OUTPUT' is a dangling reference left by the "
+        "narrative removal (#391) — the lean body is built from $DECISION/$BYLINE only, not "
+        "from reviewer output. Remove the stale Step 7 prose that names it."
+    )
 
 
 def test_reviewer_no_review_summary_section():


### PR DESCRIPTION
## Summary
- Remove the orphaned `Build $SUMMARY from $REVIEWER_OUTPUT (captured in Step 4):` prose line from Step 7 of both `workflow-pr-review/SKILL.md` and `workflow-pr-review-followup/SKILL.md`
- Replace it with an explicit directive: *"Build the lean review body `$SUMMARY` — decision line + byline only. Findings are already posted as inline comments in Step 6; do NOT restate them here:"*
- Add a `$REVIEWER_OUTPUT`-absent assertion to the existing parametrized `test_step7_lean_body_no_narrative` test (covers both skill ids)

PR #391 removed the `NARRATIVE` block and cleaned up the `$SUMMARY` bash to be lean, but left behind one prose line that named the now-unassigned `$REVIEWER_OUTPUT` variable. Because these skills are LLM-executed, the stale "build from reviewer output" instruction was a live regression vector.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_workflow_pr_review_diff_scoping.py::test_step7_lean_body_no_narrative -v` — 2 parametrized ids pass (red before prose edit, green after)
- [x] `pytest tests/ -v` — 1133 passed, 0 failures

### Type-tailored checks ([fix])
- [x] Reproduced the regression vector: grep confirmed `$REVIEWER_OUTPUT` appeared in both SKILL.md files before the fix
- [x] Verified `$REVIEWER_OUTPUT` is absent from both files after the fix (grep returns 0 matches)
- [x] Confirmed no other files reference `$REVIEWER_OUTPUT` (no collateral impact)

Closes #409
