### PR TITLE
[feat] Add worked bounded fan-out examples to principle-concurrency (9 languages)

### DIFF
--- a/skills/principle-concurrency/SKILL.md
+++ b/skills/principle-concurrency/SKILL.md
@@ -69,6 +69,7 @@ Unbounded queues hide a broken producer/consumer balance until memory is exhaust
 **Costs:** starvation possible without fair queueing.
 
 > For Go-specific idioms (goroutine lifecycles, channel patterns, `sync` package): see `language-go`.
+> See `examples/` for a worked bounded fan-out (bounded concurrency + ordered collection) implementation in C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).
 
 ## When Concurrency is Overkill
 

--- a/skills/principle-concurrency/examples/bounded-fan-out.cs.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.cs.md
@@ -1,0 +1,63 @@
+# Bounded Fan-out — C# — SemaphoreSlim + Task.WhenAll
+
+## Problem
+
+Fetch N items concurrently in C# using `SemaphoreSlim` to cap inflight work at K=5.
+Each task calls `await sem.WaitAsync()` before fetching and releases the semaphore in a
+`finally` block to guarantee release on both success and exception. Pre-allocating
+`results[i]` means each task writes to its own slot — no locking needed. `Task.WhenAll`
+collects everything once all tasks complete, in original order.
+
+## Implementation
+
+```csharp
+// file: bounded-fan-out.cs
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+class BoundedFanOut
+{
+    static async Task<string> FetchAsync(string id)
+    {
+        await Task.Delay(10);
+        return $"result-{id}";
+    }
+
+    static async Task Main()
+    {
+        var ids = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+        const int K = 5;
+        var sem = new SemaphoreSlim(K);
+        var results = new string[ids.Length];
+
+        var tasks = ids.Select(async (id, i) =>
+        {
+            await sem.WaitAsync();
+            try
+            {
+                results[i] = await FetchAsync(id); // each task owns its index slot
+            }
+            finally
+            {
+                sem.Release(); // always release, even on exception
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        Console.WriteLine(string.Join(", ", results));
+    }
+}
+```
+
+## Common Mistake
+
+`Task.WhenAll` over a direct projection launches all tasks at once with no cap.
+
+```csharp
+// ✗ all N tasks start immediately — no semaphore, no limit
+static async Task BadFanOut(string[] ids) {
+    await Task.WhenAll(ids.Select(FetchAsync)); // ✗ unbounded inflight
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.cs.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.cs.md
@@ -29,7 +29,7 @@ class BoundedFanOut
     {
         var ids = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
         const int K = 5;
-        var sem = new SemaphoreSlim(K);
+        using var sem = new SemaphoreSlim(K); // IDisposable: using ensures release on scope exit
         var results = new string[ids.Length];
 
         var tasks = ids.Select(async (id, i) =>

--- a/skills/principle-concurrency/examples/bounded-fan-out.go.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.go.md
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -52,7 +53,7 @@ func main() {
 	}
 
 	if err := g.Wait(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	fmt.Println(results)
 }

--- a/skills/principle-concurrency/examples/bounded-fan-out.go.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.go.md
@@ -3,9 +3,10 @@
 ## Problem
 
 Fetch N items concurrently but cap inflight work at K=5 using `errgroup.SetLimit`.
-Pre-allocate `results[i]` so each goroutine writes its own index slot — no mutex needed.
-`errgroup.WithContext` wires cancellation: if any fetch fails the remaining goroutines see
-a cancelled context. Order is preserved by index, not by completion time.
+Pre-allocate `results[i]` and shadow the loop variables so each goroutine captures its own
+`i` and writes exactly one slot — the pre-allocation, the shadow (`i, id := i, id`), and
+the indexed write are three load-bearing parts of the same ordering invariant. `errgroup.WithContext`
+propagates cancellation: a failed fetch signals the remaining goroutines to stop early.
 
 ## Implementation
 
@@ -39,13 +40,13 @@ func main() {
 	g.SetLimit(K) // at most K goroutines running at once
 
 	for i, id := range ids {
-		i, id := i, id
+		i, id := i, id // required for Go <1.22: range vars are shared across iterations
 		g.Go(func() error {
 			val, err := fetch(ctx, id)
 			if err != nil {
 				return err
 			}
-			results[i] = val // safe: each goroutine owns its index
+			results[i] = val // safe: pre-allocated slice + one goroutine per index slot
 			return nil
 		})
 	}

--- a/skills/principle-concurrency/examples/bounded-fan-out.go.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.go.md
@@ -1,0 +1,75 @@
+# Bounded Fan-out — Go — errgroup with concurrency limit
+
+## Problem
+
+Fetch N items concurrently but cap inflight work at K=5 using `errgroup.SetLimit`.
+Pre-allocate `results[i]` so each goroutine writes its own index slot — no mutex needed.
+`errgroup.WithContext` wires cancellation: if any fetch fails the remaining goroutines see
+a cancelled context. Order is preserved by index, not by completion time.
+
+## Implementation
+
+```go
+// file: bounded-fan-out.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func fetch(ctx context.Context, id string) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-time.After(10 * time.Millisecond):
+		return "result-" + id, nil
+	}
+}
+
+func main() {
+	ids := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	const K = 5
+	results := make([]string, len(ids))
+
+	g, ctx := errgroup.WithContext(context.Background())
+	g.SetLimit(K) // at most K goroutines running at once
+
+	for i, id := range ids {
+		i, id := i, id
+		g.Go(func() error {
+			val, err := fetch(ctx, id)
+			if err != nil {
+				return err
+			}
+			results[i] = val // safe: each goroutine owns its index
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		panic(err)
+	}
+	fmt.Println(results)
+}
+```
+
+## Common Mistake
+
+Fire-and-forget goroutines with no WaitGroup and no concurrency cap.
+
+```go
+// ✗ no WaitGroup — main exits before goroutines finish
+// ✗ no limit — all N goroutines start simultaneously
+func badFanOut(ids []string) {
+	for _, id := range ids {
+		go func(id string) { // ✗ unbounded goroutine launch
+			fmt.Println(fetch(context.Background(), id))
+		}(id)
+	}
+	// ✗ returns immediately; results are lost
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.java.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.java.md
@@ -19,7 +19,7 @@ import java.util.concurrent.*;
 public class BoundedFanOut {
 
     static String fetch(String id) throws InterruptedException {
-        Thread.sleep(10);
+        Thread.sleep(10); // InterruptedException propagates up; don't swallow it in callers
         return "result-" + id;
     }
 

--- a/skills/principle-concurrency/examples/bounded-fan-out.java.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.java.md
@@ -43,7 +43,7 @@ public class BoundedFanOut {
             }
             System.out.println(results);
         } finally {
-            executor.shutdown();
+            executor.shutdown(); // safe: invokeAll already drained all tasks
         }
     }
 }

--- a/skills/principle-concurrency/examples/bounded-fan-out.java.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.java.md
@@ -57,7 +57,10 @@ public class BoundedFanOut {
 // ✗ cached pool creates an unbounded number of threads
 ExecutorService badExecutor = Executors.newCachedThreadPool();
 List<CompletableFuture<String>> futures = ids.stream()
-    .map(id -> CompletableFuture.supplyAsync(() -> fetch(id), badExecutor)) // ✗ all at once
+    .map(id -> CompletableFuture.supplyAsync(() -> {
+        try { return fetch(id); }
+        catch (InterruptedException e) { throw new RuntimeException(e); } // Supplier<T> can't throw checked
+    }, badExecutor)) // ✗ all at once
     .toList();
 CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join(); // ✗ no limit
 ```

--- a/skills/principle-concurrency/examples/bounded-fan-out.java.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.java.md
@@ -1,0 +1,63 @@
+# Bounded Fan-out — Java — fixed thread pool with invokeAll
+
+## Problem
+
+Fetch N items concurrently on a fixed thread pool of K=5 threads using `invokeAll`.
+The executor enforces the concurrency cap structurally — threads block in the pool queue
+rather than starting without limit. `invokeAll` blocks until every `Callable` completes
+and returns `List<Future<String>>` in the same order as submission, so results are
+already ordered without extra sorting.
+
+## Implementation
+
+```java
+// file: bounded-fan-out.java
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+public class BoundedFanOut {
+
+    static String fetch(String id) throws InterruptedException {
+        Thread.sleep(10);
+        return "result-" + id;
+    }
+
+    public static void main(String[] args) throws Exception {
+        List<String> ids = List.of("a", "b", "c", "d", "e", "f", "g", "h");
+        final int K = 5;
+
+        ExecutorService executor = Executors.newFixedThreadPool(K);
+        try {
+            List<Callable<String>> tasks = new ArrayList<>();
+            for (String id : ids) {
+                tasks.add(() -> fetch(id));
+            }
+
+            // invokeAll blocks until all tasks finish; order matches submission.
+            List<Future<String>> futures = executor.invokeAll(tasks);
+
+            List<String> results = new ArrayList<>();
+            for (Future<String> f : futures) {
+                results.add(f.get()); // already in original order
+            }
+            System.out.println(results);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}
+```
+
+## Common Mistake
+
+`newCachedThreadPool` spins up one thread per task with no cap.
+
+```java
+// ✗ cached pool creates an unbounded number of threads
+ExecutorService badExecutor = Executors.newCachedThreadPool();
+List<CompletableFuture<String>> futures = ids.stream()
+    .map(id -> CompletableFuture.supplyAsync(() -> fetch(id), badExecutor)) // ✗ all at once
+    .toList();
+CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join(); // ✗ no limit
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.kt.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.kt.md
@@ -1,0 +1,50 @@
+# Bounded Fan-out — Kotlin — coroutines + Semaphore
+
+## Problem
+
+Fetch N items concurrently with Kotlin coroutines, capping inflight work at K=5 using
+`kotlinx.coroutines.sync.Semaphore`. Each `async` coroutine acquires a permit before
+calling `fetch` and releases it automatically via `withPermit`. `awaitAll()` on the
+deferred list collects results in original order without extra sorting.
+
+## Implementation
+
+```kotlin
+// file: bounded-fan-out.kt
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+suspend fun fetch(id: String): String {
+    delay(10)
+    return "result-$id"
+}
+
+fun main() = runBlocking {
+    val ids = listOf("a", "b", "c", "d", "e", "f", "g", "h")
+    val K = 5
+    val sem = Semaphore(K)
+
+    val results: List<String> = coroutineScope {
+        ids.map { id ->
+            async {
+                sem.withPermit { fetch(id) } // blocks until a permit is available
+            }
+        }.awaitAll() // order matches ids list
+    }
+    println(results)
+}
+```
+
+## Common Mistake
+
+Launching all coroutines with `async` and no semaphore removes the concurrency cap.
+
+```kotlin
+// ✗ all N coroutines are launched simultaneously — no cap
+val badResults = coroutineScope {
+    ids.map { id ->
+        async { fetch(id) } // ✗ unbounded — no Semaphore
+    }.awaitAll()
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.py.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.py.md
@@ -1,0 +1,46 @@
+# Bounded Fan-out — Python — asyncio.Semaphore + gather
+
+## Problem
+
+Fetch N items concurrently with `asyncio`, capping inflight coroutines at K=5 using
+`asyncio.Semaphore`. The `bounded` wrapper acquires the semaphore with `async with sem`
+before delegating to `fetch`. `asyncio.gather` launches all wrappers at once — the
+semaphore limits how many run concurrently. Results are returned in the same order as the
+input list because `gather` preserves submission order.
+
+## Implementation
+
+```python
+# file: bounded-fan-out.py
+import asyncio
+
+async def fetch(id: str) -> str:
+    await asyncio.sleep(0.01)
+    return f"result-{id}"
+
+async def main() -> None:
+    ids = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    K = 5
+    sem = asyncio.Semaphore(K)
+
+    async def bounded(id: str) -> str:
+        async with sem:           # blocks when K coroutines are already running
+            return await fetch(id)
+
+    results = await asyncio.gather(
+        *[bounded(id) for id in ids]
+    )  # order matches ids; gather preserves submission order
+    print(list(results))
+
+asyncio.run(main())
+```
+
+## Common Mistake
+
+`gather` over bare `fetch` coroutines starts all N coroutines with no cap.
+
+```python
+# ✗ all N coroutines run concurrently — no semaphore, no limit
+async def bad_fan_out(ids: list[str]) -> list[str]:
+    return list(await asyncio.gather(*[fetch(id) for id in ids]))  # ✗ unbounded
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.rb.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.rb.md
@@ -5,7 +5,8 @@
 Fetch N items concurrently in Ruby using K=5 worker threads that drain a shared `Queue`.
 Pre-enqueue `[i, id]` pairs so each worker captures the original index alongside the item.
 Sentinel `nil` values (one per worker) signal shutdown. Workers write `results[i] = fetch(id)`
-to their owned index slot — no mutex needed — then `workers.each(&:join)` collects them all.
+to their owned index slot — no mutex needed (CRuby's GVL serializes thread execution; disjoint
+index slots remove any shared-write race) — then `workers.each(&:join)` collects them all.
 
 ## Implementation
 

--- a/skills/principle-concurrency/examples/bounded-fan-out.rb.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.rb.md
@@ -1,0 +1,49 @@
+# Bounded Fan-out — Ruby — thread pool consuming a Queue
+
+## Problem
+
+Fetch N items concurrently in Ruby using K=5 worker threads that drain a shared `Queue`.
+Pre-enqueue `[i, id]` pairs so each worker captures the original index alongside the item.
+Sentinel `nil` values (one per worker) signal shutdown. Workers write `results[i] = fetch(id)`
+to their owned index slot — no mutex needed — then `workers.each(&:join)` collects them all.
+
+## Implementation
+
+```ruby
+# file: bounded-fan-out.rb
+def fetch(id)
+  sleep(0.01)
+  "result-#{id}"
+end
+
+ids     = %w[a b c d e f g h]
+K       = 5
+results = Array.new(ids.size)
+queue   = Queue.new
+
+ids.each_with_index { |id, i| queue.push([i, id]) }
+K.times { queue.push(nil) } # one sentinel per worker
+
+workers = K.times.map do
+  Thread.new do
+    loop do
+      item = queue.pop
+      break if item.nil?       # sentinel: this worker is done
+      i, id = item
+      results[i] = fetch(id)   # write to owned index slot
+    end
+  end
+end
+
+workers.each(&:join)
+puts results.inspect
+```
+
+## Common Mistake
+
+Creating one thread per item with `Thread.new` inside `map` is unbounded.
+
+```ruby
+# ✗ one thread per item — no pool, no cap
+bad_results = ids.map { |id| Thread.new { fetch(id) } }.map(&:value) # ✗ unbounded threads
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.rs.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.rs.md
@@ -26,7 +26,7 @@ async fn main() {
     const K: usize = 5;
 
     // Enumerate to carry the original index through the async boundary.
-    let mut pairs: Vec<(usize, String)> = stream::iter(ids.iter().enumerate())
+    let mut pairs: Vec<(usize, String)> = stream::iter(ids.iter().copied().enumerate())
         .map(|(i, id)| async move { (i, fetch(id).await) })
         .buffer_unordered(K) // at most K futures polled at once
         .collect()

--- a/skills/principle-concurrency/examples/bounded-fan-out.rs.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.rs.md
@@ -47,6 +47,6 @@ use futures::future::join_all;
 
 // ✗ all N futures are polled simultaneously — no cap
 async fn bad_fan_out(ids: &[&str]) -> Vec<String> {
-    join_all(ids.iter().map(|id| fetch(id))).await // ✗ unbounded inflight
+    join_all(ids.iter().copied().map(|id| fetch(id))).await // ✗ unbounded inflight
 }
 ```

--- a/skills/principle-concurrency/examples/bounded-fan-out.rs.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.rs.md
@@ -1,0 +1,52 @@
+# Bounded Fan-out — Rust — buffer_unordered stream combinator
+
+## Problem
+
+Fetch N items concurrently using async Rust, capping inflight futures at K=5 with
+`buffer_unordered`. Each future carries its original index so results can be sorted back
+into submission order after collection. The stream combinator handles the concurrency
+window automatically — no manual semaphore bookkeeping required.
+
+## Implementation
+
+```rust
+// file: bounded-fan-out.rs
+use futures::stream::{self, StreamExt};
+use std::time::Duration;
+use tokio::time::sleep;
+
+async fn fetch(id: &str) -> String {
+    sleep(Duration::from_millis(10)).await;
+    format!("result-{}", id)
+}
+
+#[tokio::main]
+async fn main() {
+    let ids = vec!["a", "b", "c", "d", "e", "f", "g", "h"];
+    const K: usize = 5;
+
+    // Enumerate to carry the original index through the async boundary.
+    let mut pairs: Vec<(usize, String)> = stream::iter(ids.iter().enumerate())
+        .map(|(i, id)| async move { (i, fetch(id).await) })
+        .buffer_unordered(K) // at most K futures polled at once
+        .collect()
+        .await;
+
+    pairs.sort_by_key(|(i, _)| *i); // restore original order
+    let results: Vec<String> = pairs.into_iter().map(|(_, v)| v).collect();
+    println!("{:?}", results);
+}
+```
+
+## Common Mistake
+
+`join_all` launches every future at once with no concurrency cap.
+
+```rust
+use futures::future::join_all;
+
+// ✗ all N futures are polled simultaneously — no cap
+async fn bad_fan_out(ids: &[&str]) -> Vec<String> {
+    join_all(ids.iter().map(|id| fetch(id))).await // ✗ unbounded inflight
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.swift.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.swift.md
@@ -1,0 +1,70 @@
+# Bounded Fan-out — Swift — withThrowingTaskGroup drain-as-you-add
+
+## Problem
+
+Swift structured concurrency has no built-in concurrency cap on `TaskGroup`. The
+drain-as-you-add pattern enforces K=5 by adding a new child task only after an inflight
+task completes: once `active == K`, call `next()` to drain one result before adding the
+next. Results are stored in a dictionary keyed by index and converted to an ordered array
+at the end, preserving original order despite out-of-order completion.
+
+## Implementation
+
+```swift
+// file: bounded-fan-out.swift
+import Foundation
+
+func fetch(id: String) async throws -> String {
+    try await Task.sleep(nanoseconds: 10_000_000)
+    return "result-\(id)"
+}
+
+func boundedFanOut(ids: [String], limit: Int) async throws -> [String] {
+    var results = [Int: String]()
+    var active = 0
+
+    try await withThrowingTaskGroup(of: (Int, String).self) { group in
+        for (i, id) in ids.enumerated() {
+            if active == limit {
+                // Drain one before adding the next to stay at limit.
+                if let (idx, val) = try await group.next() {
+                    results[idx] = val
+                    active -= 1
+                }
+            }
+            group.addTask { (i, try await fetch(id: id)) }
+            active += 1
+        }
+        // Drain remainder.
+        for try await (idx, val) in group {
+            results[idx] = val
+        }
+    }
+    return (0..<ids.count).map { results[$0]! }
+}
+
+// Usage
+Task {
+    let ids = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    let out = try await boundedFanOut(ids: ids, limit: 5)
+    print(out)
+}
+```
+
+## Common Mistake
+
+Adding all tasks at once inside `withThrowingTaskGroup` with no drain creates unbounded concurrency.
+
+```swift
+// ✗ all N tasks added immediately — no cap on concurrent work
+func badFanOut(ids: [String]) async throws -> [String] {
+    var results = [Int: String]()
+    try await withThrowingTaskGroup(of: (Int, String).self) { group in
+        for (i, id) in ids.enumerated() {
+            group.addTask { (i, try await fetch(id: id)) } // ✗ unbounded
+        }
+        for try await (idx, val) in group { results[idx] = val }
+    }
+    return (0..<ids.count).map { results[$0]! }
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.swift.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.swift.md
@@ -40,7 +40,7 @@ func boundedFanOut(ids: [String], limit: Int) async throws -> [String] {
             results[idx] = val
         }
     }
-    return (0..<ids.count).map { results[$0]! }
+    return (0..<ids.count).map { results[$0]! } // safe: every index 0..<ids.count is populated by exactly one task
 }
 
 // Usage

--- a/skills/principle-concurrency/examples/bounded-fan-out.swift.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.swift.md
@@ -27,6 +27,7 @@ func boundedFanOut(ids: [String], limit: Int) async throws -> [String] {
         for (i, id) in ids.enumerated() {
             if active == limit {
                 // Drain one before adding the next to stay at limit.
+                // group.next() is non-nil here: exactly `limit` tasks are live.
                 if let (idx, val) = try await group.next() {
                     results[idx] = val
                     active -= 1

--- a/skills/principle-concurrency/examples/bounded-fan-out.ts.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.ts.md
@@ -1,0 +1,53 @@
+# Bounded Fan-out — TypeScript — bounded worker pool (p-limit style)
+
+## Problem
+
+Fetch N items concurrently in TypeScript, capping inflight work at K=5 using K async
+worker functions that share a mutable `cursor` index. Each worker claims the next index
+atomically (`i = cursor++`), fetches, stores into `results[i]`, then loops until the
+cursor exceeds the array bounds. `Promise.all(workers)` waits for all K workers to drain
+the list. Results land in `results` in original order because each worker writes to its
+claimed index slot.
+
+## Implementation
+
+```typescript
+// file: bounded-fan-out.ts
+async function fetch(id: string): Promise<string> {
+  await new Promise((r) => setTimeout(r, 10));
+  return `result-${id}`;
+}
+
+async function boundedFanOut(ids: string[], K: number): Promise<string[]> {
+  const results: string[] = new Array(ids.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = cursor++; // safe: JS is single-threaded; no two workers overlap here
+      if (i >= ids.length) break;
+      results[i] = await fetch(ids[i]); // write to owned slot
+    }
+  }
+
+  // Start K workers; each drains ids until none remain.
+  await Promise.all(Array.from({ length: K }, worker));
+  return results;
+}
+
+(async () => {
+  const ids = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  console.log(await boundedFanOut(ids, 5));
+})();
+```
+
+## Common Mistake
+
+`Promise.all` over a direct map launches all N promises at once with no cap.
+
+```typescript
+// ✗ all N promises are created and started immediately — no worker pool
+async function badFanOut(ids: string[]): Promise<string[]> {
+  return Promise.all(ids.map(fetch)); // ✗ unbounded inflight
+}
+```

--- a/skills/principle-concurrency/examples/bounded-fan-out.ts.md
+++ b/skills/principle-concurrency/examples/bounded-fan-out.ts.md
@@ -24,7 +24,7 @@ async function boundedFanOut(ids: string[], K: number): Promise<string[]> {
 
   async function worker(): Promise<void> {
     while (true) {
-      const i = cursor++; // safe: JS is single-threaded; no two workers overlap here
+      const i = cursor++; // safe: cursor++ is synchronous; JS only yields at `await`, so no two workers can read the same index
       if (i >= ids.length) break;
       results[i] = await fetch(ids[i]); // write to owned slot
     }


### PR DESCRIPTION
## Summary
- Added `skills/principle-concurrency/examples/` with 9 language implementations of the **bounded fan-out** scenario: fetch N item IDs concurrently with cap K=5, collect results in original order.
- Files: `bounded-fan-out.{cs,go,java,kt,py,rb,rs,swift,ts}.md` — each ≤75 lines, matching the `principle-solid/examples/` format convention (em-dash title, three `##` sections, single fenced block, `✗`-annotated Common Mistake).
- Added one read-on-demand blockquote pointer in `skills/principle-concurrency/SKILL.md` after the existing Go-idioms reference; no `@examples/...` auto-include added.

## Test Plan
- [x] `bash scripts/validate.sh` passes clean (incl. `check_examples` ≤120-line cap)
- [x] `pytest` — 1280/1280 pass
- [x] `wc -l skills/principle-concurrency/examples/*.md` — all 9 files ≤120 lines (range 46–75)
- [x] Examples manually reviewed: each uses the idiomatic bounded primitive for its language (errgroup+SetLimit, buffer_unordered, newFixedThreadPool+invokeAll, Semaphore+awaitAll, withThrowingTaskGroup drain-as-you-add, SemaphoreSlim+WhenAll, K-worker cursor pool, asyncio.Semaphore+gather, Queue+K threads)

### Type-tailored checks ([feat])
- [ ] Each example demonstrates a genuine K=5 concurrency cap (not just concurrent execution)
- [ ] Ordering invariant is present in all 9 files (indexed-slot or gather-order guarantee)
- [ ] Common Mistake in each file shows the unbounded anti-pattern with ✗ markers and a `bad`/`Bad`-prefixed identifier

Closes #377
