### PR TITLE
[chore] Normalize testing heading across language skills

### DIFF
--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -102,7 +102,7 @@ fi
 - `#!/bin/sh` only when strict POSIX portability is required — drop all bash-isms.
 - Run `shellcheck --shell=bash` (or `--shell=sh`) to enforce the declared contract.
 
-## Tests
+## Testing
 - `bats-core` for non-trivial scripts: one assertion per test, temp dirs for isolation.
 - For inline assertions in one-shot scripts:
 ```bash

--- a/skills/language-go/SKILL.md
+++ b/skills/language-go/SKILL.md
@@ -42,7 +42,7 @@ if err := g.Wait(); err != nil { return err }
 - Never store `context.Context` in a struct field.
 - Don't use `context.Value` for required parameters — only cross-cutting concerns like request IDs.
 
-## Tests
+## Testing
 - Table-driven tests are the default.
 - `t.Run(name, ...)` for subtests.
 - `t.Cleanup` beats `defer` for shared fixtures.

--- a/skills/language-java/SKILL.md
+++ b/skills/language-java/SKILL.md
@@ -84,7 +84,7 @@ List<String> emails = users.stream()
 - Gradle: `build.gradle` (Groovy) or `build.gradle.kts` (Kotlin DSL — preferred for IDE support).
 - JPMS (`module-info.java`): adopt only when publishing a library that needs strong encapsulation.
 
-## Tests
+## Testing
 - JUnit 5 (`@Test`, `@ParameterizedTest`, `@MethodSource`) — not JUnit 4.
 - AssertJ for fluent assertions: `assertThat(actual).isEqualTo(expected)`.
 - Mockito for external boundaries; do not mock domain objects.

--- a/skills/language-kotlin/SKILL.md
+++ b/skills/language-kotlin/SKILL.md
@@ -89,7 +89,7 @@ val prices: Flow<BigDecimal> = priceRepo.watch(symbol)
     .distinctUntilChanged()
 ```
 
-## Tests
+## Testing
 - JUnit 5 or Kotest for test structure; MockK for Kotlin-friendly mocking.
 - `runTest { }` from `kotlinx-coroutines-test` for coroutine tests — no manual dispatchers.
 

--- a/skills/language-swift/SKILL.md
+++ b/skills/language-swift/SKILL.md
@@ -93,7 +93,7 @@ button.onTap = { [weak self] in
 - One target per logical module. Keep `Sources/` layout mirroring the module name.
 - Pin dependencies via `Package.resolved` in version control for reproducible builds.
 
-## Tests
+## Testing
 - XCTest: `XCTAssertEqual`, `XCTUnwrap` (throws if nil, cleaner than force-unwrap in tests).
 - Swift Testing (`@Test`, `#expect`) for new projects on Swift 6.0+ (Xcode 16+).
 - Async tests: `await fulfillment(of: [expectation], timeout: 1)` in XCTest; `@Test` supports `async` natively.


### PR DESCRIPTION
## Summary
- Rename `## Tests` → `## Testing` in 5 language skill files (bash, go, java, kotlin, swift) to match the canonical form already used by the other 5 (csharp, python, ruby, rust, typescript).
- All 10 `language-*` skills now use a single consistent `## Testing` H2.
- Heading rename only; section bodies are untouched.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `grep -rn "^## Tests$" skills/language-*/SKILL.md` → 0 matches
- [x] `grep -rcn "^## Testing$" skills/language-*/SKILL.md | grep -c ":1$"` → 10
- [x] `bash scripts/validate.sh` → "All checks passed" (1158 passed)
- [x] `git diff --stat` shows exactly 5 files, 5 lines changed

Closes #339
