### PR TITLE
[feat] Route performance symptoms in /debug to workflow-performance-investigation

### DIFF
--- a/commands/debug.md
+++ b/commands/debug.md
@@ -21,9 +21,29 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 If the symptom is performance-shaped:
 
 1. If grill-me mode was active and the `## Resolved decisions` block already classifies the symptom as performance or correctness, use that classification and skip the `AskUserQuestion`.
-2. Otherwise call `AskUserQuestion` — header **Symptom type**, question "Is this a performance investigation or a correctness bug?", two options:
-   - **Performance investigation** — "Activate `swe-workbench:workflow-performance-investigation`: profile-first runbook (baseline → profile → ranked hotspots → one change → before/after measurement → regression guard)."
-   - **Correctness bug** — "Proceed with the debugger: root-cause first, minimal fix, regression test."
+2. Otherwise call `AskUserQuestion`:
+
+   ```json
+   {
+     "questions": [
+       {
+         "question": "Is this a performance investigation or a correctness bug?",
+         "header": "Symptom type",
+         "multiSelect": false,
+         "options": [
+           {
+             "label": "Performance investigation",
+             "description": "Activate `swe-workbench:workflow-performance-investigation`: profile-first runbook (baseline → profile → ranked hotspots → one change → before/after measurement → regression guard)."
+           },
+           {
+             "label": "Correctness bug",
+             "description": "Proceed with the debugger: root-cause first, minimal fix, regression test."
+           }
+         ]
+       }
+     ]
+   }
+   ```
 3. On **Performance investigation**: activate `swe-workbench:workflow-performance-investigation` and stop — do not continue to browser diagnostics or debugger delegation.
 4. On **Correctness bug**: continue with the browser diagnostic step below.
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -16,15 +16,16 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
 
-**Performance routing.** After resolving the mode, check whether the symptom is performance-shaped before proceeding. A symptom is performance-shaped when it describes speed, latency, throughput, or resource exhaustion without an assertion failure or incorrect output — key vocabulary (case-insensitive, stem-matched): `slow`, `too slow`, `latency`, `throughput`, `cpu`, `memory leak`, `oom`, `profil*`, `benchmark`, `bottleneck`, `perf`, `performance`, `high memory`, `resource exhaustion`, `takes too long`, `hangs`.
+**Performance routing.** After resolving the mode, check whether the symptom is performance-shaped before proceeding. A symptom is performance-shaped when it describes speed, latency, throughput, or resource exhaustion without an assertion failure or incorrect output — key vocabulary (case-insensitive, stem-matched): `slow`, `too slow`, `latency`, `throughput`, `cpu`, `memory leak`, `oom`, `profil*`, `benchmark`, `bottleneck`, `perf`, `performance`, `high memory`, `resource exhaustion`, `takes too long`.
 
 If the symptom is performance-shaped:
 
-1. Call `AskUserQuestion` — header **Symptom type**, question "Is this a performance investigation or a correctness bug?", two options:
-   - **Performance investigation** — "Activate `workflow-performance-investigation`: profile-first runbook (baseline → profile → ranked hotspots → one change → before/after measurement → regression guard)."
+1. If grill-me mode was active and the `## Resolved decisions` block already classifies the symptom as performance or correctness, use that classification and skip the `AskUserQuestion`.
+2. Otherwise call `AskUserQuestion` — header **Symptom type**, question "Is this a performance investigation or a correctness bug?", two options:
+   - **Performance investigation** — "Activate `swe-workbench:workflow-performance-investigation`: profile-first runbook (baseline → profile → ranked hotspots → one change → before/after measurement → regression guard)."
    - **Correctness bug** — "Proceed with the debugger: root-cause first, minimal fix, regression test."
-2. On **Performance investigation**: activate `swe-workbench:workflow-performance-investigation` and stop — do not continue to browser diagnostics or debugger delegation.
-3. On **Correctness bug**: continue with the browser diagnostic step below.
+3. On **Performance investigation**: activate `swe-workbench:workflow-performance-investigation` and stop — do not continue to browser diagnostics or debugger delegation.
+4. On **Correctness bug**: continue with the browser diagnostic step below.
 
 If the symptom is not performance-shaped: skip this step entirely.
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,5 +1,5 @@
 ---
-description: Invoke the debugger subagent to diagnose a bug, failing test, or unexpected behavior — root-cause first, then a minimal, principle-aware fix with a regression test
+description: Diagnose a bug, failing test, or unexpected behavior — root-cause first, minimal fix, regression test. Performance-shaped symptoms (slow, latency, profiling) are routed to workflow-performance-investigation via one clarifying question.
 argument-hint: <symptom, failing test, or error, optionally with a ticket ref> [--grill | --standard]
 ---
 
@@ -15,6 +15,18 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 **Standard mode:** proceed with the command's existing lightweight clarify (a restatement and at most one clarifying question) — do not ask the mode question again.
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
+
+**Performance routing.** After resolving the mode, check whether the symptom is performance-shaped before proceeding. A symptom is performance-shaped when it describes speed, latency, throughput, or resource exhaustion without an assertion failure or incorrect output — key vocabulary (case-insensitive, stem-matched): `slow`, `too slow`, `latency`, `throughput`, `cpu`, `memory leak`, `oom`, `profil*`, `benchmark`, `bottleneck`, `perf`, `performance`, `high memory`, `resource exhaustion`, `takes too long`, `hangs`.
+
+If the symptom is performance-shaped:
+
+1. Call `AskUserQuestion` — header **Symptom type**, question "Is this a performance investigation or a correctness bug?", two options:
+   - **Performance investigation** — "Activate `workflow-performance-investigation`: profile-first runbook (baseline → profile → ranked hotspots → one change → before/after measurement → regression guard)."
+   - **Correctness bug** — "Proceed with the debugger: root-cause first, minimal fix, regression test."
+2. On **Performance investigation**: activate `swe-workbench:workflow-performance-investigation` and stop — do not continue to browser diagnostics or debugger delegation.
+3. On **Correctness bug**: continue with the browser diagnostic step below.
+
+If the symptom is not performance-shaped: skip this step entirely.
 
 **Browser diagnostic step (web-UI symptoms only).** Before delegating, check whether the symptom indicates a browser / web-UI context (e.g., mentions a rendered page, console error, XHR/fetch failure, visual regression, or DOM state). If it does:
 


### PR DESCRIPTION
## Summary
- Add a **performance routing guard** to `/debug`: when the symptom is performance-shaped (slow, latency, throughput, `profil*`, bottleneck, OOM, high memory, etc.), present one `AskUserQuestion` before delegating — "Performance investigation" activates `workflow-performance-investigation`; "Correctness bug" continues the existing debugger path unchanged.
- Update the `/debug` command description to surface this routing behaviour.
- No changes to the debugger agent, `workflow-performance-investigation` skill, or any test files — the guard is purely additive to the command orchestration layer.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` exits 0 — `check_skill_skill_refs` confirms `swe-workbench:workflow-performance-investigation` resolves correctly
- [x] `python3 -m pytest tests/test_validate.py -q` → 216 passed
- [x] Pre-push hook: 1328 tests passed

### Type-tailored checks ([feat])
- [x] New routing branch present: performance-shaped symptoms hit the `AskUserQuestion` gate before browser diagnostics or debugger delegation
- [x] Existing correctness-bug path unchanged: guard fires only on performance vocabulary; all other symptoms skip it entirely
- [x] `workflow-performance-investigation` referenced correctly (skill confirmed to exist on-disk via cherry-pick of #443)

Issue: N/A — follow-on improvement discussed during #443 review; no dedicated issue filed
