### PR TITLE
[fix] Clean up residual /tmp state files in workflow skills

### DIFF
--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -79,7 +79,7 @@ You apply lightweight PM lenses, not a heavy framework. No RICE math beyond Impa
    ```
    When no label was matched, drop the `--label "<chosen-label>"` segment from the `Command:` line and show `Label: none — no matching label` instead.
 
-9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar file written in step 7 and run it exactly as written — do not regenerate the title or path. Return the issue URL. If the user requests edits, revise draft and return to step 7 (overwrite both temp files, then re-present step 8 preview).
+9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar file written in step 7 and run it exactly as written — do not regenerate the title or path. Return the issue URL. After a successful `gh issue create`, delete the temp files: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/capture-<repo-slug>-<unix-timestamp>.md" "/tmp/capture-<repo-slug>-<unix-timestamp>.cmd" 2>/dev/null` (substituting the actual paths from step 7). On failure, leave the files for retry. If the user requests edits, revise draft and return to step 7 (overwrite both temp files, then re-present step 8 preview).
 
 ## Decision boundaries
 

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -56,4 +56,4 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
    ```
    When no label was matched, drop the `--label "<chosen-label>"` segment from the `Command:` line. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
-9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.
+9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL. After a successful `gh issue create`, delete the temp files: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/capture-<repo-slug>-<unix-timestamp>.md" "/tmp/capture-<repo-slug>-<unix-timestamp>.cmd" 2>/dev/null` (substituting the actual paths from step 8). On failure, leave the files for retry.

--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -105,4 +105,4 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
    ```
    When a label was matched, render `Command:` with `--label "<chosen-label>"`. When no label was matched, omit the `--label` segment entirely. **Wait for the user to reply `confirm`. Do NOT run `gh issue create` on this turn.**
 
-9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL.
+9. **File on confirm.** Only when the user replies `confirm`, read the command from the `.cmd` sidecar written in step 8 and run it exactly as written — do not regenerate the title or path. Return the issue URL. After a successful `gh issue create`, delete the temp files: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/report-issue-lugassawan-swe-workbench-<unix-timestamp>.md" "/tmp/report-issue-lugassawan-swe-workbench-<unix-timestamp>.cmd" 2>/dev/null` (substituting the actual paths from step 8). On failure, leave the files for retry.

--- a/scripts/clean-state-files.sh
+++ b/scripts/clean-state-files.sh
@@ -49,6 +49,12 @@ validate_one() {
     reject "path contains '..' traversal: $TARGET"
   fi
 
+  # Reject symlinks — rm -f on a symlink removes the link itself (not its target), which violates
+  # the "only named state files" contract even though it is technically safe.
+  if [ -L "$TARGET" ]; then
+    reject "path is a symlink: $TARGET"
+  fi
+
   # Reject directories and other non-regular files; absent files are allowed (rm -f is idempotent).
   if [ -e "$TARGET" ] && [ ! -f "$TARGET" ]; then
     reject "path is not a regular file: $TARGET"

--- a/scripts/clean-state-files.sh
+++ b/scripts/clean-state-files.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# clean-state-files.sh <file>...
+#
+# Delete named workflow state files, but only after proving each is a
+# sanctioned /tmp artifact.  Exits 1 (never silently) when any safety
+# check fails.  Called on the success path by workflow skills to remove
+# per-invocation state files under /tmp/.
+#
+# Safety checks (ALL must pass for each argument):
+#   1. Argument is non-empty, absolute, and contains no ".." segment.
+#   2. Argument is a regular file, or does not exist (rm -f is idempotent).
+#      Must NOT be a directory or other non-regular-file type.
+#   3. Path is under one of the sanctioned tmp locations:
+#        /tmp/swe-workbench-pr-review/<file>
+#        /tmp/swe-workbench-address-feedback/<file>
+#      OR basename matches ^(capture|report-issue|audit-emit|extend)- and
+#      parent directory is directly /tmp.
+#
+# Unlike clean-ephemeral.sh (which rm -rf a worktree directory), this
+# script only calls rm -f on named regular files — never recursive.
+#
+# Call form:
+#   bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" \
+#     <file1> [<file2>...] 2>/dev/null
+
+set -euo pipefail
+
+reject() {
+  printf 'clean-state-files: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$#" -gt 0 ] || reject "at least one file argument is required"
+
+# Resolve /tmp -> /private/tmp on macOS once.
+CANON_TMP=$(cd /tmp 2>/dev/null && pwd -P) || CANON_TMP="/tmp"
+
+validate_one() {
+  local TARGET="$1"
+
+  [ -n "$TARGET" ] || reject "empty file argument"
+
+  case "$TARGET" in
+    /*) ;;
+    *) reject "path must be absolute: $TARGET" ;;
+  esac
+
+  if printf '%s' "$TARGET" | grep -qE '(^|/)\.\.(\/|$)'; then
+    reject "path contains '..' traversal: $TARGET"
+  fi
+
+  # Reject directories and other non-regular files; absent files are allowed (rm -f is idempotent).
+  if [ -e "$TARGET" ] && [ ! -f "$TARGET" ]; then
+    reject "path is not a regular file: $TARGET"
+  fi
+
+  local parent base canon_parent canon_target
+  parent="$(dirname "$TARGET")"
+  base="$(basename "$TARGET")"
+  canon_parent=$(cd "$parent" 2>/dev/null && pwd -P) || canon_parent="$parent"
+  canon_target="${canon_parent}/${base}"
+
+  # Path A: under a sanctioned /tmp/swe-workbench-* directory (canonical path).
+  case "$canon_target" in
+    "${CANON_TMP}/swe-workbench-pr-review/"*)        return 0 ;;
+    "${CANON_TMP}/swe-workbench-address-feedback/"*) return 0 ;;
+  esac
+  # Fallback: raw /tmp path (handles missing parent dir when macOS /tmp -> /private/tmp).
+  case "$TARGET" in
+    "/tmp/swe-workbench-pr-review/"*)        return 0 ;;
+    "/tmp/swe-workbench-address-feedback/"*) return 0 ;;
+  esac
+
+  # Path B: basename matches a known single-file-writer pattern, parent is /tmp.
+  if [ "$canon_parent" = "$CANON_TMP" ] || [ "$parent" = "/tmp" ]; then
+    if printf '%s' "$base" | grep -qE '^(capture|report-issue|audit-emit|extend)-'; then
+      return 0
+    fi
+  fi
+
+  reject "path did not pass sanctioned-location check: $TARGET"
+}
+
+for arg in "$@"; do
+  validate_one "$arg"
+done
+
+rm -f -- "$@"

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -226,6 +226,12 @@ After all replies and resolutions land, emit the follow-up CTA:
 
 > "Want me to ping the reviewer to re-check? Reply `yes` to run `/review --check-followup <N>`."
 
+On the Phase 5 success path, delete the address-feedback state files:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-address-feedback/${PR}.json" "/tmp/swe-workbench-address-feedback/${PR}-threads.json" "/tmp/swe-workbench-address-feedback/${PR}-triage.json" 2>/dev/null
+```
+
 Then run **Phase 6 — Cleanup**.
 
 ### Phase 6 — Cleanup (always)

--- a/skills/workflow-audit-emit-issues/SKILL.md
+++ b/skills/workflow-audit-emit-issues/SKILL.md
@@ -119,7 +119,7 @@ Reply `confirm` to file all · `drop N` to remove group N · `edit N` to revise 
 
 | Reply | Action |
 |-------|--------|
-| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, delete the temp `.md` files and the `.cmd` sidecar: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" <each-md-path> <cmd-sidecar-path> 2>/dev/null` (substituting the actual paths written in Phase 3). |
+| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, delete the temp files: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" /tmp/audit-emit-<repo-slug>-<unix-ts>-1.md … /tmp/audit-emit-<repo-slug>-<unix-ts>-N.md /tmp/audit-emit-<repo-slug>-<unix-ts>.cmd 2>/dev/null` — use the actual paths written in Phase 3 (pattern: `/tmp/audit-emit-<repo-slug>-<unix-ts>-<n>.md` and `.cmd`). |
 | `drop N` | Remove group N from the batch; rewrite temp files and sidecar; re-print preview. |
 | `edit N` | Show group N's body; accept revised text; rewrite temp file; re-print preview. |
 | anything else | Re-prompt; do **not** file. |

--- a/skills/workflow-audit-emit-issues/SKILL.md
+++ b/skills/workflow-audit-emit-issues/SKILL.md
@@ -119,7 +119,7 @@ Reply `confirm` to file all · `drop N` to remove group N · `edit N` to revise 
 
 | Reply | Action |
 |-------|--------|
-| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, delete the temp `.md` files and the `.cmd` sidecar. |
+| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, delete the temp `.md` files and the `.cmd` sidecar: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" <each-md-path> <cmd-sidecar-path> 2>/dev/null` (substituting the actual paths written in Phase 3). |
 | `drop N` | Remove group N from the batch; rewrite temp files and sidecar; re-print preview. |
 | `edit N` | Show group N's body; accept revised text; rewrite temp file; re-print preview. |
 | anything else | Re-prompt; do **not** file. |

--- a/skills/workflow-extend/SKILL.md
+++ b/skills/workflow-extend/SKILL.md
@@ -86,6 +86,8 @@ Push. Then invoke `swe-workbench:workflow-commit-and-pr`. That skill will surfac
 
 Optional: if the user opts in ("append follow-on section"), fetch the current PR body first (`gh pr view --json body -q .body`), append the `## Follow-on` section, write to a tempfile, then `gh pr edit --body-file <tmp>` — this avoids overwriting collaborator edits.
 
+After Phase D delivery succeeds, delete the spec temp file: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/extend-${TS}.md" 2>/dev/null`. The `Ref: extend-${TS}` commit traceability string remains in git history; only the temp file is removed. On abort before delivery, leave the file for inspection.
+
 ## Project Detection
 
 Inherits detections from `workflow-development` for shared markers; adds extend-specific PR markers.

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -228,7 +228,7 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 ```bash
-( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}-followup.json" "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json" 2>/dev/null; \
+( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}-followup.json" "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json" 2>/dev/null || true; \
   rimba remove "pr-followup-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-followup-$PR" 2>/dev/null; \

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -228,7 +228,8 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 ```bash
-( rimba remove "pr-followup-$PR" --force 2>/dev/null \
+( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}-followup.json" "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json" 2>/dev/null; \
+  rimba remove "pr-followup-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-followup-$PR" 2>/dev/null; \
        bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -227,7 +227,7 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 ```bash
-( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}.json" "/tmp/swe-workbench-pr-review/${PR}-threads.json" 2>/dev/null; \
+( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}.json" "/tmp/swe-workbench-pr-review/${PR}-threads.json" 2>/dev/null || true; \
   rimba remove "pr-review-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-review-$PR" 2>/dev/null; \

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -227,7 +227,8 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
 ```bash
-( rimba remove "pr-review-$PR" --force 2>/dev/null \
+( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}.json" "/tmp/swe-workbench-pr-review/${PR}-threads.json" 2>/dev/null; \
+  rimba remove "pr-review-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-review-$PR" 2>/dev/null; \
        bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/scripts/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &

--- a/tests/test_capture_command.py
+++ b/tests/test_capture_command.py
@@ -1,0 +1,50 @@
+"""Tests for /swe-workbench:capture command (issue #428 state-file cleanup)."""
+
+from pathlib import Path
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+CAPTURE_MD = ROOT / "commands" / "capture.md"
+
+
+def test_capture_has_required_frontmatter():
+    """commands/capture.md must have description: and argument-hint: frontmatter."""
+    text = CAPTURE_MD.read_text()
+    fm = validate.parse_frontmatter(CAPTURE_MD, text=text)
+    assert fm is not None, "commands/capture.md must have valid frontmatter"
+    assert "description" in fm, (
+        "commands/capture.md must include a 'description:' frontmatter field"
+    )
+    assert "argument-hint" in fm, (
+        "commands/capture.md must include an 'argument-hint:' frontmatter field"
+    )
+
+
+def test_capture_step9_deletes_temp_files():
+    """commands/capture.md step 9 must invoke clean-state-files.sh on success."""
+    text = CAPTURE_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "commands/capture.md step 9 must call scripts/clean-state-files.sh "
+        "to delete the temp .md and .cmd files after successful issue creation"
+    )
+    assert "/tmp/capture-" in text, (
+        "commands/capture.md must reference the /tmp/capture-<repo-slug>-<ts>* "
+        "file pattern in the clean-state-files.sh call"
+    )
+
+
+def test_capture_step9_cleanup_on_success_only():
+    """commands/capture.md must specify that temp files are left on failure (for retry)."""
+    text = CAPTURE_MD.read_text()
+    assert "failure" in text.lower() or "retry" in text.lower(), (
+        "commands/capture.md must state that temp files are left intact on failure (for retry)"
+    )
+
+
+def test_capture_delegates_to_product_manager():
+    """commands/capture.md must delegate to the product-manager subagent."""
+    text = CAPTURE_MD.read_text()
+    assert "product-manager" in text, (
+        "commands/capture.md must reference the product-manager subagent"
+    )

--- a/tests/test_clean_state_files.py
+++ b/tests/test_clean_state_files.py
@@ -180,6 +180,27 @@ def test_rejects_capture_directory(tmp_path):
         subdir.rmdir()
 
 
+def test_rejects_symlink(tmp_path):
+    """A symlink — even under a sanctioned location — is rejected (exit 1).
+    rm -f on a symlink removes the link itself, not its target; the script's
+    'regular files only' contract requires an explicit -L rejection.
+    """
+    d = _tmp_pr_review_dir()
+    target = tmp_path / "real-file.json"
+    target.write_text("{}")
+    link = d / f"test-symlink-{tmp_path.name}.json"
+    link.symlink_to(target)
+    try:
+        result = run_script(str(link))
+        assert result.returncode != 0, (
+            f"Expected non-zero for symlink {link}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert link.exists(), "symlink must NOT be removed when rejected"
+    finally:
+        link.unlink(missing_ok=True)
+
+
 # ── rejection: path traversal ────────────────────────────────────────────────
 
 def test_rejects_dotdot_traversal():

--- a/tests/test_clean_state_files.py
+++ b/tests/test_clean_state_files.py
@@ -196,7 +196,7 @@ def test_rejects_symlink(tmp_path):
             f"Expected non-zero for symlink {link}\n"
             f"stderr: {result.stderr!r}"
         )
-        assert link.exists(), "symlink must NOT be removed when rejected"
+        assert link.is_symlink(), "symlink link inode must NOT be removed when rejected"
     finally:
         link.unlink(missing_ok=True)
 

--- a/tests/test_clean_state_files.py
+++ b/tests/test_clean_state_files.py
@@ -1,0 +1,267 @@
+"""Tests for scripts/clean-state-files.sh — file-only state cleanup helper.
+
+Mirrors tests/test_clean_ephemeral.py.  Each test invokes the script as a
+subprocess.  Exit code 0 + file removed → allowed deletion.  Exit code 1 +
+file untouched → rejected path.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "clean-state-files.sh"
+ROOT = Path(__file__).parent.parent
+TMP = Path("/tmp")
+
+
+def run_script(*paths: str, env=None):
+    merged_env = dict(_CLEAN_ENV)
+    if env is not None:
+        merged_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)] + list(paths),
+        capture_output=True, text=True,
+        cwd=str(ROOT),
+        env=merged_env,
+    )
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _tmp_pr_review_dir() -> Path:
+    d = TMP / "swe-workbench-pr-review"
+    d.mkdir(exist_ok=True)
+    return d
+
+
+def _tmp_addr_feedback_dir() -> Path:
+    d = TMP / "swe-workbench-address-feedback"
+    d.mkdir(exist_ok=True)
+    return d
+
+
+# ── script existence ──────────────────────────────────────────────────────────
+
+def test_script_exists_and_is_executable():
+    """scripts/clean-state-files.sh must exist and be executable."""
+    assert SCRIPT.exists(), f"missing {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} must be executable"
+
+
+# ── happy path: pr-review state files ────────────────────────────────────────
+
+def test_accepts_pr_review_json(tmp_path):
+    """A file under /tmp/swe-workbench-pr-review/ is accepted and deleted (exit 0)."""
+    d = _tmp_pr_review_dir()
+    f = d / f"test-clean-state-{tmp_path.name}.json"
+    f.write_text("{}")
+    try:
+        result = run_script(str(f))
+        assert result.returncode == 0, (
+            f"Expected exit 0 for valid state file {f}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert not f.exists(), "file must be removed after exit 0"
+    finally:
+        f.unlink(missing_ok=True)
+
+
+def test_accepts_pr_review_threads_json(tmp_path):
+    """A -threads.json file under /tmp/swe-workbench-pr-review/ is accepted."""
+    d = _tmp_pr_review_dir()
+    f = d / f"test-clean-state-{tmp_path.name}-threads.json"
+    f.write_text("{}")
+    try:
+        result = run_script(str(f))
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert not f.exists()
+    finally:
+        f.unlink(missing_ok=True)
+
+
+def test_accepts_two_pr_review_files(tmp_path):
+    """Passing two files in the same sanctioned directory deletes both (exit 0)."""
+    d = _tmp_pr_review_dir()
+    f1 = d / f"test-multi-{tmp_path.name}.json"
+    f2 = d / f"test-multi-{tmp_path.name}-threads.json"
+    f1.write_text("{}")
+    f2.write_text("{}")
+    try:
+        result = run_script(str(f1), str(f2))
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert not f1.exists() and not f2.exists()
+    finally:
+        f1.unlink(missing_ok=True)
+        f2.unlink(missing_ok=True)
+
+
+# ── happy path: single-file-writer patterns ───────────────────────────────────
+
+@pytest.mark.parametrize("prefix,ext", [
+    ("capture", "md"),
+    ("capture", "cmd"),
+    ("report-issue", "md"),
+    ("report-issue", "cmd"),
+    ("audit-emit", "md"),
+    ("audit-emit", "cmd"),
+    ("extend", "md"),
+])
+def test_accepts_single_file_writer_patterns(prefix, ext, tmp_path):
+    """All four single-file-writer basename patterns under /tmp are accepted."""
+    f = TMP / f"{prefix}-{tmp_path.name}.{ext}"
+    f.write_text("test")
+    try:
+        result = run_script(str(f))
+        assert result.returncode == 0, (
+            f"Expected exit 0 for {prefix!r} pattern ({ext})\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert not f.exists(), f"{f} must be removed"
+    finally:
+        f.unlink(missing_ok=True)
+
+
+# ── happy path: idempotent on missing file ────────────────────────────────────
+
+def test_idempotent_on_missing_pr_review_file():
+    """A valid path that does not exist exits 0 (rm -f is idempotent)."""
+    f = "/tmp/swe-workbench-pr-review/nonexistent-clean-state-test.json"
+    result = run_script(f)
+    assert result.returncode == 0, (
+        f"Expected exit 0 for missing-but-valid path {f!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_idempotent_on_missing_capture_file():
+    """A valid capture- path that does not exist exits 0."""
+    f = "/tmp/capture-nonexistent-clean-state-test-99999.md"
+    result = run_script(f)
+    assert result.returncode == 0, (
+        f"Expected exit 0 for missing-but-valid path {f!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+# ── rejection: directory ──────────────────────────────────────────────────────
+
+def test_rejects_directory(tmp_path):
+    """A directory — even under a sanctioned location — is rejected (exit 1)."""
+    d = _tmp_pr_review_dir()
+    subdir = d / f"test-dir-{tmp_path.name}"
+    subdir.mkdir(exist_ok=True)
+    try:
+        result = run_script(str(subdir))
+        assert result.returncode != 0, (
+            f"Expected non-zero for directory {subdir}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert subdir.exists(), "directory must NOT be deleted when rejected"
+    finally:
+        subdir.rmdir()
+
+
+def test_rejects_capture_directory(tmp_path):
+    """A directory with a capture- prefix directly in /tmp is rejected."""
+    subdir = TMP / f"capture-test-dir-{tmp_path.name}"
+    subdir.mkdir(exist_ok=True)
+    try:
+        result = run_script(str(subdir))
+        assert result.returncode != 0, (
+            f"Expected non-zero for directory {subdir}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert subdir.exists(), "directory must NOT be deleted when rejected"
+    finally:
+        subdir.rmdir()
+
+
+# ── rejection: path traversal ────────────────────────────────────────────────
+
+def test_rejects_dotdot_traversal():
+    """Paths with .. segments are rejected."""
+    result = run_script("/tmp/swe-workbench-pr-review/../../../etc/passwd")
+    assert result.returncode != 0, (
+        "Expected non-zero for path with .. traversal\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_rejects_dotdot_in_capture_path():
+    """.. in a capture- prefixed path is rejected."""
+    result = run_script("/tmp/capture-repo-123/../../../etc/shadow")
+    assert result.returncode != 0, (
+        "Expected non-zero for path with .. traversal\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+# ── rejection: unsanctioned locations ────────────────────────────────────────
+
+def test_rejects_relative_path():
+    """Relative paths (not starting with /) are rejected."""
+    result = run_script("capture-repo-123.md")
+    assert result.returncode != 0, (
+        "Expected non-zero for relative path\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+@pytest.mark.parametrize("bad_path", [
+    "/",
+    "",
+    os.environ.get("HOME", "/Users/testuser") + "/secrets.json",
+    "/usr/local/bin/env",
+    "/tmp/evil.json",
+])
+def test_rejects_unsanctioned_paths(bad_path):
+    """Root, empty, $HOME paths, and /tmp/<no-prefix> are rejected."""
+    result = run_script(bad_path)
+    assert result.returncode != 0, (
+        f"Expected non-zero for unsanctioned path {bad_path!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_rejects_tmp_subdir_wrong_prefix(tmp_path):
+    """A file in /tmp/ whose basename does not match any prefix pattern is rejected."""
+    f = TMP / f"wrongprefix-{tmp_path.name}.json"
+    f.write_text("{}")
+    try:
+        result = run_script(str(f))
+        assert result.returncode != 0, (
+            f"Expected non-zero for wrong-prefix {f}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert f.exists(), "file must NOT be deleted when rejected"
+    finally:
+        f.unlink(missing_ok=True)
+
+
+def test_rejects_no_args():
+    """Calling the script with no arguments exits 1."""
+    result = run_script()
+    assert result.returncode != 0, "Expected non-zero for zero arguments"
+
+
+# ── rejection: one invalid arg prevents all deletions ────────────────────────
+
+def test_one_bad_arg_prevents_all_deletions(tmp_path):
+    """If one arg fails validation, no files are deleted."""
+    d = _tmp_pr_review_dir()
+    good = d / f"test-guard-{tmp_path.name}.json"
+    good.write_text("{}")
+    bad = "/tmp/evil.json"
+    try:
+        result = run_script(str(good), bad)
+        assert result.returncode != 0, (
+            f"Expected non-zero when one arg is invalid\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert good.exists(), "valid file must NOT be deleted when another arg is invalid"
+    finally:
+        good.unlink(missing_ok=True)

--- a/tests/test_extend_command.py
+++ b/tests/test_extend_command.py
@@ -194,3 +194,30 @@ def test_extend_skill_under_orchestrator_cap():
         f"skills/workflow-extend/SKILL.md has {line_count} lines — "
         f"exceeds the 300-line orchestrator cap"
     )
+
+
+# --- State-file cleanup assertions (issue #428) ---
+
+def test_extend_skill_phase_d_deletes_tmp_file():
+    """SKILL.md Phase D must invoke clean-state-files.sh on /tmp/extend-${TS}.md after delivery."""
+    text = SKILL_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "SKILL.md Phase D must call scripts/clean-state-files.sh to remove /tmp/extend-${TS}.md "
+        "after successful delivery"
+    )
+    assert "/tmp/extend-${TS}.md" in text, (
+        "SKILL.md must pass /tmp/extend-${TS}.md to clean-state-files.sh"
+    )
+
+
+def test_extend_skill_cleanup_after_delivery():
+    """SKILL.md: clean-state-files.sh call must appear AFTER Phase D delivery text (success-only)."""
+    text = SKILL_MD.read_text()
+    phase_d_idx = text.find("## Phase D")
+    cleanup_idx = text.find("clean-state-files.sh")
+    assert phase_d_idx != -1, "SKILL.md must have a Phase D section"
+    assert cleanup_idx != -1, "SKILL.md must reference clean-state-files.sh"
+    assert cleanup_idx > phase_d_idx, (
+        "clean-state-files.sh call must appear within/after Phase D — "
+        "cleanup runs on the success delivery path only"
+    )

--- a/tests/test_product_manager_agent.py
+++ b/tests/test_product_manager_agent.py
@@ -1,0 +1,52 @@
+"""Tests for agents/product-manager.md (issue #428 state-file cleanup)."""
+
+from pathlib import Path
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+AGENT_MD = ROOT / "agents" / "product-manager.md"
+
+
+def test_product_manager_has_required_frontmatter():
+    """agents/product-manager.md must have description: frontmatter."""
+    text = AGENT_MD.read_text()
+    fm = validate.parse_frontmatter(AGENT_MD, text=text)
+    assert fm is not None, "agents/product-manager.md must have valid frontmatter"
+    assert "description" in fm, (
+        "agents/product-manager.md must include a 'description:' frontmatter field"
+    )
+
+
+def test_product_manager_step9_deletes_temp_files():
+    """agents/product-manager.md step 9 must invoke clean-state-files.sh on success."""
+    text = AGENT_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "agents/product-manager.md step 9 must call scripts/clean-state-files.sh "
+        "to delete the temp .md and .cmd files after successful issue creation"
+    )
+    assert "/tmp/capture-" in text, (
+        "agents/product-manager.md must reference the /tmp/capture-<repo-slug>-<ts>* "
+        "file pattern in the clean-state-files.sh call"
+    )
+
+
+def test_product_manager_step9_cleanup_on_success_only():
+    """agents/product-manager.md must specify that temp files are left on failure (for retry)."""
+    text = AGENT_MD.read_text()
+    assert "failure" in text.lower() or "retry" in text.lower(), (
+        "agents/product-manager.md must state that temp files are left intact on failure (for retry)"
+    )
+
+
+def test_product_manager_confirm_gate_before_cleanup():
+    """Cleanup must occur AFTER confirm, not before (cleanup is on success path only)."""
+    text = AGENT_MD.read_text()
+    confirm_pos = text.find("confirm")
+    cleanup_pos = text.find("clean-state-files.sh")
+    assert confirm_pos != -1, "agents/product-manager.md must mention 'confirm'"
+    assert cleanup_pos != -1, "agents/product-manager.md must mention clean-state-files.sh"
+    assert confirm_pos < cleanup_pos, (
+        "The 'confirm' gate must appear before the clean-state-files.sh call — "
+        "cleanup runs on the success path only, after gh issue create succeeds"
+    )

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -152,3 +152,26 @@ def test_report_issue_redaction_before_preview():
     assert redaction_pos < redacted_line_pos < confirm_pos, (
         "Order must be: 'Redaction pass' → 'Redacted:' line → \"Reply 'confirm'\""
     )
+
+
+# --- State-file cleanup assertions (issue #428) ---
+
+def test_report_issue_step9_deletes_temp_files():
+    """commands/report-issue.md step 9 must invoke clean-state-files.sh on success."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "commands/report-issue.md step 9 must call scripts/clean-state-files.sh "
+        "to delete the temp .md and .cmd files after successful issue creation"
+    )
+    assert "/tmp/report-issue-lugassawan-swe-workbench-" in text, (
+        "commands/report-issue.md must reference the /tmp/report-issue-lugassawan-swe-workbench-* "
+        "file pattern in the clean-state-files.sh call"
+    )
+
+
+def test_report_issue_step9_cleanup_on_success_only():
+    """commands/report-issue.md must specify that temp files are left on failure."""
+    text = REPORT_ISSUE_MD.read_text()
+    assert "failure" in text.lower() or "on failure" in text.lower() or "retry" in text.lower(), (
+        "commands/report-issue.md must state that temp files are left intact on failure (for retry)"
+    )

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -313,3 +313,64 @@ def test_address_feedback_skill_no_bare_rm_rf_wt():
         f"Found bare rm -rf \"$WT\" lines in Phase 6 (should use clean-ephemeral.sh):\n"
         + "\n".join(lines_with_rm)
     )
+
+
+# --- State-file cleanup assertions (issue #428) ---
+
+def test_address_feedback_skill_deletes_three_state_files():
+    """Phase 5 success path must invoke clean-state-files.sh with all three state files."""
+    text = SKILL_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "SKILL.md must call scripts/clean-state-files.sh to remove address-feedback state files"
+    )
+    assert "/tmp/swe-workbench-address-feedback/${PR}.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-address-feedback/${PR}.json to clean-state-files.sh"
+    )
+    assert "/tmp/swe-workbench-address-feedback/${PR}-threads.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-address-feedback/${PR}-threads.json to clean-state-files.sh"
+    )
+    assert "/tmp/swe-workbench-address-feedback/${PR}-triage.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-address-feedback/${PR}-triage.json to clean-state-files.sh"
+    )
+
+
+def test_address_feedback_skill_triage_cleanup_before_phase6():
+    """${PR}-triage.json removal must appear BEFORE ### Phase 6 (Q-quit safety invariant).
+
+    Phase 6 fires on Q-quit too.  triage.json is durable resume state that must survive Q-quit
+    so the user can resume from Phase 3.  Removing it on the Phase 5 success path (before Phase 6)
+    ensures Q-quit leaves it intact.
+    """
+    text = SKILL_MD.read_text()
+    triage_cleanup_idx = text.find("/tmp/swe-workbench-address-feedback/${PR}-triage.json")
+    phase6_idx = text.find("### Phase 6")
+    assert triage_cleanup_idx != -1, (
+        "SKILL.md must reference /tmp/swe-workbench-address-feedback/${PR}-triage.json for cleanup"
+    )
+    assert phase6_idx != -1, "SKILL.md must have a ### Phase 6 section"
+    assert triage_cleanup_idx < phase6_idx, (
+        "triage.json cleanup must appear BEFORE ### Phase 6 — "
+        "Phase 6 also fires on Q-quit; triage.json must survive Q-quit for resume"
+    )
+
+
+def test_address_feedback_skill_phase6_does_not_delete_triage_json():
+    """Phase 6 code block must NOT contain a triage.json deletion (Q-quit must leave it intact)."""
+    text = SKILL_MD.read_text()
+    phase6_idx = text.find("### Phase 6")
+    assert phase6_idx != -1, "Phase 6 section must exist"
+    # Extract only up to the next top-level section (## Failure modes or ## Common mistakes).
+    next_section = re.search(r'\n## ', text[phase6_idx:])
+    phase6_text = text[phase6_idx: phase6_idx + next_section.start()] if next_section else text[phase6_idx:]
+    # triage.json must not appear in the Phase 6 action blocks (only in the failure-modes table which follows)
+    # Filter out lines that are in a table row referencing the failure-mode description
+    phase6_lines_with_triage = [
+        line for line in phase6_text.splitlines()
+        if "triage.json" in line
+        and not line.lstrip().startswith("|")   # table rows describe the failure, not Phase 6 actions
+    ]
+    assert not phase6_lines_with_triage, (
+        "Phase 6 action blocks must NOT delete triage.json — Phase 6 runs on Q-quit too, and "
+        "triage.json is durable resume state that must survive Q-quit.\n"
+        "Lines found: " + "\n".join(phase6_lines_with_triage)
+    )

--- a/tests/test_workflow_audit_emit_issues_skill.py
+++ b/tests/test_workflow_audit_emit_issues_skill.py
@@ -251,6 +251,31 @@ def test_catalog_md_contains_name():
     )
 
 
+# ── state-file cleanup assertions (issue #428) ───────────────────────────────
+
+def test_audit_emit_uses_clean_state_files_for_deletion():
+    """SKILL.md Phase 4 confirm path must invoke clean-state-files.sh (not inline rm -f)."""
+    text = SKILL_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "SKILL.md Phase 4 must call scripts/clean-state-files.sh to delete temp files after "
+        "successful issue filing — migrated from inline rm for consistency (issue #428)"
+    )
+
+
+def test_audit_emit_cleanup_on_confirm_success():
+    """clean-state-files.sh must appear in the confirm-success row of the Phase 4 table."""
+    text = SKILL_MD.read_text()
+    # The confirm row contains clean-state-files.sh in its action description
+    confirm_idx = text.find("`confirm` (literal)")
+    cleanup_idx = text.find("clean-state-files.sh")
+    assert confirm_idx != -1, "SKILL.md must have a 'confirm' table row"
+    assert cleanup_idx != -1, "SKILL.md must reference clean-state-files.sh"
+    # The cleanup instruction should appear near the confirm row (within 500 chars)
+    assert abs(cleanup_idx - confirm_idx) < 500, (
+        "clean-state-files.sh must appear within the Phase 4 confirm table row"
+    )
+
+
 def test_readme_contains_name():
     readme = ROOT / "README.md"
     text = readme.read_text()

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -144,3 +144,13 @@ def test_followup_skill_state_cleanup_inside_background_subshell():
     assert subshell_match, (
         "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
     )
+
+
+def test_followup_skill_state_cleanup_has_or_true_guard():
+    """clean-state-files.sh call must be followed by || true so set -e in the subshell cannot
+    abort rimba remove when the state files are already absent or fail validation."""
+    text = SKILL_MD.read_text()
+    assert re.search(r'clean-state-files\.sh.*?\|\|\s*true', text, re.DOTALL), (
+        "SKILL.md Step 7 clean-state-files.sh call must use '|| true' so a non-zero exit "
+        "does not abort rimba remove via set -e propagation into the background subshell"
+    )

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -119,3 +119,28 @@ def test_followup_skill_has_owner_repo_guard_clause():
         "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
         "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
     )
+
+
+# --- State-file cleanup assertions (issue #428) ---
+
+def test_followup_skill_cleanup_deletes_followup_json():
+    """Step 7 success-path subshell must invoke clean-state-files.sh with the followup state files."""
+    text = SKILL_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "SKILL.md Step 7 must call scripts/clean-state-files.sh to remove per-run followup state files"
+    )
+    assert "/tmp/swe-workbench-pr-review/${PR}-followup.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-pr-review/${PR}-followup.json to clean-state-files.sh"
+    )
+    assert "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-pr-review/${PR}-followup-threads.json to clean-state-files.sh"
+    )
+
+
+def test_followup_skill_state_cleanup_inside_background_subshell():
+    """clean-state-files.sh must appear inside the background ( ... ) & subshell."""
+    text = SKILL_MD.read_text()
+    subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
+    assert subshell_match, (
+        "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
+    )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -99,3 +99,29 @@ def test_pr_review_skill_no_bare_rm_rf_wt():
         f"Found bare rm -rf \"$WT\" lines (should use clean-ephemeral.sh):\n"
         + "\n".join(lines_with_rm)
     )
+
+
+# --- State-file cleanup assertions (issue #428) ---
+
+def test_pr_review_skill_cleanup_deletes_pr_json():
+    """Step 7 success-path subshell must invoke clean-state-files.sh with the PR state files."""
+    text = SKILL_MD.read_text()
+    assert "clean-state-files.sh" in text, (
+        "SKILL.md Step 7 must call scripts/clean-state-files.sh to remove per-run state files"
+    )
+    assert "/tmp/swe-workbench-pr-review/${PR}.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-pr-review/${PR}.json to clean-state-files.sh"
+    )
+    assert "/tmp/swe-workbench-pr-review/${PR}-threads.json" in text, (
+        "SKILL.md must pass /tmp/swe-workbench-pr-review/${PR}-threads.json to clean-state-files.sh"
+    )
+
+
+def test_pr_review_skill_state_cleanup_inside_background_subshell():
+    """clean-state-files.sh must appear inside the background ( ... ) & subshell (success-path only)."""
+    text = SKILL_MD.read_text()
+    # The subshell is opened with '(' and closed with ') &' — find it
+    subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
+    assert subshell_match, (
+        "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
+    )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -125,3 +125,13 @@ def test_pr_review_skill_state_cleanup_inside_background_subshell():
     assert subshell_match, (
         "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
     )
+
+
+def test_pr_review_skill_state_cleanup_has_or_true_guard():
+    """clean-state-files.sh call must be followed by || true so set -e in the subshell cannot
+    abort rimba remove when the state files are already absent or fail validation."""
+    text = SKILL_MD.read_text()
+    assert re.search(r'clean-state-files\.sh.*?\|\|\s*true', text, re.DOTALL), (
+        "SKILL.md Step 7 clean-state-files.sh call must use '|| true' so a non-zero exit "
+        "does not abort rimba remove via set -e propagation into the background subshell"
+    )


### PR DESCRIPTION
## Summary

- Add `scripts/clean-state-files.sh`: a guarded file-only helper (sibling of `clean-ephemeral.sh`) that validates each argument (absolute, no `..` traversal, regular file or absent, under a sanctioned `/tmp/swe-workbench-*` directory or matching a known single-file-writer prefix) before `rm -f -- "$@"`. Never recursive.
- Call the helper on the **success path** of six workflow surfaces so per-invocation `/tmp/` state files are cleaned up after each run. Abort/error paths intentionally leave files intact for inspection (mirrors the "leave the worktree on abort" convention).
- Surfaces updated: `workflow-pr-review` (Step 7 subshell), `workflow-pr-review-followup` (Step 7 subshell), `workflow-address-feedback` (Phase 5, before Phase 6 — preserving `triage.json` on Q-quit), `commands/capture.md` + `commands/report-issue.md` + `agents/product-manager.md` (step 9 on confirm), `workflow-extend` (Phase D after delivery), `workflow-audit-emit-issues` (Phase 4 confirm — migrated from inline `rm`).
- Add 26 tests in `tests/test_clean_state_files.py` mirroring `test_clean_ephemeral.py`; add `tests/test_capture_command.py` and `tests/test_product_manager_agent.py`; extend 6 existing test files with cleanup-call assertions and the address-feedback Q-quit safety invariant.

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `shellcheck scripts/clean-state-files.sh` passes with 0 issues
- [x] `bash scripts/validate.sh` passes (all checks)
- [x] `pytest tests/ -v` — 1209 passed, 0 failed (including 26 new tests for the helper and new tests for all 6 surfaces)

### Type-tailored checks ([fix])

- [x] Verified each cleanup call sits on the success path only (abort/error preserves files)
- [x] Verified `workflow-address-feedback` triage.json cleanup appears before `### Phase 6` (Q-quit safety invariant — `test_address_feedback_skill_triage_cleanup_before_phase6` asserts this)
- [x] Verified Phase 6 does NOT delete `triage.json` (`test_address_feedback_skill_phase6_does_not_delete_triage_json`)
- [x] Verified `clean-state-files.sh` rejects directories, `..` traversal, out-of-tmp paths, and paths with wrong prefix

Closes #428
