### PR TITLE
[feat] address-feedback: detect & revise stale PR title/description

### DIFF
--- a/runtime/sync-pr-metadata.sh
+++ b/runtime/sync-pr-metadata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Apply a revised title and/or body to an existing PR (address-feedback Phase 6 drift sync).
+# Usage: sync-pr-metadata.sh <pr> <new_title> <body_file>
+# Empty new_title skips --title; empty body_file skips --body-file.
+set -euo pipefail
+PR="${1:?sync-pr-metadata: PR number required}"
+NEW_TITLE="${2:-}"; BODY_FILE="${3:-}"
+args=()
+[ -n "$NEW_TITLE" ] && args+=(--title "$NEW_TITLE")
+if [ -n "$BODY_FILE" ]; then
+  [ -f "$BODY_FILE" ] || { echo "sync-pr-metadata: body file not found: $BODY_FILE" >&2; exit 1; }
+  args+=(--body-file "$BODY_FILE")
+fi
+[ ${#args[@]} -gt 0 ] || { echo "sync-pr-metadata: nothing to update (no title, no body)" >&2; exit 1; }
+gh pr edit "$PR" "${args[@]}"

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-address-feedback
-description: Use when a PR owner wants to address review feedback — fetches outstanding threads, presents a per-thread triage (ADDRESSED / CLARIFIED / DEFERRED), applies fixes via the Edit tool, commits via workflow-commit-and-pr, posts per-thread replies via the GitHub comments API, and resolves addressed threads via GraphQL resolveReviewThread.
+description: Use when a PR owner wants to address review feedback — fetches outstanding threads, presents a per-thread triage (ADDRESSED / CLARIFIED / DEFERRED), applies fixes via the Edit tool, commits via workflow-commit-and-pr, posts per-thread replies via the GitHub comments API, resolves addressed threads via GraphQL resolveReviewThread, and syncs stale PR metadata when drift is detected.
 orchestrator: true
 ---
 
@@ -26,7 +26,7 @@ This skill orchestrates:
 - `swe-workbench:ticket-context` — prepended context when PR references a ticket.
 - `swe-workbench:workflow-commit-and-pr` — invoked after all ADDRESSED fixes are applied to commit and push.
 
-## 5-phase flow
+## Phase flow
 
 ### Phase 1 — Pre-flight + fetch
 
@@ -131,7 +131,7 @@ git fetch origin "${PR_BRANCH}"
 git worktree add "$WT" "${PR_BRANCH}"
 ```
 
-This worktree is **disposable** — fixes are committed and pushed to the PR branch in Phase 4, so the work lives on the remote, not the worktree. Phase 6 removes it on every exit (success, Q-quit, or error). If removal fails, a fallback is attempted; see Phase 6 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 6 before stopping.
+This worktree is **disposable** — fixes are committed and pushed to the PR branch in Phase 4, so the work lives on the remote, not the worktree. Phase 7 removes it on every exit (success, Q-quit, or error). If removal fails, a fallback is attempted; see Phase 7 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 7 before stopping.
 
 ### Phase 3 — Triage digest
 
@@ -147,7 +147,7 @@ If no threads remain after filtering:
 - When N ≥ 1 (threads were skipped under rule 2): print "No new threads to triage — N already clarified."
 - When N = 0 (only resolved threads filtered): print "No new threads to triage."
 
-Then run **Phase 6 — Cleanup** and exit cleanly.
+Then run **Phase 7 — Cleanup** and exit cleanly.
 
 For each remaining thread:
 
@@ -167,7 +167,7 @@ Parse severity from `Severity: <level>` prefix in comment body if present; other
 
 Capture: `triage[<thread_id>] = A|C|D`.
 
-If the owner replies `Q`, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, then run **Phase 6 — Cleanup**, and exit. Re-invocation resumes from this file (Phase 2 re-creates the worktree).
+If the owner replies `Q`, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, then run **Phase 7 — Cleanup**, and exit. Re-invocation resumes from this file (Phase 2 re-creates the worktree).
 
 ### Phase 4 — Implement + commit
 
@@ -218,9 +218,32 @@ for f in "/tmp/swe-workbench-address-feedback/${PR}.json" \
 done
 ```
 
-Then run **Phase 6 — Cleanup**.
+Then run **Phase 6 — Sync PR metadata**.
 
-### Phase 6 — Cleanup (always)
+### Phase 6 — Sync PR metadata (when fixes were committed)
+
+Skip this phase entirely if `$FIX_SHA` is unset (no fixes were committed in Phase 4).
+
+Fetch: `gh pr view "$PR" --json title,body`; commit subjects via `git -C "$WT" log "$BASE"..HEAD --format='%s'`; diff stat via `git -C "$WT" diff "$BASE"..HEAD --stat`. No new state file — the reap already ran in Phase 5.
+
+**Judge drift** by comparing the live title and `## Summary` section of the PR body against the commit subjects and diff stat. If aligned, emit "PR metadata is up to date — no changes needed." and fall through to Phase 7 — Cleanup.
+
+**If drift is detected,** draft a revised `$NEW_TITLE` and `$NEW_SUMMARY`. Rewrite only the `## Summary` section of the body; preserve `## Test Plan`, the `Closes #`/`Fixes #`/`Issue: N/A` trailer, and all other collaborator sections. Preview old→new for title and summary, then:
+
+> Reply `yes` to apply these changes to PR #N.
+
+On `yes`:
+
+```bash
+NEW_BODY_FILE=$(mktemp)
+trap 'rm -f "$NEW_BODY_FILE"' EXIT
+printf '%s' "$NEW_BODY" > "$NEW_BODY_FILE"
+bash "$_RT/runtime/sync-pr-metadata.sh" "$PR" "$NEW_TITLE" "$NEW_BODY_FILE"
+```
+
+Then run **Phase 7 — Cleanup**.
+
+### Phase 7 — Cleanup (always)
 
 Run on every exit that occurs after a worktree was **created** in Phase 2 (success, Q-quit, or error). Skip on Phase 1 early-exits (before any worktree exists) and when the reuse-guard fired (`REUSED_WT=1`) — the reuse path sets `$WT` to an existing checkout, never creates a worktree, so there is nothing to remove.
 
@@ -249,7 +272,7 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 | PR not found | `gh pr view` fails | Abort. |
 | `CURRENT_USER != AUTHOR_LOGIN` | JSON mismatch | Warn + ask to continue. |
 | No outstanding threads | GraphQL returns 0 unresolved | Print "No open threads — nothing to address." Exit. |
-| Owner picks Q mid-triage | Loop exit | Save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, run Phase 6 cleanup, then exit. |
+| Owner picks Q mid-triage | Loop exit | Save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, run Phase 7 cleanup, then exit. |
 | Worktree removal fails (rimba absent or busy) | `rimba remove` non-zero | Attempt `git worktree remove --force` fallback; log warning; do not block. |
 | Reply REST fails (404 — comment deleted) | HTTP 404 | Skip that thread, log "skipped (comment deleted)". |
 | Resolve mutation fails | GraphQL error | Reply already posted — log "reply posted but resolve failed". Continue. Do not roll back the reply. |
@@ -260,8 +283,8 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 |---|---|
 | Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
 | Omit `--skip-deps --skip-hooks` on the rimba call | Always pass both flags — same as other worktree-creating skills. Deps can be installed manually in the worktree if needed. |
-| Leave the worktree behind after skill exits | Phase 6 always removes it — skip Phase 6 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
-| Deleting `$PR_BRANCH` directly in Phase 6 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
+| Leave the worktree behind after skill exits | Phase 7 always removes it — skip Phase 7 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
+| Deleting `$PR_BRANCH` directly in Phase 7 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |
 | Resolve a CLARIFIED thread | Only resolve ADDRESSED threads. CLARIFIED = reply only, no resolve. |
 | Try to resolve via REST | Thread resolution is GraphQL-only (`resolveReviewThread` mutation). REST has no equivalent endpoint. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -238,7 +238,8 @@ On `yes`:
 NEW_BODY_FILE=$(mktemp)
 trap 'rm -f "$NEW_BODY_FILE"' EXIT
 printf '%s' "$NEW_BODY" > "$NEW_BODY_FILE"
-bash "$_RT/runtime/sync-pr-metadata.sh" "$PR" "$NEW_TITLE" "$NEW_BODY_FILE"
+bash "$_RT/runtime/sync-pr-metadata.sh" "$PR" "$NEW_TITLE" "$NEW_BODY_FILE" \
+  || echo "Warning: PR metadata update failed — continuing to cleanup." >&2
 ```
 
 Then run **Phase 7 — Cleanup**.

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -16,6 +16,7 @@ RUNTIME_SCRIPTS = [
     "fetch-pr.sh",
     "preflight-pr.sh",
     "reply-and-resolve.sh",
+    "sync-pr-metadata.sh",
 ]
 
 

--- a/tests/test_sync_pr_metadata_script.py
+++ b/tests/test_sync_pr_metadata_script.py
@@ -1,0 +1,148 @@
+"""Tests for runtime/sync-pr-metadata.sh — PR metadata drift sync helper.
+
+Each test invokes the script with a recording `gh` stub. The stub logs each
+invocation to a temp file so tests can assert which gh sub-commands were called
+and how many times, without needing a real GitHub token.
+
+Behavioral paths under test:
+  - title + body: one gh pr edit call carrying --title and --body-file
+  - empty title: only --body-file (no --title flag)
+  - missing body file: exit 1, gh never called
+  - no title and no body: exit 1 (nothing to update)
+"""
+
+import subprocess
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+SCRIPT = Path(__file__).parent.parent / "runtime" / "sync-pr-metadata.sh"
+ROOT = Path(__file__).parent.parent
+
+
+def _make_recording_gh_stub(stub_dir: Path, log_file: Path) -> None:
+    """gh stub that appends all positional args as one line per invocation."""
+    stub_dir.mkdir(exist_ok=True)
+    stub = stub_dir / "gh"
+    stub.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{log_file}'\nexit 0\n")
+    stub.chmod(0o755)
+
+
+def _run(pr, new_title, body_file, *, stub_dir: Path):
+    env = dict(_CLEAN_ENV)
+    env["PATH"] = f"{stub_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+    return subprocess.run(
+        ["bash", str(SCRIPT), pr, new_title, body_file],
+        capture_output=True, text=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+
+
+def _gh_calls(log_file: Path) -> list[str]:
+    if not log_file.exists():
+        return []
+    return [ln for ln in log_file.read_text().splitlines() if ln.strip()]
+
+
+# ── title + body ──────────────────────────────────────────────────────────────
+
+def test_title_and_body_calls_gh_pr_edit(tmp_path):
+    """title + body → one 'gh pr edit' call carrying --title and --body-file."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    body = tmp_path / "body.md"
+    body.write_text("## Summary\nFix stuff.")
+    result = _run("99", "feat: new title", str(body), stub_dir=stub_dir)
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 1, f"Expected 1 gh call, got {len(calls)}: {calls}"
+    assert "--title" in calls[0], f"Call must include --title: {calls[0]!r}"
+    assert "--body-file" in calls[0], f"Call must include --body-file: {calls[0]!r}"
+
+
+# ── body-only (empty title) ───────────────────────────────────────────────────
+
+def test_body_only_omits_title_flag(tmp_path):
+    """Empty title → gh pr edit with only --body-file (no --title flag)."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    body = tmp_path / "body.md"
+    body.write_text("## Summary\nUpdated summary.")
+    result = _run("99", "", str(body), stub_dir=stub_dir)
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 1, f"Expected 1 gh call, got {len(calls)}: {calls}"
+    assert "--body-file" in calls[0], f"Call must include --body-file: {calls[0]!r}"
+    assert "--title" not in calls[0], (
+        f"Call must NOT include --title when title is empty: {calls[0]!r}"
+    )
+
+
+# ── missing body file ─────────────────────────────────────────────────────────
+
+def test_missing_body_file_exits_nonzero(tmp_path):
+    """Body file path given but file does not exist → exit 1, gh never called."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run("99", "", str(tmp_path / "nonexistent.md"), stub_dir=stub_dir)
+    assert result.returncode != 0, (
+        f"Expected non-zero when body file does not exist\nstdout: {result.stdout!r}"
+    )
+    assert _gh_calls(log) == [], "gh must NOT be called when body file is missing"
+
+
+# ── title-only (empty body file) ─────────────────────────────────────────────
+
+def test_title_only_omits_body_flag(tmp_path):
+    """Non-empty title, empty body → gh pr edit with only --title (no --body-file flag)."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run("99", "feat: updated title", "", stub_dir=stub_dir)
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 1, f"Expected 1 gh call, got {len(calls)}: {calls}"
+    assert "--title" in calls[0], f"Call must include --title: {calls[0]!r}"
+    assert "--body-file" not in calls[0], (
+        f"Call must NOT include --body-file when body is empty: {calls[0]!r}"
+    )
+
+
+# ── no args (nothing to update) ───────────────────────────────────────────────
+
+def test_no_title_no_body_exits_nonzero(tmp_path):
+    """Neither title nor body file → exit 1 (nothing to update)."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run("99", "", "", stub_dir=stub_dir)
+    assert result.returncode != 0, (
+        f"Expected non-zero when both title and body are empty\nstdout: {result.stdout!r}"
+    )
+    assert _gh_calls(log) == [], "gh must NOT be called when both title and body are empty"
+
+
+# ── PR number required guard ({1:?}) ─────────────────────────────────────────
+
+def test_pr_number_required_guard(tmp_path):
+    """Omitting PR number entirely → exit non-zero with error on stderr."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    env = dict(_CLEAN_ENV)
+    env["PATH"] = f"{stub_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True, text=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+    assert result.returncode != 0, "Expected non-zero when PR number is omitted"
+    assert "PR number required" in result.stderr or result.stderr, (
+        f"Expected error on stderr when PR is omitted; got: {result.stderr!r}"
+    )
+    assert _gh_calls(log) == [], "gh must NOT be called when PR is omitted"

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -134,7 +134,75 @@ def test_address_feedback_skill_clarified_no_resolve():
     )
 
 
-# --- Cleanup (Phase 6) tests — AC#1, AC#2, AC#3 from issue #291 ---
+# --- Phase 6 — Sync PR metadata (issue #454) ---
+
+
+def _phase6_sync_text(text: str) -> str:
+    """Extract the Phase 6 Sync PR metadata section (between ### Phase 6 and ### Phase 7)."""
+    start = text.find("### Phase 6")
+    assert start != -1, "### Phase 6 section must exist"
+    end = text.find("### Phase 7", start)
+    return text[start:end] if end != -1 else text[start:]
+
+
+def test_address_feedback_skill_has_phase6_sync_section():
+    """SKILL.md must have a Phase 6 Sync PR metadata section (closes #454)."""
+    text = SKILL_MD.read_text()
+    assert re.search(r"### Phase 6.*Sync PR metadata", text), (
+        "SKILL.md must include '### Phase 6 — Sync PR metadata' section (closes #454)"
+    )
+
+
+def test_address_feedback_skill_phase6_skips_when_no_fix_sha():
+    """Phase 6 must be skipped entirely when $FIX_SHA is unset (no fixes committed)."""
+    text = SKILL_MD.read_text()
+    phase6 = _phase6_sync_text(text)
+    assert "FIX_SHA" in phase6, (
+        "Phase 6 Sync section must reference $FIX_SHA to decide whether to run"
+    )
+    assert re.search(r"[Ss]kip|unset|not set", phase6), (
+        "Phase 6 must describe skipping when $FIX_SHA is unset (no commits in Phase 4)"
+    )
+
+
+def test_address_feedback_skill_phase6_detects_drift_against_diff_and_subjects():
+    """Phase 6 must compare title + ## Summary against the cumulative diff and commit subjects."""
+    text = SKILL_MD.read_text()
+    phase6 = _phase6_sync_text(text)
+    assert "git diff" in phase6 or "--stat" in phase6, (
+        "Phase 6 must fetch the cumulative diff (git diff or --stat) as drift signal"
+    )
+    assert "git log" in phase6 or "commit subjects" in phase6.lower(), (
+        "Phase 6 must fetch commit subjects (git log --format='%s') as drift signal"
+    )
+    assert "## Summary" in phase6, (
+        "Phase 6 must compare against the ## Summary section of the PR body"
+    )
+
+
+def test_address_feedback_skill_phase6_apply_is_preview_gated():
+    """Phase 6 revision must be preview-gated with Reply `yes` before applying."""
+    text = SKILL_MD.read_text()
+    phase6 = _phase6_sync_text(text)
+    assert re.search(r"Reply\s+`yes`", phase6), (
+        "Phase 6 must gate the metadata update behind 'Reply `yes`' (same convention as Phase 1)"
+    )
+    assert "sync-pr-metadata.sh" in phase6, (
+        "Phase 6 must apply the revision via runtime/sync-pr-metadata.sh"
+    )
+
+
+def test_address_feedback_skill_phase6_preserves_trailer():
+    """Phase 6 body rewrite must preserve the Closes #/Fixes #/Issue: N/A trailer."""
+    text = SKILL_MD.read_text()
+    phase6 = _phase6_sync_text(text)
+    assert re.search(r"Closes #|trailer|scaffold", phase6, re.IGNORECASE), (
+        "Phase 6 must describe preserving the 'Closes #' trailer and PR template scaffolding "
+        "when rewriting the ## Summary section"
+    )
+
+
+# --- Cleanup (Phase 7) tests — AC#1, AC#2, AC#3 from issue #291 ---
 
 def test_address_feedback_skill_cleans_up_worktree():
     """Phase 6 must include rimba remove "address-feedback-$PR" --force (AC#1)."""
@@ -179,22 +247,22 @@ def test_address_feedback_skill_drops_durable_no_cleanup_claim():
 
 
 def test_address_feedback_skill_has_cleanup_phase():
-    """SKILL.md must have a Phase 6 / Cleanup section that runs on every post-Phase-2 exit (AC#3)."""
+    """SKILL.md must have a Phase 7 / Cleanup section that runs on every post-Phase-2 exit (AC#3)."""
     text = SKILL_MD.read_text()
-    assert re.search(r"Phase 6|## Phase 6|### Phase 6", text), (
-        "SKILL.md must include a Phase 6 (Cleanup) section — "
+    assert re.search(r"Phase 7|## Phase 7|### Phase 7", text), (
+        "SKILL.md must include a Phase 7 (Cleanup) section — "
         "it must run on success, Q-exit, and error paths after a worktree has been created (AC#3)"
     )
 
 
 def test_address_feedback_skill_cleanup_uses_existing_wt():
-    """Phase 6 fallback must use $WT from Phase 2 — must not re-assign WT= in the else branch."""
+    """Phase 7 fallback must use $WT from Phase 2 — must not re-assign WT= in the else branch."""
     text = SKILL_MD.read_text()
-    phase6_match = re.search(r"### Phase 6.*", text, re.DOTALL)
-    assert phase6_match, "Phase 6 section must exist for this check"
-    phase6_text = phase6_match.group(0)
-    assert not re.search(r'\bWT\s*=\s*["\'\$]', phase6_text), (
-        "Phase 6 must not re-assign $WT — use the value set in Phase 2 so the fallback "
+    phase7_match = re.search(r"### Phase 7.*", text, re.DOTALL)
+    assert phase7_match, "Phase 7 section must exist for this check"
+    phase7_text = phase7_match.group(0)
+    assert not re.search(r'\bWT\s*=\s*["\'\$]', phase7_text), (
+        "Phase 7 must not re-assign $WT — use the value set in Phase 2 so the fallback "
         "targets the correct worktree directory regardless of which Phase 2 branch (rimba vs. git) ran"
     )
 
@@ -218,14 +286,14 @@ def test_address_feedback_skill_reuses_worktree_when_on_pr_branch():
 
 
 def test_address_feedback_skill_phase6_skips_cleanup_on_reuse():
-    """Phase 6 must not run git worktree remove / rm -rf when the worktree was reused (closes #295)."""
+    """Phase 7 must not run git worktree remove / rm -rf when the worktree was reused (closes #295)."""
     text = SKILL_MD.read_text()
-    phase6_idx = text.find("### Phase 6")
-    assert phase6_idx != -1, "Phase 6 section must exist"
-    phase6_text = text[phase6_idx:]
-    # Phase 6 must reference REUSED_WT so the cleanup is skipped for the reuse path.
-    assert "REUSED_WT" in phase6_text, (
-        "SKILL.md Phase 6 must guard cleanup with REUSED_WT — when the reuse-guard "
+    phase7_idx = text.find("### Phase 7")
+    assert phase7_idx != -1, "Phase 7 section must exist"
+    phase7_text = text[phase7_idx:]
+    # Phase 7 must reference REUSED_WT so the cleanup is skipped for the reuse path.
+    assert "REUSED_WT" in phase7_text, (
+        "SKILL.md Phase 7 must guard cleanup with REUSED_WT — when the reuse-guard "
         "fires (WT=$(pwd)), rimba remove will fail for an unregistered task, causing "
         "git worktree remove --force / rm -rf to run against the user's live checkout"
     )
@@ -325,44 +393,44 @@ def test_address_feedback_skill_deletes_three_state_files():
 
 
 def test_address_feedback_skill_triage_cleanup_before_phase6():
-    """${PR}-triage.json removal must appear BEFORE ### Phase 6 (Q-quit safety invariant).
+    """${PR}-triage.json removal must appear BEFORE ### Phase 7 (Q-quit safety invariant).
 
-    Phase 6 fires on Q-quit too.  triage.json is durable resume state that must survive Q-quit
-    so the user can resume from Phase 3.  Removing it on the Phase 5 success path (before Phase 6)
+    Phase 7 fires on Q-quit too.  triage.json is durable resume state that must survive Q-quit
+    so the user can resume from Phase 3.  Removing it on the Phase 5 success path (before Phase 7)
     ensures Q-quit leaves it intact.
     """
     text = SKILL_MD.read_text()
     triage_cleanup_idx = text.find("/tmp/swe-workbench-address-feedback/${PR}-triage.json")
-    phase6_idx = text.find("### Phase 6")
+    phase7_idx = text.find("### Phase 7")
     assert triage_cleanup_idx != -1, (
         "SKILL.md must reference /tmp/swe-workbench-address-feedback/${PR}-triage.json for cleanup"
     )
-    assert phase6_idx != -1, "SKILL.md must have a ### Phase 6 section"
-    assert triage_cleanup_idx < phase6_idx, (
-        "triage.json cleanup must appear BEFORE ### Phase 6 — "
-        "Phase 6 also fires on Q-quit; triage.json must survive Q-quit for resume"
+    assert phase7_idx != -1, "SKILL.md must have a ### Phase 7 section"
+    assert triage_cleanup_idx < phase7_idx, (
+        "triage.json cleanup must appear BEFORE ### Phase 7 — "
+        "Phase 7 also fires on Q-quit; triage.json must survive Q-quit for resume"
     )
 
 
 def test_address_feedback_skill_phase6_does_not_delete_triage_json():
-    """Phase 6 code block must NOT contain a triage.json deletion (Q-quit must leave it intact)."""
+    """Phase 7 code block must NOT contain a triage.json deletion (Q-quit must leave it intact)."""
     text = SKILL_MD.read_text()
-    phase6_idx = text.find("### Phase 6")
-    assert phase6_idx != -1, "Phase 6 section must exist"
+    phase7_idx = text.find("### Phase 7")
+    assert phase7_idx != -1, "Phase 7 section must exist"
     # Extract only up to the next top-level section (## Failure modes or ## Common mistakes).
-    next_section = re.search(r'\n## ', text[phase6_idx:])
-    phase6_text = text[phase6_idx: phase6_idx + next_section.start()] if next_section else text[phase6_idx:]
-    # triage.json must not appear in the Phase 6 action blocks (only in the failure-modes table which follows)
+    next_section = re.search(r'\n## ', text[phase7_idx:])
+    phase7_text = text[phase7_idx: phase7_idx + next_section.start()] if next_section else text[phase7_idx:]
+    # triage.json must not appear in the Phase 7 action blocks (only in the failure-modes table which follows)
     # Filter out lines that are in a table row referencing the failure-mode description
-    phase6_lines_with_triage = [
-        line for line in phase6_text.splitlines()
+    phase7_lines_with_triage = [
+        line for line in phase7_text.splitlines()
         if "triage.json" in line
-        and not line.lstrip().startswith("|")   # table rows describe the failure, not Phase 6 actions
+        and not line.lstrip().startswith("|")   # table rows describe the failure, not Phase 7 actions
     ]
-    assert not phase6_lines_with_triage, (
-        "Phase 6 action blocks must NOT delete triage.json — Phase 6 runs on Q-quit too, and "
+    assert not phase7_lines_with_triage, (
+        "Phase 7 action blocks must NOT delete triage.json — Phase 7 runs on Q-quit too, and "
         "triage.json is durable resume state that must survive Q-quit.\n"
-        "Lines found: " + "\n".join(phase6_lines_with_triage)
+        "Lines found: " + "\n".join(phase7_lines_with_triage)
     )
 
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -205,34 +205,34 @@ def test_address_feedback_skill_phase6_preserves_trailer():
 # --- Cleanup (Phase 7) tests — AC#1, AC#2, AC#3 from issue #291 ---
 
 def test_address_feedback_skill_cleans_up_worktree():
-    """Phase 6 must include rimba remove "address-feedback-$PR" --force (AC#1)."""
+    """Phase 7 must include rimba remove "address-feedback-$PR" --force (AC#1)."""
     text = SKILL_MD.read_text()
     assert re.search(r'rimba remove ["\']?address-feedback-\$PR["\']? --force', text), (
-        'SKILL.md Phase 6 must include: rimba remove "address-feedback-$PR" --force — '
+        'SKILL.md Phase 7 must include: rimba remove "address-feedback-$PR" --force — '
         "the worktree is disposable; fixes are on the remote branch after Phase 4"
     )
 
 
 def test_address_feedback_skill_cleanup_failure_tolerant():
-    """Phase 6 cleanup must include a git-worktree fallback and must not block on failure (AC#2)."""
+    """Phase 7 cleanup must include a git-worktree fallback and must not block on failure (AC#2)."""
     text = SKILL_MD.read_text()
     assert "git worktree remove" in text, (
-        "SKILL.md Phase 6 must include a 'git worktree remove' fallback for when rimba is absent"
+        "SKILL.md Phase 7 must include a 'git worktree remove' fallback for when rimba is absent"
     )
     assert re.search(
         r"warn|do not block|never block|not block|continue|non.blocking|emit.*notice",
         text, re.IGNORECASE
     ), (
-        "SKILL.md Phase 6 must state that cleanup failure is non-blocking (warn, do not block, continue)"
+        "SKILL.md Phase 7 must state that cleanup failure is non-blocking (warn, do not block, continue)"
     )
 
 
 def test_address_feedback_skill_cleanup_preserves_pr_branch():
-    """Phase 6 fallback must NEVER contain git branch -D \"$PR_BRANCH\" — that deletes the real PR head branch."""
+    """Phase 7 fallback must NEVER contain git branch -D \"$PR_BRANCH\" — that deletes the real PR head branch."""
     text = SKILL_MD.read_text()
     assert not re.search(r'branch\s+-D\s+["\']?\$PR_BRANCH', text), (
         'SKILL.md must NOT contain: git branch -D "$PR_BRANCH" — '
-        "the git-worktree fallback in Phase 6 only removes the worktree dir; "
+        "the git-worktree fallback in Phase 7 only removes the worktree dir; "
         "deleting $PR_BRANCH would destroy the owner's actual PR head branch"
     )
 
@@ -242,7 +242,7 @@ def test_address_feedback_skill_drops_durable_no_cleanup_claim():
     text = SKILL_MD.read_text()
     assert "no auto-cleanup" not in text, (
         "SKILL.md must not claim 'no auto-cleanup' — issue #291 reversed this stance; "
-        "Phase 6 always removes the worktree on exit"
+        "Phase 7 always removes the worktree on exit"
     )
 
 


### PR DESCRIPTION
## Summary

- Adds **Phase 6 — Sync PR metadata** to `workflow-address-feedback` between Phase 5 (reply + resolve) and cleanup (now Phase 7). Phase 6 runs only when `$FIX_SHA` is set (fixes were committed in Phase 4).
- Fetches live PR title/body, commit subjects (`git log --format='%s'`), and diff stat; judges drift against the `## Summary` section; previews old→new; gates the revision on `Reply \`yes\``; applies via the new `runtime/sync-pr-metadata.sh` helper; preserves `Closes #`/trailer and all non-Summary sections.
- New **`runtime/sync-pr-metadata.sh`** — minimal helper mirroring `reply-and-resolve.sh` conventions: skips `--title` when empty, validates body file exists, exits 1 when nothing to do, `trap`-guarded temp file cleanup in the SKILL.md call-site.
- Renumbers old Phase 6 Cleanup → **Phase 7** throughout (heading, all back-references, failure-modes table, common-mistakes table).
- Updates frontmatter description and renames `## 5-phase flow` → `## Phase flow` (count-agnostic).

## Test Plan

- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [ ] `shellcheck runtime/sync-pr-metadata.sh` — 0 issues
- [ ] `bash scripts/validate.sh` — clean (291 lines, ≤ 300 cap)
- [ ] `pytest tests/ -v` — 1357/1357 pass (11 new tests: 6 script tests + 5 SKILL Phase 6 content assertions)
- [ ] 5 existing cleanup tests updated to reference Phase 7 (previously Phase 6)

### Type-tailored checks ([feat])
- [ ] New Phase 6 behaviour: sync is skipped when `$FIX_SHA` is unset (no commit in Phase 4)
- [ ] Drift-detected path: preview shown, apply requires `yes` confirmation
- [ ] `sync-pr-metadata.sh` title-only, body-only, title+body, and guard paths all covered by subprocess tests

Closes #454