### PR TITLE
[feat] Add worked Light DDD examples to principle-ddd (9 OO languages)

### DIFF
--- a/skills/principle-ddd/SKILL.md
+++ b/skills/principle-ddd/SKILL.md
@@ -68,3 +68,5 @@ Stateless domain logic that does not belong on a single entity (e.g., a transfer
 | **Complex invariants** | Aggregates, domain events, specifications | Interface + unit of work | Portfolio rebalancing with multi-asset constraints |
 
 **Light DDD is the floor when business rules exist**: entity behavior + repository interfaces + value objects for constrained types are non-negotiable even for "simple" cases.
+
+> See `examples/` for a worked Light DDD Order-aggregate implementation (Money value object, aggregate root enforcing one invariant, repository port) in C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, and TypeScript (read on demand — not auto-loaded).

--- a/skills/principle-ddd/examples/order.cs.md
+++ b/skills/principle-ddd/examples/order.cs.md
@@ -1,0 +1,90 @@
+# Light DDD — C# — Order Aggregate
+
+## Problem
+
+C#'s `readonly record struct` gives `Money` structural equality and immutability with
+zero boilerplate — the compiler enforces it. Keeping `_lines` private on `Order` means
+`AddLine` and `Submit` are the only mutation paths; the aggregate root invariant is a
+naming and access-modifier discipline rather than a compiler guarantee, which makes the
+mistake of exposing a public `List<T>` especially easy to commit by accident.
+
+## Implementation
+
+```csharp
+// file: Money.cs
+public readonly record struct Money(long MinorUnits, string Currency)
+{
+    public Money Plus(Money other)
+    {
+        if (Currency != other.Currency)
+            throw new ArgumentException(
+                $"Currency mismatch: {Currency} vs {other.Currency}");
+        return new Money(MinorUnits + other.MinorUnits, Currency);
+    }
+}
+```
+
+```csharp
+// file: Order.cs
+public record OrderLine(string Sku, Money Price);
+
+public sealed class Order
+{
+    private enum Status { Draft, Submitted }
+
+    private readonly List<OrderLine> _lines = new();
+    private Status _status = Status.Draft;
+
+    public string Id { get; }
+    public int LineCount => _lines.Count;
+
+    public Order(string id) => Id = id;
+
+    public void AddLine(string sku, Money price)
+    {
+        if (_status == Status.Submitted)
+            throw new InvalidOperationException(
+                "Cannot add lines to a submitted order");
+        _lines.Add(new OrderLine(sku, price));
+    }
+
+    public void Submit() => _status = Status.Submitted;
+}
+```
+
+```csharp
+// file: IOrderRepository.cs  (domain port only — no implementation)
+public interface IOrderRepository
+{
+    Order? Find(string id);
+    void Save(Order order);
+}
+```
+
+```csharp
+// file: Program.cs
+var order = new Order("ord-1");
+order.AddLine("SKU-1", new Money(1299, "USD"));
+order.Submit();
+try
+{
+    order.AddLine("SKU-2", new Money(500, "USD"));
+}
+catch (InvalidOperationException e)
+{
+    Console.WriteLine($"rejected: {e.Message}");
+    // rejected: Cannot add lines to a submitted order
+}
+```
+
+## Common Mistake
+
+Exposing lines as a public `List<OrderLine>` property lets any caller call `.Add()`
+directly after `Submit()`, bypassing the aggregate root and silently breaking the invariant.
+
+```csharp
+public sealed class Order
+{
+    public List<OrderLine> Lines { get; } = new();  // ✗ callers can .Add() after Submit()
+}
+```

--- a/skills/principle-ddd/examples/order.go.md
+++ b/skills/principle-ddd/examples/order.go.md
@@ -12,6 +12,7 @@ exceptions) and `OrderRepository` is a plain `interface` — a domain port with
 zero infrastructure coupling.
 
 ## Implementation
+
 ```go
 // file: money.go
 package ddd
@@ -111,7 +112,6 @@ func main() {
 ## Common Mistake
 
 Exporting `Lines` as a public field lets callers `append` after `Submit()`, bypassing the aggregate root.
-
 ```go
 type Order struct {
 	ID     string

--- a/skills/principle-ddd/examples/order.go.md
+++ b/skills/principle-ddd/examples/order.go.md
@@ -1,0 +1,120 @@
+# Light DDD — Go — Order Aggregate
+
+## Problem
+
+Go has no `immutable` or `final` keyword — value object semantics come from
+unexported fields, value receivers, and the absence of setters. Callers cannot
+mutate `Money` directly; they go through constructors or methods that return new
+values. The `Order` aggregate root hides `lines []orderLine` behind an unexported
+field so only `AddLine` and `Submit` can mutate it, keeping the draft-only
+invariant enforceable. `AddLine` returns `error` (Go's idiomatic flow — no
+exceptions) and `OrderRepository` is a plain `interface` — a domain port with
+zero infrastructure coupling.
+
+## Implementation
+```go
+// file: money.go
+package ddd
+
+import "fmt"
+
+type Money struct {
+	minorUnits int64
+	currency   string
+}
+
+func NewMoney(minorUnits int64, currency string) Money {
+	return Money{minorUnits: minorUnits, currency: currency}
+}
+
+func (m Money) Plus(other Money) (Money, error) {
+	if m.currency != other.currency {
+		return Money{}, fmt.Errorf("currency mismatch: %s vs %s", m.currency, other.currency)
+	}
+	return Money{minorUnits: m.minorUnits + other.minorUnits, currency: m.currency}, nil
+}
+
+func (m Money) Equal(other Money) bool {
+	return m.minorUnits == other.minorUnits && m.currency == other.currency
+}
+```
+
+```go
+// file: order.go
+package ddd
+
+import "errors"
+
+type status int
+
+const (
+	draft status = iota
+	submitted
+)
+
+type orderLine struct {
+	sku   string
+	price Money
+}
+
+type Order struct {
+	ID     string
+	status status
+	lines  []orderLine // unexported: only mutated through aggregate root methods
+}
+
+func NewOrder(id string) *Order {
+	return &Order{ID: id}
+}
+
+func (o *Order) AddLine(sku string, price Money) error {
+	if o.status == submitted {
+		return errors.New("cannot add lines to a submitted order")
+	}
+	o.lines = append(o.lines, orderLine{sku: sku, price: price})
+	return nil
+}
+
+func (o *Order) Submit()       { o.status = submitted }
+func (o *Order) LineCount() int { return len(o.lines) }
+```
+
+```go
+// file: repository.go
+package ddd
+
+type OrderRepository interface {
+	Find(id string) (*Order, bool)
+	Save(order *Order)
+}
+```
+
+```go
+// file: main.go
+package main
+
+import (
+	"ddd"
+	"fmt"
+)
+
+func main() {
+	order := ddd.NewOrder("ord-1")
+	_ = order.AddLine("SKU-1", ddd.NewMoney(1299, "USD"))
+	order.Submit()
+	if err := order.AddLine("SKU-2", ddd.NewMoney(500, "USD")); err != nil {
+		fmt.Println("rejected:", err) // rejected: cannot add lines to a submitted order
+	}
+}
+```
+
+## Common Mistake
+
+Exporting `Lines` as a public field lets callers `append` after `Submit()`, bypassing the aggregate root.
+
+```go
+type Order struct {
+	ID     string
+	Lines []OrderLine // ✗ callers can append after Submit() — invariant broken (OrderLine also exported)
+}
+```

--- a/skills/principle-ddd/examples/order.java.md
+++ b/skills/principle-ddd/examples/order.java.md
@@ -1,0 +1,99 @@
+# Light DDD — Java — Order Aggregate
+
+## Problem
+
+Java records give value-object semantics with zero boilerplate: `equals`, `hashCode`,
+and accessors are generated, so `Money` is compared by value without a custom `equals`.
+The `Order` aggregate root keeps its `lines` list private; the only mutation paths are
+`addLine` and `submit`, which enforce the invariant that lines cannot be added once
+an order is submitted.
+
+## Implementation
+
+```java
+// file: Money.java
+public record Money(long minorUnits, String currency) {
+    public Money plus(Money other) {
+        if (!this.currency.equals(other.currency)) {
+            throw new IllegalArgumentException(
+                "currency mismatch: " + this.currency + " vs " + other.currency);
+        }
+        return new Money(this.minorUnits + other.minorUnits, this.currency);
+    }
+}
+```
+
+```java
+// file: Order.java
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Order {
+
+    public record OrderLine(String sku, Money price) {}
+
+    private enum Status { DRAFT, SUBMITTED }
+
+    private final String id;
+    private Status status = Status.DRAFT;
+    private final List<OrderLine> lines = new ArrayList<>();
+
+    public Order(String id) { this.id = id; }
+
+    public void addLine(String sku, Money price) {
+        if (status == Status.SUBMITTED) {
+            throw new IllegalStateException("cannot add lines to a submitted order");
+        }
+        lines.add(new OrderLine(sku, price));
+    }
+
+    public void submit() { this.status = Status.SUBMITTED; }
+
+    public int lineCount() { return lines.size(); }
+
+    public List<OrderLine> getLines() {
+        return Collections.unmodifiableList(lines); // defensive copy — callers cannot mutate
+    }
+
+    public String getId() { return id; }
+}
+```
+
+```java
+// file: OrderRepository.java
+import java.util.Optional;
+
+public interface OrderRepository {
+    Optional<Order> find(String id);
+    void save(Order order);
+}
+```
+
+```java
+// file: Main.java
+public class Main {
+    public static void main(String[] args) {
+        Order order = new Order("ord-1");
+        order.addLine("SKU-1", new Money(1299, "USD"));
+        order.submit();
+        try {
+            order.addLine("SKU-2", new Money(500, "USD"));
+        } catch (IllegalStateException e) {
+            System.out.println("rejected: " + e.getMessage());
+            // rejected: cannot add lines to a submitted order
+        }
+    }
+}
+```
+
+## Common Mistake
+
+Returning the internal `List<OrderLine>` directly lets callers call `.add()` on it,
+bypassing the aggregate root and silently breaking the submitted-order invariant.
+
+```java
+public List<OrderLine> getLines() {
+    return lines; // ✗ callers can call lines.add(...) after submit() — invariant broken
+}
+```

--- a/skills/principle-ddd/examples/order.java.md
+++ b/skills/principle-ddd/examples/order.java.md
@@ -53,7 +53,7 @@ public class Order {
     public int lineCount() { return lines.size(); }
 
     public List<OrderLine> getLines() {
-        return Collections.unmodifiableList(lines); // defensive copy — callers cannot mutate
+        return Collections.unmodifiableList(lines); // read-only view — callers cannot mutate via this reference
     }
 
     public String getId() { return id; }

--- a/skills/principle-ddd/examples/order.kt.md
+++ b/skills/principle-ddd/examples/order.kt.md
@@ -1,0 +1,82 @@
+# Light DDD — Kotlin — Order Aggregate
+
+## Problem
+
+Kotlin `data class` gives value-object semantics with structural equality built-in, so
+`Money` is compared by value without a custom `equals`. The `Order` aggregate root keeps
+`_lines` private and backs a read-only `List<OrderLine>` property; the only mutation
+paths are `addLine` and `submit`, which use Kotlin's `check(...)` to enforce the invariant
+that lines cannot be added once an order is submitted.
+
+## Implementation
+
+```kotlin
+// file: Money.kt
+data class Money(val minorUnits: Long, val currency: String) {
+    operator fun plus(other: Money): Money {
+        require(currency == other.currency) {
+            "currency mismatch: $currency vs ${other.currency}"
+        }
+        return Money(minorUnits + other.minorUnits, currency)
+    }
+}
+```
+
+```kotlin
+// file: Order.kt
+data class OrderLine(val sku: String, val price: Money)
+
+class Order(val id: String) {
+
+    private enum class Status { DRAFT, SUBMITTED }
+
+    private var status = Status.DRAFT
+    private val _lines: MutableList<OrderLine> = mutableListOf()
+
+    val lines: List<OrderLine> get() = _lines.toList()
+    val lineCount: Int get() = _lines.size
+
+    fun addLine(sku: String, price: Money) {
+        check(status == Status.DRAFT) { "cannot add lines to a submitted order" }
+        _lines.add(OrderLine(sku, price))
+    }
+
+    fun submit() {
+        status = Status.SUBMITTED
+    }
+}
+```
+
+```kotlin
+// file: OrderRepository.kt
+interface OrderRepository {
+    fun find(id: String): Order?
+    fun save(order: Order)
+}
+```
+
+```kotlin
+// file: main.kt (usage)
+fun main() {
+    val order = Order("ord-1")
+    order.addLine("SKU-1", Money(1299, "USD"))
+    order.submit()
+    try {
+        order.addLine("SKU-2", Money(500, "USD"))
+    } catch (e: IllegalStateException) {
+        println("rejected: ${e.message}")
+        // rejected: cannot add lines to a submitted order
+    }
+}
+```
+
+## Common Mistake
+
+Exposing `_lines` as a `val lines: MutableList<OrderLine>` property lets callers call
+`.add()` directly, bypassing the aggregate root and silently breaking the submitted-order
+invariant.
+
+```kotlin
+// file: Order.kt (anti-pattern)
+val lines: MutableList<OrderLine> = mutableListOf() // ✗ callers can call lines.add(...) after submit() — invariant broken
+```

--- a/skills/principle-ddd/examples/order.py.md
+++ b/skills/principle-ddd/examples/order.py.md
@@ -1,0 +1,104 @@
+# Light DDD — Python — Order Aggregate
+
+## Problem
+
+Python's `@dataclass(frozen=True)` gives `Money` immutability plus structural equality
+(`__eq__` and `__hash__` generated from fields) — no manual `__eq__` needed. The `Order`
+aggregate root guards its `_lines` list behind `add_line` and `submit`, enforcing the
+invariant that lines may not be added once an order is submitted. `Protocol` expresses the
+repository port without requiring inheritance.
+
+## Implementation
+
+```python
+# file: money.py
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Money:
+    minor_units: int
+    currency: str
+
+    def plus(self, other: "Money") -> "Money":
+        if self.currency != other.currency:
+            raise ValueError(
+                f"currency mismatch: {self.currency} vs {other.currency}"
+            )
+        return Money(self.minor_units + other.minor_units, self.currency)
+```
+
+```python
+# file: order.py
+from dataclasses import dataclass
+from enum import Enum, auto
+from money import Money
+
+
+class _Status(Enum):
+    DRAFT = auto()
+    SUBMITTED = auto()
+
+
+@dataclass(frozen=True)
+class OrderLine:
+    sku: str
+    price: Money
+
+
+class Order:
+    def __init__(self, id: str) -> None:
+        self.id = id
+        self._status = _Status.DRAFT
+        self._lines: list[OrderLine] = []
+
+    def add_line(self, sku: str, price: Money) -> None:
+        if self._status == _Status.SUBMITTED:
+            raise ValueError("cannot add lines to a submitted order")
+        self._lines.append(OrderLine(sku, price))
+
+    def submit(self) -> None:
+        self._status = _Status.SUBMITTED
+
+    def line_count(self) -> int:
+        return len(self._lines)
+
+    def lines(self) -> list[OrderLine]:
+        return list(self._lines)  # defensive copy — callers cannot mutate the root
+```
+
+```python
+# file: order_repository.py
+from typing import Optional, Protocol
+from order import Order
+
+
+class OrderRepository(Protocol):
+    def find(self, id: str) -> Optional[Order]: ...
+    def save(self, order: Order) -> None: ...
+```
+
+```python
+# file: main.py
+from money import Money
+from order import Order
+
+order = Order("ord-1")
+order.add_line("SKU-1", Money(1299, "USD"))
+order.submit()
+try:
+    order.add_line("SKU-2", Money(500, "USD"))
+except ValueError as e:
+    print(f"rejected: {e}")
+    # rejected: cannot add lines to a submitted order
+```
+
+## Common Mistake
+
+Returning `self._lines` directly lets callers call `.append()` on the list, bypassing the
+aggregate root and silently breaking the submitted-order invariant.
+
+```python
+def lines(self) -> list[OrderLine]:
+    return self._lines  # ✗ callers can append after submit() — invariant broken
+```

--- a/skills/principle-ddd/examples/order.rb.md
+++ b/skills/principle-ddd/examples/order.rb.md
@@ -43,7 +43,9 @@ require_relative 'money'
 
 class OrderError < StandardError; end
 
-OrderLine = Struct.new(:sku, :price)
+OrderLine = Struct.new(:sku, :price) do
+  def initialize(sku, price) = super.freeze
+end
 
 class Order
   attr_reader :id

--- a/skills/principle-ddd/examples/order.rb.md
+++ b/skills/principle-ddd/examples/order.rb.md
@@ -1,0 +1,106 @@
+# Light DDD — Ruby — Order Aggregate
+
+## Problem
+
+Ruby has no built-in value-object construct, so `Money` is a plain class with `attr_reader`,
+a custom `==`/`hash`, and `freeze` in the constructor to enforce immutability. The `Order`
+aggregate root keeps `@lines` as a private instance variable; `add_line` and `submit` are
+the only mutation paths. `OrderRepository` is a module that raises `NotImplementedError` on
+every abstract method — a duck-typed port with no infrastructure coupling.
+
+## Implementation
+
+```ruby
+# file: money.rb
+class Money
+  attr_reader :minor_units, :currency
+
+  def initialize(minor_units, currency)
+    @minor_units = minor_units
+    @currency    = currency
+    freeze
+  end
+
+  def plus(other)
+    raise ArgumentError, "currency mismatch: #{currency} vs #{other.currency}" unless currency == other.currency
+    Money.new(minor_units + other.minor_units, currency)
+  end
+
+  def ==(other)
+    other.is_a?(Money) && minor_units == other.minor_units && currency == other.currency
+  end
+  alias eql? ==
+
+  def hash
+    [minor_units, currency].hash
+  end
+end
+```
+
+```ruby
+# file: order.rb
+require_relative 'money'
+
+class OrderError < StandardError; end
+
+OrderLine = Struct.new(:sku, :price)
+
+class Order
+  attr_reader :id
+
+  def initialize(id)
+    @id     = id
+    @status = :draft
+    @lines  = []
+  end
+
+  def add_line(sku, price)
+    raise OrderError, "cannot add lines to a submitted order" if @status == :submitted
+    @lines << OrderLine.new(sku, price)
+  end
+
+  def submit
+    @status = :submitted
+  end
+
+  def line_count
+    @lines.size
+  end
+end
+```
+
+```ruby
+# file: order_repository.rb
+# Ruby has no interface keyword — this module raises NotImplementedError at call time,
+# not load time; callers must override both methods or a runtime error occurs on use.
+module OrderRepository
+  def find(id)    = raise NotImplementedError
+  def save(order) = raise NotImplementedError
+end
+```
+
+```ruby
+# file: main.rb (usage)
+require_relative 'money'
+require_relative 'order'
+
+order = Order.new("ord-1")
+order.add_line("SKU-1", Money.new(1299, "USD"))
+order.submit
+begin
+  order.add_line("SKU-2", Money.new(500, "USD"))
+rescue OrderError => e
+  puts "rejected: #{e.message}"
+  # rejected: cannot add lines to a submitted order
+end
+```
+
+## Common Mistake
+
+Adding `attr_reader :lines` exposes `@lines` directly; callers can call `.push()` on the
+array after `submit`, bypassing the aggregate root and silently breaking the invariant.
+
+```ruby
+# file: order.rb (anti-pattern)
+attr_reader :lines # ✗ callers can call order.lines.push(...) after submit — invariant broken
+```

--- a/skills/principle-ddd/examples/order.rs.md
+++ b/skills/principle-ddd/examples/order.rs.md
@@ -1,0 +1,97 @@
+# Light DDD — Rust — Order Aggregate
+
+## Problem
+
+Rust's ownership model makes the aggregate root pattern a natural fit: private fields
+with `&mut self` methods are the only mutation path, so the compiler enforces the sole
+entry point rule structurally. `Money` is a value object with `derive(PartialEq, Eq)` —
+compared by value, no identity. The same-currency guard in `plus()` is a domain
+invariant expressed as a `Result`, not a panic.
+
+## Implementation
+
+```rust
+// file: money.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Money { minor_units: i64, currency: String }
+
+impl Money {
+    pub fn new(minor_units: i64, currency: &str) -> Self {
+        Self { minor_units, currency: currency.to_string() }
+    }
+    pub fn plus(&self, other: &Money) -> Result<Money, String> {
+        if self.currency != other.currency {
+            return Err(format!("currency mismatch: {} vs {}", self.currency, other.currency));
+        }
+        Ok(Money::new(self.minor_units + other.minor_units, &self.currency))
+    }
+}
+```
+
+```rust
+// file: order.rs
+use crate::money::Money;
+
+#[derive(PartialEq)]
+enum Status { Draft, Submitted }
+
+pub struct OrderLine { pub sku: String, pub price: Money }
+
+pub struct Order {
+    pub id: String,
+    status: Status,
+    lines: Vec<OrderLine>,  // private: only mutated through aggregate root methods
+}
+
+impl Order {
+    pub fn new(id: &str) -> Self {
+        Self { id: id.to_string(), status: Status::Draft, lines: Vec::new() }
+    }
+    pub fn add_line(&mut self, sku: &str, price: Money) -> Result<(), String> {
+        if self.status == Status::Submitted {
+            return Err("cannot add lines to a submitted order".into());
+        }
+        self.lines.push(OrderLine { sku: sku.to_string(), price });
+        Ok(())
+    }
+    pub fn submit(&mut self) { self.status = Status::Submitted; }
+    pub fn line_count(&self) -> usize { self.lines.len() }
+}
+```
+
+```rust
+// file: repository.rs  (domain-layer port — no implementation)
+use crate::order::Order;
+
+pub trait OrderRepository {
+    fn find(&self, id: &str) -> Option<Order>;
+    fn save(&mut self, order: Order);
+}
+```
+
+```rust
+// file: main.rs
+mod money; mod order; mod repository;
+use money::Money; use order::Order;
+
+fn main() {
+    let mut order = Order::new("ord-1");
+    order.add_line("SKU-1", Money::new(1299, "USD")).unwrap();
+    order.submit();
+    match order.add_line("SKU-2", Money::new(500, "USD")) {
+        Ok(())  => println!("added"),
+        Err(e)  => println!("rejected: {e}"),  // "rejected: cannot add lines to a submitted order"
+    }
+}
+```
+
+## Common Mistake
+
+Exposing `lines` as `pub` (or returning `&mut Vec<OrderLine>`) lets callers call `.push()`
+directly after `submit()`, bypassing the root and silently breaking the invariant.
+
+```rust
+pub struct Order {
+    pub lines: Vec<OrderLine>,  // ✗ callers can push after submit() — invariant broken
+}
+```

--- a/skills/principle-ddd/examples/order.rs.md
+++ b/skills/principle-ddd/examples/order.rs.md
@@ -32,11 +32,13 @@ impl Money {
 // file: order.rs
 use crate::money::Money;
 
-#[derive(PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 enum Status { Draft, Submitted }
 
+#[derive(Debug, Clone)]
 pub struct OrderLine { pub sku: String, pub price: Money }
 
+#[derive(Debug, Clone)]
 pub struct Order {
     pub id: String,
     status: Status,

--- a/skills/principle-ddd/examples/order.swift.md
+++ b/skills/principle-ddd/examples/order.swift.md
@@ -39,9 +39,9 @@ struct OrderLine {
     let price: Money
 }
 
-private enum Status { case draft, submitted }
-
 class Order {
+    private enum Status { case draft, submitted }
+
     let id: String
     private var status: Status = .draft
     private var lines: [OrderLine] = []

--- a/skills/principle-ddd/examples/order.swift.md
+++ b/skills/principle-ddd/examples/order.swift.md
@@ -1,0 +1,94 @@
+# Light DDD — Swift — Order Aggregate
+
+## Problem
+
+Swift `struct` gives value-object semantics with `Equatable` structural equality, so `Money`
+compares by value without custom logic. `Order` is a `class` aggregate root — reference
+semantics mean a single instance is mutated in place, so invariants enforced by `addLine`
+and `submit` hold for every caller that holds the same reference.
+
+## Implementation
+
+```swift
+// file: Money.swift
+enum MoneyError: Error {
+    case currencyMismatch(String, String)
+}
+
+struct Money: Equatable {
+    let minorUnits: Int
+    let currency: String
+
+    func plus(_ other: Money) throws -> Money {
+        guard currency == other.currency else {
+            throw MoneyError.currencyMismatch(currency, other.currency)
+        }
+        return Money(minorUnits: minorUnits + other.minorUnits, currency: currency)
+    }
+}
+```
+
+```swift
+// file: Order.swift
+enum OrderError: Error {
+    case submittedOrderCannotBeModified
+}
+
+struct OrderLine {
+    let sku: String
+    let price: Money
+}
+
+private enum Status { case draft, submitted }
+
+class Order {
+    let id: String
+    private var status: Status = .draft
+    private var lines: [OrderLine] = []
+
+    init(id: String) { self.id = id }
+
+    func addLine(sku: String, price: Money) throws {
+        guard status == .draft else {
+            throw OrderError.submittedOrderCannotBeModified
+        }
+        lines.append(OrderLine(sku: sku, price: price))
+    }
+
+    func submit() { status = .submitted }
+    var lineCount: Int { lines.count }
+}
+```
+
+```swift
+// file: OrderRepository.swift
+protocol OrderRepository {
+    func find(id: String) -> Order?
+    func save(_ order: Order)
+}
+```
+
+```swift
+// file: main.swift (usage)
+let order = Order(id: "ord-1")
+do {
+    try order.addLine(sku: "SKU-1", price: Money(minorUnits: 1299, currency: "USD"))
+    order.submit()
+    try order.addLine(sku: "SKU-2", price: Money(minorUnits: 500, currency: "USD"))
+} catch {
+    print("rejected: \(error)")  // rejected: submittedOrderCannotBeModified
+}
+```
+
+## Common Mistake
+
+Removing `private` from `lines` lets any caller call `.append()` after `submit()`,
+bypassing the aggregate root and silently breaking the invariant.
+
+```swift
+class Order {
+    var lines: [OrderLine] = []          // ✗ callers can append after submit() — invariant broken
+    private var status: Status = .draft
+    func addLine(sku: String, price: Money) throws { ... }
+}
+```

--- a/skills/principle-ddd/examples/order.ts.md
+++ b/skills/principle-ddd/examples/order.ts.md
@@ -1,0 +1,98 @@
+# Light DDD — TypeScript — Order Aggregate
+
+## Problem
+
+TypeScript's `readonly` constructor parameters give `Money` immutable fields
+without a separate assignment step, and an explicit `equals()` method handles
+value comparison (JS/TS lacks built-in structural equality for class instances).
+The `Order` aggregate root guards `private lines: OrderLine[]` behind `addLine`
+and `submit`, so no caller can bypass the draft-only invariant. `OrderRepository`
+is a plain `interface` — a domain port with zero infrastructure coupling.
+
+## Implementation
+
+```typescript
+// file: money.ts
+export class Money {
+  constructor(
+    readonly minorUnits: number,
+    readonly currency: string,
+  ) {}
+
+  plus(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new Error(`currency mismatch: ${this.currency} vs ${other.currency}`);
+    }
+    return new Money(this.minorUnits + other.minorUnits, this.currency);
+  }
+
+  equals(other: Money): boolean {
+    return this.minorUnits === other.minorUnits && this.currency === other.currency;
+  }
+}
+```
+
+```typescript
+// file: order.ts
+import { Money } from "./money";
+
+type Status = "draft" | "submitted";
+
+export interface OrderLine { sku: string; price: Money }
+
+export class Order {
+  private status: Status = "draft";
+  private lines: OrderLine[] = [];
+
+  constructor(readonly id: string) {}
+
+  addLine(sku: string, price: Money): void {
+    if (this.status === "submitted") {
+      throw new Error("cannot add lines to a submitted order");
+    }
+    this.lines.push({ sku, price });
+  }
+
+  submit(): void { this.status = "submitted"; }
+  lineCount(): number { return this.lines.length; }
+}
+```
+
+```typescript
+// file: orderRepository.ts
+import { Order } from "./order";
+
+export interface OrderRepository {
+  find(id: string): Order | undefined;
+  save(order: Order): void;
+}
+```
+
+```typescript
+// file: main.ts
+import { Money } from "./money";
+import { Order } from "./order";
+
+console.log(new Money(1299, "USD").equals(new Money(1299, "USD"))); // true — value equality
+
+const order = new Order("ord-1");
+order.addLine("SKU-1", new Money(1299, "USD"));
+order.submit();
+try {
+  order.addLine("SKU-2", new Money(500, "USD"));
+} catch (e) {
+  console.log(`rejected: ${(e as Error).message}`);
+  // rejected: cannot add lines to a submitted order
+}
+```
+
+## Common Mistake
+
+Declaring `lines` as a `public` field lets any caller call `.push()` directly
+after `submit()`, bypassing the aggregate root and silently breaking the invariant.
+
+```typescript
+export class Order {
+  public lines: OrderLine[] = [];  // ✗ callers can push after submit() — invariant broken
+}
+```

--- a/skills/principle-ddd/examples/order.ts.md
+++ b/skills/principle-ddd/examples/order.ts.md
@@ -38,7 +38,7 @@ import { Money } from "./money";
 
 type Status = "draft" | "submitted";
 
-export interface OrderLine { sku: string; price: Money }
+export interface OrderLine { readonly sku: string; readonly price: Money }
 
 export class Order {
   private status: Status = "draft";


### PR DESCRIPTION
## Summary
- Add `skills/principle-ddd/examples/` with 9 worked "Light DDD" Order-aggregate examples (one per OO language: C#, Go, Java, Kotlin, Python, Ruby, Rust, Swift, TypeScript)
- Each file shows: `Money` value object (immutable, value equality, same-currency `plus()` guard), `Order` aggregate root (private `lines`, invariant enforced at the sole `addLine` entry point, Draft→Submitted state transition), `OrderRepository` domain port (interface/trait/protocol only), usage snippet (construct → addLine → submit → rejected addLine), and a per-language Common Mistake
- Append a single on-demand pointer blockquote to `skills/principle-ddd/SKILL.md` after the "Light DDD is the floor" sentence — nothing auto-loaded

## Test Plan
- [x] Changed skills/commands/agents load without errors (`bash scripts/validate.sh` — 0 failures, 1324 tests pass)
- [x] Examples in the diff were exercised manually — read 3 files (Rust, Go, Python); confirmed immutable VO, aggregate root invariant, port-only repository, and real Common Mistake in each
- [x] All 9 example files ≤120 lines (`wc -l skills/principle-ddd/examples/*.md` — max 120 for Go, min 82 for Kotlin)

### Type-tailored checks ([feat])
- [x] New behaviour demonstrated: invariant-guarded `addLine` and `submit()` transition verified in the usage snippet of each language file
- [x] `OrderRepository` is a port only (no implementation) in all 9 files
- [x] `Money.plus()` same-currency guard present in all 9 languages
- [x] `✗` Common Mistake annotation present in all 9 files

Closes #440
