### PR TITLE
[feat] Add worked error-handling examples to principle-error-handling (9 OO languages)

### DIFF
--- a/skills/principle-error-handling/SKILL.md
+++ b/skills/principle-error-handling/SKILL.md
@@ -88,6 +88,8 @@ Log once; at the boundary. Never log-and-return.
 - Prototypes under two weeks with no production callers.
 - Single-team internal tools where the author is also the operator and on-call.
 
+> See `examples/` for worked config parse-and-validate, HTTP fetch with retry, and account-withdrawal error handling in C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).
+
 ## Red Flags
 
 | Flag | Problem |

--- a/skills/principle-error-handling/examples/config.cs.md
+++ b/skills/principle-error-handling/examples/config.cs.md
@@ -1,0 +1,98 @@
+# Error Handling — C# — Config Parse & Validate
+
+## Problem
+
+C# exceptions carry an `InnerException` chain that preserves cause across tiers.
+A `ConfigException` hierarchy with three subclasses — `IoConfigException`,
+`ParseConfigException`, and `ValidationConfigException` — each passing `innerException`
+to `base(msg, inner)`, lets callers catch at the right granularity and inspect the
+full chain via `Exception.InnerException`.
+
+## Implementation
+
+```csharp
+// file: ConfigLoader.cs
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+public class ConfigException : Exception {
+    public ConfigException(string msg, Exception? inner = null) : base(msg, inner) { }
+}
+public class IoConfigException : ConfigException {
+    public IoConfigException(string msg, Exception inner) : base(msg, inner) { }
+}
+public class ParseConfigException : ConfigException {
+    public int Line { get; }
+    public ParseConfigException(int line, string reason)
+        : base($"line {line}: {reason}") => Line = line;
+}
+public class ValidationConfigException : ConfigException {
+    public string Field { get; }
+    public ValidationConfigException(string field, string reason)
+        : base($"field '{field}': {reason}") => Field = field;
+}
+
+public record Config(string Host, int Port);
+
+public static class ConfigLoader {
+    public static Config Parse(string path) {
+        string[] lines;
+        try {
+            lines = File.ReadAllLines(path);
+        } catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+            throw new IoConfigException($"cannot read '{path}'", e);
+        }
+
+        var kv = new Dictionary<string, string>();
+        for (int n = 0; n < lines.Length; n++) {
+            var line = lines[n].Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+            int eq = line.IndexOf('=');
+            if (eq < 1)
+                throw new ParseConfigException(n + 1, "missing '=' separator");
+            var key = line[..eq].Trim();
+            if (key.Length == 0)
+                throw new ParseConfigException(n + 1, "empty key");
+            kv[key] = line[(eq + 1)..].Trim();
+        }
+        return Validate(kv);
+    }
+
+    private static Config Validate(Dictionary<string, string> kv) {
+        if (!kv.TryGetValue("host", out var host) || host.Length == 0)
+            throw new ValidationConfigException("host", "required key missing");
+        if (!kv.TryGetValue("port", out var portStr))
+            throw new ValidationConfigException("port", "required key missing");
+        if (!int.TryParse(portStr, out int port))
+            throw new ValidationConfigException("port", $"'{portStr}' is not an integer");
+        if (port < 1 || port > 65535)
+            throw new ValidationConfigException("port", $"{port} out of range 1-65535");
+        return new Config(host, port);
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+try {
+    var cfg = ConfigLoader.Parse("app.conf");
+    Console.WriteLine($"host={cfg.Host} port={cfg.Port}");
+} catch (IoConfigException e) {
+    Console.Error.WriteLine($"IO error: {e.Message}");
+} catch (ParseConfigException e) {
+    Console.Error.WriteLine($"Parse error line {e.Line}: {e.Message}");
+} catch (ValidationConfigException e) {
+    Console.Error.WriteLine($"Validation error '{e.Field}': {e.Message}");
+}
+```
+
+## Common Mistake
+
+Catching `Exception` and returning a default — the inner exception is lost and the caller has no way to know what failed.
+
+```csharp
+catch (Exception) {             // ✗ swallows IoConfigException, ParseConfigException, etc.
+    return new Config("", 0);   // ✗ caller sees zero Config; InnerException discarded
+}
+```

--- a/skills/principle-error-handling/examples/config.go.md
+++ b/skills/principle-error-handling/examples/config.go.md
@@ -1,0 +1,111 @@
+# Error Handling — Go — Config Parse & Validate
+
+## Problem
+
+Go surfaces errors as values, not exceptions. Each tier (IO, parse, validation) returns
+a distinct `error` wrapped with `%w` so callers can inspect cause chains with
+`errors.Is`/`errors.As` while still reading a human-friendly message at every layer.
+
+## Implementation
+
+```go
+// file: config.go
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Config struct{ Host string; Port int }
+
+type ConfigError struct{ Code, Msg string }
+
+func (e *ConfigError) Error() string { return fmt.Sprintf("[%s] %s", e.Code, e.Msg) }
+
+func Parse(path string) (Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("reading config: %w", err)
+	}
+	defer f.Close()
+
+	kv := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for n := 1; sc.Scan(); n++ {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
+			return Config{}, fmt.Errorf("parsing line %d: %w", n,
+				&ConfigError{Code: "PARSE", Msg: "malformed line, expected key=value"})
+		}
+		kv[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+
+	return validate(kv)
+}
+
+func validate(kv map[string]string) (Config, error) {
+	host, ok := kv["host"]
+	if !ok || host == "" {
+		return Config{}, fmt.Errorf("validating config: %w",
+			&ConfigError{Code: "VALIDATION", Msg: "missing required key: host"})
+	}
+	portStr, ok := kv["port"]
+	if !ok {
+		return Config{}, fmt.Errorf("validating config: %w",
+			&ConfigError{Code: "VALIDATION", Msg: "missing required key: port"})
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return Config{}, fmt.Errorf("validating config: %w",
+			&ConfigError{Code: "VALIDATION", Msg: "port must be an integer"})
+	}
+	if port < 1 || port > 65535 {
+		return Config{}, fmt.Errorf("validating config: %w",
+			&ConfigError{Code: "VALIDATION", Msg: "port out of range 1-65535"})
+	}
+	return Config{Host: host, Port: port}, nil
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"example/config"
+)
+
+func main() {
+	cfg, err := config.Parse("app.conf")
+	if err != nil {
+		var ce *config.ConfigError
+		if errors.As(err, &ce) {
+			fmt.Println("config error:", ce.Code, "-", ce.Msg)
+		} else {
+			fmt.Println("io error:", err)
+		}
+		return
+	}
+	fmt.Printf("host=%s port=%d\n", cfg.Host, cfg.Port)
+}
+```
+
+## Common Mistake
+
+Returning `nil` instead of the error — silently drops failures every caller depends on.
+
+```go
+if err != nil {
+    return Config{}, nil // ✗ error swallowed; caller sees a zero Config, no signal
+}
+```

--- a/skills/principle-error-handling/examples/config.go.md
+++ b/skills/principle-error-handling/examples/config.go.md
@@ -22,9 +22,10 @@ import (
 
 type Config struct{ Host string; Port int }
 
-type ConfigError struct{ Code, Msg string }
+type ConfigError struct{ Code, Msg string; Err error }
 
-func (e *ConfigError) Error() string { return fmt.Sprintf("[%s] %s", e.Code, e.Msg) }
+func (e *ConfigError) Error() string  { return fmt.Sprintf("[%s] %s", e.Code, e.Msg) }
+func (e *ConfigError) Unwrap() error  { return e.Err }
 
 func Parse(path string) (Config, error) {
 	f, err := os.Open(path)
@@ -65,7 +66,7 @@ func validate(kv map[string]string) (Config, error) {
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return Config{}, fmt.Errorf("validating config: %w",
-			&ConfigError{Code: "VALIDATION", Msg: "port must be an integer"})
+			&ConfigError{Code: "VALIDATION", Msg: "port must be an integer", Err: err})
 	}
 	if port < 1 || port > 65535 {
 		return Config{}, fmt.Errorf("validating config: %w",

--- a/skills/principle-error-handling/examples/config.java.md
+++ b/skills/principle-error-handling/examples/config.java.md
@@ -1,0 +1,111 @@
+# Error Handling — Java — Config Parse & Validate
+
+## Problem
+
+Java's checked exceptions force callers to acknowledge failure, but a single broad
+`Exception` catch loses the distinction between an IO fault, a bad line, and a missing
+key. Three `ConfigException` subclasses, each wrapping its cause via `super(msg, cause)`,
+give callers precise `catch` branches while preserving the full stack trace.
+
+## Implementation
+
+```java
+// file: ConfigLoader.java
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
+public class ConfigLoader {
+
+    public static class ConfigException extends Exception {
+        public ConfigException(String msg) { super(msg); }
+        public ConfigException(String msg, Throwable cause) { super(msg, cause); }
+    }
+    public static class IoConfigException extends ConfigException {
+        public IoConfigException(String msg, Throwable cause) { super(msg, cause); }
+    }
+    public static class ParseConfigException extends ConfigException {
+        public final int line;
+        public ParseConfigException(int line, String reason) {
+            super("line " + line + ": " + reason); this.line = line;
+        }
+    }
+    public static class ValidationConfigException extends ConfigException {
+        public final String field;
+        public ValidationConfigException(String field, String reason) {
+            super("field '" + field + "': " + reason); this.field = field;
+        }
+        public ValidationConfigException(String field, String reason, Throwable cause) {
+            super("field '" + field + "': " + reason, cause); this.field = field;
+        }
+    }
+
+    public record Config(String host, int port) {}
+
+    public static Config parse(String path) throws ConfigException {
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(Path.of(path));
+        } catch (IOException e) {
+            throw new IoConfigException("cannot read '" + path + "'", e);
+        }
+
+        Map<String, String> kv = new LinkedHashMap<>();
+        for (int n = 0; n < lines.size(); n++) {
+            String line = lines.get(n).strip();
+            if (line.isEmpty() || line.startsWith("#")) continue;
+            int eq = line.indexOf('=');
+            if (eq < 1) throw new ParseConfigException(n + 1, "missing '=' separator");
+            String key = line.substring(0, eq).strip();
+            if (key.isEmpty()) throw new ParseConfigException(n + 1, "empty key");
+            kv.put(key, line.substring(eq + 1).strip());
+        }
+        return validate(kv);
+    }
+
+    private static Config validate(Map<String, String> kv) throws ConfigException {
+        if (!kv.containsKey("host") || kv.get("host").isEmpty())
+            throw new ValidationConfigException("host", "required key missing");
+        if (!kv.containsKey("port"))
+            throw new ValidationConfigException("port", "required key missing");
+        int port;
+        try { port = Integer.parseInt(kv.get("port")); }
+        catch (NumberFormatException e) {
+            throw new ValidationConfigException("port", "'" + kv.get("port") + "' is not an integer", e);
+        }
+        if (port < 1 || port > 65535)
+            throw new ValidationConfigException("port", port + " out of range 1-65535");
+        return new Config(kv.get("host"), port);
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        try {
+            var cfg = ConfigLoader.parse("app.conf");
+            System.out.printf("host=%s port=%d%n", cfg.host(), cfg.port());
+        } catch (ConfigLoader.IoConfigException e) {
+            System.err.println("IO error: " + e.getMessage());
+        } catch (ConfigLoader.ParseConfigException e) {
+            System.err.println("Parse error line " + e.line + ": " + e.getMessage());
+        } catch (ConfigLoader.ValidationConfigException e) {
+            System.err.println("Validation error '" + e.field + "': " + e.getMessage());
+        } catch (ConfigLoader.ConfigException e) {
+            System.err.println("Config error: " + e.getMessage());
+        }
+    }
+}
+```
+
+## Common Mistake
+
+Catching all exceptions and returning a default — the cause is swallowed and the caller sees valid-looking data with no diagnostic.
+
+```java
+} catch (Exception e) {    // ✗ swallows IO, parse, and validation errors
+    return new Config("", 0);  // ✗ caller sees defaults; no error surfaced
+}
+```

--- a/skills/principle-error-handling/examples/config.kt.md
+++ b/skills/principle-error-handling/examples/config.kt.md
@@ -1,0 +1,84 @@
+# Error Handling — Kotlin — Config Parse & Validate
+
+## Problem
+
+Kotlin's sealed class hierarchy gives exhaustive `when` matching without checked
+exceptions. Wrapping each tier in a `ConfigError` subclass and returning
+`Result<Config>` keeps the happy path readable with `getOrThrow`/`fold`, while
+`runCatching` at the IO boundary converts platform exceptions into typed failures.
+
+## Implementation
+
+```kotlin
+// file: Config.kt
+import java.io.File
+
+data class Config(val host: String, val port: Int)
+
+sealed class ConfigError(message: String) : Exception(message) {
+    class IoError(reason: String) : ConfigError("IO error: $reason")
+    class ParseError(val line: Int, val reason: String)
+        : ConfigError("line $line: $reason")
+    class ValidationError(val field: String, val reason: String)
+        : ConfigError("field '$field': $reason")
+}
+
+fun parseConfig(path: String): Result<Config> {
+    val lines = runCatching { File(path).readLines() }
+        .getOrElse { e -> return Result.failure(ConfigError.IoError(e.message ?: "unreadable")) }
+
+    val kv = mutableMapOf<String, String>()
+    lines.forEachIndexed { idx, raw ->
+        val line = raw.trim()
+        if (line.isEmpty() || line.startsWith("#")) return@forEachIndexed
+        val eq = line.indexOf('=')
+        if (eq < 1) return Result.failure(
+            ConfigError.ParseError(idx + 1, "missing '=' separator"))
+        val key = line.substring(0, eq).trim()
+        if (key.isEmpty()) return Result.failure(
+            ConfigError.ParseError(idx + 1, "empty key"))
+        kv[key] = line.substring(eq + 1).trim()
+    }
+
+    return validateConfig(kv)
+}
+
+fun validateConfig(kv: Map<String, String>): Result<Config> {
+    val host = kv["host"]?.takeIf { it.isNotEmpty() }
+        ?: return Result.failure(ConfigError.ValidationError("host", "required key missing"))
+    val portStr = kv["port"]
+        ?: return Result.failure(ConfigError.ValidationError("port", "required key missing"))
+    val port = portStr.toIntOrNull()
+        ?: return Result.failure(ConfigError.ValidationError("port", "'$portStr' is not an integer"))
+    if (port !in 1..65535) return Result.failure(
+        ConfigError.ValidationError("port", "$port out of range 1-65535"))
+    return Result.success(Config(host, port))
+}
+```
+
+```kotlin
+// file: Main.kt
+fun main() {
+    parseConfig("app.conf").fold(
+        onSuccess = { cfg -> println("host=${cfg.host} port=${cfg.port}") },
+        onFailure = { err ->
+            when (err) {
+                is ConfigError.IoError         -> System.err.println("IO error: ${err.message}")
+                is ConfigError.ParseError      -> System.err.println("Parse error line ${err.line}: ${err.reason}")
+                is ConfigError.ValidationError -> System.err.println("Validation error '${err.field}': ${err.reason}")
+                else                           -> System.err.println("Unexpected: ${err.message}")
+            }
+        }
+    )
+}
+```
+
+## Common Mistake
+
+Catching all exceptions at the parse level and returning an empty `Config` — type safety is lost and the caller has no way to detect or diagnose the failure.
+
+```kotlin
+} catch (e: Exception) {    // ✗ catches IO, parse, and validation alike
+    return Result.success(Config("", 0))  // ✗ zero Config masks every failure tier
+}
+```

--- a/skills/principle-error-handling/examples/config.kt.md
+++ b/skills/principle-error-handling/examples/config.kt.md
@@ -28,9 +28,9 @@ fun parseConfig(path: String): Result<Config> {
         .getOrElse { e -> return Result.failure(ConfigError.IoError(e.message ?: "unreadable")) }
 
     val kv = mutableMapOf<String, String>()
-    lines.forEachIndexed { idx, raw ->
+    for ((idx, raw) in lines.withIndex()) {
         val line = raw.trim()
-        if (line.isEmpty() || line.startsWith("#")) return@forEachIndexed
+        if (line.isEmpty() || line.startsWith("#")) continue
         val eq = line.indexOf('=')
         if (eq < 1) return Result.failure(
             ConfigError.ParseError(idx + 1, "missing '=' separator"))

--- a/skills/principle-error-handling/examples/config.py.md
+++ b/skills/principle-error-handling/examples/config.py.md
@@ -1,0 +1,95 @@
+# Error Handling — Python — Config Parse & Validate
+
+## Problem
+
+Python uses exceptions for flow control, so clear error hierarchies matter more than
+in languages with typed returns. A `ConfigError` base class with three subclasses
+(`IoConfigError`, `ParseConfigError`, `ValidationConfigError`) lets callers catch at
+the right granularity and `raise ... from err` preserves the original cause chain.
+
+## Implementation
+
+```python
+# file: config.py
+
+class ConfigError(Exception):
+    """Base for all config errors."""
+
+class IoConfigError(ConfigError):
+    pass
+
+class ParseConfigError(ConfigError):
+    def __init__(self, line: int, reason: str):
+        super().__init__(f"line {line}: {reason}")
+        self.line = line
+        self.reason = reason
+
+class ValidationConfigError(ConfigError):
+    def __init__(self, field: str, reason: str):
+        super().__init__(f"field '{field}': {reason}")
+        self.field = field
+        self.reason = reason
+
+
+def parse(path: str) -> dict[str, str]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError as err:
+        raise IoConfigError(f"cannot read '{path}': {err}") from err
+
+    kv: dict[str, str] = {}
+    for n, raw in enumerate(lines, start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ParseConfigError(n, "missing '=' separator")
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            raise ParseConfigError(n, "empty key")
+        kv[key] = value.strip()
+
+    return validate(kv)
+
+
+def validate(kv: dict[str, str]) -> dict[str, str]:
+    for field in ("host", "port"):
+        if field not in kv:
+            raise ValidationConfigError(field, "required key missing")
+    port_str = kv["port"]
+    try:
+        port = int(port_str)
+    except ValueError as err:
+        raise ValidationConfigError("port", f"'{port_str}' is not an integer") from err
+    if not 1 <= port <= 65535:
+        raise ValidationConfigError("port", f"{port} out of range 1-65535")
+    return kv
+```
+
+```python
+# file: main.py
+from config import parse, IoConfigError, ParseConfigError, ValidationConfigError
+
+try:
+    cfg = parse("app.conf")
+    print(f"host={cfg['host']} port={cfg['port']}")
+except IoConfigError as e:
+    print(f"IO error: {e}")
+except ParseConfigError as e:
+    print(f"Parse error at line {e.line}: {e.reason}")
+except ValidationConfigError as e:
+    print(f"Validation error for '{e.field}': {e.reason}")
+```
+
+## Common Mistake
+
+Using a bare `except: pass` — the exception is silently dropped and the caller receives an empty dict with no indication of what went wrong.
+
+```python
+try:
+    cfg = parse("app.conf")
+except:          # ✗ catches everything including KeyboardInterrupt
+    pass         # ✗ caller gets nothing; failure is invisible
+```

--- a/skills/principle-error-handling/examples/config.rb.md
+++ b/skills/principle-error-handling/examples/config.rb.md
@@ -58,11 +58,13 @@ def validate_config(kv)
   %w[host port].each do |field|
     raise ValidationConfigError.new(field, "required key missing") unless kv.key?(field)
   end
-  port = Integer(kv["port"])
+  begin
+    port = Integer(kv["port"])
+  rescue ArgumentError
+    raise ValidationConfigError.new("port", "'#{kv['port']}' is not an integer")
+  end
   raise ValidationConfigError.new("port", "#{port} out of range 1-65535") unless (1..65535).cover?(port)
   kv
-rescue ArgumentError
-  raise ValidationConfigError.new("port", "'#{kv['port']}' is not an integer")
 end
 ```
 

--- a/skills/principle-error-handling/examples/config.rb.md
+++ b/skills/principle-error-handling/examples/config.rb.md
@@ -1,0 +1,95 @@
+# Error Handling — Ruby — Config Parse & Validate
+
+## Problem
+
+Ruby's exception system is expressive but easy to misuse by rescuing `StandardError`
+too broadly. A hierarchy rooted at `ConfigError < StandardError` with subclasses for
+each tier lets callers rescue exactly what they can handle, while structured `rescue`
+blocks re-raise wrapped errors so the original cause is never silently dropped.
+
+## Implementation
+
+```ruby
+# file: config.rb
+
+class ConfigError < StandardError; end
+
+class IoConfigError < ConfigError; end
+
+class ParseConfigError < ConfigError
+  attr_reader :line
+  def initialize(line, reason)
+    super("line #{line}: #{reason}")
+    @line = line
+  end
+end
+
+class ValidationConfigError < ConfigError
+  attr_reader :field
+  def initialize(field, reason)
+    super("field '#{field}': #{reason}")
+    @field = field
+  end
+end
+
+def parse_config(path)
+  begin
+    lines = File.readlines(path, encoding: "utf-8")
+  rescue SystemCallError => e
+    raise IoConfigError, "cannot read '#{path}': #{e.message}"
+  end
+
+  kv = {}
+  lines.each_with_index do |raw, idx|
+    line = raw.strip
+    next if line.empty? || line.start_with?("#")
+    unless line.include?("=")
+      raise ParseConfigError.new(idx + 1, "missing '=' separator")
+    end
+    key, value = line.split("=", 2).map(&:strip)
+    raise ParseConfigError.new(idx + 1, "empty key") if key.nil? || key.empty?
+    kv[key] = value
+  end
+
+  validate_config(kv)
+end
+
+def validate_config(kv)
+  %w[host port].each do |field|
+    raise ValidationConfigError.new(field, "required key missing") unless kv.key?(field)
+  end
+  port = Integer(kv["port"])
+  raise ValidationConfigError.new("port", "#{port} out of range 1-65535") unless (1..65535).cover?(port)
+  kv
+rescue ArgumentError
+  raise ValidationConfigError.new("port", "'#{kv['port']}' is not an integer")
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "config"
+
+begin
+  cfg = parse_config("app.conf")
+  puts "host=#{cfg['host']} port=#{cfg['port']}"
+rescue IoConfigError => e
+  warn "IO error: #{e.message}"
+rescue ParseConfigError => e
+  warn "Parse error at line #{e.line}: #{e.message}"
+rescue ValidationConfigError => e
+  warn "Validation error for '#{e.field}': #{e.message}"
+end
+```
+
+## Common Mistake
+
+Rescuing all errors and returning an empty hash — the caller sees valid-looking data with no indication that anything failed.
+
+```ruby
+def parse_config(path)
+  # ... parsing ...
+rescue => _e        # ✗ catches every tier
+  return {}         # ✗ caller gets empty hash; no error propagates
+end
+```

--- a/skills/principle-error-handling/examples/config.rs.md
+++ b/skills/principle-error-handling/examples/config.rs.md
@@ -1,0 +1,96 @@
+# Error Handling — Rust — Config Parse & Validate
+
+## Problem
+
+Rust's `Result<T, E>` makes the happy path and every failure mode explicit in the
+type signature. A typed `enum ConfigError` with distinct variants for IO, parse, and
+validation lets callers pattern-match exhaustively, while `?` keeps propagation concise
+without hiding which tier the failure came from.
+
+## Implementation
+
+```rust
+// file: config.rs
+use std::{fmt, fs, io, num::ParseIntError};
+
+#[derive(Debug)]
+pub enum ConfigError {
+    Io(io::Error),
+    Parse { line: usize, reason: String },
+    Validation(String),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "io error: {e}"),
+            Self::Parse { line, reason } => write!(f, "parse error line {line}: {reason}"),
+            Self::Validation(msg) => write!(f, "validation error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+impl From<io::Error> for ConfigError {
+    fn from(e: io::Error) -> Self { Self::Io(e) }
+}
+
+pub struct Config { pub host: String, pub port: u16 }
+
+pub fn parse(path: &str) -> Result<Config, ConfigError> {
+    let text = fs::read_to_string(path)?; // IO tier — ? converts via From<io::Error>
+    let mut kv = std::collections::HashMap::new();
+
+    for (n, line) in text.lines().enumerate().map(|(i, l)| (i + 1, l)) {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') { continue; }
+        let (k, v) = line.split_once('=').ok_or_else(|| ConfigError::Parse {
+            line: n, reason: "missing '=' separator".into(),
+        })?;
+        let key = k.trim();
+        if key.is_empty() {
+            return Err(ConfigError::Parse { line: n, reason: "empty key".into() });
+        }
+        kv.insert(key.to_string(), v.trim().to_string());
+    }
+    validate(kv)
+}
+
+fn validate(kv: std::collections::HashMap<String, String>) -> Result<Config, ConfigError> {
+    let host = kv.get("host").filter(|s| !s.is_empty())
+        .ok_or_else(|| ConfigError::Validation("missing required key: host".into()))?
+        .clone();
+    let port_str = kv.get("port")
+        .ok_or_else(|| ConfigError::Validation("missing required key: port".into()))?;
+    let port: u16 = port_str.parse().map_err(|_: ParseIntError|
+        ConfigError::Validation(format!("port '{}' is not a valid integer 1-65535", port_str)))?;
+    if port == 0 {
+        return Err(ConfigError::Validation("port must be >= 1".into()));
+    }
+    Ok(Config { host, port })
+}
+```
+
+```rust
+// file: main.rs
+mod config;
+use config::ConfigError;
+
+fn main() {
+    match config::parse("app.conf") {
+        Ok(cfg) => println!("host={} port={}", cfg.host, cfg.port),
+        Err(ConfigError::Io(e)) => eprintln!("cannot read file: {e}"),
+        Err(ConfigError::Parse { line, reason }) => eprintln!("bad line {line}: {reason}"),
+        Err(ConfigError::Validation(msg)) => eprintln!("invalid config: {msg}"),
+    }
+}
+```
+
+## Common Mistake
+
+Calling `.unwrap()` at each step — panics on the first error with no context about which field or line caused it.
+
+```rust
+let text = fs::read_to_string(path).unwrap();           // ✗ panics if file missing
+let port: u16 = kv["port"].parse().unwrap();            // ✗ panics on non-integer, no line info
+```

--- a/skills/principle-error-handling/examples/config.swift.md
+++ b/skills/principle-error-handling/examples/config.swift.md
@@ -1,0 +1,88 @@
+# Error Handling — Swift — Config Parse & Validate
+
+## Problem
+
+Swift's `throws` + typed `enum Error` make every failure site explicit in the
+function signature. A `ConfigError` enum with associated values for IO, parse, and
+validation lets callers `catch` each case individually in a `do/catch` block, while
+`try` propagation keeps the call chain concise without hiding which tier failed.
+
+## Implementation
+
+```swift
+// file: config.swift
+import Foundation
+
+enum ConfigError: Error {
+    case io(Error)
+    case parse(line: Int, reason: String)
+    case validation(field: String, reason: String)
+}
+
+struct Config { let host: String; let port: Int }
+
+func parseConfig(path: String) throws -> Config {
+    let text: String
+    do {
+        text = try String(contentsOfFile: path, encoding: .utf8)
+    } catch {
+        throw ConfigError.io(error)
+    }
+
+    var kv = [String: String]()
+    let lines = text.components(separatedBy: "\n")
+    for (idx, raw) in lines.enumerated() {
+        let line = raw.trimmingCharacters(in: .whitespaces)
+        if line.isEmpty || line.hasPrefix("#") { continue }
+        guard let eq = line.firstIndex(of: "="), eq != line.startIndex else {
+            throw ConfigError.parse(line: idx + 1, reason: "missing '=' separator")
+        }
+        let key = String(line[..<eq]).trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else {
+            throw ConfigError.parse(line: idx + 1, reason: "empty key")
+        }
+        kv[key] = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
+    }
+
+    return try validateConfig(kv)
+}
+
+func validateConfig(_ kv: [String: String]) throws -> Config {
+    guard let host = kv["host"], !host.isEmpty else {
+        throw ConfigError.validation(field: "host", reason: "required key missing")
+    }
+    guard let portStr = kv["port"] else {
+        throw ConfigError.validation(field: "port", reason: "required key missing")
+    }
+    guard let port = Int(portStr) else {
+        throw ConfigError.validation(field: "port", reason: "'\(portStr)' is not an integer")
+    }
+    guard (1...65535).contains(port) else {
+        throw ConfigError.validation(field: "port", reason: "\(port) out of range 1-65535")
+    }
+    return Config(host: host, port: port)
+}
+```
+
+```swift
+// file: main.swift
+do {
+    let cfg = try parseConfig(path: "app.conf")
+    print("host=\(cfg.host) port=\(cfg.port)")
+} catch ConfigError.io(let e) {
+    fputs("IO error: \(e.localizedDescription)\n", stderr)
+} catch ConfigError.parse(let line, let reason) {
+    fputs("Parse error line \(line): \(reason)\n", stderr)
+} catch ConfigError.validation(let field, let reason) {
+    fputs("Validation error '\(field)': \(reason)\n", stderr)
+}
+```
+
+## Common Mistake
+
+Using `try?` — the typed `ConfigError` is discarded and the caller receives `nil` with no information about which tier failed or why.
+
+```swift
+let cfg = try? parseConfig(path: "app.conf")  // ✗ all three error cases collapsed to nil
+// caller cannot distinguish missing file from invalid port — no diagnostic available
+```

--- a/skills/principle-error-handling/examples/config.swift.md
+++ b/skills/principle-error-handling/examples/config.swift.md
@@ -34,13 +34,14 @@ func parseConfig(path: String) throws -> Config {
     for (idx, raw) in lines.enumerated() {
         let line = raw.trimmingCharacters(in: .whitespaces)
         if line.isEmpty || line.hasPrefix("#") { continue }
-        guard let eq = line.firstIndex(of: "="), eq != line.startIndex else {
+        guard line.contains("=") else {
             throw ConfigError.parse(line: idx + 1, reason: "missing '=' separator")
         }
-        let key = String(line[..<eq]).trimmingCharacters(in: .whitespaces)
-        guard !key.isEmpty else {
+        let eq = line.firstIndex(of: "=")!
+        guard eq != line.startIndex else {
             throw ConfigError.parse(line: idx + 1, reason: "empty key")
         }
+        let key = String(line[..<eq]).trimmingCharacters(in: .whitespaces)
         kv[key] = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
     }
 

--- a/skills/principle-error-handling/examples/config.swift.md
+++ b/skills/principle-error-handling/examples/config.swift.md
@@ -34,15 +34,15 @@ func parseConfig(path: String) throws -> Config {
     for (idx, raw) in lines.enumerated() {
         let line = raw.trimmingCharacters(in: .whitespaces)
         if line.isEmpty || line.hasPrefix("#") { continue }
-        guard line.contains("=") else {
+        let parts = line.split(separator: "=", maxSplits: 1)
+        guard parts.count == 2 else {
             throw ConfigError.parse(line: idx + 1, reason: "missing '=' separator")
         }
-        let eq = line.firstIndex(of: "=")!
-        guard eq != line.startIndex else {
+        let key = parts[0].trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else {
             throw ConfigError.parse(line: idx + 1, reason: "empty key")
         }
-        let key = String(line[..<eq]).trimmingCharacters(in: .whitespaces)
-        kv[key] = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
+        kv[key] = parts[1].trimmingCharacters(in: .whitespaces)
     }
 
     return try validateConfig(kv)

--- a/skills/principle-error-handling/examples/config.ts.md
+++ b/skills/principle-error-handling/examples/config.ts.md
@@ -1,0 +1,92 @@
+# Error Handling — TypeScript — Config Parse & Validate
+
+## Problem
+
+TypeScript has no checked exceptions, so thrown errors are typed `unknown` at catch
+sites and callers cannot branch on kind without unsafe narrowing. A discriminated-union
+`Result<T, E>` makes every failure explicit in the return type, forcing callers to
+handle all three tiers — IO, parse, and validation — before accessing the value.
+
+## Implementation
+
+```typescript
+// file: config.ts
+import * as fs from "fs";
+
+export type ConfigError =
+  | { kind: "io"; message: string }
+  | { kind: "parse"; line: number; message: string }
+  | { kind: "validation"; message: string };
+
+type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+export interface Config { host: string; port: number }
+
+export function parseConfig(path: string): Result<Config, ConfigError> {
+  let text: string;
+  try {
+    text = fs.readFileSync(path, "utf8");
+  } catch (e) {
+    return { ok: false, error: { kind: "io", message: String(e) } };
+  }
+
+  const kv: Record<string, string> = {};
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 1) {
+      return { ok: false, error: { kind: "parse", line: i + 1,
+        message: "malformed line, expected key=value" } };
+    }
+    const key = line.slice(0, eq).trim();
+    if (!key) {
+      return { ok: false, error: { kind: "parse", line: i + 1,
+        message: "empty key" } };
+    }
+    kv[key] = line.slice(eq + 1).trim();
+  }
+
+  return validate(kv);
+}
+
+function validate(kv: Record<string, string>): Result<Config, ConfigError> {
+  if (!kv["host"]) return { ok: false, error: { kind: "validation",
+    message: "missing required key: host" } };
+  if (!kv["port"]) return { ok: false, error: { kind: "validation",
+    message: "missing required key: port" } };
+  const port = Number(kv["port"]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return { ok: false, error: { kind: "validation",
+      message: `port '${kv["port"]}' must be an integer 1-65535` } };
+  }
+  return { ok: true, value: { host: kv["host"], port } };
+}
+```
+
+```typescript
+// file: main.ts
+import { parseConfig } from "./config";
+
+const result = parseConfig("app.conf");
+if (!result.ok) {
+  const e = result.error;
+  if (e.kind === "io")         console.error("IO error:", e.message);
+  else if (e.kind === "parse") console.error(`Parse error line ${e.line}:`, e.message);
+  else                         console.error("Validation error:", e.message);
+  process.exit(1);
+}
+console.log(`host=${result.value.host} port=${result.value.port}`);
+```
+
+## Common Mistake
+
+Returning `null` on failure — callers get no error kind, no message, and cannot distinguish IO from validation failures.
+
+```typescript
+function parseConfig(path: string): Config | null {
+  try { /* ... */ }
+  catch { return null; }  // ✗ all three error tiers collapsed to null — undiagnosable
+}
+```

--- a/skills/principle-error-handling/examples/fetch.cs.md
+++ b/skills/principle-error-handling/examples/fetch.cs.md
@@ -1,0 +1,119 @@
+# Error Handling — C# — HTTP Fetch with Retry
+
+## Problem
+
+C# exceptions carry rich metadata, so a `FetchException` with an `IsTransient` property
+lets the retry loop classify errors without a parallel enum. Injecting an `ITransport`
+interface keeps the retry logic testable with a deterministic fake, and
+`Random.Shared.NextDouble()` provides jitter without allocating a new `Random` instance.
+
+## Implementation
+
+```csharp
+// file: Transport.cs
+public record Response(int Status, string Body);
+
+public class FetchException : Exception
+{
+    public bool IsTransient { get; }
+    public int? StatusCode  { get; }
+    public FetchException(string message, bool isTransient, int? statusCode = null)
+        : base(message) { IsTransient = isTransient; StatusCode = statusCode; }
+}
+
+public class ExhaustedFetchException : FetchException
+{
+    public ExhaustedFetchException(int attempts)
+        : base($"Exhausted {attempts} retries", isTransient: false) { }
+}
+
+public interface ITransport
+{
+    Response Fetch(string url);
+}
+
+public class FakeTransport : ITransport
+{
+    private int _attempt;
+
+    public Response Fetch(string url)
+    {
+        if (url == "/not-found")
+            throw new FetchException("404 Not Found", isTransient: false, statusCode: 404);
+        int a = _attempt++;
+        if (a < 2) throw new FetchException("Timeout", isTransient: true);
+        return new Response(200, "OK");
+    }
+}
+```
+
+```csharp
+// file: FetchWithRetry.cs
+public static class FetchWithRetry
+{
+    private const int BaseMs = 100;
+
+    // Retries transient failures with exponential backoff + jitter.
+    // timeoutMs modelled in FakeTransport; real impl: await Task.Delay(delay, cancellationToken)
+    public static Response Fetch(
+        ITransport transport, string url, int maxRetries, int timeoutMs)
+    {
+        for (int attempt = 0; attempt < maxRetries; attempt++)
+        {
+            try
+            {
+                return transport.Fetch(url);
+            }
+            catch (FetchException ex) when (!ex.IsTransient)
+            {
+                throw;    // permanent — bubble immediately
+            }
+            catch (FetchException)
+            {
+                double delay = BaseMs * Math.Pow(2, attempt)
+                             * (Random.Shared.NextDouble() + 0.5);
+                _ = delay; // await Task.Delay((int)delay) — real impl
+            }
+        }
+        throw new ExhaustedFetchException(maxRetries);
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+var t = new FakeTransport();
+
+// transient → success (attempts 0,1 throw Timeout; attempt 2 returns 200)
+try
+{
+    var r = FetchWithRetry.Fetch(t, "/api/data", maxRetries: 5, timeoutMs: 1000);
+    Console.WriteLine($"status={r.Status} body={r.Body}");
+}
+catch (ExhaustedFetchException e) { Console.WriteLine($"exhausted: {e.Message}"); }
+
+// permanent → fail immediately
+var t2 = new FakeTransport();
+try
+{
+    FetchWithRetry.Fetch(t2, "/not-found", maxRetries: 5, timeoutMs: 1000);
+}
+catch (FetchException e)
+{
+    Console.WriteLine($"permanent {e.StatusCode} transient={e.IsTransient}");
+}
+```
+
+## Common Mistake
+
+Catching all exceptions and retrying with no backoff wastes the retry budget on
+unrecoverable 404s and auth failures.
+
+```csharp
+while (attempts < maxRetries) {
+    try { return transport.Fetch(url); }
+    catch (FetchException) {  // ✗ catches permanent errors — no IsTransient check
+        attempts++;            // ✗ no backoff — tight loop
+    }
+}
+```

--- a/skills/principle-error-handling/examples/fetch.go.md
+++ b/skills/principle-error-handling/examples/fetch.go.md
@@ -40,7 +40,7 @@ func (f *FakeTransport) Fetch(url string) (*Response, error) {
 // file: fetch.go
 package fetch
 
-import ("errors"; "fmt"; "math/rand")
+import ("errors"; "fmt"; "math/rand") // rand v1 top-level fns deprecated in Go 1.20; use math/rand/v2 in real code
 
 func isTransient(resp *Response, err error) bool {
 	var pe *PermanentError

--- a/skills/principle-error-handling/examples/fetch.go.md
+++ b/skills/principle-error-handling/examples/fetch.go.md
@@ -1,0 +1,110 @@
+# Error Handling — Go — HTTP Fetch with Retry
+
+## Problem
+
+Go models errors as values, so callers classify them with `errors.Is` before deciding
+whether to retry. Sentinel errors (`ErrTimeout`, `ErrExhausted`) make transient-vs-permanent
+branching explicit, and injecting a `Transport` interface decouples the retry loop from real HTTP.
+
+## Implementation
+
+```go
+// file: transport.go
+package fetch
+
+import ("errors"; "fmt")
+
+var ErrTimeout   = errors.New("timeout")
+var ErrExhausted = errors.New("exhausted all retries")
+
+type Response struct{ Status int; Body string }
+
+type PermanentError struct{ Status int }
+func (e *PermanentError) Error() string { return fmt.Sprintf("permanent %d", e.Status) }
+
+type Transport interface {
+	Fetch(url string) (*Response, error)
+}
+
+type FakeTransport struct{ attempt int }
+
+func (f *FakeTransport) Fetch(url string) (*Response, error) {
+	if url == "/not-found" { return nil, &PermanentError{Status: 404} }
+	defer func() { f.attempt++ }()
+	if f.attempt < 2 { return nil, ErrTimeout }
+	return &Response{Status: 200, Body: "OK"}, nil
+}
+```
+
+```go
+// file: fetch.go
+package fetch
+
+import ("errors"; "fmt"; "math/rand")
+
+func isTransient(resp *Response, err error) bool {
+	var pe *PermanentError
+	if errors.As(err, &pe) { return false }
+	if errors.Is(err, ErrTimeout) { return true }
+	return resp != nil && resp.Status >= 500
+}
+
+// FetchWithRetry retries transient failures with exponential backoff + jitter.
+// timeoutMs is a parameter; real impl uses context.WithTimeout.
+func FetchWithRetry(t Transport, url string, maxRetries, timeoutMs int) (*Response, error) {
+	const baseMs = 100
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		resp, err := t.Fetch(url)
+		if err == nil && resp.Status < 400 { return resp, nil }
+		if !isTransient(resp, err) {
+			if err != nil { return nil, fmt.Errorf("permanent: %w", err) }
+			return resp, nil
+		}
+		delay := float64(baseMs) * float64(1<<attempt) * (rand.Float64() + 0.5)
+		_ = delay // sleep(delay) — real impl: time.Sleep(time.Duration(delay)*time.Millisecond)
+	}
+	return nil, fmt.Errorf("%w after %d attempts on %s", ErrExhausted, maxRetries, url)
+}
+```
+
+```go
+// file: main.go
+package main
+
+import ("errors"; "fmt"; "example/fetch")
+
+func main() {
+	t := &fetch.FakeTransport{}
+	// transient → success (attempts 0,1 timeout; attempt 2 succeeds)
+	resp, err := fetch.FetchWithRetry(t, "/api/data", 5, 1000)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Printf("status=%d body=%s\n", resp.Status, resp.Body)
+	}
+
+	// permanent → fail immediately
+	resp, err = fetch.FetchWithRetry(t, "/not-found", 5, 1000)
+	if err != nil {
+		var pe *fetch.PermanentError
+		if errors.As(err, &pe) { fmt.Printf("permanent %d — no retries\n", pe.Status) } else { fmt.Println("error:", err) }
+	} else {
+		fmt.Printf("unexpected ok: status=%d\n", resp.Status)
+	}
+}
+```
+
+## Common Mistake
+
+Retrying every error — including `PermanentError` and transient ones — indiscriminately
+wastes the retry budget and hammers the server on unrecoverable failures.
+
+```go
+for i := 0; i < maxRetries; i++ {
+	resp, err := t.Fetch(url) // ✗ no classify — retries PermanentError and transient errors alike
+	if err != nil {
+		continue               // ✗ no backoff — tight loop
+	}
+	return resp, nil
+}
+```

--- a/skills/principle-error-handling/examples/fetch.go.md
+++ b/skills/principle-error-handling/examples/fetch.go.md
@@ -26,12 +26,12 @@ type Transport interface {
 	Fetch(url string) (*Response, error)
 }
 
-type FakeTransport struct{ attempt int }
+type FakeTransport struct{ Attempt int }
 
 func (f *FakeTransport) Fetch(url string) (*Response, error) {
 	if url == "/not-found" { return nil, &PermanentError{Status: 404} }
-	defer func() { f.attempt++ }()
-	if f.attempt < 2 { return nil, ErrTimeout }
+	defer func() { f.Attempt++ }()
+	if f.Attempt < 2 { return nil, ErrTimeout }
 	return &Response{Status: 200, Body: "OK"}, nil
 }
 ```
@@ -84,7 +84,8 @@ func main() {
 	}
 
 	// permanent → fail immediately
-	resp, err = fetch.FetchWithRetry(t, "/not-found", 5, 1000)
+	t2 := &fetch.FakeTransport{}
+	resp, err = fetch.FetchWithRetry(t2, "/not-found", 5, 1000)
 	if err != nil {
 		var pe *fetch.PermanentError
 		if errors.As(err, &pe) { fmt.Printf("permanent %d — no retries\n", pe.Status) } else { fmt.Println("error:", err) }

--- a/skills/principle-error-handling/examples/fetch.java.md
+++ b/skills/principle-error-handling/examples/fetch.java.md
@@ -1,0 +1,111 @@
+# Error Handling — Java — HTTP Fetch with Retry
+
+## Problem
+
+Java checked exceptions make the failure contract visible in method signatures, but
+the retry loop needs to distinguish transient from permanent failures before deciding
+whether to catch-and-continue or rethrow. Injecting a `Transport` interface decouples
+the retry policy from real HTTP and keeps the fake implementation self-contained.
+
+## Implementation
+
+```java
+// file: Transport.java
+public record Response(int status, String body) {}
+
+public class FetchException extends Exception {
+    private final boolean transient_;
+    public FetchException(String msg, boolean transient_) {
+        super(msg);
+        this.transient_ = transient_;
+    }
+    public boolean isTransient() { return transient_; }
+}
+
+public interface Transport {
+    Response fetch(String url) throws FetchException;
+}
+
+public class FakeTransport implements Transport {
+    private int attempt = 0;
+
+    @Override
+    public Response fetch(String url) throws FetchException {
+        if ("/not-found".equals(url)) {
+            throw new FetchException("404 Not Found", false); // permanent
+        }
+        int a = attempt++;
+        if (a < 2) throw new FetchException("timeout", true); // transient
+        return new Response(200, "OK");
+    }
+}
+```
+
+```java
+// file: FetchWithRetry.java
+public class FetchWithRetry {
+    private static final int BASE_MS = 100;
+
+    /**
+     * Retries transient failures with exponential backoff + jitter.
+     * timeoutMs is a parameter modelled in FakeTransport; real impl uses
+     * HttpClient.newBuilder().connectTimeout(Duration.ofMillis(timeoutMs)).
+     */
+    public static Response fetch(
+            Transport transport, String url, int maxRetries, int timeoutMs)
+            throws FetchException {
+        FetchException last = null;
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                return transport.fetch(url);
+            } catch (FetchException e) {
+                if (!e.isTransient()) throw e;   // permanent — bubble immediately
+                last = e;
+                double delay = BASE_MS * Math.pow(2, attempt) * (Math.random() + 0.5);
+                // Thread.sleep((long) delay); — real impl uses Thread.sleep
+            }
+        }
+        throw new FetchException("exhausted " + maxRetries + " retries on " + url, false);
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        FakeTransport t = new FakeTransport();
+
+        // transient → success (attempts 0,1 throw timeout; attempt 2 returns 200)
+        try {
+            Response r = FetchWithRetry.fetch(t, "/api/data", 5, 1000);
+            System.out.println("status=" + r.status() + " body=" + r.body());
+        } catch (FetchException e) {
+            System.out.println("exhausted: " + e.getMessage());
+        }
+
+        // permanent → fail immediately
+        FakeTransport t2 = new FakeTransport();
+        try {
+            FetchWithRetry.fetch(t2, "/not-found", 5, 1000);
+        } catch (FetchException e) {
+            System.out.println("permanent: " + e.getMessage() + " transient=" + e.isTransient());
+        }
+    }
+}
+```
+
+## Common Mistake
+
+Catching every exception and continuing in a tight loop retries auth failures and 404s
+with no backoff, burning the retry budget on unrecoverable errors.
+
+```java
+for (int i = 0; i < maxRetries; i++) {
+    try {
+        return transport.fetch(url);
+    } catch (FetchException e) { // ✗ catches permanent errors too — no classify
+        continue;                 // ✗ no backoff — tight loop
+    }
+}
+```

--- a/skills/principle-error-handling/examples/fetch.kt.md
+++ b/skills/principle-error-handling/examples/fetch.kt.md
@@ -1,0 +1,107 @@
+# Error Handling — Kotlin — HTTP Fetch with Retry
+
+## Problem
+
+Kotlin's sealed classes turn error classification into an exhaustive `when` expression
+that the compiler enforces. A `Transport` interface isolates the retry policy from real
+I/O, and `Random.nextFloat()` jitter prevents synchronized backoff spikes when multiple
+clients retry simultaneously.
+
+## Implementation
+
+```kotlin
+// file: transport.kt
+data class Response(val status: Int, val body: String)
+
+sealed class FetchError : Exception() {
+    data class Transient(val statusCode: Int) : FetchError()
+    object Timeout : FetchError()
+    data class Permanent(val statusCode: Int) : FetchError()
+    object Exhausted : FetchError()
+}
+
+interface Transport {
+    fun fetch(url: String): Result<Response>
+}
+
+class FakeTransport : Transport {
+    private var attempt = 0
+
+    override fun fetch(url: String): Result<Response> {
+        if (url == "/not-found") return Result.failure(FetchError.Permanent(404))
+        val a = attempt++
+        return if (a < 2) Result.failure(FetchError.Timeout)
+               else Result.success(Response(200, "OK"))
+    }
+}
+```
+
+```kotlin
+// file: fetch.kt
+import kotlin.math.pow
+import kotlin.random.Random
+
+private fun isTransient(error: Throwable): Boolean = when (error) {
+    is FetchError.Transient, is FetchError.Timeout -> true
+    else -> false
+}
+
+/**
+ * Retries transient failures with exponential backoff + jitter.
+ * timeoutMs is modelled in FakeTransport; real impl uses OkHttp callTimeout.
+ */
+fun fetchWithRetry(
+    transport: Transport,
+    url: String,
+    maxRetries: Int,
+    timeoutMs: Int,
+): Result<Response> {
+    val baseMs = 100.0
+    for (attempt in 0 until maxRetries) {
+        val result = transport.fetch(url)
+        if (result.isSuccess) return result
+        val err = result.exceptionOrNull()!!
+        if (!isTransient(err)) return result        // permanent — bubble immediately
+        val delay = baseMs * 2.0.pow(attempt) * (Random.nextFloat() * 1.0f + 0.5f)
+        @Suppress("UNUSED_VARIABLE") val d = delay // Thread.sleep(delay.toLong()) — real impl
+    }
+    return Result.failure(FetchError.Exhausted)
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    val t = FakeTransport()
+
+    // transient → success (attempts 0,1 timeout; attempt 2 returns 200)
+    fetchWithRetry(t, "/api/data", maxRetries = 5, timeoutMs = 1000)
+        .onSuccess { println("status=${it.status} body=${it.body}") }
+        .onFailure { println("error: $it") }
+
+    // permanent → fail immediately (no retries consumed)
+    val t2 = FakeTransport()
+    fetchWithRetry(t2, "/not-found", maxRetries = 5, timeoutMs = 1000)
+        .onSuccess { println("unexpected ok: ${it.status}") }
+        .onFailure { err ->
+            when (err) {
+                is FetchError.Permanent -> println("permanent ${err.statusCode} — no retries")
+                is FetchError.Exhausted -> println("exhausted")
+                else -> println("other: $err")
+            }
+        }
+}
+```
+
+## Common Mistake
+
+Retrying all failures including permanent ones with no delay discards the classify step
+and floods the server with pointless requests on unrecoverable errors.
+
+```kotlin
+for (attempt in 0 until maxRetries) {
+    val r = transport.fetch(url)
+    if (r.isSuccess) return r  // ✗ retries Permanent(404) — no classify
+    // ✗ no backoff — tight loop
+}
+```

--- a/skills/principle-error-handling/examples/fetch.kt.md
+++ b/skills/principle-error-handling/examples/fetch.kt.md
@@ -60,7 +60,7 @@ fun fetchWithRetry(
     for (attempt in 0 until maxRetries) {
         val result = transport.fetch(url)
         if (result.isSuccess) return result
-        val err = result.exceptionOrNull()!!
+        val err = result.exceptionOrNull() ?: return result  // isSuccess path already returned
         if (!isTransient(err)) return result        // permanent — bubble immediately
         val delay = baseMs * 2.0.pow(attempt) * (Random.nextFloat() * 1.0f + 0.5f)
         @Suppress("UNUSED_VARIABLE") val d = delay // Thread.sleep(delay.toLong()) — real impl

--- a/skills/principle-error-handling/examples/fetch.py.md
+++ b/skills/principle-error-handling/examples/fetch.py.md
@@ -1,0 +1,113 @@
+# Error Handling — Python — HTTP Fetch with Retry
+
+## Problem
+
+Python's exception hierarchy lets you classify failures by catching the most-specific
+subclass first. An abstract `Transport` base class separates the retry policy from
+real I/O, and typed `FetchError` subclasses make permanent-vs-transient explicit so
+the retry loop never wastes attempts on unrecoverable errors.
+
+## Implementation
+
+```python
+# file: transport.py
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+@dataclass
+class Response:
+    status: int
+    body: str
+
+class FetchError(Exception): pass
+class TransientError(FetchError):
+    def __init__(self, status: int):
+        super().__init__(f"transient {status}"); self.status = status
+class PermanentError(FetchError):
+    def __init__(self, status: int):
+        super().__init__(f"permanent {status}"); self.status = status
+class FetchTimeoutError(FetchError): pass
+class ExhaustedError(FetchError): pass
+
+class Transport(ABC):
+    @abstractmethod
+    def fetch(self, url: str) -> Response: ...
+
+
+class FakeTransport(Transport):
+    def __init__(self) -> None:
+        self._attempt = 0
+
+    def fetch(self, url: str) -> Response:
+        if url == "/not-found":
+            raise PermanentError(404)
+        attempt = self._attempt
+        self._attempt += 1
+        if attempt < 2:
+            raise FetchTimeoutError("simulated timeout")
+        return Response(status=200, body="OK")
+```
+
+```python
+# file: fetch.py
+import random
+from transport import ExhaustedError, FetchError, FetchTimeoutError, PermanentError, Transport, TransientError
+
+
+def fetch_with_retry(
+    transport: Transport,
+    url: str,
+    max_retries: int,
+    timeout_ms: int,  # real impl: passed to requests.get(timeout=timeout_ms/1000)
+) -> Response:
+    """Retry transient failures with exponential backoff + jitter."""
+    BASE_MS = 100
+    for attempt in range(max_retries):
+        try:
+            return transport.fetch(url)
+        except PermanentError:
+            raise                          # bubble immediately — never retry
+        except (TransientError, FetchTimeoutError):
+            delay = BASE_MS * (2 ** attempt) * random.uniform(0.5, 1.5)
+            _ = delay  # time.sleep(delay / 1000) — real impl uses time.sleep
+        except FetchError:
+            raise                          # unknown error — bubble
+
+    raise ExhaustedError(f"exhausted {max_retries} retries on {url}")
+```
+
+```python
+# file: main.py
+from transport import FakeTransport, PermanentError
+from fetch import ExhaustedError, fetch_with_retry
+
+t = FakeTransport()
+
+# transient → success (attempts 0,1 raise TimeoutError; attempt 2 returns 200)
+try:
+    resp = fetch_with_retry(t, "/api/data", max_retries=5, timeout_ms=1000)
+    print(f"status={resp.status} body={resp.body}")
+except ExhaustedError as e:
+    print(f"exhausted: {e}")
+
+# permanent → fail immediately
+t2 = FakeTransport()
+try:
+    fetch_with_retry(t2, "/not-found", max_retries=5, timeout_ms=1000)
+except PermanentError as e:
+    print(f"permanent {e.status} — no retries")
+```
+
+## Common Mistake
+
+A bare `except: continue` retries everything, including authentication failures and
+bad-request errors that will never succeed.
+
+```python
+for _ in range(max_retries):
+    try:
+        return transport.fetch(url)
+    except:          # ✗ catches PermanentError, KeyboardInterrupt, everything
+        continue     # ✗ no backoff — tight loop; auth errors retried forever
+raise ExhaustedError("exhausted")
+```

--- a/skills/principle-error-handling/examples/fetch.rb.md
+++ b/skills/principle-error-handling/examples/fetch.rb.md
@@ -1,0 +1,103 @@
+# Error Handling — Ruby — HTTP Fetch with Retry
+
+## Problem
+
+Ruby's exception hierarchy lets you rescue the narrowest class first, so transient
+failures are retried while permanent ones bubble immediately. Injecting an abstract
+`Transport` base keeps the retry logic testable with a fake that returns a canned
+sequence, and `rand(0.5..1.5)` jitter prevents thundering-herd backoff collisions.
+
+## Implementation
+
+```ruby
+# file: transport.rb
+Response = Struct.new(:status, :body)
+
+class FetchError < StandardError; end
+class TransientError < FetchError
+  attr_reader :status
+  def initialize(status) = (@status = status; super("transient #{status}"))
+end
+class PermanentError < FetchError
+  attr_reader :status
+  def initialize(status) = (@status = status; super("permanent #{status}"))
+end
+class TimeoutError  < FetchError; end
+class ExhaustedError < FetchError; end
+
+class Transport
+  def fetch(url) = raise NotImplementedError
+end
+
+class FakeTransport < Transport
+  def initialize = (@attempt = 0)
+
+  def fetch(url)
+    raise PermanentError.new(404) if url == "/not-found"
+    attempt = @attempt
+    @attempt += 1
+    raise TimeoutError, "simulated timeout" if attempt < 2
+    Response.new(200, "OK")
+  end
+end
+```
+
+```ruby
+# file: fetch.rb
+require_relative "transport"
+
+# Retries transient failures with exponential backoff + jitter.
+# timeout_ms is a parameter modelled in FakeTransport; real impl uses Net::HTTP#open_timeout.
+def fetch_with_retry(transport, url, max_retries: 5, timeout_ms: 1000)
+  base_ms = 100
+  max_retries.times do |attempt|
+    return transport.fetch(url)
+  rescue PermanentError
+    raise                          # bubble immediately — never retry
+  rescue TransientError, TimeoutError
+    delay = base_ms * (2**attempt) * rand(0.5..1.5)
+    # sleep(delay / 1000.0) — real impl uses Kernel#sleep
+    _ = delay
+  rescue FetchError
+    raise
+  end
+  raise ExhaustedError, "exhausted #{max_retries} retries on #{url}"
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "transport"
+require_relative "fetch"
+
+t = FakeTransport.new
+
+# transient → success (attempts 0,1 raise TimeoutError; attempt 2 returns 200)
+begin
+  resp = fetch_with_retry(t, "/api/data")
+  puts "status=#{resp.status} body=#{resp.body}"
+rescue ExhaustedError => e
+  puts "exhausted: #{e.message}"
+end
+
+# permanent → fail immediately
+t2 = FakeTransport.new
+begin
+  fetch_with_retry(t2, "/not-found")
+rescue PermanentError => e
+  puts "permanent #{e.status} — no retries"
+end
+```
+
+## Common Mistake
+
+Rescuing all errors and retrying with no backoff and no permanent distinction retries
+404s and auth failures indefinitely.
+
+```ruby
+max_retries.times do
+  return transport.fetch(url)
+rescue FetchError  # ✗ rescues PermanentError too — no classify
+  # ✗ no backoff — tight loop until attempts exhausted
+end
+```

--- a/skills/principle-error-handling/examples/fetch.rb.md
+++ b/skills/principle-error-handling/examples/fetch.rb.md
@@ -22,7 +22,7 @@ class PermanentError < FetchError
   attr_reader :status
   def initialize(status) = (@status = status; super("permanent #{status}"))
 end
-class TimeoutError  < FetchError; end
+class FetchTimeoutError  < FetchError; end
 class ExhaustedError < FetchError; end
 
 class Transport
@@ -36,7 +36,7 @@ class FakeTransport < Transport
     raise PermanentError.new(404) if url == "/not-found"
     attempt = @attempt
     @attempt += 1
-    raise TimeoutError, "simulated timeout" if attempt < 2
+    raise FetchTimeoutError, "simulated timeout" if attempt < 2
     Response.new(200, "OK")
   end
 end
@@ -54,7 +54,7 @@ def fetch_with_retry(transport, url, max_retries: 5, timeout_ms: 1000)
     return transport.fetch(url)
   rescue PermanentError
     raise                          # bubble immediately — never retry
-  rescue TransientError, TimeoutError
+  rescue TransientError, FetchTimeoutError
     delay = base_ms * (2**attempt) * rand(0.5..1.5)
     # sleep(delay / 1000.0) — real impl uses Kernel#sleep
     _ = delay
@@ -72,7 +72,7 @@ require_relative "fetch"
 
 t = FakeTransport.new
 
-# transient → success (attempts 0,1 raise TimeoutError; attempt 2 returns 200)
+# transient → success (attempts 0,1 raise FetchTimeoutError; attempt 2 returns 200)
 begin
   resp = fetch_with_retry(t, "/api/data")
   puts "status=#{resp.status} body=#{resp.body}"

--- a/skills/principle-error-handling/examples/fetch.rs.md
+++ b/skills/principle-error-handling/examples/fetch.rs.md
@@ -65,8 +65,9 @@ pub fn fetch_with_retry(
             Ok(resp) => return Ok(resp),
             Err(err) if !is_transient(&err) => return Err(err), // permanent — bubble
             Err(_) => {
-                // jitter without rand crate: deterministic pseudo-random in [0.5, 1.4]
-                let jitter = ((attempt * 17 + 3) % 10) as f64 / 10.0 + 0.5;
+                // deterministic stand-in for illustration only — NOT for production.
+                // Real impl: rand::thread_rng().gen_range(0.5_f64..=1.5)
+                let jitter = ((attempt * 17 + 3) % 10) as f64 / 10.0 + 0.5; // [0.5, 1.4]
                 let delay = BASE_MS * (1u64 << attempt) as f64 * jitter;
                 let _ = delay; // sleep(delay as u64) — real impl: std::thread::sleep(Duration::from_millis(...))
             }

--- a/skills/principle-error-handling/examples/fetch.rs.md
+++ b/skills/principle-error-handling/examples/fetch.rs.md
@@ -36,7 +36,8 @@ impl Transport for FakeTransport {
         let a = self.attempt.get();
         self.attempt.set(a + 1);
         match a {
-            0 | 1 => Err(FetchError::Timeout),
+            0     => Err(FetchError::Transient(503)), // first: 5xx transient
+            1     => Err(FetchError::Timeout),        // second: timeout transient
             _     => Ok(Response { status: 200, body: "OK".into() }),
         }
     }

--- a/skills/principle-error-handling/examples/fetch.rs.md
+++ b/skills/principle-error-handling/examples/fetch.rs.md
@@ -1,0 +1,118 @@
+# Error Handling — Rust — HTTP Fetch with Retry
+
+## Problem
+
+Rust's `Result<T, E>` makes every failure path explicit in the type signature.
+A `FetchError` enum with transient and permanent variants lets the retry loop
+pattern-match on the exact cause, and deterministic pseudo-jitter keeps the
+example dependency-free while still illustrating the backoff formula.
+
+## Implementation
+
+```rust
+// file: transport.rs
+#[derive(Debug)]
+pub struct Response { pub status: u16, pub body: String }
+
+#[derive(Debug)]
+pub enum FetchError {
+    Transient(u16),   // 5xx status
+    Timeout,
+    Permanent(u16),   // 4xx status
+    Exhausted,
+}
+
+pub trait Transport {
+    fn fetch(&self, url: &str) -> Result<Response, FetchError>;
+}
+
+pub struct FakeTransport { pub attempt: std::cell::Cell<usize> }
+
+impl Transport for FakeTransport {
+    fn fetch(&self, url: &str) -> Result<Response, FetchError> {
+        if url == "/not-found" {
+            return Err(FetchError::Permanent(404));
+        }
+        let a = self.attempt.get();
+        self.attempt.set(a + 1);
+        match a {
+            0 | 1 => Err(FetchError::Timeout),
+            _     => Ok(Response { status: 200, body: "OK".into() }),
+        }
+    }
+}
+```
+
+```rust
+// file: fetch.rs
+use crate::transport::{FetchError, Response, Transport};
+
+fn is_transient(err: &FetchError) -> bool {
+    matches!(err, FetchError::Transient(_) | FetchError::Timeout)
+}
+
+/// Retries transient failures with exponential backoff + deterministic jitter.
+/// timeoutMs is a parameter modelled in FakeTransport; real impl uses tokio::time::timeout.
+pub fn fetch_with_retry(
+    t: &dyn Transport,
+    url: &str,
+    max_retries: usize,
+    _timeout_ms: u64,
+) -> Result<Response, FetchError> {
+    const BASE_MS: f64 = 100.0;
+    for attempt in 0..max_retries {
+        match t.fetch(url) {
+            Ok(resp) => return Ok(resp),
+            Err(err) if !is_transient(&err) => return Err(err), // permanent — bubble
+            Err(_) => {
+                // jitter without rand crate: deterministic pseudo-random in [0.5, 1.4]
+                let jitter = ((attempt * 17 + 3) % 10) as f64 / 10.0 + 0.5;
+                let delay = BASE_MS * (1u64 << attempt) as f64 * jitter;
+                let _ = delay; // sleep(delay as u64) — real impl: std::thread::sleep(Duration::from_millis(...))
+            }
+        }
+    }
+    Err(FetchError::Exhausted)
+}
+```
+
+```rust
+// file: main.rs
+mod transport;
+mod fetch;
+
+use transport::{FakeTransport, FetchError};
+use std::cell::Cell;
+
+fn main() {
+    // transient → success
+    let t = FakeTransport { attempt: Cell::new(0) };
+    match fetch::fetch_with_retry(&t, "/api/data", 5, 1000) {
+        Ok(r)  => println!("status={} body={}", r.status, r.body),
+        Err(e) => println!("error: {:?}", e),
+    }
+
+    // permanent → fail immediately
+    let t2 = FakeTransport { attempt: Cell::new(0) };
+    match fetch::fetch_with_retry(&t2, "/not-found", 5, 1000) {
+        Ok(r)                         => println!("unexpected ok: {}", r.status),
+        Err(FetchError::Permanent(c)) => println!("permanent {c} — no retries"),
+        Err(FetchError::Exhausted)    => println!("exhausted"),
+        Err(e)                        => println!("other: {:?}", e),
+    }
+}
+```
+
+## Common Mistake
+
+Retrying on every `Err` variant — including `Permanent` — without a classify step
+burns the retry budget and never recovers.
+
+```rust
+for _ in 0..max_retries {
+    match t.fetch(url) {
+        Ok(r)  => return Ok(r),
+        Err(_) => continue, // ✗ retries Permanent(404) forever — no classify, no backoff
+    }
+}
+```

--- a/skills/principle-error-handling/examples/fetch.swift.md
+++ b/skills/principle-error-handling/examples/fetch.swift.md
@@ -1,0 +1,112 @@
+# Error Handling — Swift — HTTP Fetch with Retry
+
+## Problem
+
+Swift's typed `throws` and `enum` errors make every failure path explicit and
+exhaustively handled at the call site. A `Transport` protocol separates the retry
+policy from real URLSession I/O, and `Double.random(in: 0.5...1.5)` jitter prevents
+synchronized backoff when multiple clients retry the same endpoint.
+
+## Implementation
+
+```swift
+// file: Transport.swift
+struct Response { let status: Int; let body: String }
+
+enum FetchError: Error {
+    case transient(Int)   // 5xx status code
+    case timeout
+    case permanent(Int)   // 4xx status code
+    case exhausted
+}
+
+protocol Transport {
+    func fetch(url: String) throws -> Response
+}
+
+class FakeTransport: Transport {
+    private var attempt = 0
+
+    func fetch(url: String) throws -> Response {
+        if url == "/not-found" { throw FetchError.permanent(404) }
+        let a = attempt; attempt += 1
+        if a < 2 { throw FetchError.timeout }
+        return Response(status: 200, body: "OK")
+    }
+}
+```
+
+```swift
+// file: fetch.swift
+import Foundation
+
+private func isTransient(_ error: FetchError) -> Bool {
+    switch error {
+    case .transient, .timeout: return true
+    default: return false
+    }
+}
+
+/// Retries transient failures with exponential backoff + jitter.
+/// timeoutMs is a parameter modelled in FakeTransport;
+/// real impl: // Thread.sleep(forTimeInterval: delay / 1000)
+func fetchWithRetry(
+    transport: Transport,
+    url: String,
+    maxRetries: Int,
+    timeoutMs: Int
+) throws -> Response {
+    let baseMs: Double = 100
+    var lastError: FetchError = .timeout
+
+    for attempt in 0..<maxRetries {
+        do {
+            return try transport.fetch(url: url)
+        } catch let err as FetchError {
+            guard isTransient(err) else { throw err }  // permanent — bubble immediately
+            lastError = err
+            let delay = baseMs * pow(2.0, Double(attempt)) * Double.random(in: 0.5...1.5)
+            _ = delay  // Thread.sleep(forTimeInterval: delay / 1000) — real impl
+        }
+    }
+    throw FetchError.exhausted
+}
+```
+
+```swift
+// file: main.swift
+let t = FakeTransport()
+
+// transient → success (attempts 0,1 throw .timeout; attempt 2 returns 200)
+do {
+    let r = try fetchWithRetry(transport: t, url: "/api/data", maxRetries: 5, timeoutMs: 1000)
+    print("status=\(r.status) body=\(r.body)")
+} catch FetchError.exhausted {
+    print("exhausted all retries")
+} catch {
+    print("error: \(error)")
+}
+
+// permanent → fail immediately
+let t2 = FakeTransport()
+do {
+    _ = try fetchWithRetry(transport: t2, url: "/not-found", maxRetries: 5, timeoutMs: 1000)
+} catch FetchError.permanent(let code) {
+    print("permanent \(code) — no retries consumed")
+} catch {
+    print("unexpected: \(error)")
+}
+```
+
+## Common Mistake
+
+Catching all errors and retrying without backoff or a permanent check retries 404s
+and auth failures until the budget is gone.
+
+```swift
+while attempts < maxRetries {
+    if let r = try? transport.fetch(url: url) { return r }  // ✗ swallows permanent errors
+    attempts += 1  // ✗ no classify, no backoff — tight loop
+}
+throw FetchError.exhausted
+```

--- a/skills/principle-error-handling/examples/fetch.ts.md
+++ b/skills/principle-error-handling/examples/fetch.ts.md
@@ -1,0 +1,116 @@
+# Error Handling — TypeScript — HTTP Fetch with Retry
+
+## Problem
+
+TypeScript discriminated unions make transient-vs-permanent classification a compile-time
+concern: the `FetchResult` type forces every caller to narrow the error variant before
+using the response. Injecting a `Transport` interface keeps the retry loop testable
+without real network I/O.
+
+## Implementation
+
+```typescript
+// file: transport.ts
+export type FetchResult =
+  | { status: number; body: string }
+  | { error: "timeout" | "network" | "exhausted"; status?: never };
+
+export interface Transport {
+  fetch(url: string): FetchResult;
+}
+
+export class FakeTransport implements Transport {
+  private attempt = 0;
+
+  fetch(url: string): FetchResult {
+    if (url === "/not-found") return { status: 404, body: "Not Found" };
+    const a = this.attempt++;
+    if (a < 2) return { error: "timeout" };          // transient: attempts 0, 1
+    return { status: 200, body: "OK" };               // success: attempt 2+
+  }
+}
+```
+
+```typescript
+// file: fetch.ts
+import type { FetchResult, Transport } from "./transport";
+
+function isTransient(result: FetchResult): boolean {
+  if ("error" in result) return result.error === "timeout" || result.error === "network";
+  return result.status >= 500;                        // 5xx
+}
+
+function isPermanent(result: FetchResult): boolean {
+  if ("error" in result) return false;
+  return result.status >= 400 && result.status < 500; // 4xx
+}
+
+/**
+ * Retries transient failures with exponential backoff + jitter.
+ * timeoutMs is modelled as a parameter; real impl passes AbortSignal to fetch().
+ */
+export function fetchWithRetry(
+  transport: Transport,
+  url: string,
+  maxRetries: number,
+  timeoutMs: number,
+): FetchResult {
+  const BASE_MS = 100;
+  let last: FetchResult = { error: "network" };
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const result = transport.fetch(url);
+
+    if (!("error" in result) && result.status < 400) return result;
+    if (isPermanent(result)) return result;           // bubble permanent immediately
+
+    last = result;
+    const delay = BASE_MS * Math.pow(2, attempt) * (Math.random() * 1.0 + 0.5);
+    void delay; // setTimeout(delay) — real impl: await new Promise(r => setTimeout(r, delay))
+  }
+
+  return { error: "exhausted" }; // retries consumed; distinct from transient errors
+}
+```
+
+```typescript
+// file: main.ts
+import { FakeTransport } from "./transport";
+import { fetchWithRetry } from "./fetch";
+
+const t = new FakeTransport();
+
+// transient → success (attempts 0,1 timeout; attempt 2 returns 200)
+const r1 = fetchWithRetry(t, "/api/data", 5, 1000);
+if ("error" in r1) {
+  if (r1.error === "exhausted") {
+    console.log("retries consumed — all attempts failed with transient errors");
+  } else {
+    console.log("transient error:", r1.error);
+  }
+} else {
+  console.log(`status=${r1.status} body=${r1.body}`);
+}
+
+// permanent → fail immediately (no retries)
+const t2 = new FakeTransport();
+const r2 = fetchWithRetry(t2, "/not-found", 5, 1000);
+if ("error" in r2) {
+  console.log("error:", r2.error);
+} else {
+  console.log(`permanent status=${r2.status} — returned without retry`);
+}
+```
+
+## Common Mistake
+
+Retrying all results with no delay and no permanent check turns a 404 into an infinite
+spin loop.
+
+```typescript
+while (attempts < max) {
+  const r = t.fetch(url); // ✗ no classify — retries 404 and auth errors
+  if (!("error" in r)) break; // ✗ no backoff — tight loop burns CPU
+  attempts++;
+}
+```

--- a/skills/principle-error-handling/examples/fetch.ts.md
+++ b/skills/principle-error-handling/examples/fetch.ts.md
@@ -61,6 +61,7 @@ export function fetchWithRetry(
 
     if (result.ok && result.status < 400) return result;
     if (isPermanent(result)) return result;           // bubble permanent immediately
+    if (!isTransient(result)) return result;          // non-transient — bubble
 
     const delay = BASE_MS * Math.pow(2, attempt) * (Math.random() * 1.0 + 0.5);
     void delay; // real impl: await new Promise(r => setTimeout(r, delay))

--- a/skills/principle-error-handling/examples/fetch.ts.md
+++ b/skills/principle-error-handling/examples/fetch.ts.md
@@ -13,7 +13,7 @@ without real network I/O.
 // file: transport.ts
 export type FetchResult =
   | { status: number; body: string }
-  | { error: "timeout" | "network" | "exhausted"; status?: never };
+  | { error: "timeout" | "network" | "exhausted" | "permanent"; statusCode?: number };
 
 export interface Transport {
   fetch(url: string): FetchResult;
@@ -23,7 +23,7 @@ export class FakeTransport implements Transport {
   private attempt = 0;
 
   fetch(url: string): FetchResult {
-    if (url === "/not-found") return { status: 404, body: "Not Found" };
+    if (url === "/not-found") return { error: "permanent", statusCode: 404 };
     const a = this.attempt++;
     if (a < 2) return { error: "timeout" };          // transient: attempts 0, 1
     return { status: 200, body: "OK" };               // success: attempt 2+
@@ -41,8 +41,7 @@ function isTransient(result: FetchResult): boolean {
 }
 
 function isPermanent(result: FetchResult): boolean {
-  if ("error" in result) return false;
-  return result.status >= 400 && result.status < 500; // 4xx
+  return "error" in result && result.error === "permanent";
 }
 
 /**
@@ -95,10 +94,12 @@ if ("error" in r1) {
 // permanent → fail immediately (no retries)
 const t2 = new FakeTransport();
 const r2 = fetchWithRetry(t2, "/not-found", 5, 1000);
-if ("error" in r2) {
+if ("error" in r2 && r2.error === "permanent") {
+  console.log(`permanent ${r2.statusCode} — no retries`);
+} else if ("error" in r2) {
   console.log("error:", r2.error);
 } else {
-  console.log(`permanent status=${r2.status} — returned without retry`);
+  console.log(`unexpected ok: status=${r2.status}`);
 }
 ```
 

--- a/skills/principle-error-handling/examples/fetch.ts.md
+++ b/skills/principle-error-handling/examples/fetch.ts.md
@@ -12,8 +12,8 @@ without real network I/O.
 ```typescript
 // file: transport.ts
 export type FetchResult =
-  | { status: number; body: string }
-  | { error: "timeout" | "network" | "exhausted" | "permanent"; statusCode?: number };
+  | { ok: true;  status: number; body: string }
+  | { ok: false; error: "timeout" | "network" | "exhausted" | "permanent"; statusCode?: number };
 
 export interface Transport {
   fetch(url: string): FetchResult;
@@ -23,10 +23,10 @@ export class FakeTransport implements Transport {
   private attempt = 0;
 
   fetch(url: string): FetchResult {
-    if (url === "/not-found") return { error: "permanent", statusCode: 404 };
+    if (url === "/not-found") return { ok: false, error: "permanent", statusCode: 404 };
     const a = this.attempt++;
-    if (a < 2) return { error: "timeout" };          // transient: attempts 0, 1
-    return { status: 200, body: "OK" };               // success: attempt 2+
+    if (a < 2) return { ok: false, error: "timeout" }; // transient: attempts 0, 1
+    return { ok: true, status: 200, body: "OK" };       // success: attempt 2+
   }
 }
 ```
@@ -36,12 +36,12 @@ export class FakeTransport implements Transport {
 import type { FetchResult, Transport } from "./transport";
 
 function isTransient(result: FetchResult): boolean {
-  if ("error" in result) return result.error === "timeout" || result.error === "network";
+  if (!result.ok) return result.error === "timeout" || result.error === "network";
   return result.status >= 500;                        // 5xx
 }
 
 function isPermanent(result: FetchResult): boolean {
-  return "error" in result && result.error === "permanent";
+  return !result.ok && result.error === "permanent";
 }
 
 /**
@@ -55,20 +55,18 @@ export function fetchWithRetry(
   timeoutMs: number,
 ): FetchResult {
   const BASE_MS = 100;
-  let last: FetchResult = { error: "network" };
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     const result = transport.fetch(url);
 
-    if (!("error" in result) && result.status < 400) return result;
+    if (result.ok && result.status < 400) return result;
     if (isPermanent(result)) return result;           // bubble permanent immediately
 
-    last = result;
     const delay = BASE_MS * Math.pow(2, attempt) * (Math.random() * 1.0 + 0.5);
-    void delay; // setTimeout(delay) — real impl: await new Promise(r => setTimeout(r, delay))
+    void delay; // real impl: await new Promise(r => setTimeout(r, delay))
   }
 
-  return { error: "exhausted" }; // retries consumed; distinct from transient errors
+  return { ok: false, error: "exhausted" }; // retries consumed; distinct from transient errors
 }
 ```
 
@@ -81,7 +79,7 @@ const t = new FakeTransport();
 
 // transient → success (attempts 0,1 timeout; attempt 2 returns 200)
 const r1 = fetchWithRetry(t, "/api/data", 5, 1000);
-if ("error" in r1) {
+if (!r1.ok) {
   if (r1.error === "exhausted") {
     console.log("retries consumed — all attempts failed with transient errors");
   } else {
@@ -94,9 +92,9 @@ if ("error" in r1) {
 // permanent → fail immediately (no retries)
 const t2 = new FakeTransport();
 const r2 = fetchWithRetry(t2, "/not-found", 5, 1000);
-if ("error" in r2 && r2.error === "permanent") {
+if (!r2.ok && r2.error === "permanent") {
   console.log(`permanent ${r2.statusCode} — no retries`);
-} else if ("error" in r2) {
+} else if (!r2.ok) {
   console.log("error:", r2.error);
 } else {
   console.log(`unexpected ok: status=${r2.status}`);
@@ -110,8 +108,8 @@ spin loop.
 
 ```typescript
 while (attempts < max) {
-  const r = t.fetch(url); // ✗ no classify — retries 404 and auth errors
-  if (!("error" in r)) break; // ✗ no backoff — tight loop burns CPU
-  attempts++;
+  const r = t.fetch(url);
+  if (r.ok) break;                    // ✗ no classify — retries 404 and auth errors
+  attempts++;                         // ✗ no backoff — tight loop burns CPU
 }
 ```

--- a/skills/principle-error-handling/examples/withdraw.cs.md
+++ b/skills/principle-error-handling/examples/withdraw.cs.md
@@ -1,0 +1,81 @@
+# Error Handling — C# — Withdraw from Account
+
+## Problem
+
+C# exceptions carry an `InnerException` chain and typed subclasses that let callers
+`catch` at the right granularity. Three exception classes — `InvalidAmountException`
+(unchecked: bad caller input), `AccountFrozenException`, and `InsufficientFundsException`
+(domain state) — give callers precise `catch` branches with structured fields like
+`Available` and `Requested`. The domain never writes to a logger or console; the caller
+logs exactly once at the boundary.
+
+## Implementation
+
+```csharp
+// file: Account.cs
+using System;
+
+public class InvalidAmountException : ArgumentException {
+    public InvalidAmountException(decimal amount)
+        : base($"amount {amount:F2} must be positive") { }
+}
+public class AccountFrozenException : Exception {
+    public AccountFrozenException() : base("account is frozen") { }
+}
+public class InsufficientFundsException : Exception {
+    public decimal Available { get; }
+    public decimal Requested { get; }
+    public InsufficientFundsException(decimal available, decimal requested)
+        : base($"insufficient funds: available={available:F2} requested={requested:F2}") {
+        Available = available;
+        Requested = requested;
+    }
+}
+
+public class Account {
+    public string Id      { get; }
+    private decimal balance;
+    private bool frozen;
+
+    public Account(string id, decimal balance) { Id = id; this.balance = balance; }
+    public void Freeze() { frozen = true; }
+
+    public void Withdraw(decimal amount) {
+        if (amount <= 0)        throw new InvalidAmountException(amount);
+        if (frozen)             throw new AccountFrozenException();
+        if (balance < amount)   throw new InsufficientFundsException(balance, amount);
+        balance -= amount;
+    }
+}
+```
+
+```csharp
+// file: Program.cs
+var acc = new Account("acct-42", 100m);
+try {
+    acc.Withdraw(150m);
+    Console.WriteLine("withdrawal successful");
+} catch (AccountFrozenException e) {
+    // log ONCE at the boundary with account ID and amount
+    Console.Error.WriteLine($"[{acc.Id}] withdraw 150.00 failed: {e.Message}");
+    Console.Error.WriteLine("hint: contact support to unfreeze");
+} catch (InsufficientFundsException e) {
+    Console.Error.WriteLine($"[{acc.Id}] withdraw 150.00 failed: {e.Message}");
+    Console.Error.WriteLine($"hint: available balance is {e.Available:F2}");
+}
+```
+
+## Common Mistake
+
+The domain writes to `Console.Error` before throwing — every layer that also logs the
+exception produces duplicate entries, making it impossible to trace which layer owns
+the failure.
+
+```csharp
+public void Withdraw(decimal amount) {
+    if (balance < amount) {
+        Console.Error.WriteLine($"insufficient funds: balance={balance}"); // ✗ domain logs
+        throw new InsufficientFundsException(balance, amount);             // ✗ then throws
+    }
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.go.md
+++ b/skills/principle-error-handling/examples/withdraw.go.md
@@ -1,0 +1,106 @@
+# Error Handling — Go — Withdraw from Account
+
+## Problem
+
+Go surfaces errors as values; choosing between sentinel errors, typed structs, and
+coded fields depends on what callers must branch on. The `withdraw` function returns
+a typed `WithdrawError` with a `Code` field — illustrating coded errors — while
+sentinel values let callers use `errors.Is` for the two expected domain failures.
+The domain never logs; the boundary logs exactly once with account ID and amount.
+
+## Implementation
+
+```go
+// file: account.go
+package account
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrInsufficientFunds = errors.New("insufficient funds")
+var ErrAccountFrozen    = errors.New("account frozen")
+
+type WithdrawError struct {
+	Code    string
+	Amount  float64
+	Balance float64
+	Err     error
+}
+
+func (e *WithdrawError) Error() string {
+	return fmt.Sprintf("[%s] amount=%.2f balance=%.2f: %v", e.Code, e.Amount, e.Balance, e.Err)
+}
+func (e *WithdrawError) Unwrap() error { return e.Err }
+
+type Account struct {
+	ID      string
+	balance float64
+	frozen  bool
+}
+
+func New(id string, balance float64) *Account { return &Account{ID: id, balance: balance} }
+func (a *Account) Freeze()                    { a.frozen = true }
+
+func (a *Account) Withdraw(amount float64) error {
+	if amount <= 0 {
+		return &WithdrawError{Code: "INVALID_AMOUNT", Amount: amount, Balance: a.balance,
+			Err: fmt.Errorf("amount must be positive")}
+	}
+	if a.frozen {
+		return &WithdrawError{Code: "ACCOUNT_FROZEN", Amount: amount, Balance: a.balance,
+			Err: ErrAccountFrozen}
+	}
+	if a.balance < amount {
+		return &WithdrawError{Code: "INSUFFICIENT_FUNDS", Amount: amount, Balance: a.balance,
+			Err: ErrInsufficientFunds}
+	}
+	a.balance -= amount
+	return nil
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"errors"
+	"log"
+	"example/account"
+)
+
+func main() {
+	acc := account.New("acct-42", 100.00)
+
+	err := acc.Withdraw(150.00)
+	if err != nil {
+		// log ONCE at the boundary with full context
+		log.Printf("withdraw failed [%s] amount=150.00: %v", acc.ID, err)
+
+		if errors.Is(err, account.ErrInsufficientFunds) {
+			log.Println("hint: reduce withdrawal amount or top up balance")
+		} else if errors.Is(err, account.ErrAccountFrozen) {
+			log.Println("hint: contact support to unfreeze the account")
+		}
+		return
+	}
+	log.Println("withdrawal successful")
+}
+```
+
+## Common Mistake
+
+Domain code logs before returning the error — every caller that also logs produces
+duplicate lines, burying the root cause in noise.
+
+```go
+func (a *Account) Withdraw(amount float64) error {
+	if a.balance < amount {
+		log.Printf("insufficient funds: balance=%.2f amount=%.2f", a.balance, amount) // ✗ domain logs
+		return &WithdrawError{Code: "INSUFFICIENT_FUNDS", Err: ErrInsufficientFunds}  // ✗ then returns
+	}
+	// ...
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.java.md
+++ b/skills/principle-error-handling/examples/withdraw.java.md
@@ -1,0 +1,87 @@
+# Error Handling — Java — Withdraw from Account
+
+## Problem
+
+Java's checked exceptions force callers to acknowledge failure, but mixing business
+errors and programmer errors in a single `Exception` loses the distinction. Three
+exception classes — `InvalidAmountException` (unchecked: bad caller input),
+`AccountFrozenException`, and `InsufficientFundsException` (both checked: domain state)
+— give callers precise `catch` branches. The domain never calls a logger; the caller
+logs exactly once at the boundary with account ID and amount.
+
+## Implementation
+
+```java
+// file: Account.java
+public class Account {
+
+    public static class InvalidAmountException extends IllegalArgumentException {
+        public InvalidAmountException(double amount) {
+            super(String.format("amount %.2f must be positive", amount));
+        }
+    }
+    public static class AccountFrozenException extends Exception {
+        public AccountFrozenException() { super("account is frozen"); }
+    }
+    public static class InsufficientFundsException extends Exception {
+        public final double available;
+        public final double requested;
+        public InsufficientFundsException(double available, double requested) {
+            super(String.format("insufficient funds: available=%.2f requested=%.2f",
+                available, requested));
+            this.available = available;
+            this.requested = requested;
+        }
+    }
+
+    public final String id;
+    private double balance;
+    private boolean frozen;
+
+    public Account(String id, double balance) { this.id = id; this.balance = balance; }
+    public void freeze() { this.frozen = true; }
+
+    public void withdraw(double amount)
+            throws AccountFrozenException, InsufficientFundsException {
+        if (amount <= 0) throw new InvalidAmountException(amount);
+        if (frozen)      throw new AccountFrozenException();
+        if (balance < amount) throw new InsufficientFundsException(balance, amount);
+        balance -= amount;
+    }
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        var acc = new Account("acct-42", 100.0);
+        try {
+            acc.withdraw(150.0);
+            System.out.println("withdrawal successful");
+        } catch (Account.AccountFrozenException e) {
+            // log ONCE at the boundary with account ID and amount
+            System.err.println("[" + acc.id + "] withdraw 150.00 failed: " + e.getMessage());
+            System.err.println("hint: contact support to unfreeze");
+        } catch (Account.InsufficientFundsException e) {
+            System.err.println("[" + acc.id + "] withdraw 150.00 failed: " + e.getMessage());
+            System.err.printf("hint: available balance is %.2f%n", e.available);
+        }
+    }
+}
+```
+
+## Common Mistake
+
+The domain calls `logger.warning` before throwing — every layer that also logs the
+exception produces duplicate log lines, obscuring which layer owns the failure.
+
+```java
+public void withdraw(double amount)
+        throws AccountFrozenException, InsufficientFundsException {
+    if (balance < amount) {
+        System.err.println("insufficient funds: balance=" + balance); // ✗ domain logs
+        throw new InsufficientFundsException(balance, amount);        // ✗ then throws
+    }
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.kt.md
+++ b/skills/principle-error-handling/examples/withdraw.kt.md
@@ -50,14 +50,11 @@ fun main() {
         onFailure = { err ->
             // log ONCE at the boundary with account ID and amount
             System.err.println("[${acc.id}] withdraw 150.0 failed: ${err.message}")
-            val e = err as WithdrawError
-            when (e) {
-                is WithdrawError.InvalidAmount ->
-                    System.err.println("hint: amount must be a positive number")
-                is WithdrawError.AccountFrozen ->
-                    System.err.println("hint: contact support to unfreeze")
-                is WithdrawError.InsufficientFunds ->
-                    System.err.println("hint: available balance is ${e.available}")
+            when (err) {
+                is WithdrawError.InvalidAmount    -> System.err.println("hint: amount must be positive")
+                is WithdrawError.AccountFrozen    -> System.err.println("hint: contact support to unfreeze")
+                is WithdrawError.InsufficientFunds -> System.err.println("hint: available is ${err.available}")
+                else                              -> Unit  // unexpected — the log above is sufficient
             }
         }
     )

--- a/skills/principle-error-handling/examples/withdraw.kt.md
+++ b/skills/principle-error-handling/examples/withdraw.kt.md
@@ -1,0 +1,80 @@
+# Error Handling — Kotlin — Withdraw from Account
+
+## Problem
+
+Kotlin's sealed class hierarchy gives exhaustive `when` matching without checked
+exceptions. Returning `Result<Unit>` from `withdraw` keeps the happy path readable
+with `fold`, while sealed `WithdrawError` subclasses carry structured fields so callers
+can act on `available` balance or frozen state — without any `println` inside the domain.
+The caller logs exactly once at the boundary.
+
+## Implementation
+
+```kotlin
+// file: account.kt
+
+sealed class WithdrawError(message: String) : Exception(message) {
+    class InvalidAmount(val amount: Double)
+        : WithdrawError("amount $amount must be positive")
+    object AccountFrozen
+        : WithdrawError("account is frozen")
+    class InsufficientFunds(val available: Double, val requested: Double)
+        : WithdrawError("insufficient funds: available=$available requested=$requested")
+}
+
+class Account(val id: String, private var balance: Double) {
+    private var frozen = false
+
+    fun freeze() { frozen = true }
+
+    fun withdraw(amount: Double): Result<Unit> {
+        if (amount <= 0.0)
+            return Result.failure(WithdrawError.InvalidAmount(amount))
+        if (frozen)
+            return Result.failure(WithdrawError.AccountFrozen)
+        if (balance < amount)
+            return Result.failure(WithdrawError.InsufficientFunds(balance, amount))
+        balance -= amount
+        return Result.success(Unit)
+    }
+}
+```
+
+```kotlin
+// file: main.kt
+fun main() {
+    val acc = Account("acct-42", 100.0)
+
+    acc.withdraw(150.0).fold(
+        onSuccess = { println("withdrawal successful") },
+        onFailure = { err ->
+            // log ONCE at the boundary with account ID and amount
+            System.err.println("[${acc.id}] withdraw 150.0 failed: ${err.message}")
+            val e = err as WithdrawError
+            when (e) {
+                is WithdrawError.InvalidAmount ->
+                    System.err.println("hint: amount must be a positive number")
+                is WithdrawError.AccountFrozen ->
+                    System.err.println("hint: contact support to unfreeze")
+                is WithdrawError.InsufficientFunds ->
+                    System.err.println("hint: available balance is ${e.available}")
+            }
+        }
+    )
+}
+```
+
+## Common Mistake
+
+The domain logs inside `withdraw` AND the result propagates — every layer that also
+logs produces duplicate output, burying the root cause in noise.
+
+```kotlin
+fun withdraw(amount: Double): Result<Unit> {
+    if (balance < amount) {
+        println("[WARN] insufficient funds: balance=$balance amount=$amount") // ✗ domain logs
+        return Result.failure(WithdrawError.InsufficientFunds(balance, amount)) // ✗ then returns
+    }
+    // ...
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.py.md
+++ b/skills/principle-error-handling/examples/withdraw.py.md
@@ -1,0 +1,88 @@
+# Error Handling — Python — Withdraw from Account
+
+## Problem
+
+Python uses exceptions for flow control, so a clear error hierarchy matters more than
+in languages with typed returns. A `WithdrawError` base class with subclasses for each
+failure — `InvalidAmountError`, `AccountFrozenError`, and `InsufficientFundsError` —
+lets callers catch at the right granularity. The `withdraw` method raises typed errors
+without calling `logging.error`; the caller logs exactly once at the boundary with
+account ID and amount.
+
+## Implementation
+
+```python
+# file: account.py
+
+class WithdrawError(Exception):
+    """Base for all withdrawal errors."""
+
+class InvalidAmountError(WithdrawError):
+    def __init__(self, amount: float):
+        super().__init__(f"amount {amount} must be positive")
+        self.amount = amount
+
+class AccountFrozenError(WithdrawError):
+    def __init__(self):
+        super().__init__("account is frozen")
+
+class InsufficientFundsError(WithdrawError):
+    def __init__(self, available: float, requested: float):
+        super().__init__(
+            f"insufficient funds: available={available:.2f} requested={requested:.2f}"
+        )
+        self.available = available
+        self.requested = requested
+
+
+class Account:
+    def __init__(self, account_id: str, balance: float) -> None:
+        self.account_id = account_id
+        self._balance   = balance
+        self._frozen    = False
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+    def withdraw(self, amount: float) -> None:
+        if amount <= 0:
+            raise InvalidAmountError(amount)
+        if self._frozen:
+            raise AccountFrozenError()
+        if self._balance < amount:
+            raise InsufficientFundsError(self._balance, amount)
+        self._balance -= amount
+```
+
+```python
+# file: main.py
+import logging
+from account import Account, AccountFrozenError, InsufficientFundsError
+
+logging.basicConfig(level=logging.INFO)
+
+acc = Account("acct-42", 100.0)
+
+try:
+    acc.withdraw(150.0)
+    logging.info("withdrawal successful")
+except AccountFrozenError as e:
+    # log ONCE at the boundary with account ID and amount
+    logging.error("withdraw failed [%s] amount=150.0: %s", acc.account_id, e)
+    logging.error("hint: contact support to unfreeze")
+except InsufficientFundsError as e:
+    logging.error("withdraw failed [%s] amount=150.0: %s", acc.account_id, e)
+    logging.error("hint: available balance is %.2f", e.available)
+```
+
+## Common Mistake
+
+The domain calls `logging.error` then re-raises — every layer that also logs produces
+duplicate log entries, burying the root cause in noise.
+
+```python
+def withdraw(self, amount: float) -> None:
+    if self._balance < amount:
+        logging.error("insufficient funds: balance=%.2f", self._balance)  # ✗ domain logs
+        raise InsufficientFundsError(self._balance, amount)                # ✗ then raises
+```

--- a/skills/principle-error-handling/examples/withdraw.rb.md
+++ b/skills/principle-error-handling/examples/withdraw.rb.md
@@ -1,0 +1,95 @@
+# Error Handling — Ruby — Withdraw from Account
+
+## Problem
+
+Ruby's exception system is expressive but easy to misuse by rescuing `StandardError`
+too broadly. A hierarchy rooted at `WithdrawError < StandardError` with subclasses for
+each failure tier lets callers rescue exactly what they can handle. The `withdraw`
+method raises typed errors without writing to `$stderr`; the caller logs exactly once
+at the boundary with account ID and amount.
+
+## Implementation
+
+```ruby
+# file: account.rb
+
+class WithdrawError < StandardError; end
+
+class InvalidAmountError < WithdrawError
+  attr_reader :amount
+  def initialize(amount)
+    super("amount #{amount} must be positive")
+    @amount = amount
+  end
+end
+
+class AccountFrozenError < WithdrawError
+  def initialize
+    super("account is frozen")
+  end
+end
+
+class InsufficientFundsError < WithdrawError
+  attr_reader :available, :requested
+  def initialize(available, requested)
+    super("insufficient funds: available=#{format('%.2f', available)} " \
+          "requested=#{format('%.2f', requested)}")
+    @available = available
+    @requested = requested
+  end
+end
+
+class Account
+  attr_reader :account_id
+
+  def initialize(account_id, balance)
+    @account_id = account_id
+    @balance    = balance
+    @frozen     = false
+  end
+
+  def freeze!
+    @frozen = true
+  end
+
+  def withdraw(amount)
+    raise InvalidAmountError.new(amount)               if amount <= 0
+    raise AccountFrozenError.new                       if @frozen
+    raise InsufficientFundsError.new(@balance, amount) if @balance < amount
+    @balance -= amount
+  end
+end
+```
+
+```ruby
+# file: main.rb
+require_relative "account"
+
+acc = Account.new("acct-42", 100.0)
+
+begin
+  acc.withdraw(150.0)
+  puts "withdrawal successful"
+rescue AccountFrozenError => e
+  # log ONCE at the boundary with account ID and amount
+  $stderr.puts "[#{acc.account_id}] withdraw 150.0 failed: #{e.message}"
+  $stderr.puts "hint: contact support to unfreeze"
+rescue InsufficientFundsError => e
+  $stderr.puts "[#{acc.account_id}] withdraw 150.0 failed: #{e.message}"
+  $stderr.puts "hint: available balance is #{format('%.2f', e.available)}"
+end
+```
+
+## Common Mistake
+
+The domain calls `$stderr.puts` before raising — every layer that also logs the
+exception produces duplicate log lines, obscuring which layer owns the failure.
+
+```ruby
+def withdraw(amount)
+  if @balance < amount
+    $stderr.puts "insufficient funds: balance=#{@balance}"        # ✗ domain logs
+    raise InsufficientFundsError.new(@balance, amount)            # ✗ then raises
+  end
+end
+```

--- a/skills/principle-error-handling/examples/withdraw.rs.md
+++ b/skills/principle-error-handling/examples/withdraw.rs.md
@@ -1,0 +1,109 @@
+# Error Handling — Rust — Withdraw from Account
+
+## Problem
+
+Rust's `Result<T, E>` with a typed `enum` error makes every failure path visible in
+the function signature and forces exhaustive handling at the call site. The `withdraw`
+method carries structured fields (`available`, `requested`) so callers get actionable
+data — not just a message — without any logging inside the domain type.
+The caller logs exactly once at the boundary with full context.
+
+## Implementation
+
+```rust
+// file: account.rs
+use std::fmt;
+
+#[derive(Debug)]
+pub enum WithdrawError {
+    InvalidAmount(f64),
+    AccountFrozen,
+    InsufficientFunds { available: f64, requested: f64 },
+}
+
+impl fmt::Display for WithdrawError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidAmount(a)  => write!(f, "invalid amount: {a:.2} must be positive"),
+            Self::AccountFrozen     => write!(f, "account is frozen"),
+            Self::InsufficientFunds { available, requested } =>
+                write!(f, "insufficient funds: available={available:.2} requested={requested:.2}"),
+        }
+    }
+}
+
+impl std::error::Error for WithdrawError {}
+
+pub struct Account {
+    pub id: String,
+    balance: f64,
+    frozen: bool,
+}
+
+impl Account {
+    pub fn new(id: &str, balance: f64) -> Self {
+        Self { id: id.to_string(), balance, frozen: false }
+    }
+    pub fn freeze(&mut self) { self.frozen = true; }
+
+    pub fn withdraw(&mut self, amount: f64) -> Result<(), WithdrawError> {
+        if amount <= 0.0 {
+            return Err(WithdrawError::InvalidAmount(amount));
+        }
+        if self.frozen {
+            return Err(WithdrawError::AccountFrozen);
+        }
+        if self.balance < amount {
+            return Err(WithdrawError::InsufficientFunds {
+                available: self.balance,
+                requested: amount,
+            });
+        }
+        self.balance -= amount;
+        Ok(())
+    }
+}
+```
+
+```rust
+// file: main.rs
+mod account;
+use account::WithdrawError;
+
+fn main() {
+    let mut acc = account::Account::new("acct-42", 100.0);
+
+    match acc.withdraw(150.0) {
+        Ok(()) => println!("withdrawal successful"),
+        Err(e) => {
+            // log ONCE at the boundary with account ID and amount
+            eprintln!("[{}] withdraw 150.00 failed: {}", acc.id, e);
+            match e {
+                WithdrawError::InsufficientFunds { available, .. } =>
+                    eprintln!("hint: available balance is {available:.2}"),
+                WithdrawError::AccountFrozen =>
+                    eprintln!("hint: contact support to unfreeze"),
+                WithdrawError::InvalidAmount(_) =>
+                    eprintln!("hint: amount must be a positive number"),
+            }
+        }
+    }
+}
+```
+
+## Common Mistake
+
+The domain method calls `eprintln!` before returning `Err` — every layer that also
+logs the error produces a duplicate line, making log correlation impossible.
+
+```rust
+pub fn withdraw(&mut self, amount: f64) -> Result<(), WithdrawError> {
+    if self.balance < amount {
+        eprintln!("insufficient funds: {}", self.balance); // ✗ domain logs
+        return Err(WithdrawError::InsufficientFunds {      // ✗ then returns error
+            available: self.balance, requested: amount,
+        });
+    }
+    // ...
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.swift.md
+++ b/skills/principle-error-handling/examples/withdraw.swift.md
@@ -1,0 +1,88 @@
+# Error Handling — Swift — Withdraw from Account
+
+## Problem
+
+Swift's `throws` + typed `enum Error` make every failure site explicit in the function
+signature. A `WithdrawError` enum with associated values for each case — `.invalidAmount`,
+`.accountFrozen`, and `.insufficientFunds` — lets callers `catch` each case individually
+in a `do/catch` block with pattern matching. The domain never calls `print`; the caller
+logs exactly once at the boundary with account ID and amount.
+
+## Implementation
+
+```swift
+// file: account.swift
+import Foundation
+
+enum WithdrawError: Error {
+    case invalidAmount(Double)
+    case accountFrozen
+    case insufficientFunds(available: Double, requested: Double)
+}
+
+extension WithdrawError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidAmount(let a):
+            return "amount \(a) must be positive"
+        case .accountFrozen:
+            return "account is frozen"
+        case .insufficientFunds(let available, let requested):
+            return String(format: "insufficient funds: available=%.2f requested=%.2f",
+                          available, requested)
+        }
+    }
+}
+
+struct Account {
+    let id: String
+    private var balance: Double
+    private var frozen: Bool = false
+
+    init(id: String, balance: Double) { self.id = id; self.balance = balance }
+
+    mutating func freeze() { frozen = true }
+
+    mutating func withdraw(amount: Double) throws {
+        if amount <= 0      { throw WithdrawError.invalidAmount(amount) }
+        if frozen           { throw WithdrawError.accountFrozen }
+        if balance < amount { throw WithdrawError.insufficientFunds(available: balance,
+                                                                      requested: amount) }
+        balance -= amount
+    }
+}
+```
+
+```swift
+// file: main.swift
+var acc = Account(id: "acct-42", balance: 100.0)
+
+do {
+    try acc.withdraw(amount: 150.0)
+    print("withdrawal successful")
+} catch WithdrawError.accountFrozen {
+    // log ONCE at the boundary with account ID and amount
+    fputs("[\(acc.id)] withdraw 150.0 failed: account is frozen\n", stderr)
+    fputs("hint: contact support to unfreeze\n", stderr)
+} catch WithdrawError.insufficientFunds(let available, _) {
+    fputs("[\(acc.id)] withdraw 150.0 failed: insufficient funds\n", stderr)
+    fputs(String(format: "hint: available balance is %.2f\n", available), stderr)
+} catch {
+    fputs("[\(acc.id)] withdraw failed: \(error)\n", stderr)
+}
+```
+
+## Common Mistake
+
+The domain calls `print` before throwing — every layer that also logs the error
+produces two outputs per failure, making log correlation impossible.
+
+```swift
+mutating func withdraw(amount: Double) throws {
+    if balance < amount {
+        print("insufficient funds: balance=\(balance)")          // ✗ domain logs
+        throw WithdrawError.insufficientFunds(available: balance, // ✗ then throws
+                                              requested: amount)
+    }
+}
+```

--- a/skills/principle-error-handling/examples/withdraw.ts.md
+++ b/skills/principle-error-handling/examples/withdraw.ts.md
@@ -1,0 +1,89 @@
+# Error Handling — TypeScript — Withdraw from Account
+
+## Problem
+
+TypeScript has no checked exceptions, so thrown errors are `unknown` at catch sites
+and callers cannot branch on kind without unsafe narrowing. A discriminated-union
+`WithdrawError` returned inside a `Result`-style object makes every failure case
+explicit in the return type, forcing callers to handle `invalid_amount`, `frozen`,
+and `insufficient_funds` before accessing a successful result — with no `console.log`
+inside the domain code.
+
+## Implementation
+
+```typescript
+// file: account.ts
+
+export type WithdrawError =
+  | { kind: "invalid_amount"; message: string }
+  | { kind: "frozen";          message: string }
+  | { kind: "insufficient_funds"; message: string; available: number };
+
+type WithdrawResult = { ok: true } | { ok: false; error: WithdrawError };
+
+export class Account {
+  readonly id: string;
+  private balance: number;
+  private frozen: boolean;
+
+  constructor(id: string, balance: number) {
+    this.id      = id;
+    this.balance = balance;
+    this.frozen  = false;
+  }
+
+  freeze(): void { this.frozen = true; }
+
+  withdraw(amount: number): WithdrawResult {
+    if (amount <= 0) {
+      return { ok: false, error: { kind: "invalid_amount",
+        message: `amount ${amount} must be positive` } };
+    }
+    if (this.frozen) {
+      return { ok: false, error: { kind: "frozen",
+        message: "account is frozen" } };
+    }
+    if (this.balance < amount) {
+      return { ok: false, error: { kind: "insufficient_funds",
+        message: `insufficient funds: available ${this.balance}, requested ${amount}`,
+        available: this.balance } };
+    }
+    this.balance -= amount;
+    return { ok: true };
+  }
+}
+```
+
+```typescript
+// file: main.ts
+import { Account } from "./account";
+
+const acc = new Account("acct-42", 100);
+const result = acc.withdraw(150);
+
+if (!result.ok) {
+  // log ONCE at the boundary with account ID and amount
+  console.error(`[${acc.id}] withdraw 150 failed: ${result.error.message}`);
+  if (result.error.kind === "insufficient_funds") {
+    console.error(`hint: available balance is ${result.error.available}`);
+  }
+  process.exit(1);
+}
+console.log("withdrawal successful");
+```
+
+## Common Mistake
+
+The domain method calls `console.error` before returning the failure object — every
+caller that also logs produces a duplicate entry, making log correlation impossible.
+
+```typescript
+withdraw(amount: number): WithdrawResult {
+  if (this.balance < amount) {
+    console.error(`insufficient funds: ${this.balance}`);         // ✗ domain logs
+    return { ok: false, error: { kind: "insufficient_funds",      // ✗ then returns
+      message: "insufficient funds", available: this.balance } };
+  }
+  // ...
+}
+```


### PR DESCRIPTION
## Summary

- Add 27 worked error-handling example files to `skills/principle-error-handling/examples/` — 3 scenarios × 9 OO languages (C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript)
- **Scenario 1 — `config.<lang>.md`:** parse & validate a `key=value` config file; three error tiers (IO / parse / validation); each language uses its idiomatic style (Go `%w` wrap, Rust `Result`+`?`+typed enum, TypeScript discriminated union, Kotlin sealed class, Java/C# checked exception hierarchy, Python `raise…from`, Ruby `rescue` re-raise, Swift `throws`+`do/catch`)
- **Scenario 2 — `fetch.<lang>.md`:** HTTP fetch with retry; injected `Transport` interface + deterministic `FakeTransport`; classifies transient (5xx/timeout) vs permanent (4xx); exponential backoff + jitter; per-attempt timeout modelled; exhausted sentinel after `maxRetries`
- **Scenario 3 — `withdraw.<lang>.md`:** in-memory account withdrawal; three typed errors in order (invalid amount → frozen → insufficient funds); domain returns errors **without logging**; caller logs once at the boundary (log-once discipline)
- Add one pointer blockquote to `SKILL.md` immediately before `## Red Flags`, listing all 3 scenarios + 9 languages + "(read on demand — not auto-loaded)"

> **Scope note:** Issue #376's written acceptance said "one shared scenario × 9 files." During planning review the scope was expanded to three scenarios × 9 languages = 27 files, mirroring the Core-4 precedent in PR #439. This expansion is intentional.

## Test Plan

- [x] `bash scripts/validate.sh` → `All checks passed.` (enforces ≤120 lines/example, ≤150 lines SKILL.md)
- [x] `python3 -m pytest tests/` → 1324/1324 pass (no regression)
- [x] `wc -l skills/principle-error-handling/examples/*.md` → max 119 lines, all ≤120
- [x] `ls skills/principle-error-handling/examples/ | wc -l` → 27 files
- [x] `wc -l skills/principle-error-handling/SKILL.md` → 102 lines (cap 150)
- [x] Spot-read `config.rs.md`, `fetch.go.md`, `withdraw.py.md` — idiom and `✗`-annotated Common Mistake render correctly
- [x] Two-stage review (spec compliance + code quality) per scenario; all Critical and Important issues fixed before push

### Type-tailored checks ([feat])
- [x] New behaviour present: 27 example files exist under `examples/` with correct naming convention
- [x] SKILL.md pointer added and loads only on demand (not in frontmatter `description:`)
- [x] Each file exercises the skill sections it is mapped to (config → Errors as Values / Wrap Don't Swallow; fetch → Retries and Backoff / Timeouts; withdraw → Sentinel vs Typed / Where to Handle)

Closes #376
