### PR TITLE
[feat] Add worked DIP+OCP examples to principle-solid (9 languages)

### DIFF
--- a/skills/principle-solid/SKILL.md
+++ b/skills/principle-solid/SKILL.md
@@ -72,3 +72,6 @@ SOLID is about making change cheap. If nothing is changing, it costs complexity 
 | "The entity is just data, logic goes elsewhere" | Anemic domain. Move behavior onto the entity. |
 | "Let me import the store directly, it's faster" | Faster to write, impossible to test in isolation. Define the interface. |
 | "YAGNI — we might never need another implementation" | DIP isn't about multiple implementations. It's about testability and decoupling. |
+
+> See `examples/` for a worked DIP + OCP payment-gateway implementation in C#, Go, Java, Kotlin,
+> Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).

--- a/skills/principle-solid/examples/payment-gateway.cs.md
+++ b/skills/principle-solid/examples/payment-gateway.cs.md
@@ -10,6 +10,7 @@ constructor-injected, compatible with any DI container like `Microsoft.Extension
 
 ```csharp
 // file: IPaymentGateway.cs
+#nullable enable
 public interface IPaymentGateway
 {
     bool Charge(int amountCents, string reference);

--- a/skills/principle-solid/examples/payment-gateway.cs.md
+++ b/skills/principle-solid/examples/payment-gateway.cs.md
@@ -1,0 +1,75 @@
+# DIP & OCP — C# — Payment Processing
+
+## Problem
+`OrderService` depends on an `IPaymentGateway` interface (prefix `I` is the C# convention).
+Nullable reference types are enabled — `string reference` is non-nullable by design. Adding
+`PayPalGateway` is a new class; `OrderService` is never edited (OCP). The gateway is
+constructor-injected, compatible with any DI container like `Microsoft.Extensions.DI` (DIP).
+
+## Implementation
+
+```csharp
+// file: IPaymentGateway.cs
+public interface IPaymentGateway
+{
+    bool Charge(int amountCents, string reference);
+}
+```
+
+```csharp
+// file: StripeGateway.cs
+public sealed class StripeGateway : IPaymentGateway
+{
+    public bool Charge(int amountCents, string reference)
+    {
+        Console.WriteLine($"Stripe: charging {amountCents}¢ for {reference}");
+        return true;
+    }
+}
+```
+
+```csharp
+// file: PayPalGateway.cs
+// Adding PayPal requires no edits to OrderService — this is OCP.
+public sealed class PayPalGateway : IPaymentGateway
+{
+    public bool Charge(int amountCents, string reference)
+    {
+        Console.WriteLine($"PayPal: charging {amountCents}¢ for {reference}");
+        return true;
+    }
+}
+```
+
+```csharp
+// file: OrderService.cs
+public sealed class OrderService
+{
+    private readonly IPaymentGateway _gateway; // injected — never newed-up here (DIP)
+
+    public OrderService(IPaymentGateway gateway) => _gateway = gateway;
+
+    public bool PlaceOrder(string item, int amountCents)
+    {
+        Console.WriteLine($"Placing order for \"{item}\"");
+        return _gateway.Charge(amountCents, item);
+    }
+}
+```
+
+## Common Mistake
+
+```csharp
+// ✗ DIP violation — OrderService constructs the concrete StripeGateway
+// ✗ OCP violation — switch expression must be edited for every new provider
+public sealed class BadOrderService
+{
+    public bool PlaceOrder(string item, int cents, string method) =>
+        method switch
+        {
+            "stripe" => new StripeGateway().Charge(cents, item),  // ✗ newing concrete dep
+            "paypal" => new PayPalGateway().Charge(cents, item),  // ✗ edit per new provider
+            _ => throw new ArgumentException($"Unknown method: {method}")
+        };
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.go.md
+++ b/skills/principle-solid/examples/payment-gateway.go.md
@@ -1,0 +1,99 @@
+# DIP & OCP — Go — Payment Processing
+
+## Problem
+`OrderService` charges payments through an interface it defines itself — the consumer-defines-
+the-interface pattern. Go's implicit satisfaction means no import cycle: `StripeGateway` and
+`PayPalGateway` implement `PaymentGateway` without importing the `order` package. Adding a new
+provider is a new file; `OrderService` is never edited (OCP). The interface is injected (DIP).
+
+## Implementation
+
+```go
+// file: order_service.go
+package order
+
+import "fmt"
+
+// PaymentGateway is defined by the consumer (order package), not the provider.
+type PaymentGateway interface {
+	Charge(amountCents int, reference string) bool
+}
+
+type OrderService struct {
+	gateway PaymentGateway // injected — never constructed here (DIP)
+}
+
+func NewOrderService(g PaymentGateway) *OrderService {
+	return &OrderService{gateway: g}
+}
+
+func (s *OrderService) PlaceOrder(item string, amountCents int) bool {
+	fmt.Printf("Placing order for %q\n", item)
+	return s.gateway.Charge(amountCents, item)
+}
+```
+
+```go
+// file: stripe_gateway.go
+package stripe
+
+import "fmt"
+
+type Gateway struct{}
+
+func (g *Gateway) Charge(amountCents int, reference string) bool {
+	fmt.Printf("Stripe: charging %d¢ for %s\n", amountCents, reference)
+	return true
+}
+```
+
+```go
+// file: paypal_gateway.go
+// Adding PayPal requires no edits to OrderService — this is OCP.
+package paypal
+
+import "fmt"
+
+type Gateway struct{}
+
+func (g *Gateway) Charge(amountCents int, reference string) bool {
+	fmt.Printf("PayPal: charging %d¢ for %s\n", amountCents, reference)
+	return true
+}
+```
+
+```go
+// file: main.go
+// Go's implicit satisfaction: stripe.Gateway satisfies order.PaymentGateway without
+// importing the order package — the consumer-defines-interface pattern in action.
+package main
+
+import (
+	"example/order"
+	"example/stripe"
+)
+
+func main() {
+	svc := order.NewOrderService(&stripe.Gateway{})
+	svc.PlaceOrder("widget", 1999)
+}
+```
+
+## Common Mistake
+
+```go
+// ✗ DIP violation — OrderService imports the concrete stripe package
+// ✗ OCP violation — adding PayPal requires editing PlaceOrder
+import stripe "github.com/stripe/stripe-go/v74"
+
+type BadOrderService struct{}
+
+func (s *BadOrderService) PlaceOrder(item, method string, cents int) {
+	if method == "stripe" {                   // ✗ switch on payment type
+		stripe.Key = "sk_live_..."            // ✗ concrete SDK dep inside high-level policy
+		// charge.New(params) — SDK call here
+	} else if method == "paypal" {            // ✗ edit required for every new provider
+		// paypal SDK call here
+	}
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.go.md
+++ b/skills/principle-solid/examples/payment-gateway.go.md
@@ -84,7 +84,7 @@ func main() {
 ```go
 // ✗ DIP violation — OrderService imports the concrete stripe package
 // ✗ OCP violation — adding PayPal requires editing PlaceOrder
-import stripe "github.com/stripe/stripe-go/v2"
+import stripe "github.com/stripe/stripe-go/v74"
 
 type BadOrderService struct{}
 

--- a/skills/principle-solid/examples/payment-gateway.go.md
+++ b/skills/principle-solid/examples/payment-gateway.go.md
@@ -84,7 +84,7 @@ func main() {
 ```go
 // ✗ DIP violation — OrderService imports the concrete stripe package
 // ✗ OCP violation — adding PayPal requires editing PlaceOrder
-import stripe "github.com/stripe/stripe-go/v74"
+import stripe "github.com/stripe/stripe-go/v2"
 
 type BadOrderService struct{}
 

--- a/skills/principle-solid/examples/payment-gateway.go.md
+++ b/skills/principle-solid/examples/payment-gateway.go.md
@@ -84,7 +84,9 @@ func main() {
 ```go
 // ✗ DIP violation — OrderService imports the concrete stripe package
 // ✗ OCP violation — adding PayPal requires editing PlaceOrder
-import stripe "github.com/stripe/stripe-go/v74"
+import (
+	stripe "github.com/stripe/stripe-go/v74"
+)
 
 type BadOrderService struct{}
 

--- a/skills/principle-solid/examples/payment-gateway.java.md
+++ b/skills/principle-solid/examples/payment-gateway.java.md
@@ -1,0 +1,72 @@
+# DIP & OCP — Java — Payment Processing
+
+## Problem
+`OrderService` declares a `PaymentGateway` interface and depends only on that abstraction.
+Java's explicit `implements` keyword makes the inversion visible in the type hierarchy.
+Adding `PayPalGateway` is a new class in a new file; `OrderService` is never modified (OCP).
+The gateway is constructor-injected so the service never calls `new StripeGateway()` (DIP).
+
+## Implementation
+
+```java
+// file: PaymentGateway.java
+public interface PaymentGateway {
+    boolean charge(int amountCents, String reference);
+}
+```
+
+```java
+// file: StripeGateway.java
+public class StripeGateway implements PaymentGateway {
+    @Override
+    public boolean charge(int amountCents, String reference) {
+        System.out.printf("Stripe: charging %d¢ for %s%n", amountCents, reference);
+        return true;
+    }
+}
+```
+
+```java
+// file: PayPalGateway.java
+// Adding PayPal requires no edits to OrderService — this is OCP.
+public class PayPalGateway implements PaymentGateway {
+    @Override
+    public boolean charge(int amountCents, String reference) {
+        System.out.printf("PayPal: charging %d¢ for %s%n", amountCents, reference);
+        return true;
+    }
+}
+```
+
+```java
+// file: OrderService.java
+public class OrderService {
+    private final PaymentGateway gateway; // injected — never newed-up here (DIP)
+
+    public OrderService(PaymentGateway gateway) {
+        this.gateway = gateway;
+    }
+
+    public boolean placeOrder(String item, int amountCents) {
+        System.out.println("Placing order for \"" + item + "\"");
+        return gateway.charge(amountCents, item);
+    }
+}
+```
+
+## Common Mistake
+
+```java
+// ✗ DIP violation — OrderService constructs the concrete class
+// ✗ OCP violation — adding PayPal requires editing placeOrder
+public class BadOrderService {
+    public boolean placeOrder(String item, int cents, String method) {
+        if ("stripe".equals(method)) {                      // ✗ switch on payment type
+            return new StripeGateway().charge(cents, item); // ✗ newing concrete dep
+        } else if ("paypal".equals(method)) {               // ✗ edit required per new provider
+            return new PayPalGateway().charge(cents, item);
+        }
+        return false;
+    }
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.kt.md
+++ b/skills/principle-solid/examples/payment-gateway.kt.md
@@ -1,0 +1,63 @@
+# DIP & OCP — Kotlin — Payment Processing
+
+## Problem
+`OrderService` depends on a `PaymentGateway` interface, never a concrete class. Kotlin's
+`interface` keyword mirrors Java's but gains default implementations and is null-safe by default.
+`object` declarations (singletons) are idiomatic for stateless gateways. Adding `PayPalGateway`
+is a new file; `OrderService` is never edited (OCP). The gateway is constructor-injected (DIP).
+
+## Implementation
+
+```kotlin
+// file: PaymentGateway.kt
+interface PaymentGateway {
+    fun charge(amountCents: Int, reference: String): Boolean
+}
+```
+
+```kotlin
+// file: StripeGateway.kt
+object StripeGateway : PaymentGateway {
+    override fun charge(amountCents: Int, reference: String): Boolean {
+        println("Stripe: charging ${amountCents}¢ for $reference")
+        return true
+    }
+}
+```
+
+```kotlin
+// file: PayPalGateway.kt
+// Adding PayPal requires no edits to OrderService — this is OCP.
+object PayPalGateway : PaymentGateway {
+    override fun charge(amountCents: Int, reference: String): Boolean {
+        println("PayPal: charging ${amountCents}¢ for $reference")
+        return true
+    }
+}
+```
+
+```kotlin
+// file: OrderService.kt
+class OrderService(private val gateway: PaymentGateway) { // injected (DIP)
+    fun placeOrder(item: String, amountCents: Int): Boolean {
+        println("Placing order for \"$item\"")
+        return gateway.charge(amountCents, item)
+    }
+}
+```
+
+## Common Mistake
+
+```kotlin
+// ✗ DIP violation — concrete class constructed inside OrderService
+// ✗ OCP violation — when keyword forces edits for every new provider
+class BadOrderService {
+    fun placeOrder(item: String, cents: Int, method: String): Boolean {
+        return when (method) {                        // ✗ switch on payment type
+            "stripe" -> StripeGateway.charge(cents, item)  // ✗ direct dep on concrete
+            "paypal" -> PayPalGateway.charge(cents, item)  // ✗ direct dep on concrete, edit required per provider
+            else -> error("Unknown payment method: $method")
+        }
+    }
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.kt.md
+++ b/skills/principle-solid/examples/payment-gateway.kt.md
@@ -49,7 +49,7 @@ class OrderService(private val gateway: PaymentGateway) { // injected (DIP)
 ## Common Mistake
 
 ```kotlin
-// ✗ DIP violation — concrete class constructed inside OrderService
+// ✗ DIP violation — placeOrder dispatches directly to concrete singleton objects
 // ✗ OCP violation — when keyword forces edits for every new provider
 class BadOrderService {
     fun placeOrder(item: String, cents: Int, method: String): Boolean {

--- a/skills/principle-solid/examples/payment-gateway.py.md
+++ b/skills/principle-solid/examples/payment-gateway.py.md
@@ -45,7 +45,7 @@ class OrderService:
 
     def place_order(self, item: str, amount_cents: int) -> bool:
         print(f"Placing order for {item!r}")
-        return self._gateway.charge(amount_cents, reference=item)
+        return self._gateway.charge(amount_cents, item)
 ```
 
 ## Common Mistake

--- a/skills/principle-solid/examples/payment-gateway.py.md
+++ b/skills/principle-solid/examples/payment-gateway.py.md
@@ -1,0 +1,65 @@
+# DIP & OCP — Python — Payment Processing
+
+## Problem
+`OrderService` must charge payments without knowing which provider is active. Python
+expresses the abstraction either as an `ABC` (runtime-enforced) or a structural `Protocol`
+(duck-typed, preferred with `mypy`). New providers are new files — `OrderService` is never
+touched (OCP). The gateway is injected at construction (DIP).
+
+## Implementation
+
+```python
+# file: payment_gateway.py
+from typing import Protocol
+
+
+class PaymentGateway(Protocol):
+    def charge(self, amount_cents: int, reference: str) -> bool: ...
+```
+
+```python
+# file: stripe_gateway.py
+class StripeGateway:
+    def charge(self, amount_cents: int, reference: str) -> bool:
+        print(f"Stripe: charging {amount_cents}¢ for {reference}")
+        return True
+```
+
+```python
+# file: paypal_gateway.py
+# Adding PayPal requires no edits to OrderService — this is OCP.
+class PayPalGateway:
+    def charge(self, amount_cents: int, reference: str) -> bool:
+        print(f"PayPal: charging {amount_cents}¢ for {reference}")
+        return True
+```
+
+```python
+# file: order_service.py
+from payment_gateway import PaymentGateway
+
+
+class OrderService:
+    def __init__(self, gateway: PaymentGateway) -> None:
+        self._gateway = gateway  # injected — never constructed here (DIP)
+
+    def place_order(self, item: str, amount_cents: int) -> bool:
+        print(f"Placing order for {item!r}")
+        return self._gateway.charge(amount_cents, reference=item)
+```
+
+## Common Mistake
+
+```python
+# ✗ DIP violation — OrderService owns the concrete dependency
+# ✗ OCP violation — adding PayPal requires editing this method
+import stripe  # type: ignore
+
+class BadOrderService:
+    def place_order(self, item: str, amount_cents: int, method: str) -> bool:
+        if method == "stripe":                    # ✗ switch on type
+            stripe.Charge.create(amount=amount_cents, currency="usd")
+        elif method == "paypal":                  # ✗ edit required for every new provider
+            ...
+        return True
+```

--- a/skills/principle-solid/examples/payment-gateway.rb.md
+++ b/skills/principle-solid/examples/payment-gateway.rb.md
@@ -1,0 +1,78 @@
+# DIP & OCP — Ruby — Payment Processing
+
+## Problem
+Ruby is duck-typed: any object responding to `charge` satisfies the `PaymentGateway` contract.
+An abstract base class (using `raise NotImplementedError`) documents intent but is optional —
+the duck type is the real contract. Adding `PayPalGateway` is a new file; `OrderService` is
+never edited (OCP). The gateway is injected at `initialize` time (DIP).
+
+## Implementation
+
+```ruby
+# file: payment_gateway.rb
+# Abstract base documents the expected interface; Ruby does not enforce it at runtime.
+class PaymentGateway
+  def charge(amount_cents, reference)
+    raise NotImplementedError, "#{self.class}#charge not implemented"
+  end
+end
+```
+
+```ruby
+# file: stripe_gateway.rb
+require_relative "payment_gateway"
+
+class StripeGateway < PaymentGateway
+  def charge(amount_cents, reference)
+    puts "Stripe: charging #{amount_cents}¢ for #{reference}"
+    true
+  end
+end
+```
+
+```ruby
+# file: paypal_gateway.rb
+# Adding PayPal requires no edits to OrderService — this is OCP.
+require_relative "payment_gateway"
+
+class PayPalGateway < PaymentGateway
+  def charge(amount_cents, reference)
+    puts "PayPal: charging #{amount_cents}¢ for #{reference}"
+    true
+  end
+end
+```
+
+```ruby
+# file: order_service.rb
+class OrderService
+  def initialize(gateway) # injected — never constructed here (DIP)
+    @gateway = gateway
+  end
+
+  def place_order(item, amount_cents)
+    puts "Placing order for #{item.inspect}"
+    @gateway.charge(amount_cents, item)
+  end
+end
+```
+
+## Common Mistake
+
+```ruby
+# ✗ DIP violation — OrderService constructs StripeGateway directly
+# ✗ OCP violation — case statement must be edited for every new provider
+require_relative "stripe_gateway"
+require_relative "paypal_gateway"
+
+class BadOrderService
+  def place_order(item, cents, method)
+    case method                                    # ✗ switch on payment type
+    when :stripe
+      StripeGateway.new.charge(cents, item)        # ✗ concrete dep newed inline
+    when :paypal                                   # ✗ edit required per new provider
+      PayPalGateway.new.charge(cents, item)
+    end
+  end
+end
+```

--- a/skills/principle-solid/examples/payment-gateway.rs.md
+++ b/skills/principle-solid/examples/payment-gateway.rs.md
@@ -69,11 +69,12 @@ impl OrderService {
 // file: main.rs
 mod order_service;
 mod payment_gateway;
-mod paypal_gateway;
+mod paypal_gateway; // swap `use` below to exercise OCP — no OrderService edits needed
 mod stripe_gateway;
 
 use order_service::OrderService;
 use stripe_gateway::StripeGateway;
+// use paypal_gateway::PayPalGateway; // ← uncomment to swap provider; OrderService unchanged
 
 fn main() {
     // Box<dyn PaymentGateway> is the seam — swap for PayPalGateway; OrderService unchanged (OCP).

--- a/skills/principle-solid/examples/payment-gateway.rs.md
+++ b/skills/principle-solid/examples/payment-gateway.rs.md
@@ -1,0 +1,91 @@
+# DIP & OCP — Rust — Payment Processing
+
+## Problem
+`OrderService` depends on a `PaymentGateway` trait. Rust has no inheritance — polymorphism is
+always via traits, either static dispatch (`impl Trait` / generics) or dynamic dispatch
+(`Box<dyn Trait>`). Dynamic dispatch is used here so the gateway can be swapped at runtime
+(e.g., from config). Adding `PayPalGateway` is a new struct; `OrderService` is never edited
+(OCP). The gateway is constructor-injected as `Box<dyn PaymentGateway>` (DIP).
+
+## Implementation
+
+```rust
+// file: payment_gateway.rs
+pub trait PaymentGateway {
+    fn charge(&self, amount_cents: u32, reference: &str) -> bool;
+}
+```
+
+```rust
+// file: stripe_gateway.rs
+use crate::payment_gateway::PaymentGateway;
+
+pub struct StripeGateway;
+
+impl PaymentGateway for StripeGateway {
+    fn charge(&self, amount_cents: u32, reference: &str) -> bool {
+        println!("Stripe: charging {}¢ for {}", amount_cents, reference);
+        true
+    }
+}
+```
+
+```rust
+// file: paypal_gateway.rs
+// Adding PayPal requires no edits to OrderService — this is OCP.
+use crate::payment_gateway::PaymentGateway;
+
+pub struct PayPalGateway;
+
+impl PaymentGateway for PayPalGateway {
+    fn charge(&self, amount_cents: u32, reference: &str) -> bool {
+        println!("PayPal: charging {}¢ for {}", amount_cents, reference);
+        true
+    }
+}
+```
+
+```rust
+// file: order_service.rs
+use crate::payment_gateway::PaymentGateway;
+
+pub struct OrderService {
+    gateway: Box<dyn PaymentGateway>, // injected — never constructed here (DIP)
+}
+
+impl OrderService {
+    pub fn new(gateway: Box<dyn PaymentGateway>) -> Self {
+        Self { gateway }
+    }
+
+    pub fn place_order(&self, item: &str, amount_cents: u32) -> bool {
+        println!("Placing order for \"{}\"", item);
+        self.gateway.charge(amount_cents, item)
+    }
+}
+```
+
+## Common Mistake
+
+```rust
+// ✗ DIP violation — enum dispatch replaces the trait abstraction; no gateway is injected
+// ✗ OCP violation — match arm must be edited for every new provider
+enum PaymentMethod { Stripe, PayPal }
+
+struct BadOrderService;
+
+impl BadOrderService {
+    fn place_order(&self, item: &str, cents: u32, method: PaymentMethod) -> bool {
+        match method {
+            PaymentMethod::Stripe => {              // ✗ switch on payment type
+                println!("Stripe: charging {}¢", cents); // ✗ logic inline, not abstracted
+                true
+            }
+            PaymentMethod::PayPal => {              // ✗ edit required per new provider
+                println!("PayPal: charging {}¢", cents);
+                true
+            }
+        }
+    }
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.rs.md
+++ b/skills/principle-solid/examples/payment-gateway.rs.md
@@ -65,6 +65,22 @@ impl OrderService {
 }
 ```
 
+```rust
+// file: main.rs
+mod order_service;
+mod payment_gateway;
+mod stripe_gateway;
+
+use order_service::OrderService;
+use stripe_gateway::StripeGateway;
+
+fn main() {
+    // Box<dyn PaymentGateway> is the seam — swap for PayPalGateway; OrderService unchanged (OCP).
+    let svc = OrderService::new(Box::new(StripeGateway));
+    svc.place_order("widget", 1999);
+}
+```
+
 ## Common Mistake
 
 ```rust

--- a/skills/principle-solid/examples/payment-gateway.rs.md
+++ b/skills/principle-solid/examples/payment-gateway.rs.md
@@ -69,6 +69,7 @@ impl OrderService {
 // file: main.rs
 mod order_service;
 mod payment_gateway;
+mod paypal_gateway;
 mod stripe_gateway;
 
 use order_service::OrderService;

--- a/skills/principle-solid/examples/payment-gateway.swift.md
+++ b/skills/principle-solid/examples/payment-gateway.swift.md
@@ -1,0 +1,75 @@
+# DIP & OCP — Swift — Payment Processing
+
+## Problem
+`OrderService` depends on a `PaymentGateway` protocol. Swift protocols are first-class: a class,
+struct, or enum can conform. Structs are used for stateless gateways (value semantics); the
+protocol type is stored as `any PaymentGateway` (Swift 5.7+ existential syntax). Adding
+`PayPalGateway` is a new struct; `OrderService` is never edited (OCP). The gateway is injected
+at `init` time (DIP).
+
+## Implementation
+
+```swift
+// file: PaymentGateway.swift
+protocol PaymentGateway {
+    func charge(amountCents: Int, reference: String) -> Bool
+}
+```
+
+```swift
+// file: StripeGateway.swift
+struct StripeGateway: PaymentGateway {
+    func charge(amountCents: Int, reference: String) -> Bool {
+        print("Stripe: charging \(amountCents)¢ for \(reference)")
+        return true
+    }
+}
+```
+
+```swift
+// file: PayPalGateway.swift
+// Adding PayPal requires no edits to OrderService — this is OCP.
+struct PayPalGateway: PaymentGateway {
+    func charge(amountCents: Int, reference: String) -> Bool {
+        print("PayPal: charging \(amountCents)¢ for \(reference)")
+        return true
+    }
+}
+```
+
+```swift
+// file: OrderService.swift  (requires Swift 5.7+ for `any` existential syntax)
+final class OrderService {
+    private let gateway: any PaymentGateway // injected — never constructed here (DIP)
+
+    init(gateway: any PaymentGateway) {
+        self.gateway = gateway
+    }
+
+    func placeOrder(item: String, amountCents: Int) -> Bool {
+        print("Placing order for \"\(item)\"")
+        return gateway.charge(amountCents: amountCents, reference: item)
+    }
+}
+```
+
+## Common Mistake
+
+```swift
+// ✗ DIP violation — OrderService stores the concrete StripeGateway type
+// ✗ OCP violation — switch must be edited for every new payment method
+enum PaymentMethod { case stripe, paypal }
+
+final class BadOrderService {
+    func placeOrder(item: String, cents: Int, method: PaymentMethod) -> Bool {
+        switch method {                               // ✗ switch on payment type
+        case .stripe:                                // ✗ concrete logic inline
+            print("Stripe: charging \(cents)¢")
+            return true
+        case .paypal:                                // ✗ edit required per new provider
+            print("PayPal: charging \(cents)¢")
+            return true
+        }
+    }
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.ts.md
+++ b/skills/principle-solid/examples/payment-gateway.ts.md
@@ -1,0 +1,76 @@
+# DIP & OCP — TypeScript — Payment Processing
+
+## Problem
+`OrderService` depends on a `PaymentGateway` interface it owns, never on a concrete class.
+TypeScript's structural typing means any object with the right shape satisfies the interface —
+no `implements` keyword required, though it's used here for explicitness. Adding `PayPalGateway`
+is a new file; `OrderService` is never edited (OCP). The gateway is constructor-injected (DIP).
+
+## Implementation
+
+```ts
+// file: payment-gateway.ts
+export interface PaymentGateway {
+  charge(amountCents: number, reference: string): boolean;
+}
+```
+
+```ts
+// file: stripe-gateway.ts
+import type { PaymentGateway } from "./payment-gateway";
+
+export class StripeGateway implements PaymentGateway {
+  public charge(amountCents: number, reference: string): boolean {
+    console.log(`Stripe: charging ${amountCents}¢ for ${reference}`);
+    return true;
+  }
+}
+```
+
+```ts
+// file: paypal-gateway.ts
+// Adding PayPal requires no edits to OrderService — this is OCP.
+import type { PaymentGateway } from "./payment-gateway";
+
+export class PayPalGateway implements PaymentGateway {
+  public charge(amountCents: number, reference: string): boolean {
+    console.log(`PayPal: charging ${amountCents}¢ for ${reference}`);
+    return true;
+  }
+}
+```
+
+```ts
+// file: order-service.ts
+import type { PaymentGateway } from "./payment-gateway";
+
+export class OrderService {
+  public constructor(private readonly gateway: PaymentGateway) {} // injected (DIP)
+
+  public placeOrder(item: string, amountCents: number): boolean {
+    console.log(`Placing order for "${item}"`);
+    return this.gateway.charge(amountCents, item);
+  }
+}
+```
+
+## Common Mistake
+
+```ts
+// ✗ DIP violation — importing a concrete class crosses the abstraction boundary
+// ✗ OCP violation — adding PayPal requires editing placeOrder
+import Stripe from "stripe"; // ✗ concrete provider dep
+
+export class BadOrderService {
+  private stripe = new Stripe(process.env.STRIPE_KEY!);  // ✗ constructed internally
+
+  public placeOrder(item: string, cents: number, method: string): boolean {
+    if (method === "stripe") {          // ✗ switch on payment type
+      this.stripe.charges.create(...);
+    } else if (method === "paypal") {   // ✗ edit required for every new provider
+      ...
+    }
+    return true;
+  }
+}
+```

--- a/skills/principle-solid/examples/payment-gateway.ts.md
+++ b/skills/principle-solid/examples/payment-gateway.ts.md
@@ -66,7 +66,7 @@ export class BadOrderService {
 
   public placeOrder(item: string, cents: number, method: string): boolean {
     if (method === "stripe") {          // ✗ switch on payment type
-      this.stripe.charges.create(...);
+      // this.stripe.paymentIntents.create(params);
     } else if (method === "paypal") {   // ✗ edit required for every new provider
       ...
     }

--- a/skills/principle-solid/examples/payment-gateway.ts.md
+++ b/skills/principle-solid/examples/payment-gateway.ts.md
@@ -68,7 +68,7 @@ export class BadOrderService {
     if (method === "stripe") {          // ✗ switch on payment type
       // this.stripe.paymentIntents.create(params);
     } else if (method === "paypal") {   // ✗ edit required for every new provider
-      ...
+      // paypal SDK call here
     }
     return true;
   }


### PR DESCRIPTION
## Summary
- Add `skills/principle-solid/examples/` with a shared payment-gateway scenario in all 9 OO languages (C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript)
- Each file demonstrates **DIP** (`OrderService` depends on a `PaymentGateway` abstraction, never on a concrete class) and **OCP** (`PayPalGateway` added as a new file — `OrderService` untouched)
- Add an on-demand pointer blockquote at the end of `SKILL.md`; nothing is auto-loaded

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues (incl. `check_examples` ≤120-line cap on all 9 new files)
- [x] `pytest tests/ -v` — 1241/1241 pass

### Type-tailored checks ([feat])
- [x] All 9 `payment-gateway.<lang>.md` files present under `skills/principle-solid/examples/`
- [x] DIP seam visible: `OrderService` depends on abstraction, gateway constructor-injected
- [x] OCP seam visible: `PayPalGateway` is a new file; `OrderService` not edited to add it
- [x] All 9 files ≤120 lines (largest is 99 lines)
- [x] `SKILL.md` pointer blockquote renders at end of file; no auto-load behaviour change

Closes #378