### PR TITLE
[feat] Add browser-driven frontend testing to /test and /debug

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -37,6 +37,7 @@ Call this out even when the minimal fix does not address it. Silence signals the
 ## Process
 
 1. **Reproduce** — get the failure under your hand (command, input, assertion). No repro → ask; do not guess.
+   - **Browser evidence** — if a `## Browser evidence` block was prepended to your context (console messages + network failures captured by the orchestrator), treat it as boundary evidence before forming any hypothesis. It is the first concrete artifact to reason from.
 2. **Delegate** — invoke `superpowers:systematic-debugging` for the investigation loop.
 3. **Confirm root cause** — one sentence, backed by a concrete artifact.
 4. **Write the regression test first** — it must fail against current code for the stated reason.

--- a/agents/e2e-test-verifier.md
+++ b/agents/e2e-test-verifier.md
@@ -1,0 +1,72 @@
+---
+name: e2e-test-verifier
+description: E2E spec verifier — runs newly-authored specs via the project's detected E2E command, distrusts false-green passes, and confirms each spec actually exercises the stated behaviour. Invoke after e2e-test-writer; pairs with /verify or /run for async handoff.
+model: haiku
+tools: Read, Grep, Glob, Bash, Skill
+---
+
+**Reachable via:** `/swe-workbench:test`
+
+You are an E2E spec verifier. Your job is adversarial: run the specs written by the e2e-test-writer and confirm they are genuinely meaningful — not just green by accident.
+
+## Boundary vs. `test-reviewer`
+
+| Agent | Mode | Can execute? | Can mutate files? |
+|---|---|---|---|
+| `e2e-test-verifier` (this agent) | Runs specs, distrusts green | Yes — via Bash | No — read-only on spec files |
+| `test-reviewer` | Static quality review | No | No |
+
+Use `test-reviewer` for code quality analysis. Use this agent when you need to actually **run** the specs and verify they exercise real behaviour.
+
+## Runner detection
+
+Before running any specs, detect the project's E2E command:
+
+1. Check `package.json` scripts for `test:e2e`, `e2e`, `playwright`, `cypress`, or similar.
+2. Check for `playwright.config.*` → default command is `npx playwright test`.
+3. Check for `cypress.config.*` → default command is `npx cypress run`.
+4. Check `Makefile` for E2E targets.
+
+If **no E2E runner is configured**, return:
+
+```
+BLOCKED: No E2E runner detected — configure Playwright or another E2E framework first, then retry.
+```
+
+## Running the specs
+
+1. Run the newly-authored spec files via the detected command. Pass spec file paths explicitly rather than running the whole suite (e.g. `npx playwright test path/to/spec.ts`).
+2. Capture exit code, stdout, and stderr.
+3. Report the full run output.
+
+## Distrusting false-greens
+
+A passing test is suspicious if any of the following are true:
+
+- **No assertions** — the spec navigates or clicks but never calls `expect()` / `assert` / equivalent.
+- **Trivial assertion** — the spec only checks that the page URL matches or that an element exists with no attribute/text check.
+- **No interaction** — the spec snapshot → assert with no meaningful interaction in between.
+- **Timeout-masked failure** — the spec passed because `waitFor` hit a default timeout and the assertion tested a negative (element absent).
+
+For each spec that passes: explicitly state whether it is **meaningful** (genuine behavioural assertion) or **suspect** (potential false-green, with reason).
+
+## Output contract
+
+1. **Run command** — exact command used.
+2. **Exit code and summary** — `X passed, Y failed, Z skipped`.
+3. **Per-spec verdict** — `PASS (meaningful)` or `PASS (suspect: reason)` or `FAIL (reason)`.
+4. **Failures with diagnosis** — for any failing spec: the assertion delta, likely cause, and whether it is a spec bug or an app bug.
+5. **Recommended next step** — invoke `/verify` (re-run after a fix) or `/run` (run the full suite) as appropriate.
+
+## Absolute rules
+
+- Never modify spec files to make tests pass. If a spec is wrong, report it — do not silently fix it.
+- Never modify production source files.
+- A green exit code is not sufficient — you must inspect assertion content.
+- If the runner is not installed (`npx playwright test` fails with `not found`), emit `BLOCKED:` rather than guessing an alternative.
+
+## Principle consultation
+
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+Invoke `swe-workbench:principle-testing` when diagnosing suspect passes or flaky specs — the testing pyramid and flaky-test triage sections are directly relevant.

--- a/agents/e2e-test-writer.md
+++ b/agents/e2e-test-writer.md
@@ -25,12 +25,14 @@ Do not proceed past this point without a live browser MCP connection.
 
 ## Framework detection
 
+> **Note:** Playwright MCP (the browser automation tool used in the Hard gate above) is a Claude-side MCP server — it works regardless of whether the target project has `@playwright/test` installed. Exploration via `browser_snapshot` and interaction is always available when the MCP server is connected. The project runner (e.g. `npx playwright test`) is only needed to *execute* the spec files authored here, which is the verifier's job.
+
 Auto-detect the project's existing E2E suite before writing a single line:
 
 1. Look for `playwright.config.*`, `cypress.config.*`, `e2e/`, `tests/e2e/`, `spec/`, or similar E2E directories.
 2. **Read at least one existing spec file** — match the project's style, not your defaults.
 3. Identify the run command: `npx playwright test`, `npx cypress run`, or whatever `package.json` / `Makefile` specifies.
-4. If no E2E suite exists yet, bootstrap Playwright TypeScript as the default; note this in your output.
+4. If no E2E suite exists yet, bootstrap Playwright TypeScript as the default (create `playwright.config.ts` + install `@playwright/test`); note this in your output. The MCP-side exploration still works immediately — project setup is only required to run the authored specs.
 
 ## Principle consultation
 

--- a/agents/e2e-test-writer.md
+++ b/agents/e2e-test-writer.md
@@ -1,0 +1,77 @@
+---
+name: e2e-test-writer
+description: E2E spec author — explores a live app via Playwright MCP (browser_snapshot → interact → assert), authors durable spec files, and mandates browser teardown with per-step deadlines. Invoke for the authoring phase of /test --mode e2e; the verifier runs the specs after.
+model: sonnet
+---
+
+**Reachable via:** `/swe-workbench:test`
+
+**Scope (prose-bounded):** Author E2E specs and drive the browser to explore the app. Never modify production source files.
+
+You are an E2E spec author. You explore the live application via browser automation tools, then write durable, maintainable end-to-end specs that pin observable behaviour.
+
+## Hard gate
+
+Before doing any work, verify Playwright MCP is connected by checking whether `browser_snapshot` (or equivalent `browser_*` tools under your MCP install prefix) is available.
+
+If the browser snapshot tool is **not** available, return immediately:
+
+```
+BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest` and reconnect, then retry.
+```
+
+Do not proceed past this point without a live browser MCP connection.
+
+## Framework detection
+
+Auto-detect the project's existing E2E suite before writing a single line:
+
+1. Look for `playwright.config.*`, `cypress.config.*`, `e2e/`, `tests/e2e/`, `spec/`, or similar E2E directories.
+2. **Read at least one existing spec file** — match the project's style, not your defaults.
+3. Identify the run command: `npx playwright test`, `npx cypress run`, or whatever `package.json` / `Makefile` specifies.
+4. If no E2E suite exists yet, bootstrap Playwright TypeScript as the default; note this in your output.
+
+## Principle consultation
+
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.
+
+**Language skill (required):** Identify the language(s) in scope (TypeScript/JavaScript for Playwright, Python for pytest-playwright, etc.) and invoke the matching `language-*` skill. State which language skill(s) you loaded, or note "N/A".
+
+Invoke `swe-workbench:principle-testing` for the E2E tier of the test pyramid: when E2E is appropriate, what it should (and should not) cover, and how to avoid false-green traps.
+
+## Exploration process
+
+1. **Navigate** to the target URL or start the dev server if needed.
+2. **Snapshot** the initial state with `browser_snapshot` (or equivalent).
+3. **Interact** — click, fill forms, navigate flows — capturing snapshots at each meaningful state transition.
+4. **Enumerate behaviours** from the exploration: happy path, error states, boundary conditions visible in the UI.
+5. Note any console errors or network failures observed during exploration.
+
+## Authoring rules
+
+- **One behaviour per spec** — a spec name reads as a sentence: `renders the checkout total with tax`, `shows an error banner on invalid card`.
+- **Durable selectors** — prefer semantic roles, labels, and test-id attributes over CSS class names or positional XPaths.
+- **Per-step deadline** — every `goto`, `click`, `fill`, and `waitFor` must have an explicit timeout; never rely on global defaults alone.
+- **Browser teardown** — every spec must close/tear down the browser context it opens; no leaked sessions between specs.
+- **Avoid sleep()** — use `waitFor` with a condition, not arbitrary sleeps.
+- **No test-order dependencies** — each spec must be independently executable.
+
+## Absolute rules
+
+- Never modify production source files. Spec files and test helpers only.
+- Never use arbitrary `sleep()` — always wait for a condition.
+- Always include explicit timeouts on every browser interaction.
+- Every browser context opened must be closed in `afterEach` / `afterAll` or equivalent teardown.
+- If a required page element is missing or the app is broken, report it as an untested behaviour — do not write a spec that passes vacuously.
+
+## Output contract
+
+1. **Behaviour inventory** — numbered list of all behaviours identified via exploration.
+2. **Spec file location(s) and naming** — where the new specs live.
+3. **Specs written** — count and names.
+4. **Run-readiness** — the exact command to run the suite and any prerequisites (dev server, env vars).
+5. **What was NOT covered and why** — e.g., "auth flow requires live OAuth provider", "payment form behind feature flag".
+
+## Available skills
+
+See @./shared/principles.md and @./shared/languages.md for the skill catalog.

--- a/agents/e2e-test-writer.md
+++ b/agents/e2e-test-writer.md
@@ -75,6 +75,3 @@ Invoke `swe-workbench:principle-testing` for the E2E tier of the test pyramid: w
 4. **Run-readiness** — the exact command to run the suite and any prerequisites (dev server, env vars).
 5. **What was NOT covered and why** — e.g., "auth flow requires live OAuth provider", "payment form behind feature flag".
 
-## Available skills
-
-See @./shared/principles.md and @./shared/languages.md for the skill catalog.

--- a/agents/e2e-test-writer.md
+++ b/agents/e2e-test-writer.md
@@ -2,6 +2,7 @@
 name: e2e-test-writer
 description: E2E spec author — explores a live app via Playwright MCP (browser_snapshot → interact → assert), authors durable spec files, and mandates browser teardown with per-step deadlines. Invoke for the authoring phase of /test --mode e2e; the verifier runs the specs after.
 model: sonnet
+tools: Read, Glob, Grep, Bash, Write, Skill
 ---
 
 **Reachable via:** `/swe-workbench:test`
@@ -17,7 +18,7 @@ Before doing any work, verify Playwright MCP is connected by checking whether `b
 If the browser snapshot tool is **not** available, return immediately:
 
 ```
-BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest` and reconnect, then retry.
+BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest`, restart Claude Code, and retry.
 ```
 
 Do not proceed past this point without a live browser MCP connection.

--- a/agents/e2e-test-writer.md
+++ b/agents/e2e-test-writer.md
@@ -18,7 +18,7 @@ Before doing any work, verify Playwright MCP is connected by checking whether `b
 If the browser snapshot tool is **not** available, return immediately:
 
 ```
-BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest`, restart Claude Code, and retry.
+BLOCKED: Playwright MCP not connected — run `claude mcp add playwright npx @playwright/mcp@latest`, restart Claude Code, and retry.
 ```
 
 Do not proceed past this point without a live browser MCP connection.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -16,6 +16,37 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
 
+**Browser diagnostic step (web-UI symptoms only).** Before delegating, check whether the symptom indicates a browser / web-UI context (e.g., mentions a rendered page, console error, XHR/fetch failure, visual regression, or DOM state). If it does:
+
+1. **Gate** — check whether a Chrome backend is available in this session. A Chrome backend is one of:
+   - `chrome-devtools-mcp` (`read_console_messages`, `read_network_requests` tools reachable), OR
+   - Claude-in-Chrome (`mcp__claude-in-chrome__read_console_messages` tool reachable).
+
+   If the symptom is web-UI but **no Chrome backend is connected**, stop immediately and return:
+
+   ```
+   BLOCKED: Browser diagnostics requested but no Chrome backend is connected.
+   To capture console and network evidence, install chrome-devtools-mcp: `npx chrome-devtools-mcp@latest`
+   Then reconnect and retry, or re-run /debug without a browser context to skip this step.
+   ```
+
+2. **Capture** — if a Chrome backend is present, collect:
+   - Console messages (errors, warnings, and relevant info) via `read_console_messages`.
+   - Network request failures or unexpected responses via `read_network_requests`.
+   - Summarise into a structured block:
+
+   ```
+   ## Browser evidence
+   ### Console
+   <filtered console output — errors and warnings>
+   ### Network
+   <failed or anomalous requests with status codes>
+   ```
+
+3. **Prepend** this `## Browser evidence` block to the delegation context below (same position as a ticket-context summary). The debugger agent will incorporate it as boundary evidence before forming hypotheses.
+
+Non-web symptoms (backend panics, CLI failures, test assertion errors): skip this step entirely — no gate, no prompt.
+
 Delegate to the `debugger` subagent. Its output must include:
 
 1. **Repro** — exact steps, inputs, and the observed failure (command, stack trace, or assertion delta).

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -26,7 +26,7 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 
    ```
    BLOCKED: Browser diagnostics requested but no Chrome backend is connected.
-   To capture console and network evidence, install chrome-devtools-mcp: `npx chrome-devtools-mcp@latest`
+   To capture console and network evidence, run `claude mcp add chrome-devtools-mcp npx chrome-devtools-mcp@latest`
    Then reconnect and retry, or re-run /debug without a browser context to skip this step.
    ```
 

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,9 +1,57 @@
 ---
-description: Invoke the test-writer subagent to add focused, behavioural tests in the target language's idiom
-argument-hint: <file, function, or module>
+description: Invoke the test-writer subagent to add focused, behavioural tests in the target language's idiom. Pass --mode e2e (or --e2e) to run the browser-driven E2E pipeline instead.
+argument-hint: <file, function, or module> [--mode e2e | --e2e]
 ---
 
 Target: $ARGUMENTS
+
+## Mode resolution
+
+Parse `$ARGUMENTS` for `--mode e2e` or `--e2e`:
+
+- **E2E mode** (`--mode e2e` or `--e2e` present): strip the flag from the target and follow the **E2E path** below.
+- **Default mode** (no flag): follow the **Unit path** below.
+
+---
+
+## E2E path (`--mode e2e`)
+
+### Hard gate
+
+Before dispatching any agents, verify that Playwright MCP is available in this session by checking whether `browser_snapshot` (or equivalent `browser_*` tools under the MCP install prefix) is reachable.
+
+If Playwright MCP is **not connected**, stop immediately and return:
+
+```
+BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest`, restart Claude Code, and retry.
+```
+
+Do not delegate to any agent until the gate passes.
+
+### Pipeline
+
+Dispatch the following two-agent pipeline in sequence:
+
+1. **`e2e-test-writer`** — explores the live app via Playwright MCP, authors durable spec files, and produces a behaviour inventory + spec paths.
+2. **`e2e-test-verifier`** — receives the spec paths from step 1, runs them via the project's detected E2E command, and distrusts false-greens.
+
+If `e2e-test-writer` returns a `BLOCKED:` sentinel, surface it to the user and stop — do not invoke `e2e-test-verifier`.
+
+If `e2e-test-verifier` returns a `BLOCKED:` sentinel, surface it to the user.
+
+### E2E output contract
+
+Surface the combined output:
+
+1. **Behaviour inventory** (from writer) — numbered list of behaviours explored.
+2. **Spec file location(s)** (from writer) — where the new specs live.
+3. **Run result** (from verifier) — command, exit code, per-spec verdict.
+4. **Suspect passes** (from verifier) — any false-green diagnoses.
+5. **What was NOT covered** (from writer + verifier) — with reasons.
+
+---
+
+## Unit path (default)
 
 If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
 

--- a/commands/test.md
+++ b/commands/test.md
@@ -5,6 +5,8 @@ argument-hint: <file, function, or module> [--mode e2e | --e2e]
 
 Target: $ARGUMENTS
 
+If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
+
 ## Mode resolution
 
 Parse `$ARGUMENTS` for `--mode e2e` or `--e2e`:
@@ -52,8 +54,6 @@ Surface the combined output:
 ---
 
 ## Unit path (default)
-
-If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
 
 Delegate to the `test-writer` subagent. Its output must include:
 

--- a/commands/test.md
+++ b/commands/test.md
@@ -23,7 +23,7 @@ Before dispatching any agents, verify that Playwright MCP is available in this s
 If Playwright MCP is **not connected**, stop immediately and return:
 
 ```
-BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest`, restart Claude Code, and retry.
+BLOCKED: Playwright MCP not connected — run `claude mcp add playwright npx @playwright/mcp@latest`, restart Claude Code, and retry.
 ```
 
 Do not delegate to any agent until the gate passes.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -10,6 +10,20 @@
 
 Install them via `/plugin marketplace add …` + `/plugin install …` before using the `workflow-development` skill.
 
+## Browser automation (optional, feature-gated)
+
+The following MCP servers enable browser-driven E2E testing and console/network diagnostics. All three are **optional** and **hard-gated**: if the required server is absent when a browser feature is invoked, the command returns a `BLOCKED:` message with a per-backend install hint rather than silently degrading.
+
+| Server | Source | Used by | Install | Required? |
+|---|---|---|---|---|
+| Playwright MCP | [`microsoft/playwright-mcp`](https://github.com/microsoft/playwright-mcp) | `/test --mode e2e` — browser snapshot → interact → assert spec authoring via `e2e-test-writer` | `npx @playwright/mcp@latest` | Required **only** for `/test --mode e2e` (hard-gated: absent → `BLOCKED:`) |
+| Chrome DevTools MCP | [`ChromeDevTools/chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) | `/debug` console/network/perf diagnostics for web-UI symptoms via `read_console_messages` + `read_network_requests` | `npx chrome-devtools-mcp@latest` | Optional; one Chrome backend required for `/debug` browser diagnostics (hard-gated) |
+| Claude-in-Chrome | In-harness (`mcp__claude-in-chrome__*`) | `/debug` console/network capture when the Claude browser extension is connected — alternative to chrome-devtools-mcp | None (provided by the Claude Code harness) | Optional alternative to chrome-devtools-mcp for `/debug` browser diagnostics |
+
+**Gate behaviour:** when a browser feature is invoked and the required server is absent, the command returns `BLOCKED: … install with \`npx <server>@latest\` …` and stops. It does not fall back silently or produce partial results. Non-browser `/test` (unit) and non-web-UI `/debug` are completely unaffected by these servers.
+
+**`hangwin/mcp-chrome` — evaluated and not adopted:** this server is oriented toward semantic page search and content extraction; it does not provide the deterministic console/network capture (`read_console_messages`, `read_network_requests`) or E2E interaction primitives needed here. `chrome-devtools-mcp` and Claude-in-Chrome provide the right primitives for `/debug`; Playwright MCP provides the right primitives for `/test --mode e2e`.
+
 ## Claude Code native tools
 
 The following tools are built into Claude Code itself — no plugin install required:

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -16,13 +16,11 @@ The following MCP servers enable browser-driven E2E testing and console/network 
 
 | Server | Source | Used by | Install | Required? |
 |---|---|---|---|---|
-| Playwright MCP | [`microsoft/playwright-mcp`](https://github.com/microsoft/playwright-mcp) | `/test --mode e2e` — browser snapshot → interact → assert spec authoring via `e2e-test-writer` | `npx @playwright/mcp@latest` | Required **only** for `/test --mode e2e` (hard-gated: absent → `BLOCKED:`) |
-| Chrome DevTools MCP | [`ChromeDevTools/chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) | `/debug` console/network/perf diagnostics for web-UI symptoms via `read_console_messages` + `read_network_requests` | `npx chrome-devtools-mcp@latest` | Optional; one Chrome backend required for `/debug` browser diagnostics (hard-gated) |
+| Playwright MCP | [`microsoft/playwright-mcp`](https://github.com/microsoft/playwright-mcp) | `/test --mode e2e` — browser snapshot → interact → assert spec authoring via `e2e-test-writer` | `claude mcp add playwright npx @playwright/mcp@latest` | Required **only** for `/test --mode e2e` (hard-gated: absent → `BLOCKED:`) |
+| Chrome DevTools MCP | [`ChromeDevTools/chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) | `/debug` console/network/perf diagnostics for web-UI symptoms via `read_console_messages` + `read_network_requests` | `claude mcp add chrome-devtools-mcp npx chrome-devtools-mcp@latest` | Optional; one Chrome backend required for `/debug` browser diagnostics (hard-gated) |
 | Claude-in-Chrome | In-harness (`mcp__claude-in-chrome__*`) | `/debug` console/network capture when the Claude browser extension is connected — alternative to chrome-devtools-mcp | None (provided by the Claude Code harness) | Optional alternative to chrome-devtools-mcp for `/debug` browser diagnostics |
 
-**Gate behaviour:** when a browser feature is invoked and the required server is absent, the command returns `BLOCKED: … install with \`npx <server>@latest\` …` and stops. It does not fall back silently or produce partial results. Non-browser `/test` (unit) and non-web-UI `/debug` are completely unaffected by these servers.
-
-**`hangwin/mcp-chrome` — evaluated and not adopted:** this server is oriented toward semantic page search and content extraction; it does not provide the deterministic console/network capture (`read_console_messages`, `read_network_requests`) or E2E interaction primitives needed here. `chrome-devtools-mcp` and Claude-in-Chrome provide the right primitives for `/debug`; Playwright MCP provides the right primitives for `/test --mode e2e`.
+**Gate behaviour:** when a browser feature is invoked and the required server is absent, the command returns `BLOCKED: … run \`claude mcp add …\` …` and stops. It does not fall back silently or produce partial results. Non-browser `/test` (unit) and non-web-UI `/debug` are completely unaffected by these servers.
 
 ## Claude Code native tools
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -33,7 +33,7 @@ _BROWSER_MCP_SIGNALS = re.compile(
     r'browser_snapshot|read_console_messages|read_network_requests'
     r'|mcp__\S*chrome\S*|@playwright/mcp'
 )
-_CLAUDE_IN_CHROME_ONLY = re.compile(r'mcp__claude-in-chrome__')
+_CLAUDE_IN_CHROME_ONLY = re.compile(r'mcp__claude-in-chrome__\S*')
 _BROWSER_INSTALL_HINTS = re.compile(
     r'claude mcp add \S+|npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
 )

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -869,6 +869,7 @@ def check_browser_tool_gate(cache=None):
             if use_cache and agents_cache is not None and md in agents_cache:
                 text = agents_cache[md]
                 if text is None:
+                    fail(md.relative_to(ROOT), "could not read file")
                     continue
             else:
                 try:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -26,10 +26,14 @@ _NON_CODE_AGENTS = frozenset({
 # Browser MCP tool patterns that trigger the hard gate (#364).
 # Any agent or command containing one of these strings must also carry
 # a BLOCKED: sentinel and a per-backend install hint.
+# Exception: mcp__claude-in-chrome__* is the in-harness Claude browser extension —
+# it has no installable package, so the install-hint requirement is waived for
+# files whose only browser signal is claude-in-chrome references.
 _BROWSER_MCP_SIGNALS = re.compile(
     r'browser_snapshot|read_console_messages|read_network_requests'
     r'|mcp__\S*chrome\S*|@playwright/mcp'
 )
+_CLAUDE_IN_CHROME_ONLY = re.compile(r'mcp__claude-in-chrome__')
 _BROWSER_INSTALL_HINTS = re.compile(
     r'claude mcp add \S+|npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
 )
@@ -879,6 +883,11 @@ def check_browser_tool_gate(cache=None):
                     fail(md.relative_to(ROOT), "could not read file")
                     continue
             if not _BROWSER_MCP_SIGNALS.search(text):
+                continue
+            # Claude-in-Chrome is in-harness (no installable package); if the file's
+            # only browser signal is claude-in-chrome references, waive the install-hint.
+            stripped = _CLAUDE_IN_CHROME_ONLY.sub("", text)
+            if not _BROWSER_MCP_SIGNALS.search(stripped):
                 continue
             rel = md.relative_to(ROOT)
             if "BLOCKED:" not in text:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -875,6 +875,7 @@ def check_browser_tool_gate(cache=None):
                 try:
                     text = md.read_text(encoding="utf-8")
                 except OSError:
+                    fail(md.relative_to(ROOT), "could not read file")
                     continue
             if not _BROWSER_MCP_SIGNALS.search(text):
                 continue

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -23,6 +23,17 @@ _NON_CODE_AGENTS = frozenset({
     "product-manager",
 })
 
+# Browser MCP tool patterns that trigger the hard gate (#364).
+# Any agent or command containing one of these strings must also carry
+# a BLOCKED: sentinel and a per-backend install hint.
+_BROWSER_MCP_SIGNALS = re.compile(
+    r'browser_snapshot|read_console_messages|read_network_requests'
+    r'|mcp__\S*chrome\S*|@playwright/mcp'
+)
+_BROWSER_INSTALL_HINTS = re.compile(
+    r'npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
+)
+
 
 def fail(path, reason):
     FAILURES.append(f"  {path}: {reason}")
@@ -219,7 +230,11 @@ def check_agents(cache=None):
         for field in ("name", "description"):
             if field not in fm:
                 fail(agent_md.relative_to(ROOT), f"frontmatter missing required field: {field!r}")
-        if re.search(r'`swe-workbench:[\w-]+`', text) and "Skill" not in fm.get("tools", ""):
+        if (
+            re.search(r'`swe-workbench:[\w-]+`', text)
+            and "tools" in fm
+            and "Skill" not in fm["tools"]
+        ):
             fail(agent_md.relative_to(ROOT), "references swe-workbench: skills but 'Skill' is missing from tools: frontmatter")
 
 
@@ -837,6 +852,48 @@ def check_plan_mode_workflow_embedding():
             )
 
 
+def check_browser_tool_gate(cache=None):
+    """Any agent or command referencing browser MCP tools must carry a BLOCKED: sentinel
+    and a per-backend install hint — enforces the hard gate from #364.
+
+    Signals that trigger the check: browser_snapshot, read_console_messages,
+    read_network_requests, mcp__*chrome*, @playwright/mcp.
+    Required when triggered: BLOCKED: string + npx @playwright/mcp@latest
+    or npx chrome-devtools-mcp@latest.
+    """
+    agents_cache = cache[0] if cache is not None else None
+    for subdir, use_cache in ((ROOT / "agents", True), (ROOT / "commands", False)):
+        if not subdir.is_dir():
+            continue
+        for md in sorted(subdir.glob("*.md")):
+            if use_cache and agents_cache is not None and md in agents_cache:
+                text = agents_cache[md]
+                if text is None:
+                    continue
+            else:
+                try:
+                    text = md.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+            if not _BROWSER_MCP_SIGNALS.search(text):
+                continue
+            rel = md.relative_to(ROOT)
+            if "BLOCKED:" not in text:
+                fail(
+                    rel,
+                    "references browser MCP tools but missing BLOCKED: sentinel — "
+                    "add a hard-gate that returns BLOCKED: with a per-backend install hint "
+                    "(e.g. `npx @playwright/mcp@latest` or `npx chrome-devtools-mcp@latest`) "
+                    "when the required MCP server is absent (#364)",
+                )
+            elif not _BROWSER_INSTALL_HINTS.search(text):
+                fail(
+                    rel,
+                    "references browser MCP tools and has BLOCKED: but missing a per-backend install hint — "
+                    "add `npx @playwright/mcp@latest` or `npx chrome-devtools-mcp@latest` (#364)",
+                )
+
+
 # ──────────────────────────────────────────────
 # Entry point
 # ──────────────────────────────────────────────
@@ -867,6 +924,7 @@ def main():
     check_hook_scripts()
     check_test_subprocess_env()
     check_no_cycles(cache=cache)
+    check_browser_tool_gate(cache=cache)
 
     if FAILURES:
         print(f"FAILED — {len(FAILURES)} issue(s) found:", file=sys.stderr)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -31,7 +31,7 @@ _BROWSER_MCP_SIGNALS = re.compile(
     r'|mcp__\S*chrome\S*|@playwright/mcp'
 )
 _BROWSER_INSTALL_HINTS = re.compile(
-    r'npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
+    r'claude mcp add \S+|npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
 )
 
 
@@ -858,8 +858,9 @@ def check_browser_tool_gate(cache=None):
 
     Signals that trigger the check: browser_snapshot, read_console_messages,
     read_network_requests, mcp__*chrome*, @playwright/mcp.
-    Required when triggered: BLOCKED: string + npx @playwright/mcp@latest
-    or npx chrome-devtools-mcp@latest.
+    Required when triggered: BLOCKED: string + a per-backend install hint,
+    either `claude mcp add <name> npx <package>@latest` (preferred) or the
+    legacy `npx <package>@latest` form.
     """
     agents_cache = cache[0] if cache is not None else None
     for subdir, use_cache in ((ROOT / "agents", True), (ROOT / "commands", False)):
@@ -885,14 +886,15 @@ def check_browser_tool_gate(cache=None):
                     rel,
                     "references browser MCP tools but missing BLOCKED: sentinel — "
                     "add a hard-gate that returns BLOCKED: with a per-backend install hint "
-                    "(e.g. `npx @playwright/mcp@latest` or `npx chrome-devtools-mcp@latest`) "
+                    "(e.g. `claude mcp add playwright npx @playwright/mcp@latest`) "
                     "when the required MCP server is absent (#364)",
                 )
             elif not _BROWSER_INSTALL_HINTS.search(text):
                 fail(
                     rel,
                     "references browser MCP tools and has BLOCKED: but missing a per-backend install hint — "
-                    "add `npx @playwright/mcp@latest` or `npx chrome-devtools-mcp@latest` (#364)",
+                    "add `claude mcp add playwright npx @playwright/mcp@latest` or "
+                    "`claude mcp add chrome-devtools-mcp npx chrome-devtools-mcp@latest` (#364)",
                 )
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2155,6 +2155,25 @@ class TestCheckBrowserToolGate:
         validate.check_browser_tool_gate()
         assert len(validate.FAILURES) == 0
 
+    def test_cache_none_sentinel_emits_failure(self, reset_validate):
+        """None sentinel in the agent cache (unreadable file) must emit a failure, not silently skip."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        agent_path = agents_dir / "my-agent.md"
+        # Write a file that would pass the gate if readable — but the cache marks it unreadable.
+        agent_path.write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Use browser_snapshot.\nBLOCKED: ...\nnpx @playwright/mcp@latest\n",
+            encoding="utf-8",
+        )
+        cache = ({agent_path: None}, {})
+        validate.check_browser_tool_gate(cache=cache)
+        rel = str(agent_path.relative_to(root))
+        assert any("could not read file" in f for f in validate.FAILURES), (
+            f"Expected 'could not read file' failure for None sentinel; got: {validate.FAILURES}"
+        )
+
     def test_live_tree_passes(self, reset_validate, monkeypatch):
         """All real agents/commands referencing browser MCP tools must carry BLOCKED: + install hint."""
         import validate as val

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2210,8 +2210,8 @@ class TestE2eTestWriterAgent:
 
     def test_playwright_mcp_install_hint_present(self):
         text = self.AGENT_PATH.read_text(encoding="utf-8")
-        assert "npx @playwright/mcp@latest" in text, (
-            "agent must include the Playwright MCP install hint"
+        assert "claude mcp add" in text and "@playwright/mcp" in text, (
+            "agent must include the Playwright MCP install hint (claude mcp add ... @playwright/mcp)"
         )
 
     def test_principle_testing_wired(self):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2173,6 +2173,24 @@ class TestCheckBrowserToolGate:
             f"Expected 'could not read file' failure for None sentinel; got: {validate.FAILURES}"
         )
 
+    def test_cache_hit_with_valid_content_passes(self, reset_validate):
+        """Valid-text cache hit (agent satisfies gate) must not emit any failure."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        agent_path = agents_dir / "my-agent.md"
+        content = (
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Use browser_snapshot.\nBLOCKED: ...\n"
+            "claude mcp add playwright npx @playwright/mcp@latest\n"
+        )
+        agent_path.write_text(content, encoding="utf-8")
+        cache = ({agent_path: content}, {})
+        validate.check_browser_tool_gate(cache=cache)
+        assert len(validate.FAILURES) == 0, (
+            f"Expected no failures for cached valid content; got: {validate.FAILURES}"
+        )
+
     def test_live_tree_passes(self, reset_validate, monkeypatch):
         """All real agents/commands referencing browser MCP tools must carry BLOCKED: + install hint."""
         import validate as val

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2169,7 +2169,6 @@ class TestCheckBrowserToolGate:
         )
         cache = ({agent_path: None}, {})
         validate.check_browser_tool_gate(cache=cache)
-        rel = str(agent_path.relative_to(root))
         assert any("could not read file" in f for f in validate.FAILURES), (
             f"Expected 'could not read file' failure for None sentinel; got: {validate.FAILURES}"
         )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2161,3 +2161,129 @@ class TestCheckBrowserToolGate:
         monkeypatch.setattr(val, "ROOT", self._REPO_ROOT)
         val.check_browser_tool_gate()
         assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
+# e2e-test-writer agent structural assertions
+# ──────────────────────────────────────────────
+
+class TestE2eTestWriterAgent:
+    """Integration tests: assert agents/e2e-test-writer.md satisfies structural invariants (#364)."""
+
+    AGENT_PATH = Path(__file__).parent.parent / "agents" / "e2e-test-writer.md"
+
+    def test_file_exists(self):
+        assert self.AGENT_PATH.exists(), "agents/e2e-test-writer.md must exist"
+
+    def test_frontmatter_fields(self):
+        import re
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "frontmatter block not found"
+        fm_text = match.group(1)
+        assert "name: e2e-test-writer" in fm_text
+        assert "description:" in fm_text
+        assert "model: sonnet" in fm_text
+        assert re.search(r"tools:.*\bSkill\b", fm_text), "tools: must include Skill"
+
+    def test_blocked_sentinel_present(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "BLOCKED:" in text, "agent must carry a BLOCKED: hard-gate sentinel"
+
+    def test_playwright_mcp_install_hint_present(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "npx @playwright/mcp@latest" in text, (
+            "agent must include the Playwright MCP install hint"
+        )
+
+    def test_principle_testing_wired(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "`swe-workbench:principle-testing`" in text, (
+            "agent must reference swe-workbench:principle-testing"
+        )
+
+    def test_shared_skills_include(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "@./shared/principles.md" in text, (
+            "agent must include @./shared/principles.md"
+        )
+        assert "@./shared/languages.md" in text, (
+            "agent must include @./shared/languages.md"
+        )
+
+    def test_agent_and_skill_ref_checks_pass(self, reset_validate, monkeypatch):
+        """The real file must pass check_agents() and check_agent_skill_refs() against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.AGENT_PATH.parent.parent)
+        val.FAILURES.clear()
+        cache = val._build_cache()
+        val.check_agents(cache=cache)
+        val.check_agent_skill_refs(cache=cache)
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
+# e2e-test-verifier agent structural assertions
+# ──────────────────────────────────────────────
+
+class TestE2eTestVerifierAgent:
+    """Integration tests: assert agents/e2e-test-verifier.md satisfies structural invariants (#364)."""
+
+    AGENT_PATH = Path(__file__).parent.parent / "agents" / "e2e-test-verifier.md"
+
+    def test_file_exists(self):
+        assert self.AGENT_PATH.exists(), "agents/e2e-test-verifier.md must exist"
+
+    def test_frontmatter_fields(self):
+        import re
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "frontmatter block not found"
+        fm_text = match.group(1)
+        assert "name: e2e-test-verifier" in fm_text
+        assert "description:" in fm_text
+        assert "model: haiku" in fm_text
+        assert re.search(r"tools:.*\bRead\b", fm_text)
+        assert re.search(r"tools:.*\bBash\b", fm_text), "tools: must include Bash (runs specs)"
+        assert re.search(r"tools:.*\bSkill\b", fm_text)
+
+    def test_no_browser_mcp_tools_in_frontmatter(self):
+        """Verifier uses the CLI runner, not browser MCP — tools: must not list MCP browser tools."""
+        import re
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, "frontmatter block not found"
+        fm_text = match.group(1)
+        tools_line = next(
+            (line for line in fm_text.splitlines() if line.startswith("tools:")), ""
+        )
+        assert "browser_snapshot" not in tools_line
+        assert "mcp__" not in tools_line
+
+    def test_boundary_section_present(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "Boundary vs. `test-reviewer`" in text, (
+            "agent must have a Boundary vs. test-reviewer section"
+        )
+
+    def test_principle_testing_wired(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "`swe-workbench:principle-testing`" in text, (
+            "agent must reference swe-workbench:principle-testing"
+        )
+
+    def test_shared_skills_include(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "@./shared/principles.md" in text, (
+            "agent must include @./shared/principles.md"
+        )
+
+    def test_agent_and_skill_ref_checks_pass(self, reset_validate, monkeypatch):
+        """The real file must pass check_agents() and check_agent_skill_refs() against the live tree."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self.AGENT_PATH.parent.parent)
+        val.FAILURES.clear()
+        cache = val._build_cache()
+        val.check_agents(cache=cache)
+        val.check_agent_skill_refs(cache=cache)
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2198,6 +2198,32 @@ class TestCheckBrowserToolGate:
         val.check_browser_tool_gate()
         assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
 
+    def test_claude_in_chrome_only_passes(self, reset_validate):
+        """File referencing only mcp__claude-in-chrome__* is exempt from the install-hint requirement."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Call mcp__claude-in-chrome__read_console_messages to get logs.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert len(validate.FAILURES) == 0
+
+    def test_claude_in_chrome_plus_browser_snapshot_requires_blocked(self, reset_validate):
+        """File mixing mcp__claude-in-chrome__* with another browser signal must still carry BLOCKED:."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Call mcp__claude-in-chrome__read_console_messages and also browser_snapshot.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("BLOCKED:" in f for f in validate.FAILURES)
+
 
 # ──────────────────────────────────────────────
 # e2e-test-writer agent structural assertions
@@ -2318,6 +2344,9 @@ class TestE2eTestVerifierAgent:
         text = self.AGENT_PATH.read_text(encoding="utf-8")
         assert "@./shared/principles.md" in text, (
             "agent must include @./shared/principles.md"
+        )
+        assert "@./shared/languages.md" in text, (
+            "agent must include @./shared/languages.md"
         )
 
     def test_agent_and_skill_ref_checks_pass(self, reset_validate, monkeypatch):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -323,6 +323,20 @@ class TestCheckAgents:
         validate.check_agents()
         assert len(validate.FAILURES) == 0
 
+    def test_skill_ref_without_tools_line_passes(self, reset_validate):
+        """Omitting tools: entirely grants all tools (Skill implicitly available) — no failure."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: An agent\n---\n"
+            "\nUse `swe-workbench:foo` to do things.\n"
+            "\n> See @./shared/principles.md\n",
+            encoding="utf-8",
+        )
+        validate.check_agents()
+        assert len(validate.FAILURES) == 0
+
 
 # ──────────────────────────────────────────────
 # performance-tuner agent structural assertions
@@ -2029,4 +2043,121 @@ class TestCheckPlanModeWorkflowEmbedding:
         import validate as val
         monkeypatch.setattr(val, "ROOT", self._REPO_ROOT)
         val.check_plan_mode_workflow_embedding()
+        assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
+# check_browser_tool_gate
+# ──────────────────────────────────────────────
+
+class TestCheckBrowserToolGate:
+    """check_browser_tool_gate: agents/commands referencing browser MCP tools must carry
+    a BLOCKED: sentinel and a per-backend install hint (#364)."""
+
+    _REPO_ROOT = Path(__file__).parent.parent
+
+    def test_browser_snapshot_without_blocked_fails(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Use browser_snapshot to capture the page.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("BLOCKED:" in f for f in validate.FAILURES)
+
+    def test_browser_snapshot_with_blocked_and_hint_passes(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Use browser_snapshot to capture the page.\n\n"
+            "BLOCKED: Playwright MCP not connected — install with `npx @playwright/mcp@latest`.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert len(validate.FAILURES) == 0
+
+    def test_playwright_mcp_ref_in_command_without_blocked_fails(self, reset_validate):
+        root = reset_validate
+        commands_dir = root / "commands"
+        commands_dir.mkdir(exist_ok=True)
+        (commands_dir / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\n"
+            "Requires @playwright/mcp for E2E testing.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("BLOCKED:" in f for f in validate.FAILURES)
+
+    def test_read_console_messages_without_blocked_fails(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Call read_console_messages to get browser logs.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("BLOCKED:" in f for f in validate.FAILURES)
+
+    def test_blocked_with_chrome_devtools_hint_passes(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "Capture read_console_messages for diagnostics.\n\n"
+            "BLOCKED: No Chrome backend connected — install with `npx chrome-devtools-mcp@latest`.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert len(validate.FAILURES) == 0
+
+    def test_blocked_without_install_hint_fails(self, reset_validate):
+        root = reset_validate
+        commands_dir = root / "commands"
+        commands_dir.mkdir(exist_ok=True)
+        (commands_dir / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\n"
+            "Use browser_snapshot to explore the UI.\n\n"
+            "BLOCKED: Playwright MCP not connected.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("install hint" in f for f in validate.FAILURES)
+
+    def test_read_network_requests_without_blocked_fails(self, reset_validate):
+        root = reset_validate
+        commands_dir = root / "commands"
+        commands_dir.mkdir(exist_ok=True)
+        (commands_dir / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\n"
+            "Capture read_network_requests to inspect XHR calls.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert any("BLOCKED:" in f for f in validate.FAILURES)
+
+    def test_no_browser_refs_passes(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\n---\n\n"
+            "This agent does not reference any browser tools.\n",
+            encoding="utf-8",
+        )
+        validate.check_browser_tool_gate()
+        assert len(validate.FAILURES) == 0
+
+    def test_live_tree_passes(self, reset_validate, monkeypatch):
+        """All real agents/commands referencing browser MCP tools must carry BLOCKED: + install hint."""
+        import validate as val
+        monkeypatch.setattr(val, "ROOT", self._REPO_ROOT)
+        val.check_browser_tool_gate()
         assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2296,6 +2296,12 @@ class TestE2eTestVerifierAgent:
         assert "browser_snapshot" not in tools_line
         assert "mcp__" not in tools_line
 
+    def test_blocked_sentinel_present(self):
+        text = self.AGENT_PATH.read_text(encoding="utf-8")
+        assert "BLOCKED:" in text, (
+            "agent must include a BLOCKED: sentinel for the missing-runner case"
+        )
+
     def test_boundary_section_present(self):
         text = self.AGENT_PATH.read_text(encoding="utf-8")
         assert "Boundary vs. `test-reviewer`" in text, (


### PR DESCRIPTION
## Summary
- Add `--mode e2e` to `/test` dispatching a two-agent pipeline: `e2e-test-writer` (explores live app via Playwright MCP, authors durable specs) → `e2e-test-verifier` (runs specs, distrusts false-green passes)
- Add a conditional browser diagnostic step to `/debug`: captures console + network evidence via chrome-devtools-mcp or Claude-in-Chrome for web-UI symptoms, prepends it as boundary evidence for the `debugger` agent
- Hard-gate on all browser paths: absent MCP server → `BLOCKED:` with per-backend install hint, never silent degradation
- New `check_browser_tool_gate()` validator enforces the BLOCKED: + install-hint contract on every agent/command referencing browser MCP tools
- Updated `docs/dependencies.md` with a "Browser automation (optional, feature-gated)" section covering all three backends

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest tests/ -v` — 1222/1222 pass (10 new tests: `TestCheckBrowserToolGate` × 9, `TestCheckAgents::test_skill_ref_without_tools_line_passes`)

### Type-tailored checks ([feat])
- [ ] `/test --mode e2e` with Playwright MCP connected → e2e-test-writer authors a spec, e2e-test-verifier runs it green
- [ ] `/test --mode e2e` with Playwright MCP disconnected → `BLOCKED: Playwright MCP not connected — install with \`npx @playwright/mcp@latest\``
- [ ] `/debug "<web-UI symptom>"` with Chrome backend connected → console/network evidence prepended to debugger delegation
- [ ] `/debug "<backend/CLI symptom>"` → no gate, no browser prompt, behaviour unchanged
- [ ] Default `/test <file>` (unit mode) — unchanged behaviour

Closes #364
