### PR TITLE
[fix] Foreground-verify state-file reap + preflight-pr.sh + _RT root guard

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -19,15 +19,25 @@ the swe-workbench plugin and are invoked at runtime by skills, commands, and age
 | `clean-state-files.sh` | Safe `rm -f` for per-invocation `/tmp` state files |
 | `doctor.sh` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) |
 | `fetch-pr.sh` | Fetch a PR's metadata JSON via `gh pr view`; exits 1 if the PR is inaccessible |
+| `preflight-pr.sh` | Consolidated pre-flight for PR-review skills: `gh auth` gate → `fetch-pr.sh` → emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as `printf %q`-quoted eval-able `KEY=VALUE` lines |
 | `reply-and-resolve.sh` | Post a PR review thread reply (REST) and optionally resolve it (GraphQL) |
 
 ## Reference pattern
 
-Skills and commands invoke these scripts with:
+Skills bind the plugin root **once** at the top of their first executable block (before any worktree
+is entered) and then reference all runtime scripts through `$_RT`:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/<name>.sh" [args...]
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
+  exit 1
+}
+# … later …
+bash "$_RT/runtime/<name>.sh" [args...]
 ```
 
-`CLAUDE_PLUGIN_ROOT` is set by the Claude Code plugin runtime to the repo root. The
-`$(git rev-parse --show-toplevel)` fallback supports local development from a checkout.
+`CLAUDE_PLUGIN_ROOT` is set by the Claude Code plugin runtime to the plugin's checkout root. The
+`$(git rev-parse --show-toplevel)` fallback supports local development. The hard-fail guard converts
+"script not found → silent inline fallback" into a loud abort, preventing silent bypass when
+`CLAUDE_PLUGIN_ROOT` is unset inside an ephemeral PR worktree.

--- a/runtime/preflight-pr.sh
+++ b/runtime/preflight-pr.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Consolidated pre-flight for PR-review workflows.
+# Usage: preflight-pr.sh <PR> <out_json> [fields]
+#
+# Outputs KEY=VALUE lines (printf %q quoted) for eval:
+#   BASE  HEAD_SHA  AUTHOR_LOGIN  OWNER  REPO  STATE
+#
+# title/body are NOT emitted — they are free-text and echoing them into
+# eval "$(...)" enables code injection.  Read them from <out_json> with jq.
+#
+# Resolves sibling scripts via dirname "$0" so the script works correctly
+# even when cwd is an ephemeral PR worktree (CLAUDE_PLUGIN_ROOT may be unset).
+set -euo pipefail
+
+PR="${1:?Usage: preflight-pr.sh <PR> <out_json> [fields]}"
+OUT_JSON="${2:?Usage: preflight-pr.sh <PR> <out_json> [fields]}"
+FIELDS="${3:-state,number,headRefName,baseRefName,headRefOid,title,body,author,reviewDecision}"
+
+SCRIPT_DIR="$(dirname "$0")"
+
+gh auth status >/dev/null || {
+  echo "gh not authenticated. Run 'gh auth login'." >&2
+  exit 1
+}
+
+bash "$SCRIPT_DIR/fetch-pr.sh" "$PR" "$OUT_JSON" "$FIELDS"
+
+BASE=$(jq -r .baseRefName     "$OUT_JSON")
+HEAD_SHA=$(jq -r .headRefOid  "$OUT_JSON")
+AUTHOR_LOGIN=$(jq -r .author.login "$OUT_JSON")
+STATE=$(jq -r .state          "$OUT_JSON")
+
+OWNER=$(gh repo view --json owner -q .owner.login)
+REPO=$(gh repo view --json name   -q .name)
+if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
+  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
+  exit 1
+fi
+
+printf 'BASE=%q\n'         "$BASE"
+printf 'HEAD_SHA=%q\n'     "$HEAD_SHA"
+printf 'AUTHOR_LOGIN=%q\n' "$AUTHOR_LOGIN"
+printf 'OWNER=%q\n'        "$OWNER"
+printf 'REPO=%q\n'         "$REPO"
+printf 'STATE=%q\n'        "$STATE"

--- a/runtime/preflight-pr.sh
+++ b/runtime/preflight-pr.sh
@@ -16,7 +16,7 @@ PR="${1:?Usage: preflight-pr.sh <PR> <out_json> [fields]}"
 OUT_JSON="${2:?Usage: preflight-pr.sh <PR> <out_json> [fields]}"
 FIELDS="${3:-state,number,headRefName,baseRefName,headRefOid,title,body,author,reviewDecision}"
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 gh auth status >/dev/null || {
   echo "gh not authenticated. Run 'gh auth login'." >&2
@@ -29,6 +29,14 @@ BASE=$(jq -r .baseRefName     "$OUT_JSON")
 HEAD_SHA=$(jq -r .headRefOid  "$OUT_JSON")
 AUTHOR_LOGIN=$(jq -r .author.login "$OUT_JSON")
 STATE=$(jq -r .state          "$OUT_JSON")
+
+for _var in BASE HEAD_SHA AUTHOR_LOGIN STATE; do
+  _val="${!_var}"
+  if [ -z "$_val" ] || [ "$_val" = "null" ]; then
+    echo "preflight-pr.sh: field $_var is empty/null in $OUT_JSON — PR data may be incomplete." >&2
+    exit 1
+  fi
+done
 
 OWNER=$(gh repo view --json owner -q .owner.login)
 REPO=$(gh repo view --json name   -q .name)

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -31,30 +31,21 @@ This skill orchestrates:
 ### Phase 1 — Pre-flight + fetch
 
 ```bash
-gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
-CURRENT_USER=$(gh api /user -q .login)
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/fetch-pr.sh" \
-  "$PR" "/tmp/swe-workbench-address-feedback/${PR}.json" \
-  "number,title,body,headRefName,baseRefName,author,reviewDecision,state"
-```
-
-Extract fields from the JSON:
-
-```bash
-JSON="/tmp/swe-workbench-address-feedback/${PR}.json"
-AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
-PR_BRANCH=$(jq -r .headRefName "$JSON")
-OWNER=$(gh repo view --json owner -q .owner.login)
-REPO=$(gh repo view --json name   -q .name)
-if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
   exit 1
-fi
+}
+JSON="/tmp/swe-workbench-address-feedback/${PR}.json"
+eval "$("$_RT/runtime/preflight-pr.sh" "$PR" "$JSON")"
+CURRENT_USER=$(gh api /user -q .login)
+PR_BRANCH=$(jq -r .headRefName "$JSON")
 ```
+
+`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `PR_BRANCH` is derived from `headRefName` in `$JSON` (address-feedback uses it for worktree setup in Phase 2).
 
 Check that the PR is open before proceeding:
 ```bash
-STATE=$(jq -r .state "$JSON")
 [ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — address-feedback only applies to open PRs."; exit 1; }
 ```
 
@@ -205,7 +196,7 @@ Reply body templates by triage classification:
 - **DEFERRED**: pass empty `$REPLY_BODY` and empty `$THREAD_ID` (neither reply nor resolve).
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/reply-and-resolve.sh" \
+bash "$_RT/runtime/reply-and-resolve.sh" \
   "$OWNER" "$REPO" "$PR" "$COMMENT_DATABASEID" "$THREAD_ID" "$REPLY_BODY"
 ```
 
@@ -213,10 +204,18 @@ After all replies and resolutions land, emit the follow-up CTA:
 
 > "Want me to ping the reviewer to re-check? Reply `yes` to run `/review --check-followup <N>`."
 
-On the Phase 5 success path, delete the address-feedback state files:
+On the Phase 5 success path, delete the address-feedback state files. The reap runs foreground; failures surface (no `2>/dev/null`):
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-state-files.sh" "/tmp/swe-workbench-address-feedback/${PR}.json" "/tmp/swe-workbench-address-feedback/${PR}-threads.json" "/tmp/swe-workbench-address-feedback/${PR}-triage.json" 2>/dev/null
+bash "$_RT/runtime/clean-state-files.sh" \
+  "/tmp/swe-workbench-address-feedback/${PR}.json" \
+  "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+  "/tmp/swe-workbench-address-feedback/${PR}-triage.json"
+for f in "/tmp/swe-workbench-address-feedback/${PR}.json" \
+         "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+         "/tmp/swe-workbench-address-feedback/${PR}-triage.json"; do
+  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
+done
 ```
 
 Then run **Phase 6 — Cleanup**.
@@ -234,7 +233,7 @@ else
     echo "Cleaned up worktree address-feedback-$PR."
   else
     # $WT is set in Phase 2 (both rimba and fallback paths); do not re-assign here
-    git worktree remove --force "$WT" 2>/dev/null; bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
+    git worktree remove --force "$WT" 2>/dev/null; bash "$_RT/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
     echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback on $WT."
   fi
 fi

--- a/skills/workflow-audit-emit-issues/SKILL.md
+++ b/skills/workflow-audit-emit-issues/SKILL.md
@@ -33,6 +33,19 @@ Findings already in the orchestrator's context from the audit render. Each findi
 carries: `file_line`, `domain`, `severity`, `confidence`, `effort`, `symptom`,
 `root_cause`, `reasoning_chain`, `counter_evidence_considered`, `suggested_fix`.
 
+## Preamble — bind plugin root
+
+Resolve and bind the plugin root before any script call. If the runtime scripts directory is
+missing (e.g. cwd is a worktree where `CLAUDE_PLUGIN_ROOT` is unset), abort loudly.
+
+```bash
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
+  exit 1
+}
+```
+
 ## Phases
 
 ### Phase 1 — Group by subsystem
@@ -119,10 +132,25 @@ Reply `confirm` to file all · `drop N` to remove group N · `edit N` to revise 
 
 | Reply | Action |
 |-------|--------|
-| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, delete the temp files: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-state-files.sh" /tmp/audit-emit-<repo-slug>-<unix-ts>-1.md … /tmp/audit-emit-<repo-slug>-<unix-ts>-N.md /tmp/audit-emit-<repo-slug>-<unix-ts>.cmd 2>/dev/null` — use the actual paths written in Phase 3 (pattern: `/tmp/audit-emit-<repo-slug>-<unix-ts>-<n>.md` and `.cmd`). |
+| `confirm` (literal) | Run each sidecar `gh issue create` line; return issue URLs. After all issues are filed successfully, reap the temp files (foreground, no `2>/dev/null`) then post-check each path (see below). |
 | `drop N` | Remove group N from the batch; rewrite temp files and sidecar; re-print preview. |
 | `edit N` | Show group N's body; accept revised text; rewrite temp file; re-print preview. |
 | anything else | Re-prompt; do **not** file. |
+
+After a successful `confirm`, reap all temp files and verify each was removed:
+
+```bash
+bash "$_RT/runtime/clean-state-files.sh" \
+  /tmp/audit-emit-<repo-slug>-<unix-ts>-1.md \
+  … \
+  /tmp/audit-emit-<repo-slug>-<unix-ts>-N.md \
+  /tmp/audit-emit-<repo-slug>-<unix-ts>.cmd
+for f in /tmp/audit-emit-<repo-slug>-<unix-ts>-1.md … /tmp/audit-emit-<repo-slug>-<unix-ts>.cmd; do
+  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
+done
+```
+
+Use the actual paths written in Phase 3 (pattern: `/tmp/audit-emit-<repo-slug>-<unix-ts>-<n>.md` and `.cmd`).
 
 On `gh issue create` failure: surface the error, print the URLs of successfully-filed
 issues so far, and rewrite the `.cmd` sidecar to contain only the remaining (unfiled)

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -69,7 +69,12 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 
 Then invoke the companion script, passing the resolved default branch as `$2`:
 
 ```bash
-_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
+  exit 1
+}
+_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"
 eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>" "$DEFAULT_BRANCH")"
 ```
 
@@ -122,7 +127,7 @@ Execute the first strategy whose preconditions hold. Fall through to the next if
 
 1. `core.hooksPath` resolves to a directory containing an executable `post-merge` file that invokes `rimba clean --merged --force`. Detection:
    ```bash
-   _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+   _SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"
    eval "$("$_SCRIPTS/check-rimba-hook.sh")"
    ```
    `RIMBA_HOOK_ACTIVE=1` is required. (The grep inside the script excludes comment-only lines so a documented-but-disabled invocation does not yield a false positive.)
@@ -143,7 +148,7 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 **Preconditions:**
 - rimba MCP server is active in the session, OR the rimba binary resolves on PATH or a known install location:
   ```bash
-  _SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+  _SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"
   RIMBA=$("$_SCRIPTS/resolve-rimba.sh")
   ```
   `RIMBA` must be non-empty (or MCP server active).
@@ -174,7 +179,7 @@ If `$RIMBA remove` exits non-zero, run a filesystem probe as the canonical signa
 Run the companion script and eval its `KEY=VALUE` output:
 
 ```bash
-_SCRIPTS="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/workflow-cleanup-merged/scripts"
+_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"
 eval "$("$_SCRIPTS/probe-worktree.sh" "<headRefName>")"
 ```
 

--- a/skills/workflow-extend/SKILL.md
+++ b/skills/workflow-extend/SKILL.md
@@ -86,7 +86,24 @@ Push. Then invoke `swe-workbench:workflow-commit-and-pr`. That skill will surfac
 
 Optional: if the user opts in ("append follow-on section"), fetch the current PR body first (`gh pr view --json body -q .body`), append the `## Follow-on` section, write to a tempfile, then `gh pr edit --body-file <tmp>` — this avoids overwriting collaborator edits.
 
-After Phase D delivery succeeds, delete the spec temp file: `bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-state-files.sh" "/tmp/extend-${TS}.md" 2>/dev/null`. The `Ref: extend-${TS}` commit traceability string remains in git history; only the temp file is removed. On abort before delivery, leave the file for inspection.
+Before any script call in Phase B (when `$TS` is first written), bind the plugin root:
+
+```bash
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
+  exit 1
+}
+```
+
+After Phase D delivery succeeds, delete the spec temp file. The reap runs foreground without suppression:
+
+```bash
+bash "$_RT/runtime/clean-state-files.sh" "/tmp/extend-${TS}.md"
+[ -e "/tmp/extend-${TS}.md" ] && echo "⚠ state file NOT reaped: /tmp/extend-${TS}.md" >&2 || echo "✓ state file reaped: /tmp/extend-${TS}.md"
+```
+
+The `Ref: extend-${TS}` commit traceability string remains in git history; only the temp file is removed. On abort before delivery, leave the file for inspection.
 
 ## Project Detection
 

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -31,31 +31,20 @@ This skill orchestrates; analysis is delegated to:
 ### Step 1 — Pre-flight
 
 ```bash
-gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
-CURRENT_USER=$(gh api /user -q .login)
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/fetch-pr.sh" \
-  "$PR" "/tmp/swe-workbench-pr-review/${PR}-followup.json" \
-  "state,number,headRefName,baseRefName,headRefOid,title,body,author"
-```
-
-Extract fields from the JSON. The state file is stored under `${PR}-followup.json` (distinct from `${PR}.json` used by the primary review) to allow both to coexist.
-
-```bash
-JSON="/tmp/swe-workbench-pr-review/${PR}-followup.json"
-BASE=$(jq -r .baseRefName "$JSON")
-HEAD_SHA=$(jq -r .headRefOid "$JSON")
-AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
-OWNER=$(gh repo view --json owner -q .owner.login)
-REPO=$(gh repo view --json name   -q .name)
-if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
   exit 1
-fi
+}
+JSON="/tmp/swe-workbench-pr-review/${PR}-followup.json"
+eval "$("$_RT/runtime/preflight-pr.sh" "$PR" "$JSON")"
+CURRENT_USER=$(gh api /user -q .login)
 ```
+
+`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON` (stored under `${PR}-followup.json` — distinct from `${PR}.json` used by the primary review to allow both to coexist), and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments.
 
 Check that the PR is open before proceeding:
 ```bash
-STATE=$(jq -r .state "$JSON")
 [ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — follow-up review only applies to open PRs."; exit 1; }
 ```
 
@@ -74,7 +63,7 @@ WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 ```bash
 WT="/tmp/swe-workbench-pr-review/${PR}-followup"
 if [ -d "$WT" ]; then
-  git worktree remove --force "$WT" 2>/dev/null || bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
+  git worktree remove --force "$WT" 2>/dev/null || bash "$_RT/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
 fi
 mkdir -p "$(dirname "$WT")"
 git fetch origin "pull/${PR}/head:pr-followup-${PR}" --force
@@ -226,12 +215,24 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
+Foreground state-file reap — runs before worktree teardown; failures surface (no `2>/dev/null` or `|| true`):
+
 ```bash
-( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}-followup.json" "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json" 2>/dev/null || true; \
-  rimba remove "pr-followup-$PR" --force 2>/dev/null \
+bash "$_RT/runtime/clean-state-files.sh" \
+  "/tmp/swe-workbench-pr-review/${PR}-followup.json" \
+  "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json"
+for f in "/tmp/swe-workbench-pr-review/${PR}-followup.json" "/tmp/swe-workbench-pr-review/${PR}-followup-threads.json"; do
+  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
+done
+```
+
+Worktree teardown stays backgrounded (slow); it no longer carries state-file cleanup:
+
+```bash
+( rimba remove "pr-followup-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-followup-$PR" 2>/dev/null; \
-       bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &
+       bash "$_RT/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &
 ```
 
 ## Footer parsing contract

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -34,27 +34,17 @@ This skill orchestrates; analysis is delegated to:
 ### Step 1 — Pre-flight
 
 ```bash
-gh auth status >/dev/null || { echo "gh not authenticated. Run 'gh auth login'."; exit 1; }
-CURRENT_USER=$(gh api /user -q .login)
-bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/fetch-pr.sh" \
-  "$PR" "/tmp/swe-workbench-pr-review/${PR}.json" \
-  "state,number,headRefName,baseRefName,headRefOid,title,body,author"
-```
-
-Extract fields from the JSON:
-
-```bash
-JSON="/tmp/swe-workbench-pr-review/${PR}.json"
-BASE=$(jq -r .baseRefName "$JSON")
-HEAD_SHA=$(jq -r .headRefOid "$JSON")
-AUTHOR_LOGIN=$(jq -r .author.login "$JSON")
-OWNER=$(gh repo view --json owner -q .owner.login)
-REPO=$(gh repo view --json name   -q .name)
-if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
-  echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
+_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
+[ -f "$_RT/runtime/clean-state-files.sh" ] || {
+  echo "swe-workbench runtime scripts not found under $_RT/runtime — set CLAUDE_PLUGIN_ROOT and retry." >&2
   exit 1
-fi
+}
+JSON="/tmp/swe-workbench-pr-review/${PR}.json"
+eval "$("$_RT/runtime/preflight-pr.sh" "$PR" "$JSON")"
+CURRENT_USER=$(gh api /user -q .login)
 ```
+
+`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `title`/`body` stay in `$JSON` — read them with `jq` when needed (Step 3 ticket-context).
 
 ### Step 2 — Ephemeral worktree
 
@@ -71,7 +61,7 @@ WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 ```bash
 WT="/tmp/swe-workbench-pr-review/${PR}"
 if [ -d "$WT" ]; then
-  git worktree remove --force "$WT" 2>/dev/null || bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
+  git worktree remove --force "$WT" 2>/dev/null || bash "$_RT/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null
 fi
 mkdir -p "$(dirname "$WT")"
 git fetch origin "pull/${PR}/head:pr-review-${PR}" --force
@@ -225,12 +215,24 @@ Identity does not gate the CTA — when the user has invoked Claude to review th
 
 Suppress this CTA silently when `DECISION = APPROVE` and `posted = 0` and `deduped = 0` — a clean approval with no feedback has nothing to address; the CTA misrepresents the review.
 
+Foreground state-file reap — runs before worktree teardown; failures surface (no `2>/dev/null` or `|| true`):
+
 ```bash
-( bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}.json" "/tmp/swe-workbench-pr-review/${PR}-threads.json" 2>/dev/null || true; \
-  rimba remove "pr-review-$PR" --force 2>/dev/null \
+bash "$_RT/runtime/clean-state-files.sh" \
+  "/tmp/swe-workbench-pr-review/${PR}.json" \
+  "/tmp/swe-workbench-pr-review/${PR}-threads.json"
+for f in "/tmp/swe-workbench-pr-review/${PR}.json" "/tmp/swe-workbench-pr-review/${PR}-threads.json"; do
+  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
+done
+```
+
+Worktree teardown stays backgrounded (slow); it no longer carries state-file cleanup:
+
+```bash
+( rimba remove "pr-review-$PR" --force 2>/dev/null \
   || { git worktree remove --force "$WT" 2>/dev/null; \
        git branch -D "pr-review-$PR" 2>/dev/null; \
-       bash "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &
+       bash "$_RT/runtime/clean-ephemeral.sh" "$WT" 2>/dev/null; } ) &
 ```
 
 ## Footer parsing contract

--- a/tests/test_extend_command.py
+++ b/tests/test_extend_command.py
@@ -221,3 +221,21 @@ def test_extend_skill_cleanup_after_delivery():
         "clean-state-files.sh call must appear within/after Phase D — "
         "cleanup runs on the success delivery path only"
     )
+
+
+# ── Foreground-reap assertions (Fix C, recurrence of #428/#429) ─────────────
+
+
+def test_extend_skill_reap_no_suppression():
+    """The clean-state-files.sh call in Phase D must have NO 2>/dev/null suppression.
+
+    The reap must run without error suppression so orphaned spec-temp files surface as failures.
+    """
+    text = SKILL_MD.read_text()
+    lines_with_reap = [ln for ln in text.splitlines() if "clean-state-files.sh" in ln]
+    assert lines_with_reap, "SKILL.md must contain a clean-state-files.sh call"
+    suppressed = [ln for ln in lines_with_reap if "2>/dev/null" in ln]
+    assert not suppressed, (
+        "clean-state-files.sh call must not carry 2>/dev/null — "
+        "foreground reap must surface failures:\n" + "\n".join(suppressed)
+    )

--- a/tests/test_preflight_pr_script.py
+++ b/tests/test_preflight_pr_script.py
@@ -1,0 +1,127 @@
+"""Structural assertions for runtime/preflight-pr.sh (Fix A).
+
+Mirrors tests/test_fetch_pr_script.py conventions.
+Verifies that preflight-pr.sh:
+  - exists and is executable (covered by test_runtime_scripts.py)
+  - resolves its sibling fetch-pr.sh via dirname "$0" (never CLAUDE_PLUGIN_ROOT)
+  - emits only safe scalars via printf %q (BASE, HEAD_SHA, AUTHOR_LOGIN, OWNER, REPO, STATE)
+  - NEVER echoes title or body (free-text → eval-injection risk)
+  - uses set -euo pipefail
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "runtime" / "preflight-pr.sh"
+
+SAFE_SCALARS = ["BASE", "HEAD_SHA", "AUTHOR_LOGIN", "OWNER", "REPO", "STATE"]
+
+
+def test_preflight_script_exists():
+    """runtime/preflight-pr.sh must exist."""
+    assert SCRIPT.exists(), "runtime/preflight-pr.sh must exist"
+
+
+def test_preflight_uses_dirname_not_env_root():
+    """preflight-pr.sh must resolve sibling scripts via dirname \"$0\", not CLAUDE_PLUGIN_ROOT.
+
+    When cwd is an ephemeral PR worktree, CLAUDE_PLUGIN_ROOT may be unset and the git
+    fallback would resolve to the worktree — fetch-pr.sh would not exist there.
+    dirname \"$0\" always points to the directory containing preflight-pr.sh itself.
+    """
+    text = SCRIPT.read_text()
+    assert 'dirname "$0"' in text or "$(dirname" in text, (
+        "runtime/preflight-pr.sh must resolve its directory via dirname \"$0\" "
+        "so sibling scripts (fetch-pr.sh) are found regardless of cwd or CLAUDE_PLUGIN_ROOT"
+    )
+    # Must NOT resolve via CLAUDE_PLUGIN_ROOT for the fetch-pr.sh call itself
+    assert "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse" not in text, (
+        "runtime/preflight-pr.sh must not use ${CLAUDE_PLUGIN_ROOT:-$(git rev-parse ...)} — "
+        "use dirname \"$0\" instead so the script works in any worktree cwd"
+    )
+
+
+def test_preflight_calls_fetch_pr_sh():
+    """preflight-pr.sh must delegate PR JSON fetching to sibling fetch-pr.sh."""
+    text = SCRIPT.read_text()
+    assert "fetch-pr.sh" in text, (
+        "runtime/preflight-pr.sh must call sibling runtime/fetch-pr.sh to write the PR JSON — "
+        "reuse the existing fetch+validation logic rather than duplicating inline gh calls"
+    )
+
+
+def test_preflight_emits_printf_q_for_scalars():
+    """preflight-pr.sh must emit each safe scalar via printf '%q' to prevent word-splitting."""
+    text = SCRIPT.read_text()
+    assert "printf" in text and "%q" in text, (
+        "runtime/preflight-pr.sh must use printf '%q' (or printf '%%q') to quote scalar output — "
+        "unquoted values in eval \"$(...)\" are vulnerable to word-splitting and injection"
+    )
+
+
+def test_preflight_emits_all_safe_scalars():
+    """preflight-pr.sh must emit all 6 safe scalars: BASE, HEAD_SHA, AUTHOR_LOGIN, OWNER, REPO, STATE."""
+    text = SCRIPT.read_text()
+    missing = [s for s in SAFE_SCALARS if s not in text]
+    assert not missing, (
+        f"runtime/preflight-pr.sh must emit all safe scalars; missing: {missing}. "
+        "Skills rely on BASE/HEAD_SHA/AUTHOR_LOGIN/OWNER/REPO/STATE being set after eval."
+    )
+
+
+def test_preflight_does_not_echo_title():
+    """preflight-pr.sh must never echo or printf the PR title (free-text → eval injection)."""
+    text = SCRIPT.read_text()
+    lines = text.splitlines()
+    title_echo_lines = [
+        ln for ln in lines
+        if re.search(r'(echo|printf)[^\n]*title', ln, re.IGNORECASE)
+        and not ln.lstrip().startswith("#")
+    ]
+    assert not title_echo_lines, (
+        "runtime/preflight-pr.sh must NOT echo/printf 'title' — "
+        "PR titles are free-text and echoing them into eval \"$(...)\" enables code injection:\n"
+        + "\n".join(title_echo_lines)
+    )
+
+
+def test_preflight_does_not_echo_body():
+    """preflight-pr.sh must never echo or printf the PR body (free-text → eval injection)."""
+    text = SCRIPT.read_text()
+    lines = text.splitlines()
+    body_echo_lines = [
+        ln for ln in lines
+        if re.search(r'(echo|printf)[^\n]*\bbody\b', ln, re.IGNORECASE)
+        and not ln.lstrip().startswith("#")
+    ]
+    assert not body_echo_lines, (
+        "runtime/preflight-pr.sh must NOT echo/printf 'body' — "
+        "PR bodies are free-text and echoing them into eval \"$(...)\" enables code injection:\n"
+        + "\n".join(body_echo_lines)
+    )
+
+
+def test_preflight_has_set_euo_pipefail():
+    """preflight-pr.sh must start with set -euo pipefail for fail-fast error handling."""
+    text = SCRIPT.read_text()
+    assert "set -euo pipefail" in text, (
+        "runtime/preflight-pr.sh must use 'set -euo pipefail' — "
+        "without it, a failing gh call or jq parse silently produces empty variables"
+    )
+
+
+def test_preflight_bash_syntax():
+    """bash -n must pass for preflight-pr.sh (no syntax errors)."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True, text=True,
+        env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 0, (
+        f"bash -n runtime/preflight-pr.sh failed:\n{result.stderr}"
+    )
+

--- a/tests/test_runtime_root_binding.py
+++ b/tests/test_runtime_root_binding.py
@@ -1,0 +1,87 @@
+"""Assert Fix B: each of the 6 PR-workflow skills binds _RT once + hard-fails if scripts missing.
+
+Root cause #2: skills resolved the plugin root inline, per-call, via
+${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}. When CLAUDE_PLUGIN_ROOT is unset and
+cwd is an ephemeral worktree, the fallback resolves to the worktree root — runtime/ scripts
+don't exist there, the call fails, and (with errors suppressed) the operator falls back to
+inline gh/jq silently.
+
+Fix: bind _RT once before worktree entry; add a hard-fail guard so a missing runtime/ is loud.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+SKILLS_WITH_RT = [
+    "workflow-pr-review",
+    "workflow-pr-review-followup",
+    "workflow-address-feedback",
+    "workflow-audit-emit-issues",
+    "workflow-cleanup-merged",
+    "workflow-extend",
+]
+
+_RT_BINDING_RE = re.compile(r'_RT\s*=.*\$\{CLAUDE_PLUGIN_ROOT:-\$\(git rev-parse')
+_GUARD_STR = "runtime scripts not found"
+# Inline ${CLAUDE_PLUGIN_ROOT:-$(git rev-parse at a SCRIPT CALL SITE (not the _RT= binding line)
+_INLINE_ROOT_RE = re.compile(
+    r'(?<!_RT\s=\s)(?<!_RT=)'   # not on the binding line
+    r'\$\{CLAUDE_PLUGIN_ROOT:-\$\(git rev-parse'
+)
+
+
+def _skill_text(skill_name: str) -> str:
+    return (ROOT / "skills" / skill_name / "SKILL.md").read_text()
+
+
+def test_rt_binding_exists_in_each_skill():
+    """Each of the 6 skills must have exactly one _RT= binding capturing the plugin root."""
+    for skill in SKILLS_WITH_RT:
+        text = _skill_text(skill)
+        matches = _RT_BINDING_RE.findall(text)
+        assert len(matches) >= 1, (
+            f"skills/{skill}/SKILL.md must contain a _RT= binding "
+            f"(_RT=\"${{CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}}\") — "
+            "this binds the plugin root before any worktree entry so the correct runtime/ is used"
+        )
+
+
+def test_hard_fail_guard_exists_in_each_skill():
+    """Each skill must contain the hard-fail guard string so missing runtime/ aborts loudly."""
+    for skill in SKILLS_WITH_RT:
+        text = _skill_text(skill)
+        assert _GUARD_STR in text, (
+            f"skills/{skill}/SKILL.md must contain the hard-fail guard message "
+            f"'{_GUARD_STR}' — missing runtime scripts must abort with a clear error, "
+            "not silently fall back to inline gh/jq"
+        )
+
+
+def test_no_inline_root_resolution_at_script_call_sites():
+    """No skill may use ${CLAUDE_PLUGIN_ROOT:-$(git rev-parse ...)} at a script call site.
+
+    Only the single _RT= binding line is allowed to contain this pattern.
+    All script invocations must use ${{_RT}}/runtime/... so the root is resolved once,
+    before worktree entry, and reused consistently.
+    """
+    for skill in SKILLS_WITH_RT:
+        text = _skill_text(skill)
+        # Find all occurrences of the raw inline pattern
+        raw_occurrences = [
+            (i, ln.strip())
+            for i, ln in enumerate(text.splitlines(), 1)
+            if "${CLAUDE_PLUGIN_ROOT:-$(git rev-parse" in ln
+        ]
+        # The _RT= binding line is allowed; all others are violations
+        violations = [
+            (lineno, ln) for lineno, ln in raw_occurrences
+            if not re.match(r'\s*_RT\s*=', ln)
+            and not ln.lstrip().startswith("#")
+        ]
+        assert not violations, (
+            f"skills/{skill}/SKILL.md has inline ${{CLAUDE_PLUGIN_ROOT:-$(git rev-parse ...)}} "
+            f"at script call sites (only the _RT= binding is allowed):\n"
+            + "\n".join(f"  line {no}: {ln}" for no, ln in violations)
+        )

--- a/tests/test_runtime_root_binding.py
+++ b/tests/test_runtime_root_binding.py
@@ -25,11 +25,6 @@ SKILLS_WITH_RT = [
 
 _RT_BINDING_RE = re.compile(r'_RT\s*=.*\$\{CLAUDE_PLUGIN_ROOT:-\$\(git rev-parse')
 _GUARD_STR = "runtime scripts not found"
-# Inline ${CLAUDE_PLUGIN_ROOT:-$(git rev-parse at a SCRIPT CALL SITE (not the _RT= binding line)
-_INLINE_ROOT_RE = re.compile(
-    r'(?<!_RT\s=\s)(?<!_RT=)'   # not on the binding line
-    r'\$\{CLAUDE_PLUGIN_ROOT:-\$\(git rev-parse'
-)
 
 
 def _skill_text(skill_name: str) -> str:

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -14,6 +14,7 @@ RUNTIME_SCRIPTS = [
     "clean-state-files.sh",
     "doctor.sh",
     "fetch-pr.sh",
+    "preflight-pr.sh",
     "reply-and-resolve.sh",
 ]
 
@@ -51,27 +52,38 @@ def test_runtime_scripts_pass_bash_syntax_check():
         )
 
 
-def test_fetch_pr_referenced_in_pr_review_skill():
-    """workflow-pr-review SKILL.md must invoke runtime/fetch-pr.sh in Step 1."""
+def test_preflight_pr_referenced_in_pr_review_skill():
+    """workflow-pr-review SKILL.md Step 1 must use preflight-pr.sh (not raw inline gh/jq)."""
     text = (ROOT / "skills" / "workflow-pr-review" / "SKILL.md").read_text()
-    assert "runtime/fetch-pr.sh" in text, (
-        "workflow-pr-review SKILL.md Step 1 must invoke runtime/fetch-pr.sh"
+    assert "runtime/preflight-pr.sh" in text, (
+        "workflow-pr-review SKILL.md Step 1 must invoke runtime/preflight-pr.sh — "
+        "the consolidated pre-flight replaces the ~20-line inline gh/jq block"
+    )
+    assert 'eval "$(' in text, (
+        "workflow-pr-review SKILL.md must use eval \"$(...)\" to source preflight-pr.sh output "
+        "into the current shell (KEY=VALUE contract)"
     )
 
 
-def test_fetch_pr_referenced_in_pr_review_followup_skill():
-    """workflow-pr-review-followup SKILL.md must invoke runtime/fetch-pr.sh in Step 1."""
+def test_preflight_pr_referenced_in_pr_review_followup_skill():
+    """workflow-pr-review-followup SKILL.md Step 1 must use preflight-pr.sh."""
     text = (ROOT / "skills" / "workflow-pr-review-followup" / "SKILL.md").read_text()
-    assert "runtime/fetch-pr.sh" in text, (
-        "workflow-pr-review-followup SKILL.md Step 1 must invoke runtime/fetch-pr.sh"
+    assert "runtime/preflight-pr.sh" in text, (
+        "workflow-pr-review-followup SKILL.md Step 1 must invoke runtime/preflight-pr.sh"
+    )
+    assert 'eval "$(' in text, (
+        "workflow-pr-review-followup SKILL.md must use eval \"$(...)\" to source preflight output"
     )
 
 
-def test_fetch_pr_referenced_in_address_feedback_skill():
-    """workflow-address-feedback SKILL.md must invoke runtime/fetch-pr.sh in Phase 1."""
+def test_preflight_pr_referenced_in_address_feedback_skill():
+    """workflow-address-feedback SKILL.md Phase 1 must use preflight-pr.sh."""
     text = (ROOT / "skills" / "workflow-address-feedback" / "SKILL.md").read_text()
-    assert "runtime/fetch-pr.sh" in text, (
-        "workflow-address-feedback SKILL.md Phase 1 must invoke runtime/fetch-pr.sh"
+    assert "runtime/preflight-pr.sh" in text, (
+        "workflow-address-feedback SKILL.md Phase 1 must invoke runtime/preflight-pr.sh"
+    )
+    assert 'eval "$(' in text, (
+        "workflow-address-feedback SKILL.md must use eval \"$(...)\" to source preflight output"
     )
 
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -66,14 +66,15 @@ def test_address_feedback_skill_uses_three_way_triage():
 
 
 def test_address_feedback_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
-    text = SKILL_MD.read_text()
+    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
+    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
     assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
@@ -101,10 +102,11 @@ def test_address_feedback_skill_no_fragile_owner_extraction():
 
 
 def test_address_feedback_skill_has_owner_repo_guard_clause():
-    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
-    text = SKILL_MD.read_text()
+    """preflight-pr.sh must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    # Fix A moved the OWNER/REPO guard to runtime/preflight-pr.sh
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"Could not determine base repo owner", text), (
-        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "runtime/preflight-pr.sh must include the guard-clause error message for missing OWNER/REPO "
         "so failures produce an actionable error rather than silently misrouting API calls"
     )
 
@@ -374,4 +376,33 @@ def test_address_feedback_skill_phase6_does_not_delete_triage_json():
         "Phase 6 action blocks must NOT delete triage.json — Phase 6 runs on Q-quit too, and "
         "triage.json is durable resume state that must survive Q-quit.\n"
         "Lines found: " + "\n".join(phase6_lines_with_triage)
+    )
+
+
+# ── Foreground-reap assertions (Fix C, recurrence of #428/#429) ─────────────
+
+
+def test_address_feedback_skill_phase5_reap_no_suppression():
+    """Phase 5 clean-state-files.sh call must have NO 2>/dev/null suppression.
+
+    The reap runs foreground; suppression would recreate the silent-orphan path
+    that was the root cause of the #428/#429 recurrence.
+    """
+    text = SKILL_MD.read_text()
+    lines_with_reap = [ln for ln in text.splitlines() if "clean-state-files.sh" in ln]
+    assert lines_with_reap, "SKILL.md must contain a clean-state-files.sh call"
+    suppressed = [ln for ln in lines_with_reap if "2>/dev/null" in ln]
+    assert not suppressed, (
+        "clean-state-files.sh call must not carry 2>/dev/null — "
+        "foreground reap must be visible so orphaned state files surface as failures:\n"
+        + "\n".join(suppressed)
+    )
+
+
+def test_address_feedback_skill_phase5_reap_has_post_check():
+    """Phase 5 must include a post-reap report line confirming each state file was reaped."""
+    text = SKILL_MD.read_text()
+    assert "state file" in text and "reaped" in text, (
+        "SKILL.md Phase 5 must include a post-reap report line "
+        "(e.g. '✓ state file reaped: ...') so operators can verify cleanup completed"
     )

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -65,19 +65,6 @@ def test_address_feedback_skill_uses_three_way_triage():
     assert "DEFERRED" in text, "SKILL.md must reference DEFERRED triage state"
 
 
-def test_address_feedback_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
-    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
-    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
-    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-
 
 def test_address_feedback_skill_no_invalid_json_field():
     """Phase 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -389,7 +389,7 @@ def test_address_feedback_skill_phase5_reap_no_suppression():
 def test_address_feedback_skill_phase5_reap_has_post_check():
     """Phase 5 must include a post-reap report line confirming each state file was reaped."""
     text = SKILL_MD.read_text()
-    assert "state file" in text and "reaped" in text, (
+    assert re.search(r'✓ state file reaped:', text), (
         "SKILL.md Phase 5 must include a post-reap report line "
-        "(e.g. '✓ state file reaped: ...') so operators can verify cleanup completed"
+        "'✓ state file reaped: ...' so operators can verify cleanup completed"
     )

--- a/tests/test_workflow_audit_emit_issues_skill.py
+++ b/tests/test_workflow_audit_emit_issues_skill.py
@@ -272,9 +272,11 @@ def test_audit_emit_cleanup_on_confirm_success():
     text = SKILL_MD.read_text()
     confirm_idx = text.find("`confirm` (literal)")
     # Use the executable invocation, not the guard check ([ -f "$_RT/runtime/clean-state-files.sh" ])
-    cleanup_idx = text.find('bash "$_RT/runtime/clean-state-files.sh"')
+    # re.search is resilient to minor quoting/whitespace changes vs. text.find()
+    cleanup_match = re.search(r'bash\s+"\$_RT/runtime/clean-state-files\.sh"', text)
     assert confirm_idx != -1, "SKILL.md must have a 'confirm' table row"
-    assert cleanup_idx != -1, "SKILL.md must reference bash invocation of clean-state-files.sh"
+    assert cleanup_match, "SKILL.md must reference bash invocation of clean-state-files.sh"
+    cleanup_idx = cleanup_match.start()
     assert cleanup_idx > confirm_idx, (
         "clean-state-files.sh invocation must appear after the Phase 4 confirm table row"
     )

--- a/tests/test_workflow_audit_emit_issues_skill.py
+++ b/tests/test_workflow_audit_emit_issues_skill.py
@@ -327,7 +327,7 @@ def test_audit_emit_reap_no_suppression():
 def test_audit_emit_reap_has_post_check():
     """The confirm path must include a post-reap report line confirming each file was reaped."""
     text = SKILL_MD.read_text()
-    assert "state file" in text and "reaped" in text, (
+    assert re.search(r'✓ state file reaped:', text), (
         "SKILL.md must include a post-reap report line "
-        "(e.g. '✓ state file reaped: ...') after the confirm-path cleanup"
+        "'✓ state file reaped: ...' after the confirm-path cleanup"
     )

--- a/tests/test_workflow_audit_emit_issues_skill.py
+++ b/tests/test_workflow_audit_emit_issues_skill.py
@@ -263,16 +263,20 @@ def test_audit_emit_uses_clean_state_files_for_deletion():
 
 
 def test_audit_emit_cleanup_on_confirm_success():
-    """clean-state-files.sh must appear in the confirm-success row of the Phase 4 table."""
+    """clean-state-files.sh invocation must appear after the Phase 4 confirm table row.
+
+    After Fix C, the reap block is a separate section below the table (not inline in the row).
+    We search for the bash invocation (not the [ -f ... ] guard check in the Preamble) so
+    the ordering check finds the correct occurrence.
+    """
     text = SKILL_MD.read_text()
-    # The confirm row contains clean-state-files.sh in its action description
     confirm_idx = text.find("`confirm` (literal)")
-    cleanup_idx = text.find("clean-state-files.sh")
+    # Use the executable invocation, not the guard check ([ -f "$_RT/runtime/clean-state-files.sh" ])
+    cleanup_idx = text.find('bash "$_RT/runtime/clean-state-files.sh"')
     assert confirm_idx != -1, "SKILL.md must have a 'confirm' table row"
-    assert cleanup_idx != -1, "SKILL.md must reference clean-state-files.sh"
-    # The cleanup instruction should appear near the confirm row (within 500 chars)
-    assert abs(cleanup_idx - confirm_idx) < 500, (
-        "clean-state-files.sh must appear within the Phase 4 confirm table row"
+    assert cleanup_idx != -1, "SKILL.md must reference bash invocation of clean-state-files.sh"
+    assert cleanup_idx > confirm_idx, (
+        "clean-state-files.sh invocation must appear after the Phase 4 confirm table row"
     )
 
 
@@ -297,4 +301,31 @@ def test_triggers_mention_audit_and_issues():
     text = TRIGGERS.read_text().lower()
     assert "audit" in text and ("issue" in text or "github" in text), (
         "triggers.txt must mention 'audit' and 'issue'/'github' for good trigger scoring"
+    )
+
+
+# ── Foreground-reap assertions (Fix C, recurrence of #428/#429) ─────────────
+
+
+def test_audit_emit_reap_no_suppression():
+    """The clean-state-files.sh call in the confirm path must have NO 2>/dev/null suppression.
+
+    The reap must run foreground; suppression would recreate the silent-orphan path.
+    """
+    text = SKILL_MD.read_text()
+    lines_with_reap = [ln for ln in text.splitlines() if "clean-state-files.sh" in ln]
+    assert lines_with_reap, "SKILL.md must contain a clean-state-files.sh call"
+    suppressed = [ln for ln in lines_with_reap if "2>/dev/null" in ln]
+    assert not suppressed, (
+        "clean-state-files.sh call must not carry 2>/dev/null — "
+        "foreground reap must surface failures:\n" + "\n".join(suppressed)
+    )
+
+
+def test_audit_emit_reap_has_post_check():
+    """The confirm path must include a post-reap report line confirming each file was reaped."""
+    text = SKILL_MD.read_text()
+    assert "state file" in text and "reaped" in text, (
+        "SKILL.md must include a post-reap report line "
+        "(e.g. '✓ state file reaped: ...') after the confirm-path cleanup"
     )

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -78,14 +78,15 @@ def test_followup_skill_documents_stale_commit_retry():
 
 
 def test_followup_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
-    text = SKILL_MD.read_text()
+    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
+    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
     assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
@@ -113,10 +114,11 @@ def test_followup_skill_no_fragile_owner_extraction():
 
 
 def test_followup_skill_has_owner_repo_guard_clause():
-    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
-    text = SKILL_MD.read_text()
+    """preflight-pr.sh must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    # Fix A moved the OWNER/REPO guard to runtime/preflight-pr.sh
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"Could not determine base repo owner", text), (
-        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "runtime/preflight-pr.sh must include the guard-clause error message for missing OWNER/REPO "
         "so fork-PR failures produce an actionable error rather than silently misrouting API calls"
     )
 
@@ -137,20 +139,43 @@ def test_followup_skill_cleanup_deletes_followup_json():
     )
 
 
-def test_followup_skill_state_cleanup_inside_background_subshell():
-    """clean-state-files.sh must appear inside the background ( ... ) & subshell."""
+def test_followup_skill_state_cleanup_outside_background_subshell():
+    """clean-state-files.sh must NOT appear inside the background ( ... ) & subshell.
+
+    The reap must run in the foreground so failures surface immediately rather than being
+    silently dropped by the backgrounded, output-suppressed worktree-teardown subshell.
+    This is the inverse of the previous #428 assertion, which encoded the bug as correct.
+    """
     text = SKILL_MD.read_text()
     subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
-    assert subshell_match, (
-        "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
+    assert not subshell_match, (
+        "SKILL.md Step 7 clean-state-files.sh call must NOT be inside the background ( ... ) & "
+        "subshell — the reap must run foreground so failures are visible (recurrence of #428/#429)"
     )
 
 
-def test_followup_skill_state_cleanup_has_or_true_guard():
-    """clean-state-files.sh call must be followed by || true so set -e in the subshell cannot
-    abort rimba remove when the state files are already absent or fail validation."""
+def test_followup_skill_state_cleanup_no_suppression():
+    """clean-state-files.sh call must have NO 2>/dev/null and NO || true guard.
+
+    The reap runs foreground (fix for #428/#429 recurrence): suppression guards would re-hide
+    the same silent-orphan path. A non-zero exit from clean-state-files.sh is a real failure.
+    """
     text = SKILL_MD.read_text()
-    assert re.search(r'clean-state-files\.sh.*?\|\|\s*true', text, re.DOTALL), (
-        "SKILL.md Step 7 clean-state-files.sh call must use '|| true' so a non-zero exit "
-        "does not abort rimba remove via set -e propagation into the background subshell"
+    lines_with_reap = [
+        ln for ln in text.splitlines() if "clean-state-files.sh" in ln
+    ]
+    assert lines_with_reap, "SKILL.md must contain a clean-state-files.sh call"
+    suppressed = [ln for ln in lines_with_reap if "2>/dev/null" in ln]
+    assert not suppressed, (
+        f"clean-state-files.sh call must not carry 2>/dev/null (foreground reap must be visible):\n"
+        + "\n".join(suppressed)
+    )
+
+
+def test_followup_skill_state_cleanup_has_post_check():
+    """Step 7 must include a post-reap verification that reports each state file as reaped or not."""
+    text = SKILL_MD.read_text()
+    assert "state file" in text and "reaped" in text, (
+        "SKILL.md Step 7 must include a post-reap report line (e.g. '✓ state file reaped: ...') "
+        "so operators can verify cleanup completed without inspecting /tmp by hand"
     )

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -77,19 +77,6 @@ def test_followup_skill_documents_stale_commit_retry():
     )
 
 
-def test_followup_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
-    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
-    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
-    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-
 
 def test_followup_skill_no_invalid_json_field():
     """Step 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""
@@ -147,7 +134,7 @@ def test_followup_skill_state_cleanup_outside_background_subshell():
     This is the inverse of the previous #428 assertion, which encoded the bug as correct.
     """
     text = SKILL_MD.read_text()
-    subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
+    subshell_match = re.search(r'\([^)]*clean-state-files\.sh[^)]*\)\s*&', text)
     assert not subshell_match, (
         "SKILL.md Step 7 clean-state-files.sh call must NOT be inside the background ( ... ) & "
         "subshell — the reap must run foreground so failures are visible (recurrence of #428/#429)"

--- a/tests/test_workflow_pr_review_followup_skill.py
+++ b/tests/test_workflow_pr_review_followup_skill.py
@@ -162,7 +162,7 @@ def test_followup_skill_state_cleanup_no_suppression():
 def test_followup_skill_state_cleanup_has_post_check():
     """Step 7 must include a post-reap verification that reports each state file as reaped or not."""
     text = SKILL_MD.read_text()
-    assert "state file" in text and "reaped" in text, (
-        "SKILL.md Step 7 must include a post-reap report line (e.g. '✓ state file reaped: ...') "
+    assert re.search(r'✓ state file reaped:', text), (
+        "SKILL.md Step 7 must include a post-reap report line '✓ state file reaped: ...' "
         "so operators can verify cleanup completed without inspecting /tmp by hand"
     )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -25,19 +25,6 @@ def test_pr_review_skill_file_exists():
     )
 
 
-def test_pr_review_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
-    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
-    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
-    assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-    assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
-        "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
-    )
-
 
 def test_pr_review_skill_no_invalid_json_field():
     """Step 1 gh pr view --json must NOT include baseRepository (it is not a valid gh CLI field)."""
@@ -127,7 +114,7 @@ def test_pr_review_skill_state_cleanup_outside_background_subshell():
     This is the inverse of the previous #428 assertion, which encoded the bug as correct.
     """
     text = SKILL_MD.read_text()
-    subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
+    subshell_match = re.search(r'\([^)]*clean-state-files\.sh[^)]*\)\s*&', text)
     assert not subshell_match, (
         "SKILL.md Step 7 clean-state-files.sh call must NOT be inside the background ( ... ) & "
         "subshell — the reap must run foreground so failures are visible (recurrence of #428/#429)"

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -143,7 +143,7 @@ def test_pr_review_skill_state_cleanup_no_suppression():
 def test_pr_review_skill_state_cleanup_has_post_check():
     """Step 7 must include a post-reap verification that reports each state file as reaped or not."""
     text = SKILL_MD.read_text()
-    assert "state file" in text and "reaped" in text, (
-        "SKILL.md Step 7 must include a post-reap report line (e.g. '✓ state file reaped: ...') "
+    assert re.search(r'✓ state file reaped:', text), (
+        "SKILL.md Step 7 must include a post-reap report line '✓ state file reaped: ...' "
         "so operators can verify cleanup completed without inspecting /tmp by hand"
     )

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -26,14 +26,15 @@ def test_pr_review_skill_file_exists():
 
 
 def test_pr_review_skill_owner_repo_from_gh_repo_view():
-    """OWNER and REPO must be derived from 'gh repo view' (not from headRepository or baseRepository)."""
-    text = SKILL_MD.read_text()
+    """OWNER and REPO must be derived from 'gh repo view' — now lives in preflight-pr.sh (Fix A)."""
+    # Fix A moved OWNER/REPO derivation to runtime/preflight-pr.sh; check there, not the skill
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"OWNER\s*=.*\$\(gh repo view[^\n]*owner", text), (
-        "SKILL.md must derive OWNER via 'gh repo view --json owner' — "
+        "runtime/preflight-pr.sh must derive OWNER via 'gh repo view --json owner' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
     assert re.search(r"REPO\s*=.*\$\(gh repo view[^\n]*name", text), (
-        "SKILL.md must derive REPO via 'gh repo view --json name' — "
+        "runtime/preflight-pr.sh must derive REPO via 'gh repo view --json name' — "
         "gh pr view --json has no baseRepository field; gh repo view resolves the base remote correctly"
     )
 
@@ -61,10 +62,11 @@ def test_pr_review_skill_no_fragile_owner_extraction():
 
 
 def test_pr_review_skill_has_owner_repo_guard_clause():
-    """SKILL.md must include a guard clause that exits if OWNER or REPO cannot be determined."""
-    text = SKILL_MD.read_text()
+    """preflight-pr.sh must include a guard clause that exits if OWNER or REPO cannot be determined."""
+    # Fix A moved the OWNER/REPO guard to runtime/preflight-pr.sh
+    text = (ROOT / "runtime" / "preflight-pr.sh").read_text()
     assert re.search(r"Could not determine base repo owner", text), (
-        "SKILL.md must include the guard-clause error message for missing OWNER/REPO "
+        "runtime/preflight-pr.sh must include the guard-clause error message for missing OWNER/REPO "
         "so failures produce an actionable error rather than silently misrouting API calls"
     )
 
@@ -117,21 +119,44 @@ def test_pr_review_skill_cleanup_deletes_pr_json():
     )
 
 
-def test_pr_review_skill_state_cleanup_inside_background_subshell():
-    """clean-state-files.sh must appear inside the background ( ... ) & subshell (success-path only)."""
+def test_pr_review_skill_state_cleanup_outside_background_subshell():
+    """clean-state-files.sh must NOT appear inside the background ( ... ) & subshell.
+
+    The reap must run in the foreground so failures surface immediately rather than being
+    silently dropped by the backgrounded, output-suppressed worktree-teardown subshell.
+    This is the inverse of the previous #428 assertion, which encoded the bug as correct.
+    """
     text = SKILL_MD.read_text()
-    # The subshell is opened with '(' and closed with ') &' — find it
     subshell_match = re.search(r'\(\s*bash.*?clean-state-files\.sh.*?\)\s*&', text, re.DOTALL)
-    assert subshell_match, (
-        "SKILL.md Step 7 clean-state-files.sh call must be inside the background ( ... ) & subshell"
+    assert not subshell_match, (
+        "SKILL.md Step 7 clean-state-files.sh call must NOT be inside the background ( ... ) & "
+        "subshell — the reap must run foreground so failures are visible (recurrence of #428/#429)"
     )
 
 
-def test_pr_review_skill_state_cleanup_has_or_true_guard():
-    """clean-state-files.sh call must be followed by || true so set -e in the subshell cannot
-    abort rimba remove when the state files are already absent or fail validation."""
+def test_pr_review_skill_state_cleanup_no_suppression():
+    """clean-state-files.sh call must have NO 2>/dev/null and NO || true guard.
+
+    The reap runs foreground (fix for #428/#429 recurrence): suppression guards would re-hide
+    the same silent-orphan path. A non-zero exit from clean-state-files.sh is a real failure.
+    """
     text = SKILL_MD.read_text()
-    assert re.search(r'clean-state-files\.sh.*?\|\|\s*true', text, re.DOTALL), (
-        "SKILL.md Step 7 clean-state-files.sh call must use '|| true' so a non-zero exit "
-        "does not abort rimba remove via set -e propagation into the background subshell"
+    # Find the line(s) containing clean-state-files.sh and assert none carry 2>/dev/null
+    lines_with_reap = [
+        ln for ln in text.splitlines() if "clean-state-files.sh" in ln
+    ]
+    assert lines_with_reap, "SKILL.md must contain a clean-state-files.sh call"
+    suppressed = [ln for ln in lines_with_reap if "2>/dev/null" in ln]
+    assert not suppressed, (
+        f"clean-state-files.sh call must not carry 2>/dev/null (foreground reap must be visible):\n"
+        + "\n".join(suppressed)
+    )
+
+
+def test_pr_review_skill_state_cleanup_has_post_check():
+    """Step 7 must include a post-reap verification that reports each state file as reaped or not."""
+    text = SKILL_MD.read_text()
+    assert "state file" in text and "reaped" in text, (
+        "SKILL.md Step 7 must include a post-reap report line (e.g. '✓ state file reaped: ...') "
+        "so operators can verify cleanup completed without inspecting /tmp by hand"
     )


### PR DESCRIPTION
## Summary

- **Fix A (preflight-pr.sh):** new `runtime/preflight-pr.sh` consolidates the ~20-line inline `gh auth + fetch-pr + jq` block across three PR-workflow skills into a single script call; emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as `printf %q`-quoted eval-able `KEY=VALUE` lines — mirrors the `eval "$(sync-and-verify.sh)"` contract already used in `workflow-cleanup-merged`. Applies to `workflow-pr-review`, `workflow-pr-review-followup`, `workflow-address-feedback`.
- **Fix B (_RT root guard):** bind `_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"` once before worktree entry in all 6 skills; add a hard-fail guard that aborts if `runtime/` is missing — converts "script not found → silent inline fallback" into a loud, actionable error. Replaces 22 scattered `${CLAUDE_PLUGIN_ROOT:-$(git rev-parse ...)}` occurrences.
- **Fix C (foreground reap):** pull `clean-state-files.sh` out of the backgrounded `( ... ) &` subshell in 5 skills; drop `2>/dev/null` and `|| true`; add a per-file post-check report line (`✓ state file reaped`). The worktree teardown (`rimba remove`) stays backgrounded — only the state-file reap moved to the foreground.
- **Tests:** invert the two #428 assertions that encoded the bug as correct (assert reap is NOT inside background subshell, NOT suppressed); add `test_preflight_pr_script.py`, `test_runtime_root_binding.py`; harden 5 skill test files + `test_runtime_scripts.py`.

## Test Plan

- [x] Changed skills/commands/agents load without errors (`bash scripts/validate.sh` passes)
- [x] Examples in the diff were exercised manually (`bash -n runtime/preflight-pr.sh` passes)
- [x] 1327/1327 pytest tests pass (pre-push hook verified)
- [x] `test_preflight_pr_script.py` (9 tests): verifies `preflight-pr.sh` uses `dirname "$0"`, emits `printf %q` for all 6 scalars, never echoes `title`/`body`, and passes `bash -n`
- [x] `test_runtime_root_binding.py`: verifies each of the 6 skills has a single `_RT=` binding, a hard-fail guard, and no raw `${CLAUDE_PLUGIN_ROOT:-$(git rev-parse` at script call sites
- [x] Inverted `test_pr_review_skill_state_cleanup_outside_background_subshell` and `test_*_no_suppression` confirm foreground reap in pr-review + followup

### Type-tailored checks ([fix])

- [ ] Reproduce the original orphan: run a PR review in a worktree where `CLAUDE_PLUGIN_ROOT` is unset and confirm Fix B aborts loudly rather than resolving to the worktree root
- [ ] Run a full review flow end-to-end and confirm `/tmp/swe-workbench-pr-review/*.json` files are removed on success with `✓ state file reaped` lines visible

Issue: N/A — recurrence of #428/#429
