### PR TITLE
[fix] Refresh remote base ref before diff in PR-review skills (#414)

### DIFF
--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -90,7 +90,8 @@ Identical to `workflow-pr-review` Step 3. Read `title` and `body` from the saved
 
 Pass the agent:
 - Working-directory hint: absolute path of the worktree (`$WT`).
-- Diff: `git -C "$WT" diff "$BASE"..HEAD`.
+- Before diffing, refresh the remote base so already-merged commits are excluded (best-effort — a fetch failure is non-fatal): `git -C "$WT" fetch origin "$BASE" --quiet || true`
+- Diff: `git -C "$WT" diff "origin/$BASE"...HEAD` (three-dot = merge-base; only commits unique to the PR branch).
 - Repo-relative-path instruction (load-bearing): emit **repo-relative** paths (e.g. `src/foo.ts:42`, NOT `$WT/src/foo.ts:42`). The orchestrator uses these paths to position GitHub comments.
 - Footer instruction (opt-in per `## Decision footer`): end with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**`. Never `REQUEST_CHANGES`.
 - Blocking-scope instruction (opt-in per `## Blocking-scope verdict`): classify each Critical/High as in-diff (`+` lines) or out-of-diff; mark out-of-diff with `**Informational (out-of-diff):** `; emit `**Blocking Scope: NONE|OUT-OF-DIFF-ONLY|IN-DIFF**` before the footer. APPROVE/COMMENT rule unchanged.

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -87,7 +87,8 @@ Read `title` and `body` from the saved JSON. Match `[A-Z]+-\d+`, atlassian/Confl
 
 Pass the agent:
 - Working-directory hint: absolute path of the worktree (`$WT`).
-- Diff: `git -C "$WT" diff "$BASE"..HEAD`.
+- Before diffing, refresh the remote base so already-merged commits are excluded (best-effort — a fetch failure is non-fatal): `git -C "$WT" fetch origin "$BASE" --quiet || true`
+- Diff: `git -C "$WT" diff "origin/$BASE"...HEAD` (three-dot = merge-base; only commits unique to the PR branch).
 - Repo-relative-path instruction (load-bearing): emit **repo-relative** paths (e.g. `src/foo.ts:42`, NOT `$WT/src/foo.ts:42`). The orchestrator uses these paths to position GitHub comments.
 - Footer instruction (opt-in per `## Decision footer`): end with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**`. Never `REQUEST_CHANGES`.
 - Blocking-scope instruction (opt-in per `## Blocking-scope verdict`): classify each Critical/High as in-diff (`+` lines) or out-of-diff; mark out-of-diff with `**Informational (out-of-diff):** `; emit `**Blocking Scope: NONE|OUT-OF-DIFF-ONLY|IN-DIFF**` before the footer. APPROVE/COMMENT rule unchanged.

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -282,3 +282,35 @@ def test_diff_scoping_contract_subsection_exists(skill_path):
         "documenting the flip gate, self-review exclusion, identity-unknown fail-safe, "
         "and the out-of-diff 422 reroute"
     )
+
+
+# ---------------------------------------------------------------------------
+# Stale-base fix (#414) — fetch + three-dot merge-base diff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_path", SKILLS, ids=[p.parent.name for p in SKILLS])
+def test_step4_fetches_base_before_diff(skill_path):
+    """Step 4 must fetch origin/$BASE in the worktree context before computing the diff."""
+    text = skill_path.read_text()
+    assert re.search(r'git -C "\$WT" fetch origin "\$BASE"', text), (
+        f"{skill_path.parent.name}: Step 4 must run "
+        "'git -C \"$WT\" fetch origin \"$BASE\" --quiet || true' (in the worktree) before "
+        "the diff so already-merged commits on the remote base are excluded (fix for #414)"
+    )
+
+
+@pytest.mark.parametrize("skill_path", SKILLS, ids=[p.parent.name for p in SKILLS])
+def test_step4_diff_uses_three_dot_remote_tracking_ref(skill_path):
+    """Step 4 diff must use three-dot merge-base against origin/$BASE, not two-dot against local $BASE."""
+    text = skill_path.read_text()
+    assert re.search(r'diff "origin/\$BASE"\.\.\.HEAD', text), (
+        f"{skill_path.parent.name}: Step 4 diff must be "
+        "'git -C \"$WT\" diff \"origin/$BASE\"...HEAD' (three-dot = merge-base, "
+        "remote-tracking ref) — not two-dot against local $BASE (fix for #414)"
+    )
+    assert not re.search(r'diff "\$BASE"\.\.HEAD', text), (
+        f"{skill_path.parent.name}: Step 4 must NOT use 'diff \"$BASE\"..HEAD' "
+        "(two-dot against local ref) — it produces a stale diff when the remote base "
+        "has advanced past the feature branch's fork point (fix for #414)"
+    )

--- a/tests/test_workflow_pr_review_diff_scoping.py
+++ b/tests/test_workflow_pr_review_diff_scoping.py
@@ -293,10 +293,11 @@ def test_diff_scoping_contract_subsection_exists(skill_path):
 def test_step4_fetches_base_before_diff(skill_path):
     """Step 4 must fetch origin/$BASE in the worktree context before computing the diff."""
     text = skill_path.read_text()
-    assert re.search(r'git -C "\$WT" fetch origin "\$BASE"', text), (
+    assert re.search(r'git -C "\$WT" fetch origin "\$BASE" --quiet \|\| true', text), (
         f"{skill_path.parent.name}: Step 4 must run "
-        "'git -C \"$WT\" fetch origin \"$BASE\" --quiet || true' (in the worktree) before "
-        "the diff so already-merged commits on the remote base are excluded (fix for #414)"
+        "'git -C \"$WT\" fetch origin \"$BASE\" --quiet || true' (in the worktree, with "
+        "non-fatal guard) before the diff so already-merged commits on the remote base "
+        "are excluded (fix for #414)"
     )
 
 


### PR DESCRIPTION
## Summary
- Add `git -C "$WT" fetch origin "$BASE" --quiet || true` before the diff in Step 4 of both `workflow-pr-review` and `workflow-pr-review-followup` so the remote-tracking ref is current before computing the diff.
- Change the diff from two-dot against the local ref (`diff "$BASE"..HEAD`) to three-dot merge-base against the remote-tracking ref (`diff "origin/$BASE"...HEAD`), matching GitHub's own "Files changed" semantics.
- Add two new parametrized tests (over both skills) asserting the fetch and three-dot diff pattern; tests are scoped to verify `-C "$WT"` worktree context and absence of the old two-dot local ref form.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_workflow_pr_review_diff_scoping.py tests/test_workflow_pr_review_skill.py tests/test_workflow_pr_review_followup_skill.py -v` — 54 passed
- [x] `pytest tests/ -v` — 1151 passed
- [x] `bash scripts/validate.sh` — all checks passed
- [x] `grep -rn 'diff "\$BASE"\.\.HEAD' skills/workflow-pr-review*/SKILL.md` — 0 matches (no stale two-dot refs remain)
- [x] `grep -rn 'diff "origin/\$BASE"\.\.\.HEAD' skills/workflow-pr-review*/SKILL.md` — 2 matches (both skills updated)

### Type-tailored checks ([fix])
- [x] Reproduce: confirm stale two-dot diff was the only diff site in Step 4 of both skills
- [x] Verify: new tests fail on unpatched files (red), pass on patched files (green) — TDD order maintained

Closes #414
