### PR TITLE
[feat] Auto-redact confidential identifiers in /report-issue before filing

### DIFF
--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -76,12 +76,12 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    **Redaction pass (privacy guard).** Before writing the body in step 8, scan the drafted body for confidential identifiers pulled from conversation context and replace each with a generic placeholder. Prefer over-redaction — the user restores false positives at the preview gate.
 
-   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and the following public tech names exactly: GitHub, Claude Code, the `gh` CLI, Python, pytest, Node, npm, pip. When uncertain whether a name is public, prefer to redact it.
+   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and the following public tech names and their canonical domains: GitHub (`github.com`, `api.github.com`), Claude Code, the `gh` CLI, Python, pytest, Node, npm, pip. When uncertain whether a name is public, prefer to redact it.
    - **Redact when NOT allowlisted** (handle camelCase / snake_case / kebab-case variants):
      - Email addresses → `[internal-email]`
      - URLs, hostnames, internal domains (e.g. `*.corp`, `*.internal`, company domains) → `[internal-host]`
      - IP addresses → `[internal-ip]`
-     - API keys, tokens, and credential strings matching common patterns (e.g. `sk-…`, `ghp_…`, `AKIA…`, `Bearer …`, UUID-format secrets) → `[redacted-token]`
+     - API keys, tokens, and credential strings matching common patterns (e.g. `sk-…`, `ghp_…`, `AKIA…`, `Bearer <token>`) → `[redacted-token]`. Do NOT redact bare UUIDs without surrounding context that identifies them as secrets (e.g., a UUID in a JSON field named `secret`, `key`, or `token`).
      - Internal service identifiers (`*-api`, `*-service`, `*-svc`, `*-worker`, `*-gateway`) that are not plugin names → `an internal service`
      - Apparent company / product / org names, and other-repo or monorepo slugs surfaced from conversation → `a downstream consumer` / `the monorepo` / `an internal repository` as fits.
    - Never redact text the user explicitly typed as their own thought intending it to be public.
@@ -103,6 +103,6 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.
    ```
-   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. When N > 0 from the redaction pass, also render the line `_Automatically redacted N internal identifier(s)._` as a plain Markdown italic line **outside and immediately above the opening triple-backtick of the `Body:` fence** — this note is **preview-only** and must NOT be written into the `.md` body file; write the `.md` file first, then append the note only to the printed preview output. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
+   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
 9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.

--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -74,12 +74,25 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
    - **Plugin version:** list `~/.claude/plugins/cache/swe-workbench/swe-workbench/` version directories, sort semantically (`sort -V`), take the highest with `tail -1`, then read `plugin.json` from it: `ls ~/.claude/plugins/cache/swe-workbench/swe-workbench/ 2>/dev/null | sort -V | tail -1 | xargs -I{} python3 -c "import json; print(json.load(open('$HOME/.claude/plugins/cache/swe-workbench/swe-workbench/{}/.claude-plugin/plugin.json'))['version'])"`. If this returns no output (not installed from cache), fall back to: `gh api repos/lugassawan/swe-workbench/contents/.claude-plugin/plugin.json --repo lugassawan/swe-workbench --jq '.content' | python3 -c "import base64,sys,json; print(json.loads(base64.b64decode(sys.stdin.read().strip()))['version'])"`.  
    - **CLI version:** `claude --version` — strip the leading `Claude Code ` prefix to get the bare semver.
 
+   **Redaction pass (privacy guard).** Before writing the body in step 8, scan the drafted body for confidential identifiers pulled from conversation context and replace each with a generic placeholder. Prefer over-redaction — the user restores false positives at the preview gate.
+
+   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and common public tech names (GitHub, Claude Code, gh, Python, pytest, etc.).
+   - **Redact when NOT allowlisted** (handle camelCase / snake_case / kebab-case variants):
+     - Email addresses → `[internal-email]`
+     - URLs, hostnames, internal domains (e.g. `*.corp`, `*.internal`, company domains) → `[internal-host]`
+     - IP addresses → `[internal-ip]`
+     - Internal service identifiers (`*-api`, `*-service`, `*-svc`, `*-worker`, `*-gateway`) that are not plugin names → `an internal service`
+     - Apparent company / product / org names, and other-repo or monorepo slugs surfaced from conversation → `a downstream consumer` / `the monorepo` / `an internal repository` as fits.
+   - Never redact text the user explicitly typed as their own thought intending it to be public.
+   - Count the replacements made; carry the count into the step 8 preview.
+
 8. **Preview gate.** Obtain a Unix timestamp once (`date +%s`) and reuse it. Write the body to `/tmp/report-issue-lugassawan-swe-workbench-<unix-timestamp>.md` using the `Write` tool (not a Bash heredoc). Also write a one-line command to `/tmp/report-issue-lugassawan-swe-workbench-<unix-timestamp>.cmd` using the `Write` tool: when a label was matched, write `gh issue create --repo lugassawan/swe-workbench --title "..." --body-file <path> --label "<matched-label>"`; when no label was matched, write `gh issue create --repo lugassawan/swe-workbench --title "..." --body-file <path>` (no `--label` segment). Then print:
    ```
    Filing into: lugassawan/swe-workbench
    Template: <chosen template> | none — default body
    Title: <drafted title>
    Label: <chosen label> | none — no matching label found
+   Redacted: <N internal identifier(s) → placeholders | none detected>
    Possibly related: <#N list, or "none">
 
    Body:
@@ -89,6 +102,6 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.
    ```
-   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
+   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. When N > 0 from the redaction pass, also render the line `_Automatically redacted N internal identifier(s)._` in the preview prose immediately before the `Body:` block — this note is **preview-only** and must NOT appear in the filed body. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
 9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.

--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -76,11 +76,12 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    **Redaction pass (privacy guard).** Before writing the body in step 8, scan the drafted body for confidential identifiers pulled from conversation context and replace each with a generic placeholder. Prefer over-redaction — the user restores false positives at the preview gate.
 
-   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and common public tech names (GitHub, Claude Code, gh, Python, pytest, etc.).
+   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and the following public tech names exactly: GitHub, Claude Code, the `gh` CLI, Python, pytest, Node, npm, pip. When uncertain whether a name is public, prefer to redact it.
    - **Redact when NOT allowlisted** (handle camelCase / snake_case / kebab-case variants):
      - Email addresses → `[internal-email]`
      - URLs, hostnames, internal domains (e.g. `*.corp`, `*.internal`, company domains) → `[internal-host]`
      - IP addresses → `[internal-ip]`
+     - API keys, tokens, and credential strings matching common patterns (e.g. `sk-…`, `ghp_…`, `AKIA…`, `Bearer …`, UUID-format secrets) → `[redacted-token]`
      - Internal service identifiers (`*-api`, `*-service`, `*-svc`, `*-worker`, `*-gateway`) that are not plugin names → `an internal service`
      - Apparent company / product / org names, and other-repo or monorepo slugs surfaced from conversation → `a downstream consumer` / `the monorepo` / `an internal repository` as fits.
    - Never redact text the user explicitly typed as their own thought intending it to be public.
@@ -102,6 +103,6 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    Reply 'confirm' to file, or edit any of the above (including the label) and I'll redraft.
    ```
-   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. When N > 0 from the redaction pass, also render the line `_Automatically redacted N internal identifier(s)._` in the preview prose immediately before the `Body:` block — this note is **preview-only** and must NOT appear in the filed body. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
+   When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. When N > 0 from the redaction pass, also render the line `_Automatically redacted N internal identifier(s)._` as a plain Markdown italic line **outside and immediately above the opening triple-backtick of the `Body:` fence** — this note is **preview-only** and must NOT be written into the `.md` body file; write the `.md` file first, then append the note only to the printed preview output. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
 9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -95,19 +95,31 @@ def test_report_issue_redaction_has_allowlist():
     assert "Allowlist" in text, (
         "commands/report-issue.md must include an 'Allowlist' section in the redaction instructions"
     )
-    assert "swe-workbench" in text, (
-        "commands/report-issue.md must include 'swe-workbench' as an allowlisted token"
+    assert "NEVER redact" in text, (
+        "commands/report-issue.md must include a 'NEVER redact' directive in the allowlist"
+    )
+    assert "swe-workbench" in text[text.find("NEVER redact"):text.find("NEVER redact") + 400], (
+        "commands/report-issue.md must name 'swe-workbench' as an allowlisted token"
     )
 
 
 def test_report_issue_redaction_has_placeholder_vocabulary():
-    """commands/report-issue.md must define placeholder vocabulary for redaction."""
+    """commands/report-issue.md must define placeholder vocabulary for all required categories."""
     text = REPORT_ISSUE_MD.read_text()
     assert "[internal-email]" in text, (
         "commands/report-issue.md must specify '[internal-email]' as a redaction placeholder"
     )
+    assert "[internal-host]" in text, (
+        "commands/report-issue.md must specify '[internal-host]' as a redaction placeholder"
+    )
+    assert "[internal-ip]" in text, (
+        "commands/report-issue.md must specify '[internal-ip]' as a redaction placeholder"
+    )
     assert "an internal service" in text, (
         "commands/report-issue.md must specify 'an internal service' as a redaction placeholder"
+    )
+    assert "[redacted-token]" in text, (
+        "commands/report-issue.md must specify '[redacted-token]' as a placeholder for API keys/tokens"
     )
 
 
@@ -120,16 +132,20 @@ def test_report_issue_preview_shows_redaction_status():
 
 
 def test_report_issue_redaction_before_preview():
-    """commands/report-issue.md: redaction pass must appear before the preview/confirm step."""
+    """commands/report-issue.md: redaction pass → Redacted: line → confirm gate, in that order."""
     text = REPORT_ISSUE_MD.read_text()
     redaction_pos = text.find("Redaction pass")
+    redacted_line_pos = text.find("Redacted:")
     confirm_pos = text.find("Reply 'confirm'")
     assert redaction_pos != -1, (
         "commands/report-issue.md must include a 'Redaction pass' instruction"
     )
+    assert redacted_line_pos != -1, (
+        "commands/report-issue.md must include a 'Redacted:' preview line"
+    )
     assert confirm_pos != -1, (
         "commands/report-issue.md must include a \"Reply 'confirm'\" instruction"
     )
-    assert redaction_pos < confirm_pos, (
-        "The 'Redaction pass' must appear before \"Reply 'confirm'\" in commands/report-issue.md"
+    assert redaction_pos < redacted_line_pos < confirm_pos, (
+        "Order must be: 'Redaction pass' → 'Redacted:' line → \"Reply 'confirm'\""
     )

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -138,14 +138,14 @@ def test_report_issue_redaction_before_preview():
     """commands/report-issue.md: redaction pass → Redacted: line → confirm gate, in that order."""
     text = REPORT_ISSUE_MD.read_text()
     redaction_pos = text.find("Redaction pass")
-    redacted_line_pos = text.find("Redacted:", redaction_pos)
-    confirm_pos = text.find("Reply 'confirm'", redacted_line_pos)
     assert redaction_pos != -1, (
         "commands/report-issue.md must include a 'Redaction pass' instruction"
     )
+    redacted_line_pos = text.find("Redacted:", redaction_pos)
     assert redacted_line_pos != -1, (
         "commands/report-issue.md must include a 'Redacted:' preview line"
     )
+    confirm_pos = text.find("Reply 'confirm'", redacted_line_pos)
     assert confirm_pos != -1, (
         "commands/report-issue.md must include a \"Reply 'confirm'\" instruction"
     )

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -98,7 +98,10 @@ def test_report_issue_redaction_has_allowlist():
     assert "NEVER redact" in text, (
         "commands/report-issue.md must include a 'NEVER redact' directive in the allowlist"
     )
-    assert "swe-workbench" in text[text.find("NEVER redact"):text.find("NEVER redact") + 400], (
+    never_redact_pos = text.find("NEVER redact")
+    allowlist_end = text.find("Redact when NOT allowlisted", never_redact_pos)
+    allowlist_block = text[never_redact_pos:allowlist_end]
+    assert "swe-workbench" in allowlist_block, (
         "commands/report-issue.md must name 'swe-workbench' as an allowlisted token"
     )
 
@@ -135,8 +138,8 @@ def test_report_issue_redaction_before_preview():
     """commands/report-issue.md: redaction pass → Redacted: line → confirm gate, in that order."""
     text = REPORT_ISSUE_MD.read_text()
     redaction_pos = text.find("Redaction pass")
-    redacted_line_pos = text.find("Redacted:")
-    confirm_pos = text.find("Reply 'confirm'")
+    redacted_line_pos = text.find("Redacted:", redaction_pos)
+    confirm_pos = text.find("Reply 'confirm'", redacted_line_pos)
     assert redaction_pos != -1, (
         "commands/report-issue.md must include a 'Redaction pass' instruction"
     )

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -79,3 +79,57 @@ def test_report_issue_supports_blank_argument():
     assert "MEMORY.md" in text, (
         "commands/report-issue.md must reference MEMORY.md as the memory fallback for blank-arg mode"
     )
+
+
+def test_report_issue_has_redaction_pass():
+    """commands/report-issue.md must include a redaction sub-step in the draft step."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "Redaction pass" in text, (
+        "commands/report-issue.md must include a 'Redaction pass' instruction in step 7"
+    )
+
+
+def test_report_issue_redaction_has_allowlist():
+    """commands/report-issue.md must define an allowlist for the redaction pass."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "Allowlist" in text, (
+        "commands/report-issue.md must include an 'Allowlist' section in the redaction instructions"
+    )
+    assert "swe-workbench" in text, (
+        "commands/report-issue.md must include 'swe-workbench' as an allowlisted token"
+    )
+
+
+def test_report_issue_redaction_has_placeholder_vocabulary():
+    """commands/report-issue.md must define placeholder vocabulary for redaction."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "[internal-email]" in text, (
+        "commands/report-issue.md must specify '[internal-email]' as a redaction placeholder"
+    )
+    assert "an internal service" in text, (
+        "commands/report-issue.md must specify 'an internal service' as a redaction placeholder"
+    )
+
+
+def test_report_issue_preview_shows_redaction_status():
+    """commands/report-issue.md must include a 'Redacted:' line in the step 8 preview block."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "Redacted:" in text, (
+        "commands/report-issue.md must include a 'Redacted:' line in the preview gate block"
+    )
+
+
+def test_report_issue_redaction_before_preview():
+    """commands/report-issue.md: redaction pass must appear before the preview/confirm step."""
+    text = REPORT_ISSUE_MD.read_text()
+    redaction_pos = text.find("Redaction pass")
+    confirm_pos = text.find("Reply 'confirm'")
+    assert redaction_pos != -1, (
+        "commands/report-issue.md must include a 'Redaction pass' instruction"
+    )
+    assert confirm_pos != -1, (
+        "commands/report-issue.md must include a \"Reply 'confirm'\" instruction"
+    )
+    assert redaction_pos < confirm_pos, (
+        "The 'Redaction pass' must appear before \"Reply 'confirm'\" in commands/report-issue.md"
+    )


### PR DESCRIPTION
## Summary

- Add a **Redaction pass (privacy guard)** sub-step to step 7 of `commands/report-issue.md`: before writing the draft body to the temp `.md` file, the model scans it for confidential identifiers from conversation context and replaces each with a generic placeholder.
- Allowlist keeps plugin-own identifiers (`swe-workbench`, `lugassawan`, command/skill/agent names, plugin paths) and a closed list of public tech names (GitHub, Claude Code, `gh`, Python, pytest, Node, npm, pip) intact.
- Redaction catalog covers: email → `[internal-email]`; hostnames/URLs → `[internal-host]`; IPs → `[internal-ip]`; API keys/tokens → `[redacted-token]`; service names → `an internal service`; org/repo slugs → prose placeholders.
- Add `Redacted: <N identifier(s) → placeholders | none detected>` line to the step 8 preview block; when N > 0, also render a preview-only italic note above the `Body:` fence (note is never written to the `.md` sidecar).
- Cover with 5 new deliberate-break-proof assertions in `tests/test_report_issue_command.py`.

## Test Plan

- [x] `pytest tests/test_report_issue_command.py` — all 11 assertions pass (6 pre-existing + 5 new)
- [x] `pytest tests/` — full suite of 1158 tests green
- [x] `python scripts/validate.py` — frontmatter, layout, and no-cycle checks pass
- [x] Deliberate-break proof: each new assertion fails when its corresponding instruction phrase is removed from the command file
- [x] Pre-push CI passed (all 1158 tests)

### Type-tailored checks ([feat])

- [ ] Invoke `/swe-workbench:report-issue` with a draft that embeds a fake email (`user@corp.internal`) and a service name (`payments-service`): confirm preview shows both replaced with placeholders and `Redacted: 2 internal identifier(s) → placeholders`
- [ ] Confirm that `swe-workbench`, `lugassawan`, `report-issue` in the same draft are NOT redacted (allowlist intact)
- [ ] Confirm the `_Automatically redacted N identifier(s)._` note does not appear in the filed body (abort at preview — do not file)
- [ ] Invoke with a clean draft (no identifiers): confirm `Redacted: none detected`

Closes #415
