### PR TITLE
[feat] Add worked Core-4 design-pattern examples (9 OO languages)

### DIFF
--- a/skills/principle-design-patterns/SKILL.md
+++ b/skills/principle-design-patterns/SKILL.md
@@ -67,3 +67,5 @@ Patterns are vocabulary, not goals. Reach for one only when the problem it solve
 - **Singleton** — almost always a disguised global; prefer a single instance composed at the root.
 - **God object** — one class that does everything; split by change vector.
 - **Pattern-itis** — five patterns where a function would do.
+
+> See `examples/` for worked Strategy, Observer, Decorator, and Factory Method implementations in C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).

--- a/skills/principle-design-patterns/examples/decorator.cs.md
+++ b/skills/principle-design-patterns/examples/decorator.cs.md
@@ -1,0 +1,109 @@
+# Decorator — C# — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without modifying `HttpFetcher`.
+The `IFetcher` interface lets `RetryFetcher` and `LoggingFetcher` each hold an inner
+`IFetcher`, add one concern, and delegate the rest. They compose in any order — the
+core class stays untouched.
+
+## Implementation
+
+```csharp
+// file: IFetcher.cs
+public interface IFetcher
+{
+    string Fetch(string url);
+}
+```
+
+```csharp
+// file: HttpFetcher.cs
+using System.Net.Http;
+
+public sealed class HttpFetcher : IFetcher
+{
+    private static readonly HttpClient _client = new();
+
+    public string Fetch(string url) =>
+        _client.GetStringAsync(url).GetAwaiter().GetResult();
+}
+```
+
+```csharp
+// file: RetryFetcher.cs
+public sealed class RetryFetcher : IFetcher
+{
+    private readonly IFetcher _inner;
+    private readonly int _retries;
+
+    public RetryFetcher(IFetcher inner, int retries)
+    {
+        _inner = inner;
+        _retries = retries;
+    }
+
+    public string Fetch(string url)
+    {
+        Exception? last = null;
+        for (int i = 0; i <= _retries; i++)
+        {
+            try { return _inner.Fetch(url); }
+            catch (Exception ex) { last = ex; }
+        }
+        throw last!;
+    }
+}
+```
+
+```csharp
+// file: LoggingFetcher.cs
+public sealed class LoggingFetcher : IFetcher
+{
+    private readonly IFetcher _inner;
+
+    public LoggingFetcher(IFetcher inner) => _inner = inner;
+
+    public string Fetch(string url)
+    {
+        Console.WriteLine($"[fetch] GET {url}");
+        try
+        {
+            var result = _inner.Fetch(url);
+            Console.WriteLine($"[fetch] OK  {url}");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[fetch] ERR {url}: {ex.Message}");
+            throw;
+        }
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+IFetcher fetcher = new LoggingFetcher(new RetryFetcher(new HttpFetcher(), 3));
+Console.WriteLine(fetcher.Fetch("https://example.com/api/data"));
+```
+
+## Common Mistake
+
+Subclassing `HttpFetcher` with a combined class — behaviors cannot be reused
+independently and every new combination requires its own subclass.
+
+```csharp
+// ✗ subclass explosion — retry + logging locked into one class
+class RetryLoggingFetcher : HttpFetcher           // ✗ fused behaviors
+{
+    public override string Fetch(string url)
+    {
+        Console.WriteLine($"[fetch] GET {url}");  // ✗ cannot retry without logging
+        for (int i = 0; i < 3; i++)
+            try { return base.Fetch(url); } catch { }
+        throw new Exception("all retries failed");
+    }
+}
+// class CachingRetryFetcher : HttpFetcher { ... } // ✗ N behaviors → N² subclasses
+```

--- a/skills/principle-design-patterns/examples/decorator.go.md
+++ b/skills/principle-design-patterns/examples/decorator.go.md
@@ -1,0 +1,102 @@
+# Decorator — Go — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch must gain retry and logging behavior without those concerns being
+embedded in the fetch function itself. Go's first-class functions make the Decorator
+pattern natural: `WithRetry` and `WithLogging` each accept a `FetchFn` and return a
+new `FetchFn`, composable in any order. No interfaces or structs are required.
+
+## Implementation
+
+```go
+// file: fetcher.go
+package fetcher
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// FetchFn is the core function type all decorators wrap.
+type FetchFn func(url string) (string, error)
+
+// HTTPFetch is the core implementation.
+func HTTPFetch(url string) (string, error) {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	return string(b), err
+}
+
+// WithRetry wraps fn, retrying up to n times on error.
+func WithRetry(fn FetchFn, n int) FetchFn {
+	return func(url string) (string, error) {
+		var err error
+		for i := 0; i <= n; i++ {
+			var result string
+			if result, err = fn(url); err == nil {
+				return result, nil
+			}
+		}
+		return "", err
+	}
+}
+
+// WithLogging wraps fn, printing each request and its outcome.
+func WithLogging(fn FetchFn) FetchFn {
+	return func(url string) (string, error) {
+		fmt.Printf("[fetch] GET %s\n", url)
+		result, err := fn(url)
+		if err != nil {
+			fmt.Printf("[fetch] ERR %s: %v\n", url, err)
+			return "", err
+		}
+		fmt.Printf("[fetch] OK  %s\n", url)
+		return result, nil
+	}
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"fmt"
+	"example/fetcher"
+)
+
+func main() {
+	fetch := fetcher.WithLogging(fetcher.WithRetry(fetcher.HTTPFetch, 3))
+	body, err := fetch("https://example.com/api/data")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(body)
+}
+```
+
+## Common Mistake
+
+Embedding retry and logging directly in `HTTPFetch` — the behaviors cannot be reused
+independently, and every new combination needs a separate function.
+
+```go
+// ✗ subclass explosion — combined into one function; behaviors cannot be separated
+func retryLoggingFetch(url string) (string, error) { // ✗ retry + logging fused
+	fmt.Printf("[fetch] GET %s\n", url)              // ✗ cannot use retry without logging
+	for i := 0; i < 3; i++ {
+		if body, err := httpGet(url); err == nil {
+			return body, nil
+		}
+	}
+	return "", fmt.Errorf("all retries failed")
+	// ✗ adding caching requires yet another combined function
+}
+```

--- a/skills/principle-design-patterns/examples/decorator.java.md
+++ b/skills/principle-design-patterns/examples/decorator.java.md
@@ -1,0 +1,110 @@
+# Decorator — Java — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior added without altering the
+`HttpFetcher` class. The classic GoF Decorator wraps a `Fetcher` interface:
+`RetryFetcher` and `LoggingFetcher` each hold an inner `Fetcher` and delegate to it,
+adding their own behavior before or after. They compose in any order and the core
+class is never touched.
+
+## Implementation
+
+```java
+// file: Fetcher.java
+public interface Fetcher {
+    String fetch(String url) throws Exception;
+}
+```
+
+```java
+// file: HttpFetcher.java
+import java.net.URI;
+import java.net.http.*;
+
+public class HttpFetcher implements Fetcher {
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    @Override
+    public String fetch(String url) throws Exception {
+        var req = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        return CLIENT.send(req, HttpResponse.BodyHandlers.ofString()).body();
+    }
+}
+```
+
+```java
+// file: RetryFetcher.java
+public class RetryFetcher implements Fetcher {
+    private final Fetcher inner;
+    private final int retries;
+
+    public RetryFetcher(Fetcher inner, int retries) {
+        this.inner = inner;
+        this.retries = retries;
+    }
+
+    @Override
+    public String fetch(String url) throws Exception {
+        Exception last = null;
+        for (int i = 0; i <= retries; i++) {
+            try { return inner.fetch(url); }
+            catch (Exception e) { last = e; }
+        }
+        throw last;
+    }
+}
+```
+
+```java
+// file: LoggingFetcher.java
+public class LoggingFetcher implements Fetcher {
+    private final Fetcher inner;
+
+    public LoggingFetcher(Fetcher inner) { this.inner = inner; }
+
+    @Override
+    public String fetch(String url) throws Exception {
+        System.out.println("[fetch] GET " + url);
+        try {
+            String result = inner.fetch(url);
+            System.out.println("[fetch] OK  " + url);
+            return result;
+        } catch (Exception e) {
+            System.out.println("[fetch] ERR " + url + ": " + e.getMessage());
+            throw e;
+        }
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) throws Exception {
+        Fetcher fetcher = new LoggingFetcher(new RetryFetcher(new HttpFetcher(), 3));
+        System.out.println(fetcher.fetch("https://example.com/api/data"));
+    }
+}
+```
+
+## Common Mistake
+
+Extending `HttpFetcher` with a combined subclass — every new behavior combination
+requires a new class, and the behaviors cannot be reused independently.
+
+```java
+// ✗ subclass explosion — every combination needs its own class
+class RetryLoggingFetcher extends HttpFetcher {  // ✗ fuses retry + logging
+    @Override
+    public String fetch(String url) throws Exception {
+        System.out.println("[fetch] GET " + url);  // ✗ cannot retry without logging
+        for (int i = 0; i < 3; i++) {
+            try { return super.fetch(url); }
+            catch (Exception e) { /* retry */ }
+        }
+        throw new Exception("all retries failed");
+    }
+}
+// class CachingRetryFetcher extends HttpFetcher { ... }  // ✗ N behaviors → N² classes
+```

--- a/skills/principle-design-patterns/examples/decorator.kt.md
+++ b/skills/principle-design-patterns/examples/decorator.kt.md
@@ -1,0 +1,72 @@
+# Decorator — Kotlin — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without those concerns being baked
+into the fetch function. Kotlin's higher-order functions make the Decorator pattern
+lightweight: `withRetry` and `withLogging` each accept a `(String) -> String` function
+and return a new one, composable in any order with no class hierarchy.
+
+## Implementation
+
+```kotlin
+// file: fetcher.kt
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+private val client = HttpClient.newHttpClient()
+
+fun httpFetch(url: String): String {
+    val req = HttpRequest.newBuilder(URI.create(url)).GET().build()
+    return client.send(req, HttpResponse.BodyHandlers.ofString()).body()
+}
+
+fun withRetry(fn: (String) -> String, n: Int): (String) -> String = { url ->
+    var lastErr: Throwable? = null
+    var result: String? = null
+    for (i in 0..n) {
+        runCatching { fn(url) }
+            .onSuccess { result = it }
+            .onFailure { lastErr = it }
+        if (result != null) break
+    }
+    result ?: throw lastErr!!
+}
+
+fun withLogging(fn: (String) -> String): (String) -> String = { url ->
+    println("[fetch] GET $url")
+    runCatching { fn(url) }
+        .onSuccess { println("[fetch] OK  $url") }
+        .onFailure { println("[fetch] ERR $url: ${it.message}") }
+        .getOrThrow()
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    val fetch = withLogging(withRetry(::httpFetch, 3))
+    println(fetch("https://example.com/api/data"))
+    // [fetch] GET https://example.com/api/data
+    // [fetch] OK  https://example.com/api/data
+}
+```
+
+## Common Mistake
+
+Fusing retry and logging into a single combined function — both behaviors are
+inseparable, and adding caching requires yet another variant for each existing combo.
+
+```kotlin
+// ✗ subclass explosion — retry and logging fused; cannot be used independently
+fun retryLoggingFetch(url: String): String {      // ✗ both behaviors locked together
+    println("[fetch] GET $url")                    // ✗ cannot retry without logging
+    repeat(3) {
+        runCatching { httpFetch(url) }.onSuccess { return it }
+    }
+    throw IllegalStateException("all retries failed")
+    // ✗ adding caching needs retryLoggingCachingFetch, cachingFetch, retryFetch, …
+}
+```

--- a/skills/principle-design-patterns/examples/decorator.py.md
+++ b/skills/principle-design-patterns/examples/decorator.py.md
@@ -1,0 +1,85 @@
+# Decorator — Python — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without embedding those concerns
+inside `http_fetch`. Python's decorator syntax is the language-native expression of
+the Decorator pattern: `@retry(3)` and `@log_fetch` each wrap the function,
+independently reusable, stackable in any order, and the core function is never
+modified.
+
+## Implementation
+
+```python
+# file: fetcher.py
+import functools
+import logging
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+def retry(n: int):
+    """Decorator factory: retry the wrapped function up to n times on exception."""
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            last_exc: BaseException | None = None
+            for _ in range(n + 1):
+                try:
+                    return fn(*args, **kwargs)
+                except Exception as exc:
+                    last_exc = exc
+            raise last_exc  # type: ignore[misc]
+        return wrapper
+    return decorator
+
+
+def log_fetch(fn):
+    """Decorator: log each fetch attempt and its outcome."""
+    @functools.wraps(fn)
+    def wrapper(url: str) -> str:
+        logger.info("[fetch] GET %s", url)
+        try:
+            result = fn(url)
+            logger.info("[fetch] OK  %s", url)
+            return result
+        except Exception as exc:
+            logger.error("[fetch] ERR %s: %s", url, exc)
+            raise
+    return wrapper
+
+
+@retry(3)
+@log_fetch
+def http_fetch(url: str) -> str:
+    with urllib.request.urlopen(url) as resp:  # noqa: S310
+        return resp.read().decode()
+```
+
+```python
+# file: main.py
+import logging
+from fetcher import http_fetch
+
+logging.basicConfig(level=logging.INFO)
+print(http_fetch("https://example.com/api/data"))
+```
+
+## Common Mistake
+
+Defining a combined function that merges retry and logging — the behaviors cannot be
+applied separately, and every new combination needs its own function.
+
+```python
+# ✗ subclass explosion — retry and logging fused into one function
+def retry_logging_fetch(url: str, retries: int = 3) -> str:  # ✗ inseparable behaviors
+    print(f"[fetch] GET {url}")                               # ✗ cannot retry silently
+    for _ in range(retries + 1):
+        try:
+            return http_get(url)
+        except Exception:
+            pass
+    raise RuntimeError("all retries failed")
+# ✗ adding caching requires retry_logging_caching_fetch, retry_caching_fetch, …
+```

--- a/skills/principle-design-patterns/examples/decorator.rb.md
+++ b/skills/principle-design-patterns/examples/decorator.rb.md
@@ -1,0 +1,82 @@
+# Decorator — Ruby — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without modifying `http_fetch`
+itself. Ruby's proc composition makes the Decorator pattern idiomatic: `with_retry`
+and `with_logging` each wrap a callable and return a new one. They compose in any
+order using `>>` or explicit lambdas, keeping each behavior independently reusable.
+
+## Implementation
+
+```ruby
+# file: fetcher.rb
+require "net/http"
+require "uri"
+
+module Fetcher
+  HTTP_FETCH = lambda do |url|
+    uri = URI.parse(url)
+    Net::HTTP.get_response(uri).body
+  end
+
+  def self.with_retry(fn, n)
+    lambda do |url|
+      last_err = nil
+      (n + 1).times do
+        begin
+          return fn.call(url)
+        rescue => e
+          last_err = e
+        end
+      end
+      raise last_err
+    end
+  end
+
+  def self.with_logging(fn)
+    lambda do |url|
+      puts "[fetch] GET #{url}"
+      begin
+        result = fn.call(url)
+        puts "[fetch] OK  #{url}"
+        result
+      rescue => e
+        puts "[fetch] ERR #{url}: #{e.message}"
+        raise
+      end
+    end
+  end
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "fetcher"
+
+fetch = Fetcher.with_logging(Fetcher.with_retry(Fetcher::HTTP_FETCH, 3))
+puts fetch.call("https://example.com/api/data")
+# [fetch] GET https://example.com/api/data
+# [fetch] OK  https://example.com/api/data
+```
+
+## Common Mistake
+
+Combining retry and logging into a single method — the behaviors are inseparable and
+every new combination requires a new method.
+
+```ruby
+# ✗ subclass explosion — retry and logging merged; behaviors cannot be reused alone
+def retry_logging_fetch(url, retries: 3)     # ✗ fused behaviors
+  puts "[fetch] GET #{url}"                   # ✗ cannot retry without logging
+  retries.times do
+    begin
+      return http_get(url)
+    rescue => _e
+      nil
+    end
+  end
+  raise "all retries failed"
+  # ✗ adding caching needs retry_logging_caching_fetch, caching_fetch, …
+end
+```

--- a/skills/principle-design-patterns/examples/decorator.rb.md
+++ b/skills/principle-design-patterns/examples/decorator.rb.md
@@ -41,7 +41,7 @@ module Fetcher
         result = fn.call(url)
         puts "[fetch] OK  #{url}"
         result
-      rescue => e
+      rescue StandardError => e
         puts "[fetch] ERR #{url}: #{e.message}"
         raise
       end

--- a/skills/principle-design-patterns/examples/decorator.rb.md
+++ b/skills/principle-design-patterns/examples/decorator.rb.md
@@ -26,7 +26,7 @@ module Fetcher
       (n + 1).times do
         begin
           return fn.call(url)
-        rescue => e
+        rescue StandardError => e
           last_err = e
         end
       end

--- a/skills/principle-design-patterns/examples/decorator.rs.md
+++ b/skills/principle-design-patterns/examples/decorator.rs.md
@@ -1,0 +1,102 @@
+# Decorator — Rust — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without modifying `HttpFetcher`.
+Rust's generic wrapper structs implement a `Fetcher` trait and hold an inner `F:
+Fetcher`, avoiding heap allocation. `LoggingFetcher<RetryFetcher<HttpFetcher>>`
+composes at the type level — behaviors are zero-cost and reusable in any order.
+
+## Implementation
+
+```rust
+// file: fetcher.rs
+pub trait Fetcher {
+    fn fetch(&self, url: &str) -> Result<String, String>;
+}
+
+pub struct HttpFetcher;
+
+impl Fetcher for HttpFetcher {
+    fn fetch(&self, url: &str) -> Result<String, String> {
+        // In real code: use ureq or reqwest.
+        Err(format!("not implemented for {url}"))
+    }
+}
+
+pub struct RetryFetcher<F: Fetcher> {
+    pub inner: F,
+    pub retries: u32,
+}
+
+impl<F: Fetcher> Fetcher for RetryFetcher<F> {
+    fn fetch(&self, url: &str) -> Result<String, String> {
+        let mut last_err = String::new();
+        for _ in 0..=self.retries {
+            match self.inner.fetch(url) {
+                Ok(body) => return Ok(body),
+                Err(e) => last_err = e,
+            }
+        }
+        Err(last_err)
+    }
+}
+
+pub struct LoggingFetcher<F: Fetcher> {
+    pub inner: F,
+}
+
+impl<F: Fetcher> Fetcher for LoggingFetcher<F> {
+    fn fetch(&self, url: &str) -> Result<String, String> {
+        println!("[fetch] GET {url}");
+        match self.inner.fetch(url) {
+            Ok(body) => {
+                println!("[fetch] OK  {url}");
+                Ok(body)
+            }
+            Err(e) => {
+                eprintln!("[fetch] ERR {url}: {e}");
+                Err(e)
+            }
+        }
+    }
+}
+```
+
+```rust
+// file: main.rs
+mod fetcher;
+use fetcher::{Fetcher, HttpFetcher, LoggingFetcher, RetryFetcher};
+
+fn main() {
+    let fetch = LoggingFetcher {
+        inner: RetryFetcher { inner: HttpFetcher, retries: 3 },
+    };
+    match fetch.fetch("https://example.com/api/data") {
+        Ok(body) => println!("{body}"),
+        Err(e) => eprintln!("error: {e}"),
+    }
+}
+```
+
+## Common Mistake
+
+Creating a monolithic struct that hardcodes both retry and logging — behaviors are
+inseparable and every new combination requires a new struct.
+
+```rust
+// ✗ subclass explosion — retry + logging fused into one struct
+struct RetryLoggingFetcher {               // ✗ behaviors cannot be used independently
+    retries: u32,
+}
+impl Fetcher for RetryLoggingFetcher {
+    fn fetch(&self, url: &str) -> Result<String, String> {
+        println!("[fetch] GET {url}");     // ✗ retry always logs; cannot silence
+        for _ in 0..=self.retries {
+            if let Ok(b) = http_get(url) { return Ok(b); }
+        }
+        Err("all retries failed".into())
+    }
+}
+// struct CachingRetryFetcher { ... }     // ✗ N behaviors → N² structs
+```

--- a/skills/principle-design-patterns/examples/decorator.swift.md
+++ b/skills/principle-design-patterns/examples/decorator.swift.md
@@ -1,0 +1,90 @@
+# Decorator — Swift — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch needs retry and logging behavior without modifying `HttpFetcher`.
+Swift's `protocol Fetcher` lets `RetryFetcher` and `LoggingFetcher` each wrap any
+`Fetcher` conformance and delegate to it, adding a single concern. They compose in
+any order — the core class is never changed.
+
+## Implementation
+
+```swift
+// file: Fetcher.swift
+import Foundation
+
+protocol Fetcher {
+    func fetch(url: String) throws -> String
+}
+
+struct HttpFetcher: Fetcher {
+    func fetch(url: String) throws -> String {
+        guard let u = URL(string: url) else { throw URLError(.badURL) }
+        let (data, _) = try URLSession.shared.data(from: u)
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+struct RetryFetcher: Fetcher {
+    let inner: any Fetcher
+    let retries: Int
+
+    func fetch(url: String) throws -> String {
+        var lastError: Error?
+        for _ in 0...retries {
+            do { return try inner.fetch(url: url) }
+            catch { lastError = error }
+        }
+        throw lastError!
+    }
+}
+
+struct LoggingFetcher: Fetcher {
+    let inner: any Fetcher
+
+    func fetch(url: String) throws -> String {
+        print("[fetch] GET \(url)")
+        do {
+            let result = try inner.fetch(url: url)
+            print("[fetch] OK  \(url)")
+            return result
+        } catch {
+            print("[fetch] ERR \(url): \(error)")
+            throw error
+        }
+    }
+}
+```
+
+```swift
+// file: main.swift
+let fetcher: any Fetcher = LoggingFetcher(
+    inner: RetryFetcher(inner: HttpFetcher(), retries: 3)
+)
+
+do {
+    let body = try fetcher.fetch(url: "https://example.com/api/data")
+    print(body)
+} catch {
+    print("error:", error)
+}
+```
+
+## Common Mistake
+
+Subclassing `HttpFetcher` with a combined class — behaviors are inseparable and every
+new combination demands a new subclass.
+
+```swift
+// ✗ subclass explosion — retry + logging fused into one class
+class RetryLoggingFetcher: HttpFetcher {         // ✗ combined into one subclass
+    override func fetch(url: String) throws -> String {
+        print("[fetch] GET \(url)")              // ✗ retry cannot be used without logging
+        for _ in 0..<3 {
+            if let result = try? super.fetch(url: url) { return result }
+        }
+        throw URLError(.cannotConnectToHost)
+    }
+}
+// class CachingRetryFetcher: HttpFetcher { ... } // ✗ N behaviors → N² subclasses
+```

--- a/skills/principle-design-patterns/examples/decorator.swift.md
+++ b/skills/principle-design-patterns/examples/decorator.swift.md
@@ -20,8 +20,14 @@ protocol Fetcher {
 struct HttpFetcher: Fetcher {
     func fetch(url: String) throws -> String {
         guard let u = URL(string: url) else { throw URLError(.badURL) }
-        let (data, _) = try URLSession.shared.data(from: u)
-        return String(decoding: data, as: UTF8.self)
+        var result: Result<Data, Error>?
+        let sem = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: u) { data, _, err in
+            result = data.map { .success($0) } ?? .failure(err ?? URLError(.unknown))
+            sem.signal()
+        }.resume()
+        sem.wait()
+        return String(decoding: try result!.get(), as: UTF8.self)
     }
 }
 
@@ -77,14 +83,17 @@ new combination demands a new subclass.
 
 ```swift
 // ✗ subclass explosion — retry + logging fused into one class
-class RetryLoggingFetcher: HttpFetcher {         // ✗ combined into one subclass
+class HttpFetcherBase {                          // must be a class for subclassing
+    func fetch(url: String) throws -> String { /* core HTTP fetch */ }
+}
+class RetryLoggingFetcher: HttpFetcherBase {     // ✗ combined into one subclass
     override func fetch(url: String) throws -> String {
         print("[fetch] GET \(url)")              // ✗ retry cannot be used without logging
         for _ in 0..<3 {
-            if let result = try? super.fetch(url: url) { return result }
+            if let r = try? super.fetch(url: url) { return r }
         }
         throw URLError(.cannotConnectToHost)
     }
 }
-// class CachingRetryFetcher: HttpFetcher { ... } // ✗ N behaviors → N² subclasses
+// class CachingRetryFetcher: HttpFetcherBase { ... } // ✗ N behaviors → N² subclasses
 ```

--- a/skills/principle-design-patterns/examples/decorator.ts.md
+++ b/skills/principle-design-patterns/examples/decorator.ts.md
@@ -1,0 +1,81 @@
+# Decorator — TypeScript — Retry and Logging Fetch
+
+## Problem
+
+A core HTTP fetch must be augmented with retry logic and request logging. Embedding
+both behaviors inside `httpFetch` couples unrelated concerns and makes them
+impossible to reuse independently. The Decorator pattern solves this with higher-order
+functions: `withRetry` and `withLogging` each wrap a `FetchFn` and return a new
+`FetchFn`, composable in any order without touching the core.
+
+## Implementation
+
+```ts
+// file: fetcher.ts
+export type FetchFn = (url: string) => Promise<string>;
+
+export async function httpFetch(url: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.text();
+}
+
+export function withRetry(fn: FetchFn, retries: number): FetchFn {
+  return async (url) => {
+    let lastErr: unknown;
+    for (let i = 0; i <= retries; i++) {
+      try {
+        return await fn(url);
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw lastErr;
+  };
+}
+
+export function withLogging(fn: FetchFn): FetchFn {
+  return async (url) => {
+    console.log(`[fetch] GET ${url}`);
+    try {
+      const result = await fn(url);
+      console.log(`[fetch] OK ${url}`);
+      return result;
+    } catch (err) {
+      console.error(`[fetch] ERR ${url}:`, err);
+      throw err;
+    }
+  };
+}
+```
+
+```ts
+// file: main.ts
+import { httpFetch, withRetry, withLogging } from "./fetcher";
+
+const fetch = withLogging(withRetry(httpFetch, 3));
+
+fetch("https://example.com/api/data").then(console.log);
+// [fetch] GET https://example.com/api/data
+// [fetch] OK  https://example.com/api/data
+```
+
+## Common Mistake
+
+Combining behaviors into a single subclass — adding caching later requires a third
+class for every combination already in use.
+
+```ts
+// ✗ subclass explosion — every combination requires its own class
+class RetryLoggingFetcher {                        // ✗ merged into one
+  async fetch(url: string): Promise<string> {      // ✗ retry and logging cannot be reused
+    console.log(`[fetch] GET ${url}`);             //   independently
+    for (let i = 0; i < 3; i++) {
+      try { return await httpFetch(url); }
+      catch { /* retry */ }
+    }
+    throw new Error("all retries failed");
+  }
+}
+// class CachingRetryFetcher { ... }              // ✗ N behaviors → N² classes
+```

--- a/skills/principle-design-patterns/examples/factory.cs.md
+++ b/skills/principle-design-patterns/examples/factory.cs.md
@@ -1,0 +1,80 @@
+# Factory Method — C# — Notification Channel
+
+## Problem
+
+A notification service must deliver messages over Email, SMS, or Push depending on a
+user preference. Newing up concrete channel types at each call site scatters the
+selection switch across the codebase and forces every caller to import implementation
+types. `ChannelFactory.Create` centralizes all construction; callers depend only on the
+`IChannel` interface.
+
+## Implementation
+
+```csharp
+// file: IChannel.cs
+public interface IChannel
+{
+    void Send(string msg);
+}
+```
+
+```csharp
+// file: Channels.cs
+public class EmailChannel : IChannel
+{
+    public void Send(string msg) => Console.WriteLine($"[email] {msg}");
+}
+
+public class SmsChannel : IChannel
+{
+    public void Send(string msg) => Console.WriteLine($"[sms] {msg}");
+}
+
+public class PushChannel : IChannel
+{
+    public void Send(string msg) => Console.WriteLine($"[push] {msg}");
+}
+```
+
+```csharp
+// file: ChannelFactory.cs
+public static class ChannelFactory
+{
+    // One switch here, nowhere else.
+    public static IChannel Create(string kind) => kind switch
+    {
+        "email" => new EmailChannel(),
+        "sms"   => new SmsChannel(),
+        "push"  => new PushChannel(),
+        _       => throw new ArgumentException($"Unknown channel: {kind}")
+    };
+}
+```
+
+```csharp
+// file: Program.cs
+foreach (var kind in new[] { "email", "sms", "push" })
+{
+    ChannelFactory.Create(kind).Send("Your order has shipped.");
+}
+```
+
+## Common Mistake
+
+A `switch` expression at every call site — adding `PushChannel` requires updating every
+notification method across the codebase.
+
+```csharp
+// ✗ construction scattered — every call site must repeat this switch
+void Notify(string kind, string msg)
+{
+    IChannel ch = kind switch
+    {
+        "email" => new EmailChannel(),   // ✗ duplicated construction
+        "sms"   => new SmsChannel(),     // ✗ duplicated construction
+        // ✗ adding push requires editing every call site
+        _       => throw new ArgumentException(kind)
+    };
+    ch.Send(msg);
+}
+```

--- a/skills/principle-design-patterns/examples/factory.go.md
+++ b/skills/principle-design-patterns/examples/factory.go.md
@@ -1,0 +1,84 @@
+# Factory Method — Go — Notification Channel
+
+## Problem
+
+A notification service must deliver messages over Email, SMS, or Push depending on a
+user's configured preference. Constructing the right channel at every call site scatters
+`switch` blocks throughout the codebase. The Factory Method centralizes that decision:
+one function inspects the kind string and returns the correct unexported implementation,
+keeping all construction logic in a single place.
+
+## Implementation
+
+```go
+// file: channel.go
+package notify
+
+import "fmt"
+
+// Channel is the contract every notification backend must satisfy.
+type Channel interface {
+	Send(msg string)
+}
+
+type emailChannel struct{}
+type smsChannel struct{}
+type pushChannel struct{}
+
+func (e emailChannel) Send(msg string) { fmt.Println("[email]", msg) }
+func (s smsChannel) Send(msg string)   { fmt.Println("[sms]", msg) }
+func (p pushChannel) Send(msg string)  { fmt.Println("[push]", msg) }
+
+// NewChannel is the factory: one switch here, nowhere else.
+func NewChannel(kind string) (Channel, error) {
+	switch kind {
+	case "email":
+		return emailChannel{}, nil
+	case "sms":
+		return smsChannel{}, nil
+	case "push":
+		return pushChannel{}, nil
+	default:
+		return nil, fmt.Errorf("unknown channel kind: %q", kind)
+	}
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"fmt"
+	"example/notify"
+)
+
+func main() {
+	for _, kind := range []string{"email", "sms", "push"} {
+		ch, err := notify.NewChannel(kind)
+		if err != nil {
+			fmt.Println("error:", err)
+			continue
+		}
+		ch.Send("Your order has shipped.")
+	}
+}
+```
+
+## Common Mistake
+
+Repeated `switch` blocks at every call site — adding a `PushChannel` requires hunting
+down and editing every site individually.
+
+```go
+// ✗ construction scattered — every call site must repeat this switch
+func notify(kind, msg string) {
+	switch kind {
+	case "email":
+		emailChannel{}.Send(msg)   // ✗ duplicated construction
+	case "sms":
+		smsChannel{}.Send(msg)     // ✗ duplicated construction
+	// ✗ adding push requires editing every switch in the codebase
+	}
+}
+```

--- a/skills/principle-design-patterns/examples/factory.java.md
+++ b/skills/principle-design-patterns/examples/factory.java.md
@@ -1,0 +1,81 @@
+# Factory Method — Java — Notification Channel
+
+## Problem
+
+A notification service must dispatch messages over Email, SMS, or Push depending on a
+user preference. Instantiating concrete channel classes at every call site duplicates
+the selection switch and couples callers to implementation types. The Factory Method
+concentrates construction in `ChannelFactory.create`; every caller depends only on the
+`Channel` interface.
+
+## Implementation
+
+```java
+// file: Channel.java
+public interface Channel {
+    void send(String msg);
+}
+```
+
+```java
+// file: EmailChannel.java
+public class EmailChannel implements Channel {
+    public void send(String msg) { System.out.println("[email] " + msg); }
+}
+```
+
+```java
+// file: SmsChannel.java
+public class SmsChannel implements Channel {
+    public void send(String msg) { System.out.println("[sms] " + msg); }
+}
+```
+
+```java
+// file: PushChannel.java
+public class PushChannel implements Channel {
+    public void send(String msg) { System.out.println("[push] " + msg); }
+}
+```
+
+```java
+// file: ChannelFactory.java
+public class ChannelFactory {
+    // One switch here, nowhere else.
+    public static Channel create(String kind) {
+        return switch (kind) {
+            case "email" -> new EmailChannel();
+            case "sms"   -> new SmsChannel();
+            case "push"  -> new PushChannel();
+            default      -> throw new IllegalArgumentException("Unknown channel: " + kind);
+        };
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        for (String kind : new String[]{"email", "sms", "push"}) {
+            ChannelFactory.create(kind).send("Your order has shipped.");
+        }
+    }
+}
+```
+
+## Common Mistake
+
+A repeated `switch` at every call site — adding `PushChannel` means hunting down and
+editing every notification method individually.
+
+```java
+// ✗ construction scattered — every call site must repeat this switch
+void notify(String kind, String msg) {
+    switch (kind) {
+        case "email" -> new EmailChannel().send(msg);  // ✗ duplicated
+        case "sms"   -> new SmsChannel().send(msg);    // ✗ duplicated
+        // ✗ adding push requires editing every call site
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/factory.kt.md
+++ b/skills/principle-design-patterns/examples/factory.kt.md
@@ -1,0 +1,63 @@
+# Factory Method — Kotlin — Notification Channel
+
+## Problem
+
+A notification service must send messages over Email, SMS, or Push depending on a
+user's stored preference. Without a factory, every call site repeats a `when` block
+and imports concrete channel types. The Factory Method places that `when` expression in
+one top-level function; callers work against the `Channel` interface and never
+instantiate channels directly.
+
+## Implementation
+
+```kotlin
+// file: Channel.kt
+interface Channel {
+    fun send(msg: String)
+}
+
+object EmailChannel : Channel {
+    override fun send(msg: String) = println("[email] $msg")
+}
+
+object SmsChannel : Channel {
+    override fun send(msg: String) = println("[sms] $msg")
+}
+
+object PushChannel : Channel {
+    override fun send(msg: String) = println("[push] $msg")
+}
+
+// Factory — one when expression, nowhere else.
+fun createChannel(kind: String): Channel = when (kind) {
+    "email" -> EmailChannel
+    "sms"   -> SmsChannel
+    "push"  -> PushChannel
+    else    -> throw IllegalArgumentException("Unknown channel: $kind")
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    listOf("email", "sms", "push").forEach { kind ->
+        createChannel(kind).send("Your order has shipped.")
+    }
+}
+```
+
+## Common Mistake
+
+Repeating the `when` block at every call site — adding Push requires editing every
+function that constructs channels.
+
+```kotlin
+// ✗ construction scattered — every call site must repeat this when block
+fun notify(kind: String, msg: String) {
+    when (kind) {
+        "email" -> EmailChannel.send(msg)   // ✗ duplicated construction
+        "sms"   -> SmsChannel.send(msg)     // ✗ duplicated construction
+        // ✗ adding push requires editing every call site
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/factory.py.md
+++ b/skills/principle-design-patterns/examples/factory.py.md
@@ -1,0 +1,73 @@
+# Factory Method — Python — Notification Channel
+
+## Problem
+
+A notification service must route messages to Email, SMS, or Push based on a user's
+configuration. Constructing channels inline at every call site repeats the same
+`if/elif` logic everywhere. The Factory Method centralizes that logic: a single
+`create_channel` function owns all construction; call sites receive a `Channel` and
+never import concrete classes.
+
+## Implementation
+
+```python
+# file: channel.py
+from typing import Protocol
+
+
+class Channel(Protocol):
+    def send(self, msg: str) -> None: ...
+
+
+class EmailChannel:
+    def send(self, msg: str) -> None:
+        print(f"[email] {msg}")
+
+
+class SmsChannel:
+    def send(self, msg: str) -> None:
+        print(f"[sms] {msg}")
+
+
+class PushChannel:
+    def send(self, msg: str) -> None:
+        print(f"[push] {msg}")
+
+
+# Registry-based factory — one mapping, no scattered switches.
+_REGISTRY: dict[str, type] = {
+    "email": EmailChannel,
+    "sms":   SmsChannel,
+    "push":  PushChannel,
+}
+
+
+def create_channel(kind: str) -> Channel:
+    cls = _REGISTRY.get(kind)
+    if cls is None:
+        raise ValueError(f"Unknown channel: {kind!r}")
+    return cls()
+```
+
+```python
+# file: main.py
+from channel import create_channel
+
+for kind in ("email", "sms", "push"):
+    create_channel(kind).send("Your order has shipped.")
+```
+
+## Common Mistake
+
+An `if/elif` chain at every call site — adding a Push channel requires editing every
+place in the codebase that constructs channels.
+
+```python
+# ✗ construction scattered — every call site must repeat this if/elif
+def notify(kind: str, msg: str) -> None:
+    if kind == "email":
+        EmailChannel().send(msg)       # ✗ duplicated construction
+    elif kind == "sms":
+        SmsChannel().send(msg)         # ✗ duplicated construction
+    # ✗ adding PushChannel requires editing every call site
+```

--- a/skills/principle-design-patterns/examples/factory.py.md
+++ b/skills/principle-design-patterns/examples/factory.py.md
@@ -35,7 +35,7 @@ class PushChannel:
 
 
 # Registry-based factory — one mapping, no scattered switches.
-_REGISTRY: dict[str, type] = {
+_REGISTRY: dict[str, type[Channel]] = {
     "email": EmailChannel,
     "sms":   SmsChannel,
     "push":  PushChannel,

--- a/skills/principle-design-patterns/examples/factory.rb.md
+++ b/skills/principle-design-patterns/examples/factory.rb.md
@@ -1,0 +1,63 @@
+# Factory Method — Ruby — Notification Channel
+
+## Problem
+
+A notification service must send messages over Email, SMS, or Push based on a user's
+preference. Instantiating concrete channel classes with `if/case` blocks at each call
+site couples callers to implementation classes and scatters construction logic. A
+registry-based factory method centralizes that knowledge; call sites receive any object
+that responds to `send_message`.
+
+## Implementation
+
+```ruby
+# file: channels.rb
+class EmailChannel
+  def send_message(msg) = puts("[email] #{msg}")
+end
+
+class SmsChannel
+  def send_message(msg) = puts("[sms] #{msg}")
+end
+
+class PushChannel
+  def send_message(msg) = puts("[push] #{msg}")
+end
+
+# Registry-based factory — one mapping, nowhere else.
+CHANNEL_REGISTRY = {
+  "email" => EmailChannel,
+  "sms"   => SmsChannel,
+  "push"  => PushChannel,
+}.freeze
+
+def create_channel(kind)
+  klass = CHANNEL_REGISTRY.fetch(kind) { raise ArgumentError, "Unknown channel: #{kind}" }
+  klass.new
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "channels"
+
+%w[email sms push].each do |kind|
+  create_channel(kind).send_message("Your order has shipped.")
+end
+```
+
+## Common Mistake
+
+A `case` expression repeated at every call site — adding `PushChannel` means finding
+and editing every place that constructs channels.
+
+```ruby
+# ✗ construction scattered — every call site must repeat this case block
+def notify(kind, msg)
+  case kind
+  when "email" then EmailChannel.new.send_message(msg)  # ✗ duplicated
+  when "sms"   then SmsChannel.new.send_message(msg)    # ✗ duplicated
+  # ✗ adding push requires editing every call site
+  end
+end
+```

--- a/skills/principle-design-patterns/examples/factory.rs.md
+++ b/skills/principle-design-patterns/examples/factory.rs.md
@@ -1,0 +1,74 @@
+# Factory Method — Rust — Notification Channel
+
+## Problem
+
+A notification service must send messages over Email, SMS, or Push depending on a
+string from user configuration. Without a factory, every caller must `match` on the
+kind string and construct the concrete type directly, scattering construction across
+the codebase. `create_channel` centralizes that `match`; callers receive a
+`Box<dyn Channel>` and remain ignorant of concrete types.
+
+## Implementation
+
+```rust
+// file: channel.rs
+pub trait Channel {
+    fn send(&self, msg: &str);
+}
+
+pub struct EmailChannel;
+pub struct SmsChannel;
+pub struct PushChannel;
+
+impl Channel for EmailChannel {
+    fn send(&self, msg: &str) { println!("[email] {}", msg); }
+}
+impl Channel for SmsChannel {
+    fn send(&self, msg: &str) { println!("[sms] {}", msg); }
+}
+impl Channel for PushChannel {
+    fn send(&self, msg: &str) { println!("[push] {}", msg); }
+}
+
+// Factory — one match here, nowhere else.
+pub fn create_channel(kind: &str) -> Result<Box<dyn Channel>, String> {
+    match kind {
+        "email" => Ok(Box::new(EmailChannel)),
+        "sms"   => Ok(Box::new(SmsChannel)),
+        "push"  => Ok(Box::new(PushChannel)),
+        other   => Err(format!("unknown channel: {other}")),
+    }
+}
+```
+
+```rust
+// file: main.rs
+mod channel;
+use channel::create_channel;
+
+fn main() {
+    for kind in ["email", "sms", "push"] {
+        match create_channel(kind) {
+            Ok(ch) => ch.send("Your order has shipped."),
+            Err(e) => eprintln!("error: {e}"),
+        }
+    }
+}
+```
+
+## Common Mistake
+
+A `match` repeated at every call site — adding `PushChannel` requires updating every
+notification function individually.
+
+```rust
+// ✗ construction scattered — every call site must repeat this match
+fn notify(kind: &str, msg: &str) {
+    match kind {
+        "email" => EmailChannel.send(msg),   // ✗ duplicated construction
+        "sms"   => SmsChannel.send(msg),     // ✗ duplicated construction
+        // ✗ adding push requires editing every call site
+        _ => {}
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/factory.rs.md
+++ b/skills/principle-design-patterns/examples/factory.rs.md
@@ -65,8 +65,8 @@ notification function individually.
 // ✗ construction scattered — every call site must repeat this match
 fn notify(kind: &str, msg: &str) {
     match kind {
-        "email" => EmailChannel.send(msg),   // ✗ duplicated construction
-        "sms"   => SmsChannel.send(msg),     // ✗ duplicated construction
+        "email" => EmailChannel{}.send(msg),   // ✗ duplicated construction
+        "sms"   => SmsChannel{}.send(msg),     // ✗ duplicated construction
         // ✗ adding push requires editing every call site
         _ => {}
     }

--- a/skills/principle-design-patterns/examples/factory.swift.md
+++ b/skills/principle-design-patterns/examples/factory.swift.md
@@ -1,0 +1,68 @@
+# Factory Method — Swift — Notification Channel
+
+## Problem
+
+A notification service must deliver messages over Email, SMS, or Push based on a
+user's stored preference string. Constructing concrete channel types at every call site
+scatters `switch` blocks and forces callers to import implementation modules. A single
+factory function owns construction; call sites receive a value conforming to `Channel`
+and never reference concrete types.
+
+## Implementation
+
+```swift
+// file: Channel.swift
+protocol Channel {
+    func send(msg: String)
+}
+
+struct EmailChannel: Channel {
+    func send(msg: String) { print("[email] \(msg)") }
+}
+
+struct SmsChannel: Channel {
+    func send(msg: String) { print("[sms] \(msg)") }
+}
+
+struct PushChannel: Channel {
+    func send(msg: String) { print("[push] \(msg)") }
+}
+
+// Factory — one switch here, nowhere else.
+func makeChannel(kind: String) -> Channel? {
+    switch kind {
+    case "email": return EmailChannel()
+    case "sms":   return SmsChannel()
+    case "push":  return PushChannel()
+    default:      return nil
+    }
+}
+```
+
+```swift
+// file: main.swift
+for kind in ["email", "sms", "push"] {
+    guard let ch = makeChannel(kind: kind) else {
+        print("Unknown channel: \(kind)")
+        continue
+    }
+    ch.send(msg: "Your order has shipped.")
+}
+```
+
+## Common Mistake
+
+A `switch` repeated at every call site — adding `PushChannel` requires finding and
+editing every notification function in the codebase.
+
+```swift
+// ✗ construction scattered — every call site must repeat this switch
+func notify(kind: String, msg: String) {
+    switch kind {
+    case "email": EmailChannel().send(msg: msg)   // ✗ duplicated construction
+    case "sms":   SmsChannel().send(msg: msg)     // ✗ duplicated construction
+    // ✗ adding push requires editing every call site
+    default: break
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/factory.ts.md
+++ b/skills/principle-design-patterns/examples/factory.ts.md
@@ -1,0 +1,64 @@
+# Factory Method — TypeScript — Notification Channel
+
+## Problem
+
+A notification service must send messages over Email, SMS, or Push depending on a
+user preference stored in config. Scattering `new EmailChannel()` at every call site
+means adding a new backend requires touching many files. The Factory Method
+centralizes construction behind a single function; callers depend only on the
+`Channel` interface.
+
+## Implementation
+
+```ts
+// file: channel.ts
+export interface Channel {
+  send(msg: string): void;
+}
+
+class EmailChannel implements Channel {
+  send(msg: string) { console.log("[email]", msg); }
+}
+class SmsChannel implements Channel {
+  send(msg: string) { console.log("[sms]", msg); }
+}
+class PushChannel implements Channel {
+  send(msg: string) { console.log("[push]", msg); }
+}
+
+// Registry-based factory — extend here, nowhere else.
+const registry: Record<string, () => Channel> = {
+  email: () => new EmailChannel(),
+  sms:   () => new SmsChannel(),
+  push:  () => new PushChannel(),
+};
+
+export function createChannel(kind: string): Channel {
+  const factory = registry[kind];
+  if (!factory) throw new Error(`Unknown channel: ${kind}`);
+  return factory();
+}
+```
+
+```ts
+// file: main.ts
+import { createChannel } from "./channel";
+
+for (const kind of ["email", "sms", "push"]) {
+  createChannel(kind).send("Your order has shipped.");
+}
+```
+
+## Common Mistake
+
+Inline `if/else` construction repeated at every call site — adding Push requires
+editing every notification function in the codebase.
+
+```ts
+// ✗ construction scattered — every call site must repeat this if/else
+function notify(kind: string, msg: string) {
+  if (kind === "email") new EmailChannel().send(msg);       // ✗ duplicated
+  else if (kind === "sms") new SmsChannel().send(msg);     // ✗ duplicated
+  // ✗ adding PushChannel requires editing every call site
+}
+```

--- a/skills/principle-design-patterns/examples/observer.cs.md
+++ b/skills/principle-design-patterns/examples/observer.cs.md
@@ -1,0 +1,67 @@
+# Observer — C# — Order Status Notifications
+
+## Problem
+
+An `Order` transitions through statuses — "shipped", "delivered" — and email, SMS, and audit
+systems must all react. C#'s native `event Action<string>` makes the Observer pattern a
+language primitive: subscribers attach with `+=`, detach with `-=`, and the emitter fires the
+event with no knowledge of who is listening. No custom interface or observer list is needed.
+
+## Implementation
+
+```csharp
+// file: Order.cs
+public class Order
+{
+    public event Action<string>? StatusChanged;
+
+    public string Status { get; private set; } = "pending";
+
+    public void Ship()
+    {
+        Status = "shipped";
+        StatusChanged?.Invoke(Status);
+    }
+
+    public void Deliver()
+    {
+        Status = "delivered";
+        StatusChanged?.Invoke(Status);
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+var order = new Order();
+
+order.StatusChanged += s => Console.WriteLine($"Email: order is now {s}");
+order.StatusChanged += s => Console.WriteLine($"SMS: order is now {s}");
+order.StatusChanged += s => Console.WriteLine($"Audit: status changed to {s}");
+
+order.Ship();
+// Email: order is now shipped
+// SMS: order is now shipped
+// Audit: status changed to shipped
+
+order.Deliver();
+// Email: order is now delivered
+// SMS: order is now delivered
+// Audit: status changed to delivered
+```
+
+## Common Mistake
+
+Calling `emailService` and `smsService` directly from `Ship()` makes `Order` own every
+notification channel; adding audit logging forces an edit to the domain class.
+
+```csharp
+// ✗ Order directly calls services — adding a new notification requires editing Order
+public void Ship()
+{
+    Status = "shipped";
+    emailService.Send("shipped");   // ✗ hard dependency on EmailService
+    smsService.Send("shipped");     // ✗ hard dependency on SmsService
+    // ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.go.md
+++ b/skills/principle-design-patterns/examples/observer.go.md
@@ -1,0 +1,86 @@
+# Observer — Go — Order Status Notifications
+
+## Problem
+
+An `Order` changes status — "shipped", "delivered" — and multiple independent systems must
+react: email, SMS, and audit log. Go's first-class functions make the Observer pattern
+idiomatic without an interface: `Order` holds a slice of `Listener` functions and calls each
+when a transition occurs. Listeners are registered as closures; the emitter stays ignorant of
+their contents.
+
+## Implementation
+
+```go
+// file: order.go
+package order
+
+// Listener is a function notified on every status change.
+type Listener func(status string)
+
+// Order emits status changes to all registered Listeners.
+type Order struct {
+	listeners []Listener
+	status    string
+}
+
+func New() *Order { return &Order{status: "pending"} }
+
+// AddListener registers fn to receive future status updates.
+func (o *Order) AddListener(fn Listener) {
+	o.listeners = append(o.listeners, fn)
+}
+
+func (o *Order) notify(status string) {
+	for _, fn := range o.listeners {
+		fn(status)
+	}
+}
+
+func (o *Order) Ship() {
+	o.status = "shipped"
+	o.notify(o.status)
+}
+
+func (o *Order) Deliver() {
+	o.status = "delivered"
+	o.notify(o.status)
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"fmt"
+	"example/order"
+)
+
+func main() {
+	o := order.New()
+
+	o.AddListener(func(s string) { fmt.Printf("Email: order is now %s\n", s) })
+	o.AddListener(func(s string) { fmt.Printf("SMS: order is now %s\n", s) })
+	o.AddListener(func(s string) { fmt.Printf("Audit: status changed to %s\n", s) })
+
+	o.Ship()
+	// Email: order is now shipped
+	// SMS: order is now shipped
+	// Audit: status changed to shipped
+}
+```
+
+## Common Mistake
+
+Calling notification services directly from `Ship` or `Deliver` couples `Order` to every
+downstream system; adding a new channel means editing the core domain type.
+
+```go
+// ✗ Order directly calls services — adding a new notification requires editing Order
+func (o *Order) Ship() {
+	o.status = "shipped"
+	emailService.Send("shipped")  // ✗ hard dependency on emailService
+	smsService.Send("shipped")    // ✗ hard dependency on smsService
+	// ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.java.md
+++ b/skills/principle-design-patterns/examples/observer.java.md
@@ -1,0 +1,80 @@
+# Observer — Java — Order Status Notifications
+
+## Problem
+
+An `Order` moves through statuses — "shipped", "delivered" — and email, SMS, and audit systems
+must all react independently. Hardcoding those calls in `Order` creates tight coupling: every
+new channel requires modifying the domain class. The Observer pattern separates concerns by
+having `Order` hold a list of `OrderObserver` implementations it notifies, while knowing nothing
+about any concrete observer.
+
+## Implementation
+
+```java
+// file: OrderObserver.java
+public interface OrderObserver {
+    void onStatusChanged(String status);
+}
+```
+
+```java
+// file: Order.java
+import java.util.ArrayList;
+import java.util.List;
+
+public class Order {
+    private final List<OrderObserver> observers = new ArrayList<>();
+    private String status = "pending";
+
+    public void addObserver(OrderObserver observer) {
+        observers.add(observer);
+    }
+
+    private void notifyObservers() {
+        for (OrderObserver o : observers) o.onStatusChanged(status);
+    }
+
+    public void ship() {
+        status = "shipped";
+        notifyObservers();
+    }
+
+    public void deliver() {
+        status = "delivered";
+        notifyObservers();
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        Order order = new Order();
+
+        order.addObserver(s -> System.out.println("Email: order is now " + s));
+        order.addObserver(s -> System.out.println("SMS: order is now " + s));
+        order.addObserver(s -> System.out.println("Audit: status changed to " + s));
+
+        order.ship();
+        // Email: order is now shipped
+        // SMS: order is now shipped
+        // Audit: status changed to shipped
+    }
+}
+```
+
+## Common Mistake
+
+Calling `EmailService` and `SmsService` directly inside `Order` makes `Order` responsible for
+knowing every notification channel, and forces a code change whenever a new one is added.
+
+```java
+// ✗ Order directly calls services — adding a new notification requires editing Order
+public void ship() {
+    this.status = "shipped";
+    emailService.send("shipped");   // ✗ hard dependency on EmailService
+    smsService.send("shipped");     // ✗ hard dependency on SmsService
+    // ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.kt.md
+++ b/skills/principle-design-patterns/examples/observer.kt.md
@@ -1,0 +1,74 @@
+# Observer — Kotlin — Order Status Notifications
+
+## Problem
+
+An `Order` emits status changes — "shipped", "delivered" — and email, SMS, and audit systems
+must all react. Kotlin's `fun interface` (SAM interface) lets lambdas serve as observers with
+no boilerplate, while keeping the emitter fully decoupled from every concrete listener. Adding
+a new channel is one `addObserver` call at the composition root; `Order` is never touched.
+
+## Implementation
+
+```kotlin
+// file: Order.kt
+fun interface OrderObserver {
+    fun onStatusChanged(status: String)
+}
+
+class Order {
+    private val observers = mutableListOf<OrderObserver>()
+    private var status = "pending"
+
+    fun addObserver(observer: OrderObserver) {
+        observers += observer
+    }
+
+    private fun notifyObservers() = observers.forEach { it.onStatusChanged(status) }
+
+    fun ship() {
+        status = "shipped"
+        notifyObservers()
+    }
+
+    fun deliver() {
+        status = "delivered"
+        notifyObservers()
+    }
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    val order = Order()
+
+    order.addObserver { s -> println("Email: order is now $s") }
+    order.addObserver { s -> println("SMS: order is now $s") }
+    order.addObserver { s -> println("Audit: status changed to $s") }
+
+    order.ship()
+    // Email: order is now shipped
+    // SMS: order is now shipped
+    // Audit: status changed to shipped
+
+    order.deliver()
+    // Email: order is now delivered
+    // SMS: order is now delivered
+    // Audit: status changed to delivered
+}
+```
+
+## Common Mistake
+
+Calling notification services from within `ship()` or `deliver()` makes `Order` own the
+wiring — each new channel requires an edit to the domain class.
+
+```kotlin
+// ✗ Order directly calls services — adding a new notification requires editing Order
+fun ship() {
+    status = "shipped"
+    emailService.send("shipped")   // ✗ hard dependency on EmailService
+    smsService.send("shipped")     // ✗ hard dependency on SmsService
+    // ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.py.md
+++ b/skills/principle-design-patterns/examples/observer.py.md
@@ -1,0 +1,75 @@
+# Observer — Python — Order Status Notifications
+
+## Problem
+
+An `Order` transitions through statuses — "shipped", "delivered" — and email, SMS, and audit
+systems must react independently. Python callables are first-class, so listeners are plain
+functions; no class hierarchy is required. `Order` holds a list of `Callable[[str], None]`
+and calls each on state change. A `Protocol` documents the expected shape for type-checkers
+without adding runtime coupling.
+
+## Implementation
+
+```python
+# file: order.py
+from __future__ import annotations
+from collections.abc import Callable
+
+StatusListener = Callable[[str], None]
+
+
+class Order:
+    def __init__(self) -> None:
+        self._listeners: list[StatusListener] = []
+        self._status = "pending"
+
+    def add_listener(self, fn: StatusListener) -> None:
+        self._listeners.append(fn)
+
+    def _notify(self, status: str) -> None:
+        for fn in self._listeners:
+            fn(status)
+
+    def ship(self) -> None:
+        self._status = "shipped"
+        self._notify(self._status)
+
+    def deliver(self) -> None:
+        self._status = "delivered"
+        self._notify(self._status)
+```
+
+```python
+# file: main.py
+from order import Order
+
+order = Order()
+
+order.add_listener(lambda s: print(f"Email: order is now {s}"))
+order.add_listener(lambda s: print(f"SMS: order is now {s}"))
+order.add_listener(lambda s: print(f"Audit: status changed to {s}"))
+
+order.ship()
+# Email: order is now shipped
+# SMS: order is now shipped
+# Audit: status changed to shipped
+
+order.deliver()
+# Email: order is now delivered
+# SMS: order is now delivered
+# Audit: status changed to delivered
+```
+
+## Common Mistake
+
+Calling `email_service` and `sms_service` directly inside `ship` makes `Order` the integration
+point for every channel — adding audit logging means editing the domain class.
+
+```python
+# ✗ Order directly calls services — adding a new notification requires editing Order
+def ship(self) -> None:
+    self._status = "shipped"
+    email_service.send("shipped")   # ✗ hard dependency on email_service
+    sms_service.send("shipped")     # ✗ hard dependency on sms_service
+    # ✗ must edit Order to add audit log
+```

--- a/skills/principle-design-patterns/examples/observer.rb.md
+++ b/skills/principle-design-patterns/examples/observer.rb.md
@@ -1,0 +1,77 @@
+# Observer — Ruby — Order Status Notifications
+
+## Problem
+
+An `Order` emits status changes — "shipped", "delivered" — and email, SMS, and audit systems
+must all react independently. Ruby's blocks and lambdas are first-class callables: `Order`
+stores an array of procs and calls each when the status changes. Listeners are registered with
+`add_listener(&block)`, keeping the emitter completely decoupled. Ruby also ships the
+`Observable` module in stdlib, but the manual approach shown here is clearer for learning.
+
+## Implementation
+
+```ruby
+# file: order.rb
+class Order
+  def initialize
+    @listeners = []
+    @status = "pending"
+  end
+
+  def add_listener(&block)
+    @listeners << block
+  end
+
+  def ship
+    @status = "shipped"
+    notify_listeners
+  end
+
+  def deliver
+    @status = "delivered"
+    notify_listeners
+  end
+
+  private
+
+  def notify_listeners
+    @listeners.each { |fn| fn.call(@status) }
+  end
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "order"
+
+order = Order.new
+
+order.add_listener { |s| puts "Email: order is now #{s}" }
+order.add_listener { |s| puts "SMS: order is now #{s}" }
+order.add_listener { |s| puts "Audit: status changed to #{s}" }
+
+order.ship
+# Email: order is now shipped
+# SMS: order is now shipped
+# Audit: status changed to shipped
+
+order.deliver
+# Email: order is now delivered
+# SMS: order is now delivered
+# Audit: status changed to delivered
+```
+
+## Common Mistake
+
+Calling `email_service` and `sms_service` directly from `ship` makes `Order` the owner of
+every notification channel; each new integration requires editing the domain class.
+
+```ruby
+# ✗ Order directly calls services — adding a new notification requires editing Order
+def ship
+  @status = "shipped"
+  email_service.send("shipped")   # ✗ hard dependency on email_service
+  sms_service.send("shipped")     # ✗ hard dependency on sms_service
+  # ✗ must edit Order to add audit log
+end
+```

--- a/skills/principle-design-patterns/examples/observer.rs.md
+++ b/skills/principle-design-patterns/examples/observer.rs.md
@@ -1,0 +1,101 @@
+# Observer — Rust — Order Status Notifications
+
+## Problem
+
+An `Order` transitions through statuses — "shipped", "delivered" — and email, SMS, and audit
+systems must each react. Rust's trait objects let `Order` hold a `Vec<Box<dyn Observer>>`
+without knowing concrete types. Each observer implements a single `Observer` trait; adding a
+new channel means writing a new struct and registering it — `Order` is never modified.
+
+## Implementation
+
+```rust
+// file: observer.rs
+pub trait Observer {
+    fn on_status_changed(&self, status: &str);
+}
+
+pub struct Order {
+    observers: Vec<Box<dyn Observer>>,
+    status: String,
+}
+
+impl Order {
+    pub fn new() -> Self {
+        Self { observers: Vec::new(), status: "pending".into() }
+    }
+
+    pub fn add_observer(&mut self, observer: Box<dyn Observer>) {
+        self.observers.push(observer);
+    }
+
+    fn notify(&self) {
+        for obs in &self.observers {
+            obs.on_status_changed(&self.status);
+        }
+    }
+
+    pub fn ship(&mut self) {
+        self.status = "shipped".into();
+        self.notify();
+    }
+
+    pub fn deliver(&mut self) {
+        self.status = "delivered".into();
+        self.notify();
+    }
+}
+```
+
+```rust
+// file: main.rs
+mod observer;
+use observer::{Observer, Order};
+
+struct EmailObserver;
+struct SmsObserver;
+struct AuditObserver;
+
+impl Observer for EmailObserver {
+    fn on_status_changed(&self, status: &str) {
+        println!("Email: order is now {status}");
+    }
+}
+impl Observer for SmsObserver {
+    fn on_status_changed(&self, status: &str) {
+        println!("SMS: order is now {status}");
+    }
+}
+impl Observer for AuditObserver {
+    fn on_status_changed(&self, status: &str) {
+        println!("Audit: status changed to {status}");
+    }
+}
+
+fn main() {
+    let mut order = Order::new();
+    order.add_observer(Box::new(EmailObserver));
+    order.add_observer(Box::new(SmsObserver));
+    order.add_observer(Box::new(AuditObserver));
+
+    order.ship();
+    // Email: order is now shipped
+    // SMS: order is now shipped
+    // Audit: status changed to shipped
+}
+```
+
+## Common Mistake
+
+Calling notification services directly from `ship` or `deliver` couples `Order` to every
+concrete integration; each new channel requires modifying the domain struct.
+
+```rust
+// ✗ Order directly calls services — adding a new notification requires editing Order
+pub fn ship(&mut self) {
+    self.status = "shipped".into();
+    email_service.send("shipped");  // ✗ hard dependency on email_service
+    sms_service.send("shipped");    // ✗ hard dependency on sms_service
+    // ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.swift.md
+++ b/skills/principle-design-patterns/examples/observer.swift.md
@@ -1,0 +1,71 @@
+# Observer — Swift — Order Status Notifications
+
+## Problem
+
+An `Order` transitions through statuses — "shipped", "delivered" — and email, SMS, and audit
+systems must react independently. Swift closures are first-class, so listeners are stored as
+`[(String) -> Void]` — no protocol required for simple cases. `NotificationCenter` is the
+language-native alternative for cross-module fanout, but the closure approach shown here is
+clearer for explicit, in-process subscribers.
+
+## Implementation
+
+```swift
+// file: Order.swift
+final class Order {
+    private var listeners: [(String) -> Void] = []
+    private(set) var status = "pending"
+
+    func addListener(_ fn: @escaping (String) -> Void) {
+        listeners.append(fn)
+    }
+
+    private func notifyListeners() {
+        listeners.forEach { $0(status) }
+    }
+
+    func ship() {
+        status = "shipped"
+        notifyListeners()
+    }
+
+    func deliver() {
+        status = "delivered"
+        notifyListeners()
+    }
+}
+```
+
+```swift
+// file: main.swift
+let order = Order()
+
+order.addListener { s in print("Email: order is now \(s)") }
+order.addListener { s in print("SMS: order is now \(s)") }
+order.addListener { s in print("Audit: status changed to \(s)") }
+
+order.ship()
+// Email: order is now shipped
+// SMS: order is now shipped
+// Audit: status changed to shipped
+
+order.deliver()
+// Email: order is now delivered
+// SMS: order is now delivered
+// Audit: status changed to delivered
+```
+
+## Common Mistake
+
+Calling `emailService` and `smsService` directly from `ship()` couples `Order` to every
+notification channel; adding audit logging requires editing the domain class.
+
+```swift
+// ✗ Order directly calls services — adding a new notification requires editing Order
+func ship() {
+    status = "shipped"
+    emailService.send("shipped")   // ✗ hard dependency on EmailService
+    smsService.send("shipped")     // ✗ hard dependency on SmsService
+    // ✗ must edit Order to add audit log
+}
+```

--- a/skills/principle-design-patterns/examples/observer.ts.md
+++ b/skills/principle-design-patterns/examples/observer.ts.md
@@ -1,0 +1,75 @@
+# Observer — TypeScript — Order Status Notifications
+
+## Problem
+
+An `Order` transitions through statuses — "processing", "shipped", "delivered" — and multiple
+independent systems must react: email, SMS, and audit log. Hardwiring those calls into `Order`
+creates direct dependencies on every notification channel. The Observer pattern decouples the
+emitter from its listeners; `Order` fires an event and knows nothing about who receives it.
+
+## Implementation
+
+```ts
+// file: order.ts
+export type StatusListener = (status: string) => void;
+
+export class Order {
+  private listeners: StatusListener[] = [];
+  private status = "pending";
+
+  addListener(fn: StatusListener): void {
+    this.listeners.push(fn);
+  }
+
+  private notifyAll(status: string): void {
+    for (const fn of this.listeners) fn(status);
+  }
+
+  ship(): void {
+    this.status = "shipped";
+    this.notifyAll(this.status);
+  }
+
+  deliver(): void {
+    this.status = "delivered";
+    this.notifyAll(this.status);
+  }
+}
+```
+
+```ts
+// file: main.ts
+import { Order } from "./order";
+
+const order = new Order();
+
+order.addListener((s) => console.log(`Email: order is now ${s}`));
+order.addListener((s) => console.log(`SMS: order is now ${s}`));
+order.addListener((s) => console.log(`Audit: status changed to ${s}`));
+
+order.ship();
+// Email: order is now shipped
+// SMS: order is now shipped
+// Audit: status changed to shipped
+
+order.deliver();
+// Email: order is now delivered
+// SMS: order is now delivered
+// Audit: status changed to delivered
+```
+
+## Common Mistake
+
+Calling each notification service directly from `Order` makes adding a new channel require
+editing the `Order` class itself — a clear violation of the open/closed principle.
+
+```ts
+// ✗ Order directly calls services — adding a new notification requires editing Order
+class Order {
+  ship() {
+    emailService.send("shipped");   // ✗ hard dependency on EmailService
+    smsService.send("shipped");     // ✗ hard dependency on SmsService
+    // ✗ must edit Order to add audit log
+  }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.cs.md
+++ b/skills/principle-design-patterns/examples/strategy.cs.md
@@ -1,0 +1,80 @@
+# Strategy — C# — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — chosen from configuration. C# supports this either through an interface or
+a `Func<int, int>` delegate. The interface approach is shown here because it names the abstraction
+and is straightforward to mock in tests. `Checkout` receives `IDiscountStrategy` via constructor,
+decoupling algorithm selection from checkout logic.
+
+## Implementation
+
+```csharp
+// file: IDiscountStrategy.cs
+public interface IDiscountStrategy
+{
+    int Apply(int cents);
+}
+```
+
+```csharp
+// file: Discounts.cs
+public sealed class PercentOff(int pct) : IDiscountStrategy
+{
+    public int Apply(int cents) => (int)Math.Round(cents * (100 - pct) / 100m);
+}
+
+public sealed class Bogo : IDiscountStrategy
+{
+    public int Apply(int cents) => cents / 2;
+}
+
+public sealed class NoDiscount : IDiscountStrategy
+{
+    public int Apply(int cents) => cents;
+}
+```
+
+```csharp
+// file: Checkout.cs
+public sealed class Checkout(IDiscountStrategy discount)
+{
+    public int Total(IEnumerable<int> itemCents)
+    {
+        int subtotal = itemCents.Sum();
+        return discount.Apply(subtotal);
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+int[] items = [1000, 2000, 500]; // 35.00
+
+Console.WriteLine(new Checkout(new PercentOff(10)).Total(items)); // 3150
+Console.WriteLine(new Checkout(new Bogo()).Total(items));          // 1750
+Console.WriteLine(new Checkout(new NoDiscount()).Total(items));    // 3500
+```
+
+## Common Mistake
+
+A `switch` on a discount-type string inside `Total` means every new pricing rule requires
+editing `Checkout`, violating the open/closed principle.
+
+```csharp
+// ✗ branching on type inside checkout — adding a new discount requires editing Total
+public int BadTotal(IEnumerable<int> itemCents, string discountType, int pct = 0)
+{
+    int subtotal = itemCents.Sum();
+    switch (discountType)                        // ✗ caller must enumerate all variants
+    {
+        case "percent":                          // ✗ algorithm baked into checkout
+            return (int)Math.Round(subtotal * (100 - pct) / 100m);
+        case "bogo":                             // ✗ edit required per new discount type
+            return subtotal / 2;
+        default:
+            return subtotal;
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.go.md
+++ b/skills/principle-design-patterns/examples/strategy.go.md
@@ -1,0 +1,98 @@
+# Strategy — Go — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply a pricing rule chosen at runtime from configuration — percent-off,
+buy-one-get-one, or no discount. Go's first-class functions make this idiom natural: a
+`Discount` function type is the strategy; factory functions return concrete strategies.
+No interface or struct embedding is needed, keeping the approach idiomatic and testable.
+
+## Implementation
+
+```go
+// file: discount.go
+package checkout
+
+// Discount is the strategy: a function from subtotal cents to discounted cents.
+type Discount func(cents int) int
+
+// PercentOff returns a Discount that takes pct% off the subtotal.
+func PercentOff(pct int) Discount {
+	return func(cents int) int {
+		return cents * (100 - pct) / 100
+	}
+}
+
+// Bogo returns a Discount that halves the subtotal (buy-one-get-one-free).
+func Bogo() Discount {
+	return func(cents int) int { return cents / 2 }
+}
+
+// NoDiscount returns a Discount that applies no reduction.
+func NoDiscount() Discount {
+	return func(cents int) int { return cents }
+}
+```
+
+```go
+// file: checkout.go
+package checkout
+
+// Checkout sums items and applies the chosen Discount strategy.
+type Checkout struct {
+	Discount Discount
+}
+
+func (c *Checkout) Total(itemCents ...int) int {
+	subtotal := 0
+	for _, v := range itemCents {
+		subtotal += v
+	}
+	return c.Discount(subtotal)
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"fmt"
+	"example/checkout"
+)
+
+func main() {
+	items := []int{1000, 2000, 500} // 35.00
+
+	co := &checkout.Checkout{Discount: checkout.PercentOff(10)}
+	fmt.Println(co.Total(items...)) // 3150
+
+	co.Discount = checkout.Bogo()
+	fmt.Println(co.Total(items...)) // 1750
+
+	co.Discount = checkout.NoDiscount()
+	fmt.Println(co.Total(items...)) // 3500
+}
+```
+
+## Common Mistake
+
+Branching on a discount-type string inside `Total` forces edits to checkout every time a
+new pricing rule is introduced.
+
+```go
+// ✗ branching on type inside checkout — adding a new discount requires editing Total
+func (c *Checkout) BadTotal(discountType string, pct int, itemCents ...int) int {
+	subtotal := 0
+	for _, v := range itemCents {
+		subtotal += v
+	}
+	switch discountType {
+	case "percent":                        // ✗ caller must enumerate all variants
+		return subtotal * (100 - pct) / 100
+	case "bogo":                           // ✗ edit required per new discount type
+		return subtotal / 2
+	}
+	return subtotal
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.java.md
+++ b/skills/principle-design-patterns/examples/strategy.java.md
@@ -1,0 +1,84 @@
+# Strategy — Java — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — selected from configuration. Hardcoding the selection as a `switch` inside
+checkout couples the algorithm to its caller. A `@FunctionalInterface` makes Strategy a single
+method; lambda expressions supply each variant without boilerplate class files.
+
+## Implementation
+
+```java
+// file: DiscountStrategy.java
+@FunctionalInterface
+public interface DiscountStrategy {
+    /** Returns the discounted price in cents. */
+    int apply(int cents);
+
+    static DiscountStrategy percentOff(int pct) {
+        return cents -> Math.round(cents * (100 - pct) / 100f);
+    }
+
+    static DiscountStrategy bogo() {
+        return cents -> cents / 2;
+    }
+
+    static DiscountStrategy none() {
+        return cents -> cents;
+    }
+}
+```
+
+```java
+// file: Checkout.java
+import java.util.List;
+
+public final class Checkout {
+    private final DiscountStrategy discount;
+
+    public Checkout(DiscountStrategy discount) {
+        this.discount = discount;
+    }
+
+    public int total(List<Integer> itemCents) {
+        int subtotal = itemCents.stream().mapToInt(Integer::intValue).sum();
+        return discount.apply(subtotal);
+    }
+}
+```
+
+```java
+// file: Main.java
+import java.util.List;
+
+public class Main {
+    public static void main(String[] args) {
+        var items = List.of(1000, 2000, 500); // 35.00
+
+        System.out.println(new Checkout(DiscountStrategy.percentOff(10)).total(items)); // 3150
+        System.out.println(new Checkout(DiscountStrategy.bogo()).total(items));         // 1750
+        System.out.println(new Checkout(DiscountStrategy.none()).total(items));         // 3500
+    }
+}
+```
+
+## Common Mistake
+
+A `switch` on a discount-type string inside `total` means every new pricing rule requires
+editing `Checkout`, which should be closed to modification.
+
+```java
+// ✗ branching on type inside checkout — adding a new discount requires editing total
+public int badTotal(List<Integer> itemCents, String discountType, int pct) {
+    int subtotal = itemCents.stream().mapToInt(Integer::intValue).sum();
+    switch (discountType) {                 // ✗ caller must enumerate all variants
+        case "percent":                     // ✗ algorithm lives inside checkout
+            return Math.round(subtotal * (100 - pct) / 100f);
+        case "bogo":                        // ✗ edit required per new discount type
+            return subtotal / 2;
+        default:
+            return subtotal;
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.kt.md
+++ b/skills/principle-design-patterns/examples/strategy.kt.md
@@ -1,0 +1,67 @@
+# Strategy — Kotlin — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — chosen from configuration. Kotlin's `fun interface` (SAM) lets lambdas satisfy
+the strategy contract directly, and factory functions produce each variant concisely. No abstract
+class hierarchy or verbose anonymous-class syntax is needed.
+
+## Implementation
+
+```kotlin
+// file: Discount.kt
+fun interface Discount {
+    fun apply(cents: Int): Int
+}
+
+fun percentOff(pct: Int): Discount = Discount { cents ->
+    (cents * (100 - pct) / 100.0).toInt()
+}
+
+val bogo: Discount = Discount { cents -> cents / 2 }
+
+val noDiscount: Discount = Discount { cents -> cents }
+```
+
+```kotlin
+// file: Checkout.kt
+class Checkout(private val discount: Discount) {
+    fun total(vararg itemCents: Int): Int {
+        val subtotal = itemCents.sum()
+        return discount.apply(subtotal)
+    }
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    val items = intArrayOf(1000, 2000, 500) // 35.00
+
+    println(Checkout(percentOff(10)).total(*items)) // 3150
+    println(Checkout(bogo).total(*items))           // 1750
+    println(Checkout(noDiscount).total(*items))     // 3500
+}
+```
+
+## Common Mistake
+
+A `when` expression inside `total` that switches on a discount-type enum requires a code edit
+for every new pricing rule and leaks algorithm details into checkout.
+
+```kotlin
+// ✗ branching on type inside checkout — adding a new discount requires editing total
+enum class DiscountType { PERCENT, BOGO, NONE }
+
+fun badTotal(itemCents: IntArray, type: DiscountType, pct: Int = 0): Int {
+    val subtotal = itemCents.sum()
+    return when (type) {                       // ✗ caller must enumerate all variants
+        DiscountType.PERCENT ->                // ✗ algorithm baked into checkout
+            (subtotal * (100 - pct) / 100.0).toInt()
+        DiscountType.BOGO ->                   // ✗ edit required per new discount type
+            subtotal / 2
+        DiscountType.NONE -> subtotal
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.py.md
+++ b/skills/principle-design-patterns/examples/strategy.py.md
@@ -1,0 +1,79 @@
+# Strategy — Python — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — chosen from configuration. Python callables are strategies: a simple closure
+or lambda satisfies the contract without a class hierarchy. A `Protocol` documents the expected
+shape for type-checkers; plain functions produce strategies at runtime.
+
+## Implementation
+
+```python
+# file: discount.py
+from typing import Protocol
+
+
+class Discount(Protocol):
+    def __call__(self, cents: int) -> int: ...
+
+
+def percent_off(pct: float) -> Discount:
+    """Return a strategy that takes pct% off the subtotal."""
+    def apply(cents: int) -> int:
+        return round(cents * (1 - pct / 100))
+    return apply
+
+
+def bogo(cents: int) -> int:
+    """Buy-one-get-one: halve the subtotal."""
+    return round(cents / 2)
+
+
+def no_discount(cents: int) -> int:
+    """No reduction applied."""
+    return cents
+```
+
+```python
+# file: checkout.py
+from collections.abc import Sequence
+from discount import Discount
+
+
+def checkout(item_cents: Sequence[int], discount: Discount) -> int:
+    subtotal = sum(item_cents)
+    return discount(subtotal)
+```
+
+```python
+# file: main.py
+from checkout import checkout
+from discount import percent_off, bogo, no_discount
+
+items = [1000, 2000, 500]  # 35.00
+
+print(checkout(items, percent_off(10)))  # 3150
+print(checkout(items, bogo))             # 1750
+print(checkout(items, no_discount))      # 3500
+```
+
+## Common Mistake
+
+An `if/elif` chain on a discount-type string inside `checkout` must be edited for every new
+pricing rule and cannot be extended without touching the caller.
+
+```python
+# ✗ branching on type inside checkout — adding a new discount requires editing checkout
+def bad_checkout(
+    item_cents: list[int],
+    discount_type: str,
+    pct: float = 0,
+) -> int:
+    subtotal = sum(item_cents)
+    if discount_type == "percent":       # ✗ caller must know all variants
+        return round(subtotal * (1 - pct / 100))
+    elif discount_type == "bogo":        # ✗ edit required per new discount type
+        return round(subtotal / 2)
+    return subtotal
+```

--- a/skills/principle-design-patterns/examples/strategy.rb.md
+++ b/skills/principle-design-patterns/examples/strategy.rb.md
@@ -1,0 +1,67 @@
+# Strategy — Ruby — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply a pricing rule chosen at runtime — percent-off, buy-one-get-one, or no
+discount. Ruby's Procs and lambdas are first-class callables: each strategy is a lambda that
+takes a subtotal in cents and returns the discounted total. `Checkout` accepts any callable,
+making new strategies a one-liner addition with zero edits to checkout.
+
+## Implementation
+
+```ruby
+# file: discount.rb
+module Discount
+  PercentOff = ->(pct) { ->(cents) { (cents * (1 - pct / 100.0)).round } }
+  Bogo       = ->(cents) { (cents / 2.0).round }
+  NoDiscount = ->(cents) { cents }
+end
+```
+
+```ruby
+# file: checkout.rb
+class Checkout
+  def initialize(discount)
+    @discount = discount
+  end
+
+  def total(*item_cents)
+    subtotal = item_cents.sum
+    @discount.call(subtotal)
+  end
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "discount"
+require_relative "checkout"
+
+items = [1000, 2000, 500]  # 35.00
+
+puts Checkout.new(Discount::PercentOff.call(10)).total(*items)  # 3150
+puts Checkout.new(Discount::Bogo).total(*items)                 # 1750
+puts Checkout.new(Discount::NoDiscount).total(*items)           # 3500
+```
+
+## Common Mistake
+
+A `case` branch on a discount-type symbol inside `total` forces a code change every time a
+new pricing rule is introduced.
+
+```ruby
+# ✗ branching on type inside checkout — adding a new discount requires editing total
+class BadCheckout
+  def total(*item_cents, discount_type:, pct: 0)
+    subtotal = item_cents.sum
+    case discount_type                          # ✗ caller must enumerate all variants
+    when :percent
+      (subtotal * (1 - pct / 100.0)).round      # ✗ algorithm baked into checkout
+    when :bogo                                  # ✗ edit required per new discount type
+      (subtotal / 2.0).round
+    else
+      subtotal
+    end
+  end
+end
+```

--- a/skills/principle-design-patterns/examples/strategy.rs.md
+++ b/skills/principle-design-patterns/examples/strategy.rs.md
@@ -1,0 +1,79 @@
+# Strategy — Rust — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — chosen from configuration. Idiomatic Rust represents a closed set of variants
+with an `enum`; a `match` inside the enum's `apply` method centralises dispatch without heap
+allocation. Adding a new variant is a single-site change in the enum, not inside checkout.
+
+## Implementation
+
+```rust
+// file: discount.rs
+pub enum Discount {
+    PercentOff(u32), // discount percentage (0–100)
+    Bogo,
+    None,
+}
+
+impl Discount {
+    pub fn apply(&self, cents: u32) -> u32 {
+        match self {
+            Discount::PercentOff(pct) => cents * (100 - pct) / 100,
+            Discount::Bogo => cents / 2,
+            Discount::None => cents,
+        }
+    }
+}
+```
+
+```rust
+// file: checkout.rs
+use crate::discount::Discount;
+
+pub struct Checkout {
+    pub discount: Discount,
+}
+
+impl Checkout {
+    pub fn total(&self, item_cents: &[u32]) -> u32 {
+        let subtotal: u32 = item_cents.iter().sum();
+        self.discount.apply(subtotal)
+    }
+}
+```
+
+```rust
+// file: main.rs
+mod checkout;
+mod discount;
+
+use checkout::Checkout;
+use discount::Discount;
+
+fn main() {
+    let items = [1000u32, 2000, 500]; // 35.00
+
+    println!("{}", Checkout { discount: Discount::PercentOff(10) }.total(&items)); // 3150
+    println!("{}", Checkout { discount: Discount::Bogo }.total(&items));           // 1750
+    println!("{}", Checkout { discount: Discount::None }.total(&items));           // 3500
+}
+```
+
+## Common Mistake
+
+Matching on a discount-type string inside `total` instead of delegating to the enum means
+checkout must be edited and re-tested for every new pricing rule.
+
+```rust
+// ✗ branching on type inside checkout — adding a new discount requires editing total
+pub fn bad_total(item_cents: &[u32], discount_type: &str, pct: u32) -> u32 {
+    let subtotal: u32 = item_cents.iter().sum();
+    match discount_type {                          // ✗ caller must enumerate all variants
+        "percent" => subtotal * (100 - pct) / 100, // ✗ algorithm baked into checkout
+        "bogo" => subtotal / 2,                    // ✗ edit required per new discount type
+        _ => subtotal,
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.swift.md
+++ b/skills/principle-design-patterns/examples/strategy.swift.md
@@ -1,0 +1,71 @@
+# Strategy — Swift — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules at runtime — percent-off, buy-one-get-one,
+or no discount — chosen from configuration. Swift stores function types as first-class values,
+so a `(Int) -> Int` stored in `Checkout` is all that is needed. Factory closures produce each
+strategy; no protocol conformance or class hierarchy is required.
+
+## Implementation
+
+```swift
+// file: Discount.swift
+typealias DiscountFn = (Int) -> Int
+
+func percentOff(_ pct: Int) -> DiscountFn {
+    { cents in Int((Double(cents) * Double(100 - pct) / 100).rounded()) }
+}
+
+let bogo: DiscountFn = { cents in cents / 2 }
+
+let noDiscount: DiscountFn = { cents in cents }
+```
+
+```swift
+// file: Checkout.swift
+struct Checkout {
+    var discount: DiscountFn
+
+    func total(_ itemCents: [Int]) -> Int {
+        let subtotal = itemCents.reduce(0, +)
+        return discount(subtotal)
+    }
+}
+```
+
+```swift
+// file: main.swift
+let items = [1000, 2000, 500] // 35.00
+
+var co = Checkout(discount: percentOff(10))
+print(co.total(items)) // 3150
+
+co.discount = bogo
+print(co.total(items)) // 1750
+
+co.discount = noDiscount
+print(co.total(items)) // 3500
+```
+
+## Common Mistake
+
+A `switch` on a discount-type enum inside `total` requires editing `Checkout` for every new
+pricing rule, and leaks algorithm knowledge into the caller.
+
+```swift
+// ✗ branching on type inside checkout — adding a new discount requires editing total
+enum DiscountType { case percent(Int), bogo, none }
+
+func badTotal(_ itemCents: [Int], discount: DiscountType) -> Int {
+    let subtotal = itemCents.reduce(0, +)
+    switch discount {                              // ✗ caller must enumerate all variants
+    case .percent(let pct):                       // ✗ algorithm baked into checkout
+        return Int((Double(subtotal) * Double(100 - pct) / 100).rounded())
+    case .bogo:                                   // ✗ edit required per new discount type
+        return subtotal / 2
+    case .none:
+        return subtotal
+    }
+}
+```

--- a/skills/principle-design-patterns/examples/strategy.ts.md
+++ b/skills/principle-design-patterns/examples/strategy.ts.md
@@ -1,0 +1,69 @@
+# Strategy — TypeScript — Checkout Discount Pricing
+
+## Problem
+
+A checkout must apply one of several pricing rules — percent-off, buy-one-get-one, or no
+discount — chosen at runtime from configuration. Embedding the selection logic as an `if/switch`
+inside checkout couples the algorithm to its caller. The Strategy pattern replaces branching with
+a first-class function; TypeScript's `type DiscountFn` makes this idiom lightweight with no class
+hierarchy required.
+
+## Implementation
+
+```ts
+// file: discount.ts
+export type DiscountFn = (cents: number) => number;
+
+export const percentOff =
+  (pct: number): DiscountFn =>
+  (cents) =>
+    Math.round(cents * (1 - pct / 100));
+
+export const bogo: DiscountFn = (cents) => Math.round(cents / 2);
+
+export const noDiscount: DiscountFn = (cents) => cents;
+```
+
+```ts
+// file: checkout.ts
+import type { DiscountFn } from "./discount";
+
+export function checkout(itemCents: number[], discount: DiscountFn): number {
+  const subtotal = itemCents.reduce((sum, c) => sum + c, 0);
+  return discount(subtotal);
+}
+```
+
+```ts
+// file: main.ts
+import { checkout } from "./checkout";
+import { percentOff, bogo, noDiscount } from "./discount";
+
+const items = [1000, 2000, 500]; // 35.00
+
+console.log(checkout(items, percentOff(10))); // 3150 (10% off)
+console.log(checkout(items, bogo));           // 1750 (half price)
+console.log(checkout(items, noDiscount));     // 3500 (full price)
+```
+
+## Common Mistake
+
+Branching on a discount type string inside `checkout` — every new discount type requires
+editing `checkout` itself, violating the open/closed principle.
+
+```ts
+// ✗ branching on type inside checkout — adding a new discount requires editing checkout
+function badCheckout(
+  itemCents: number[],
+  discountType: "percent" | "bogo" | "none",
+  pct?: number,
+): number {
+  const subtotal = itemCents.reduce((sum, c) => sum + c, 0);
+  if (discountType === "percent") {          // ✗ caller must know all variants
+    return Math.round(subtotal * (1 - (pct ?? 0) / 100));
+  } else if (discountType === "bogo") {      // ✗ edit required per new discount type
+    return Math.round(subtotal / 2);
+  }
+  return subtotal;
+}
+```


### PR DESCRIPTION
## Summary
- Add 36 worked example files (`skills/principle-design-patterns/examples/`) covering the Core-4 design patterns × 9 OO languages
- Patterns: Strategy (checkout discount pricing), Observer (order-status notifications), Decorator (retry + logging fetch), Factory Method (notification channel)
- Languages: C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript
- Each file follows the repo's example template: H1 / Problem / Implementation / Common Mistake, ≤120 lines
- Add one `>` pointer blockquote to `SKILL.md` (on-demand, not auto-loaded)
- Mirrors precedent set by `principle-concurrency/examples/` (PR #434) and `principle-clean-architecture/examples/`

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues (all 36 files ≤120 lines; existing checks green)
- [x] `pytest tests/ -v` — 1324/1324 pass
- [x] `ls skills/principle-design-patterns/examples/ | wc -l` → 36
- [x] Each file opens with H1/Problem/Implementation/Common-Mistake structure and a language-tagged fence
- [x] SKILL.md carries exactly one new `>` pointer line; `examples/` absent from any frontmatter auto-load path

### Type-tailored checks ([feat])
- [x] New behaviour (examples dir) is present on disk under the expected path
- [x] No regressions in existing skill triggers or catalog checks

Closes #375
