### PR TITLE
[docs] Make rimba MCP a first-class peer in cleanup-merged removal

### DIFF
--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -164,7 +164,7 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 **Procedure:**
 
 1. **Route by how rimba is available** (mirror the MCP → binary → shell ordering of `skills/workflow-development/SKILL.md:113-116`):
-   - **rimba MCP server active in session** → invoke the rimba `remove` tool (`task: <headRefName>`); for bulk stale-worktree cleanup (e.g., after a Mode C orchestration run) invoke the `clean` tool (`mode: merged`). No shell process needed.
+   - **rimba MCP server active in session** → invoke the rimba `remove` tool (`task: <headRefName>`); for bulk stale-worktree cleanup (e.g., after a Mode C orchestration run) invoke the `clean` tool (`mode: merged` — equivalent to the binary's `--merged` flag). No shell process needed.
    - **`$RIMBA` non-empty (binary resolved by `resolve-rimba.sh`)** → run `$RIMBA remove <headRefName>` (or `$RIMBA clean --merged` for bulk cleanup — same scope as the hook at line 136; `--force` is intentionally omitted for manual use).
    - **rimba absent** → fall through to the **shell fallback** strategy below.
 

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -165,7 +165,7 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 
 1. **Route by how rimba is available** (mirror the MCP → binary → shell ordering of `skills/workflow-development/SKILL.md:113-116`):
    - **rimba MCP server active in session** → invoke the rimba `remove` tool (`task: <headRefName>`); for bulk stale-worktree cleanup (e.g., after a Mode C orchestration run) invoke the `clean` tool (`mode: merged`). No shell process needed.
-   - **`$RIMBA` non-empty (binary resolved by `resolve-rimba.sh`)** → run `$RIMBA remove <headRefName>` (or `$RIMBA clean --merged` for bulk cleanup).
+   - **`$RIMBA` non-empty (binary resolved by `resolve-rimba.sh`)** → run `$RIMBA remove <headRefName>` (or `$RIMBA clean --merged` for bulk cleanup — same scope as the hook at line 136; `--force` is intentionally omitted for manual use).
    - **rimba absent** → fall through to the **shell fallback** strategy below.
 
    Either rimba path handles worktree location, dirty/unpushed checks, and removal internally.
@@ -173,7 +173,7 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 
 **Failure handling:**
 
-If the rimba `remove` (MCP tool or `$RIMBA` binary) reports failure, run a filesystem probe as the canonical signal — do not rely on rimba's message text:
+If the rimba `remove` or `clean` (MCP tool or `$RIMBA` binary) reports failure, run a filesystem probe as the canonical signal — do not rely on rimba's message text:
 ```bash
 [ -d "<worktree-path>" ] && WORKTREE_STILL_PRESENT=1 || WORKTREE_STILL_PRESENT=0
 ```

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -162,13 +162,18 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
   `RIMBA` must be non-empty (or MCP server active).
 
 **Procedure:**
-1. Run `$RIMBA remove <headRefName>` (or the `remove` tool on the `rimba mcp` server) — handles worktree location, dirty/unpushed checks, and removal internally.
-2. For bulk stale-worktree cleanup (e.g., after a Mode C orchestration run), use `$RIMBA clean` instead.
-3. (Once per repo) recommend the user run `rimba hook install` to automate future post-merge cleanups via a git hook — this removes the need for manual `/swe-workbench:cleanup-merged` invocations.
+
+1. **Route by how rimba is available** (mirror the MCP → binary → shell ordering of `skills/workflow-development/SKILL.md:113-116`):
+   - **rimba MCP server active in session** → invoke the rimba `remove` tool (`task: <headRefName>`); for bulk stale-worktree cleanup (e.g., after a Mode C orchestration run) invoke the `clean` tool (`mode: merged`). No shell process needed.
+   - **`$RIMBA` non-empty (binary resolved by `resolve-rimba.sh`)** → run `$RIMBA remove <headRefName>` (or `$RIMBA clean --merged` for bulk cleanup).
+   - **rimba absent** → fall through to the **shell fallback** strategy below.
+
+   Either rimba path handles worktree location, dirty/unpushed checks, and removal internally.
+2. (Once per repo) recommend the user run `rimba hook install` to automate future post-merge cleanups via a git hook — this removes the need for manual `/swe-workbench:cleanup-merged` invocations.
 
 **Failure handling:**
 
-If `$RIMBA remove` exits non-zero, run a filesystem probe as the canonical signal — do not rely on rimba's message text:
+If the rimba `remove` (MCP tool or `$RIMBA` binary) reports failure, run a filesystem probe as the canonical signal — do not rely on rimba's message text:
 ```bash
 [ -d "<worktree-path>" ] && WORKTREE_STILL_PRESENT=1 || WORKTREE_STILL_PRESENT=0
 ```


### PR DESCRIPTION
## Summary
- Replace the binary-centric 3-step Procedure in the `### rimba (MCP / binary)` strategy of `workflow-cleanup-merged/SKILL.md` with an explicit three-way routing bullet (MCP server → binary → shell), mirroring the pattern already present in `workflow-development/SKILL.md:113-116`.
- Add concrete tool-invocation shapes for the MCP path: `remove` tool with `task: <headRefName>` for single-worktree removal; `clean` tool with `mode: merged` for bulk stale-worktree cleanup.
- Generalize the failure-handling lead-in from "`$RIMBA remove` exits non-zero" to "rimba `remove` (MCP tool or `$RIMBA` binary) reports failure" — covering both paths without changing any downstream failure logic.
- Fixed reviewer finding: aligned binary bulk-clean to `$RIMBA clean --merged` (matching the MCP path's `mode: merged` scope).

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `python -m pytest tests/test_cleanup_merged_skill.py -v` — 5/5 pass (including `test_cleanup_merged_rimba_path_handles_partial_success` which pins `partial` + `fall through to Step 5` literals)
- [x] Push hook: 1338/1338 tests pass

### Type-tailored checks ([docs])
- [x] The three-way routing bullet reads parallel to `workflow-development/SKILL.md:113-116`
- [x] MCP branch names concrete tool + argument shape (`task: <headRefName>`, `mode: merged`)
- [x] Heading `### rimba (MCP / binary)` preserved verbatim (`grep -Fn` confirms line 154)
- [x] `[no ci]` not applied — file is under `skills/` (plugin behaviour path, excluded by doc-only rule)

Closes #448
