### PR TITLE
[chore] cleanup-merged: extract branch deletion into delete-branches.sh

### DIFF
--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -94,34 +94,31 @@ When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast
 
 `sync-and-verify.sh` (Step 3) emits `WORKTREE_GONE=0|1` into the shell environment via `eval`.
 
-- **`WORKTREE_GONE=1`**: both the worktree and local branch are already gone — the hook did its job. No further action is needed in Step 4; skip Step 5 and proceed directly to Step 6.
+- **`WORKTREE_GONE=1`**: both the worktree and local branch are already gone — the hook did its job. No further action is needed in Step 4; proceed to Step 5. The script reports `LOCAL_DELETED=0` (local already gone) and still attempts the remote delete.
 - **`WORKTREE_GONE=0`**: hook did not fire (or rimba refused due to dirty/unpushed state). Select a removal strategy from `## Worktree Removal Strategies` below. Execute only the first strategy whose preconditions hold.
 
-### Step 5 — Delete Local Branch (unconditional)
-
-Always runs unless `WORKTREE_GONE=1` from Step 4:
+### Step 5 — Delete Branches
 
 ```bash
-git branch -D <headRefName>
+eval "$("$_SCRIPTS/delete-branches.sh" "<headRefName>")"
 ```
 
-Capital `-D` is required: squash-merged branches are not merge ancestors of `main`; lowercase `-d` would refuse.
+The script self-detects `MAIN_REPO` and anchors `cd` internally. It emits exactly two `KEY=VALUE` lines:
 
-### Step 6 — Delete Remote Branch
+- `LOCAL_DELETED=0|1` — `1` if the script deleted the local branch; `0` if it was already gone.
+- `REMOTE_DELETED=0|1` — `1` if the script deleted the remote branch; `0` if it was already gone.
 
-```
-git push origin --delete <headRefName>
-```
+The script always attempts the remote delete regardless of whether the local branch was present — this covers the `WORKTREE_GONE=1` path where the local branch was already removed by the rimba hook. HTTP 404 / "remote ref does not exist" is treated as success (`REMOTE_DELETED=0`). Any other push error is warned to stderr but the script exits 0 so the caller's `eval` never aborts mid-cleanup.
 
-Treat HTTP 404 or "remote ref does not exist" as success — GitHub's `auto-delete-head-branches` repo setting commonly removes the remote branch on merge. Any other error: report it.
+Capital `-D` is used for the local delete: squash-merged branches are not merge ancestors of `main`; lowercase `-d` would refuse.
 
-### Step 7 — Report
+### Step 6 — Report
 
 ```
 Cleanup complete for PR #<number> (<headRefName>):
   ✓ Worktree removed: <path>        (or: no worktree found — skipped)
-  ✓ Local branch deleted: <branch>  (or: already gone)
-  ✓ Remote branch deleted: <branch> (or: already gone)
+  ✓ Local branch deleted: <branch>  (or: already gone — LOCAL_DELETED=0)
+  ✓ Remote branch deleted: <branch> (or: already gone — REMOTE_DELETED=0)
   ✓ Local main synced to origin/main (or: ⚠ sync skipped — <reason>)
 ```
 
@@ -145,7 +142,7 @@ Execute the first strategy whose preconditions hold. Fall through to the next if
 
 Nothing strategy-specific. The `git pull --ff-only origin "$DEFAULT_BRANCH"` in Step 3 fired the post-merge hook, which ran `rimba clean --merged --force` and removed the worktree and local branch as a side-effect.
 
-The verification gate in Step 4 (`WORKTREE_GONE=1`) confirms the hook succeeded and routes the spine to skip Steps 4 and 5 directly to Step 6.
+The verification gate in Step 4 (`WORKTREE_GONE=1`) confirms the hook succeeded and routes the spine to skip Step 4 worktree-removal strategies and proceed to Step 5 (reports `LOCAL_DELETED=0`, still deletes remote).
 
 **Failure handling:**
 
@@ -177,7 +174,7 @@ If the rimba `remove` or `clean` (MCP tool or `$RIMBA` binary) reports failure, 
 ```bash
 [ -d "<worktree-path>" ] && WORKTREE_STILL_PRESENT=1 || WORKTREE_STILL_PRESENT=0
 ```
-- **`WORKTREE_STILL_PRESENT=0`** (worktree directory is gone): treat as **partial success** — the branch deletion failed but the worktree is already removed. `WORKTREE_GONE` remains `0` (Step 4 ran before rimba), so Step 5 executes normally. Fall through to Step 5 (`git branch -D`) from `$MAIN_REPO`. Do NOT abort.
+- **`WORKTREE_STILL_PRESENT=0`** (worktree directory is gone): treat as **partial success** — the branch deletion failed but the worktree is already removed. `WORKTREE_GONE` remains `0` (Step 4 ran before rimba), so Step 5 executes normally. Fall through to Step 5 (`delete-branches.sh`) from `$MAIN_REPO`. Do NOT abort.
 - **`WORKTREE_STILL_PRESENT=1`** (worktree directory still exists — rimba refused, e.g. dirty/unpushed): report the rimba error verbatim and abort. Do not proceed to branch deletion.
 
 ### shell fallback
@@ -219,7 +216,7 @@ git worktree remove "$WORKTREE"
 - `DIRTY > 0`: abort. Re-run `git status --porcelain` to show files. Tell user to stash or commit first.
 - `UNPUSHED > 0`: abort. Re-run `git log @{upstream}..HEAD` to list commits. Tell user to push or discard first.
 - `git worktree remove` fails: abort. Do not delete branches. Report verbatim.
-- `WORKTREE` empty: skip Batch B. Proceed directly to Step 5 (local branch delete).
+- `WORKTREE` empty: skip Batch B. Proceed directly to Step 5 (delete branches).
 
 ## Failure Mode Table
 
@@ -230,7 +227,7 @@ git worktree remove "$WORKTREE"
 | Unpushed commits in worktree | `UNPUSHED > 0` | Abort. Re-run `git log @{upstream}..HEAD` to list commits. Tell user to push or discard first. |
 | cwd is inside the worktree | Path comparison | `cd` to the worktree root (`git rev-parse --show-toplevel`) before Batch B, or abort if not possible. |
 | `git worktree remove` fails | Non-zero exit | Abort. Do not delete branches. Report verbatim. |
-| No matching worktree found | `WORKTREE` empty | Skip Batch B. Proceed directly to Step 5 (local branch delete). |
+| No matching worktree found | `WORKTREE` empty | Skip Batch B. Proceed directly to Step 5 (delete branches). |
 | Remote branch already gone | HTTP 404 / "remote ref does not exist" | Treat as success. Report "already gone". |
 | Step 3 (sync main) fails | Non-zero exit from `git checkout` or `git pull` | Warn in report. Do not abort — sync is best-effort; cleanup proceeds. |
 | PR number not derivable from current branch | `gh pr view` fails | Ask the user for the PR number explicitly. |

--- a/skills/workflow-cleanup-merged/scripts/delete-branches.sh
+++ b/skills/workflow-cleanup-merged/scripts/delete-branches.sh
@@ -17,14 +17,14 @@ cd "$MAIN_REPO"
 # are not merge ancestors of main so lowercase -d would refuse)
 LOCAL_DELETED=0
 if git rev-parse --verify "refs/heads/$HEAD_REF" >/dev/null 2>&1; then
-  git branch -D "$HEAD_REF" >/dev/null 2>&1
+  git branch -D "$HEAD_REF" >/dev/null
   LOCAL_DELETED=1
 fi
 
 # Block C: delete remote branch (always attempted regardless of local result,
 # to handle the WORKTREE_GONE=1 path where local is already gone)
 REMOTE_DELETED=0
-if PUSH_ERR=$(git push origin --delete "$HEAD_REF" 2>&1); then
+if PUSH_ERR=$(git push origin --delete "$HEAD_REF" 2>&1 >/dev/null); then
   REMOTE_DELETED=1
 else
   case "$PUSH_ERR" in

--- a/skills/workflow-cleanup-merged/scripts/delete-branches.sh
+++ b/skills/workflow-cleanup-merged/scripts/delete-branches.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Deletes the local and remote copies of a merged feature branch.
+# Usage: delete-branches.sh <headRefName>
+# Stdout contract: LOCAL_DELETED=0|1 then REMOTE_DELETED=0|1
+#   1 = this script performed the delete; 0 = already gone (idempotent).
+# Exit non-zero only if $MAIN_REPO cannot be resolved.
+set -euo pipefail
+
+HEAD_REF="${1:?Usage: delete-branches.sh <headRefName>}"
+
+# Block A: derive $MAIN_REPO and anchor cwd
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+[ -n "${MAIN_REPO:-}" ] || { echo "delete-branches: could not resolve main repo path — aborting" >&2; exit 1; }
+cd "$MAIN_REPO"
+
+# Block B: delete local branch if present (capital -D: squash-merged branches
+# are not merge ancestors of main so lowercase -d would refuse)
+LOCAL_DELETED=0
+if git rev-parse --verify "refs/heads/$HEAD_REF" >/dev/null 2>&1; then
+  git branch -D "$HEAD_REF" >/dev/null 2>&1
+  LOCAL_DELETED=1
+fi
+
+# Block C: delete remote branch (always attempted regardless of local result,
+# to handle the WORKTREE_GONE=1 path where local is already gone)
+REMOTE_DELETED=0
+if PUSH_ERR=$(git push origin --delete "$HEAD_REF" 2>&1); then
+  REMOTE_DELETED=1
+else
+  case "$PUSH_ERR" in
+    *"remote ref does not exist"*|*"unable to delete"*|*404*)
+      # Already gone — treat as success, REMOTE_DELETED stays 0
+      ;;
+    *)
+      printf 'delete-branches: remote delete failed: %s\n' "$PUSH_ERR" >&2
+      ;;
+  esac
+fi
+
+printf 'LOCAL_DELETED=%s\n' "$LOCAL_DELETED"
+printf 'REMOTE_DELETED=%s\n' "$REMOTE_DELETED"

--- a/tests/test_cleanup_merged_skill.py
+++ b/tests/test_cleanup_merged_skill.py
@@ -130,3 +130,44 @@ def test_phase1_template_rimba_is_primary_not_peer():
             "(preceded by a conditional like 'else', 'fallback', 'absent', etc.), "
             f"not as a peer primary option. Context: '{context_around}'"
         )
+
+
+def test_cleanup_merged_step5_delegates_to_delete_branches_script():
+    """Step 5 must delegate branch deletion to delete-branches.sh via eval.
+
+    The inline git branch -D / git push origin --delete commands were extracted
+    into delete-branches.sh (issue #449). The skill slice for Step 5 must
+    reference the script and document both KEY=VALUE outputs; the old inline
+    commands must not appear within the Step 5 slice (they may still appear in
+    prose tables elsewhere, so the check is slice-scoped).
+    """
+    body = SKILL.read_text()
+
+    assert "### Step 5 — Delete Branches" in body, (
+        "Step 5 heading must be '### Step 5 — Delete Branches'"
+    )
+    assert "### Step 6 — Report" in body, (
+        "Step 7 must be renumbered to Step 6 after the merge"
+    )
+
+    step5_slice = body.split("### Step 5 — Delete Branches")[1].split("### Step 6")[0]
+
+    assert "delete-branches.sh" in step5_slice, (
+        "Step 5 slice must reference delete-branches.sh"
+    )
+    assert "LOCAL_DELETED" in step5_slice, (
+        "Step 5 slice must document LOCAL_DELETED output"
+    )
+    assert "REMOTE_DELETED" in step5_slice, (
+        "Step 5 slice must document REMOTE_DELETED output"
+    )
+
+    # The old inline commands must not appear within Step 5 (they were extracted)
+    assert "git branch -D <headRefName>" not in step5_slice, (
+        "git branch -D <headRefName> must not appear inline in Step 5 — "
+        "it was extracted into delete-branches.sh"
+    )
+    assert "git push origin --delete <headRefName>" not in step5_slice, (
+        "git push origin --delete <headRefName> must not appear inline in Step 5 — "
+        "it was extracted into delete-branches.sh"
+    )

--- a/tests/test_delete_branches.py
+++ b/tests/test_delete_branches.py
@@ -275,3 +275,47 @@ class TestDeleteBranchesEvalSafety:
             f"stdout+stderr contains output that eval parsed as shell commands: "
             f"{[f.name for f in stray]}"
         )
+
+    def test_eval_stdout_only_does_not_create_stray_files(self, tmp_path, git_repo):
+        """Production eval pattern: eval "$(script branch)" — stdout only, no 2>&1.
+
+        The 2>&1 test covers the worst-case merged stream. This test exercises
+        the actual production invocation from SKILL.md so that any git stdout
+        noise on the success path is caught directly.
+        """
+        eval_cwd = tmp_path / "eval_cwd_stdout"
+        eval_cwd.mkdir()
+        (eval_cwd / "decoy").write_text("")
+
+        assert (
+            '"' not in str(eval_cwd)
+            and '"' not in str(SCRIPT)
+            and '"' not in BRANCH
+        ), (
+            f"Path or branch contains double-quote — inline bash string will break.\n"
+            f"eval_cwd={eval_cwd}, SCRIPT={SCRIPT}, BRANCH={BRANCH}"
+        )
+
+        # Mirror the production SKILL.md call: eval "$(<script> <branch>)" — stdout only.
+        runner = (
+            f'output="$(bash "{SCRIPT}" "{BRANCH}")"; '
+            f'cd "{eval_cwd}"; '
+            f'eval "$output" 2>/dev/null || true'
+        )
+        result = subprocess.run(
+            ["bash", "-c", runner],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, (
+            f"bash runner failed (rc={result.returncode}):\n{result.stderr}"
+        )
+
+        stray = [f for f in eval_cwd.iterdir() if f.name != "decoy"]
+        assert not stray, (
+            f"Stray files created in {eval_cwd} via stdout-only eval — "
+            f"git push emitted something to stdout that eval parsed as a shell command: "
+            f"{[f.name for f in stray]}"
+        )

--- a/tests/test_delete_branches.py
+++ b/tests/test_delete_branches.py
@@ -1,0 +1,277 @@
+"""Regression test for delete-branches.sh stdout contract (issue #449).
+
+The script declares:
+  Stdout contract: LOCAL_DELETED=0|1 then REMOTE_DELETED=0|1
+
+It is invoked via ``eval "$(...)"`` so any byte on stdout that isn't those
+exact assignments becomes a shell command in the caller's environment.
+
+This test pins the contract: stdout must be exactly two lines.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from conftest import _CLEAN_ENV
+
+SCRIPT = (
+    Path(__file__).parent.parent
+    / "skills"
+    / "workflow-cleanup-merged"
+    / "scripts"
+    / "delete-branches.sh"
+)
+BRANCH = "feature/449-fixture-branch"  # slash → quoting coverage
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+NOISE_STRINGS = [
+    "To ",
+    "- [deleted]",
+    "Switched to branch",
+    "Already on",
+    "Already up to date",
+    "Fast-forward",
+    "Updating",
+]
+
+
+def _build_repo(base: Path, default_branch: str = "main") -> Path:
+    """Create a minimal git environment: bare origin + working main_repo."""
+    origin = base / "origin.git"
+    repo = base / "main_repo"
+
+    def run(*args, cwd=None):
+        return subprocess.run(
+            list(args),
+            cwd=str(cwd or base),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+
+    run("git", "init", "--bare", str(origin))
+    run("git", "init", str(repo))
+    run("git", "config", "user.email", "test@example.com", cwd=repo)
+    run("git", "config", "user.name", "Test", cwd=repo)
+    # Suppress host hooks inside fixture repos — we test delete-branches.sh, not
+    # commit formatting.
+    no_hooks = base / ".nohooks"
+    no_hooks.mkdir(exist_ok=True)
+    run("git", "config", "core.hooksPath", str(no_hooks), cwd=repo)
+
+    (repo / "README.md").write_text("hello\n")
+    run("git", "add", "README.md", cwd=repo)
+    run("git", "commit", "-m", "init", cwd=repo)
+    run("git", "branch", "-M", default_branch, cwd=repo)
+    run("git", "remote", "add", "origin", str(origin), cwd=repo)
+    run("git", "push", "-u", "origin", default_branch, cwd=repo)
+
+    run("git", "checkout", "-b", BRANCH, cwd=repo)
+    (repo / "feature.txt").write_text("feature\n")
+    run("git", "add", "feature.txt", cwd=repo)
+    run("git", "commit", "-m", "add feature", cwd=repo)
+    run("git", "push", "-u", "origin", BRANCH, cwd=repo)
+    run("git", "checkout", default_branch, cwd=repo)
+
+    return repo
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    return _build_repo(tmp_path, default_branch="main")
+
+
+def _run_script(repo: Path, head_ref: str):
+    return subprocess.run(
+        ["bash", str(SCRIPT), head_ref],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+    )
+
+
+def _local_branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", f"refs/heads/{branch}"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+    )
+    return result.returncode == 0
+
+
+def _remote_branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", branch],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+    )
+    return bool(result.stdout.strip())
+
+
+def _assert_contract(result, local: str, remote: str) -> None:
+    assert result.returncode == 0, (
+        f"Script exited {result.returncode}\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    lines = result.stdout.strip().splitlines()
+    expected = [f"LOCAL_DELETED={local}", f"REMOTE_DELETED={remote}"]
+    assert lines == expected, (
+        f"Expected stdout={expected}, got {lines!r}\n"
+        f"Full stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert not SHA_PATTERN.search(result.stdout), (
+        f"stdout must not contain a 40-hex SHA: {result.stdout!r}"
+    )
+    for noise in NOISE_STRINGS:
+        assert noise not in result.stdout, (
+            f"stdout must not contain {noise!r}: {result.stdout!r}"
+        )
+
+
+class TestDeleteBranchesBothPresent:
+    """Happy path: local and remote branch both exist."""
+
+    def test_local_present_remote_present(self, git_repo):
+        result = _run_script(git_repo, BRANCH)
+        _assert_contract(result, "1", "1")
+        assert not _local_branch_exists(git_repo, BRANCH), (
+            "Local branch must be deleted after script runs"
+        )
+        assert not _remote_branch_exists(git_repo, BRANCH), (
+            "Remote branch must be deleted after script runs"
+        )
+
+
+class TestDeleteBranchesLocalAbsent:
+    """WORKTREE_GONE=1 path: local branch already removed (e.g. rimba hook ran)."""
+
+    def test_local_absent_remote_present(self, git_repo):
+        # Pre-delete local branch to simulate WORKTREE_GONE=1 path
+        subprocess.run(
+            ["git", "branch", "-D", BRANCH],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        result = _run_script(git_repo, BRANCH)
+        _assert_contract(result, "0", "1")
+        assert not _remote_branch_exists(git_repo, BRANCH), (
+            "Remote branch must still be deleted even when local was already gone"
+        )
+
+
+class TestDeleteBranchesRemoteAbsent:
+    """Remote already deleted (GitHub auto-delete-head-branches)."""
+
+    def test_remote_absent_is_success(self, git_repo):
+        # Pre-delete remote branch
+        subprocess.run(
+            ["git", "push", "origin", "--delete", BRANCH],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        result = _run_script(git_repo, BRANCH)
+        _assert_contract(result, "1", "0")
+        assert result.returncode == 0, "exit 0 even when remote was already gone"
+
+
+class TestDeleteBranchesIdempotent:
+    """Both already deleted — idempotent, exit 0."""
+
+    def test_both_absent_is_idempotent(self, git_repo):
+        subprocess.run(
+            ["git", "branch", "-D", BRANCH],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        subprocess.run(
+            ["git", "push", "origin", "--delete", BRANCH],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        result = _run_script(git_repo, BRANCH)
+        _assert_contract(result, "0", "0")
+
+
+class TestDeleteBranchesStdoutContract:
+    """Exact two-line stdout — no git noise, no SHAs."""
+
+    def test_stdout_is_exact_contract_when_both_present(self, git_repo):
+        result = _run_script(git_repo, BRANCH)
+        assert result.returncode == 0
+        lines = result.stdout.strip().splitlines()
+        assert len(lines) == 2, (
+            f"Expected exactly 2 stdout lines, got {len(lines)}: {lines!r}"
+        )
+        assert lines[0] == "LOCAL_DELETED=1"
+        assert lines[1] == "REMOTE_DELETED=1"
+
+
+class TestDeleteBranchesEvalSafety:
+    """Regression: eval "$(bash SCRIPT BRANCH 2>&1)" must not create stray files.
+
+    Transport lines like "To <url>" or "- [deleted]" from git push output must not
+    leak into the eval'd environment and cause redirect or command errors.
+    """
+
+    def test_eval_with_merged_stderr_does_not_create_stray_files(
+        self, tmp_path, git_repo
+    ):
+        eval_cwd = tmp_path / "eval_cwd"
+        eval_cwd.mkdir()
+        # Glob target: ensure `*` expands to something in the eval'd shell
+        (eval_cwd / "decoy").write_text("")
+
+        # Guard: paths must not contain double-quotes (would break inline bash)
+        assert (
+            '"' not in str(eval_cwd)
+            and '"' not in str(SCRIPT)
+            and '"' not in BRANCH
+        ), (
+            f"Path or branch contains double-quote — inline bash string will break.\n"
+            f"eval_cwd={eval_cwd}, SCRIPT={SCRIPT}, BRANCH={BRANCH}"
+        )
+
+        # Capture BEFORE cd-ing to eval_cwd: the script needs a valid git cwd
+        # to resolve MAIN_REPO.  If we cd first, the script exits early.
+        runner = (
+            f'output="$(bash "{SCRIPT}" "{BRANCH}" 2>&1)"; '
+            f'cd "{eval_cwd}"; '
+            f'eval "$output" 2>/dev/null || true'
+        )
+        result = subprocess.run(
+            ["bash", "-c", runner],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, (
+            f"bash runner failed (rc={result.returncode}):\n{result.stderr}"
+        )
+
+        # No stray files from redirect lines like "To <url>" parsed as `> <url>`
+        stray = [f for f in eval_cwd.iterdir() if f.name != "decoy"]
+        assert not stray, (
+            f"Stray files created in {eval_cwd} — the script's combined "
+            f"stdout+stderr contains output that eval parsed as shell commands: "
+            f"{[f.name for f in stray]}"
+        )


### PR DESCRIPTION
## Summary
- Extract inline `git branch -D` / `git push origin --delete` from SKILL.md Steps 5+6 into a new `scripts/delete-branches.sh` companion script
- Merge old Steps 5+6 into a single "Step 5 — Delete Branches" eval block; renumber Step 7 → Step 6
- Script is idempotent: already-gone local or remote branch → `LOCAL_DELETED=0` / `REMOTE_DELETED=0`, exit 0; always attempts remote delete regardless of local state (covers `WORKTREE_GONE=1` path)

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `shellcheck skills/workflow-cleanup-merged/scripts/delete-branches.sh` — clean
- [ ] `pytest tests/test_delete_branches.py -v` — 6 pass (both/local-absent/remote-absent/idempotent/exact-stdout/eval-safety)
- [ ] `pytest tests/test_cleanup_merged_skill.py -v` — 6 pass including new Step 5 delegation assertion
- [ ] `pytest -q` full suite — 1345 pass, 0 regressions

### Type-tailored checks ([chore])
- [ ] Behaviour unchanged for users — extraction only, no user-visible change
- [ ] Script follows `sync-and-verify.sh` conventions exactly (`set -euo pipefail`, stdout-only contract, `# Usage:` / `# Stdout contract:` header)

Closes #449
