### PR TITLE
[docs] Normalize language-sql description separator to em-dash

### DIFF
--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: language-sql
-description: SQL idioms - query tuning, EXPLAIN plans, table definitions, constraints, indexes, transactions, window functions, CTEs, and pagination. Auto-load when working with .sql files or migrations, or when the user mentions SQL syntax, SELECT, JOIN, EXPLAIN, CTE, window functions, transaction isolation, deadlocks, or SQL indexes.
+description: SQL idioms — query tuning, EXPLAIN plans, table definitions, constraints, indexes, transactions, window functions, CTEs, and pagination. Auto-load when working with .sql files or migrations, or when the user mentions SQL syntax, SELECT, JOIN, EXPLAIN, CTE, window functions, transaction isolation, deadlocks, or SQL indexes.
 ---
 
 # SQL


### PR DESCRIPTION
## Summary
- Normalized the description separator in `language-sql/SKILL.md` from hyphen (`-`) to em-dash (`—`)
- This aligns with the formatting pattern used by all 11 language skills in the codebase
- Cosmetic consistency improvement with no code, test, or runtime implications

## Test Plan
- [x] Changed skills/commands/agents load without errors (documentation-only change)
- [x] Pattern validation: grep confirms all 11 language skills now use em-dash separator
- [x] Visual inspection: `skills/language-sql/SKILL.md:3` uses `—` instead of `-`

Closes: #331