### PR TITLE
[fix] Replace non-existent integration-* skill surface in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 <!-- Check all that apply. -->
 - [ ] Skill — `principle-*`
 - [ ] Skill — `language-*`
-- [ ] Skill — `integration-*`
+- [ ] Skill — integration (`ticket-context`)
 - [ ] Skill — `workflow-*`
 - [ ] Subagent
 - [ ] Slash command

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,7 @@ assignees: ''
 <!-- Check all surfaces this proposal touches. -->
 - [ ] Skill — `principle-*`
 - [ ] Skill — `language-*`
-- [ ] Skill — `integration-*`
+- [ ] Skill — integration (`ticket-context`)
 - [ ] Skill — `workflow-*`
 - [ ] Subagent
 - [ ] Slash command


### PR DESCRIPTION
## Summary
- Replace `- [ ] Skill — \`integration-*\`` with `- [ ] Skill — integration (\`ticket-context\`)` in both issue templates
- The `integration-*` glob matched zero real skills in this repo; `ticket-context` is the one actual integration-surface skill (it integrates with external ticket systems)
- Sibling entries use `principle-*`, `language-*`, `workflow-*` globs which are real families; the integration entry now follows the same pattern but names the single real skill explicitly

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] `grep -rn 'integration-\*' .github/ISSUE_TEMPLATE/` returns nothing (dead glob gone)
- [x] `grep -rn 'Skill — integration' .github/ISSUE_TEMPLATE/` returns 2 matches (both files updated)
- [x] `ls skills/ticket-context` confirms the named skill exists in the repo
- [x] `git diff --stat` shows exactly 2 files changed, 1 line each (no collateral changes)

### Type-tailored checks ([fix])
- [x] Reproduce: was able to confirm `integration-*` matched 0 skills before the fix
- [x] Verify: checked markdown renders correctly as `ticket-context` inline code in the checkbox

Closes #335
