### PR TITLE
[fix] Mode A embeds full ## Workflow template, not a summary

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -856,6 +856,65 @@ def check_plan_mode_workflow_embedding():
             )
 
 
+def check_workflow_full_fidelity_mandate():
+    """SKILL.md Mode A must mandate verbatim reproduction of the Workflow template, and
+    the template header must carry 'do not abridge' — locks fix for #455.
+
+    Two invariants checked:
+    1. The '## Plan-Time Behavior (Mode A)' section of workflow-development/SKILL.md
+       must contain both 'in full' and 'verbatim' (the explicit no-summarize mandate).
+    2. The header of templates/plan-workflow-section.md (before the first ```markdown
+       fence) must contain 'do not abridge' (the instruction travels with the template).
+    """
+    skill_md = ROOT / "skills" / "workflow-development" / "SKILL.md"
+    if not skill_md.is_file():
+        fail(Path("skills/workflow-development/SKILL.md"),
+             "missing — cannot check Mode A full-fidelity mandate (#455)")
+        skill_text = None
+    else:
+        try:
+            skill_text = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            fail(skill_md.relative_to(ROOT), "could not read file")
+            skill_text = None
+    if skill_text is not None:
+        mode_a_marker = "## Plan-Time Behavior (Mode A)"
+        idx = skill_text.find(mode_a_marker)
+        if idx >= 0:
+            next_h2 = skill_text.find("\n## ", idx + len(mode_a_marker))
+            section = skill_text[idx:next_h2] if next_h2 >= 0 else skill_text[idx:]
+        else:
+            section = ""
+        if "in full" not in section or "verbatim" not in section:
+            fail(
+                skill_md.relative_to(ROOT),
+                "Mode A paragraph is missing the full-fidelity mandate — the section must "
+                "contain both 'in full' and 'verbatim' to prevent the orchestrator from "
+                "condensing the ## Workflow template (#455).",
+            )
+
+    template_md = ROOT / "skills" / "workflow-development" / "templates" / "plan-workflow-section.md"
+    if not template_md.is_file():
+        fail(Path("skills/workflow-development/templates/plan-workflow-section.md"),
+             "missing — cannot check template full-fidelity header (#455)")
+        tmpl_text = None
+    else:
+        try:
+            tmpl_text = template_md.read_text(encoding="utf-8")
+        except OSError:
+            fail(template_md.relative_to(ROOT), "could not read file")
+            tmpl_text = None
+    if tmpl_text is not None:
+        fence_idx = tmpl_text.find("````markdown")
+        header = tmpl_text[:fence_idx] if fence_idx >= 0 else tmpl_text
+        if "do not abridge" not in header:
+            fail(
+                template_md.relative_to(ROOT),
+                "template header is missing 'do not abridge' — the no-summarize instruction "
+                "must travel with the template so the mandate is visible at the point of use (#455).",
+            )
+
+
 def check_browser_tool_gate(cache=None):
     """Any agent or command referencing browser MCP tools must carry a BLOCKED: sentinel
     and a per-backend install hint — enforces the hard gate from #364.
@@ -929,6 +988,7 @@ def main():
     check_skill_skill_refs(cache=cache)
     check_workflow_development_activation_contract()
     check_plan_mode_workflow_embedding()
+    check_workflow_full_fidelity_mandate()
     check_catalog_completeness(cache=cache)
     check_shared_includes_not_blockquoted(cache=cache)
     check_template_placeholders(cache=cache)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -889,6 +889,7 @@ def check_workflow_full_fidelity_mandate():
         else:
             next_h2 = skill_text.find("\n## ", idx + len(mode_a_marker))
             section = skill_text[idx:next_h2] if next_h2 >= 0 else skill_text[idx:]
+            # Fail if either token is absent — both are required.
             if "in full" not in section or "verbatim" not in section:
                 fail(
                     skill_md.relative_to(ROOT),

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -863,7 +863,7 @@ def check_workflow_full_fidelity_mandate():
     Two invariants checked:
     1. The '## Plan-Time Behavior (Mode A)' section of workflow-development/SKILL.md
        must contain both 'in full' and 'verbatim' (the explicit no-summarize mandate).
-    2. The header of templates/plan-workflow-section.md (before the first ```markdown
+    2. The header of templates/plan-workflow-section.md (before the first ````markdown
        fence) must contain 'do not abridge' (the instruction travels with the template).
     """
     skill_md = ROOT / "skills" / "workflow-development" / "SKILL.md"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -868,7 +868,7 @@ def check_workflow_full_fidelity_mandate():
     """
     skill_md = ROOT / "skills" / "workflow-development" / "SKILL.md"
     if not skill_md.is_file():
-        fail(Path("skills/workflow-development/SKILL.md"),
+        fail(skill_md.relative_to(ROOT),
              "missing — cannot check Mode A full-fidelity mandate (#455)")
         skill_text = None
     else:
@@ -880,22 +880,26 @@ def check_workflow_full_fidelity_mandate():
     if skill_text is not None:
         mode_a_marker = "## Plan-Time Behavior (Mode A)"
         idx = skill_text.find(mode_a_marker)
-        if idx >= 0:
-            next_h2 = skill_text.find("\n## ", idx + len(mode_a_marker))
-            section = skill_text[idx:next_h2] if next_h2 >= 0 else skill_text[idx:]
-        else:
-            section = ""
-        if "in full" not in section or "verbatim" not in section:
+        if idx < 0:
             fail(
                 skill_md.relative_to(ROOT),
-                "Mode A paragraph is missing the full-fidelity mandate — the section must "
-                "contain both 'in full' and 'verbatim' to prevent the orchestrator from "
-                "condensing the ## Workflow template (#455).",
+                "section '## Plan-Time Behavior (Mode A)' not found — "
+                "cannot locate Mode A full-fidelity mandate (#455).",
             )
+        else:
+            next_h2 = skill_text.find("\n## ", idx + len(mode_a_marker))
+            section = skill_text[idx:next_h2] if next_h2 >= 0 else skill_text[idx:]
+            if "in full" not in section or "verbatim" not in section:
+                fail(
+                    skill_md.relative_to(ROOT),
+                    "Mode A paragraph is missing the full-fidelity mandate — the section must "
+                    "contain both 'in full' and 'verbatim' to prevent the orchestrator from "
+                    "condensing the ## Workflow template (#455).",
+                )
 
     template_md = ROOT / "skills" / "workflow-development" / "templates" / "plan-workflow-section.md"
     if not template_md.is_file():
-        fail(Path("skills/workflow-development/templates/plan-workflow-section.md"),
+        fail(template_md.relative_to(ROOT),
              "missing — cannot check template full-fidelity header (#455)")
         tmpl_text = None
     else:

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -236,6 +236,8 @@ Two existing skills provide deeper verification when warranted — invoke ad hoc
 
 When writing or finalizing a plan, add a `## Workflow` section using the template at `templates/plan-workflow-section.md`. Substitute every `[[detect:KEY]]` marker with concrete values from Project Detection. **Before saving, grep your rendered draft for `[[detect:` — if any match remains, you skipped Project Detection; redo it.**
 
+Reproduce the template's `## Workflow` body **in full and verbatim** — copy every phase and line. The **only** permitted edit is substituting `[[detect:KEY]]` markers with concrete values; do **not** summarize, paraphrase, abridge, or collapse steps.
+
 ## Implementation-Time Behavior (Mode B)
 
 1. **Announce transitions**: `Phase N complete — <summary>. Moving to Phase N+1: <name>.`
@@ -265,6 +267,7 @@ When writing or finalizing a plan, add a `## Workflow` section using the templat
 | Plan that introduces file edits without Workflow section | Always add the Workflow section (Mode A) — skip only for pure design / analysis output |
 | Jump straight to coding | Always start at Phase 1 |
 | Ignore PR template, use generic format | Check for PR template first; fill every section |
+| Render a summarized / short Workflow section | Copy the template body verbatim — substitute only `[[detect:]]` markers (Mode A) |
 
 ### Red Flags — Never
 
@@ -284,3 +287,4 @@ When writing or finalizing a plan, add a `## Workflow` section using the templat
 | "Phase 2 sub-skill did everything" | Verify it provided evidence for Phases 3-4 |
 | "This is a small fix, no need for the full lifecycle" | Small fixes still need verify + review |
 | "The plan doesn't need a Workflow section" | If the plan introduces file edits, it does. Add one (Mode A). Skip only for pure design / analysis output. |
+| "The plan only needs the gist of the Workflow steps" | Reproduce the template in full — a summary drops the exact guidance that prevents mistakes. |

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -1,6 +1,6 @@
 # Plan Workflow Section Template
 
-Copy this `## Workflow` section into your plan and substitute `[[detect:KEY]]` markers with actual values from Project Detection.
+Copy this `## Workflow` section into your plan **in full — do not abridge, summarize, or collapse steps.** Substitute `[[detect:KEY]]` markers with actual values from Project Detection; that substitution is the only permitted edit.
 
 ---
 

--- a/tests/test_plan_workflow_section.py
+++ b/tests/test_plan_workflow_section.py
@@ -125,7 +125,7 @@ class TestFullFidelityHeader:
     def test_header_no_abridge_phrase(self):
         """Header region must carry 'do not abridge' before the fenced markdown block."""
         text = _text()
-        # Slice header: everything before the first ```markdown fence
+        # Slice header: everything before the first ````markdown fence
         fence_idx = text.find("````markdown")
         header = text[:fence_idx] if fence_idx >= 0 else text
         assert "do not abridge" in header, (

--- a/tests/test_plan_workflow_section.py
+++ b/tests/test_plan_workflow_section.py
@@ -6,6 +6,8 @@ Tests assert that:
    cd-prefix anti-pattern).
 2. The template includes a re-anchor/resume note so a continued session knows
    to call EnterWorktree before running commands.
+3. The template header carries a 'do not abridge' instruction so the mandate
+   travels with the template itself (#455).
 """
 
 from pathlib import Path
@@ -110,4 +112,23 @@ class TestReanchorNote:
         assert any(p in text for p in signal_phrases), (
             "Template must state that catching yourself cd-prefixing is the signal "
             "to stop and call EnterWorktree(path=…)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full-fidelity header mandate (#455)
+# ---------------------------------------------------------------------------
+
+class TestFullFidelityHeader:
+    """Template header must instruct the orchestrator not to abridge."""
+
+    def test_header_no_abridge_phrase(self):
+        """Header region must carry 'do not abridge' before the fenced markdown block."""
+        text = _text()
+        # Slice header: everything before the first ```markdown fence
+        fence_idx = text.find("````markdown")
+        header = text[:fence_idx] if fence_idx >= 0 else text
+        assert "do not abridge" in header, (
+            "Template header must carry 'do not abridge' so the no-summarize "
+            "instruction travels with the template itself (#455)."
         )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2413,8 +2413,8 @@ class TestCheckWorkflowFullFidelityMandate:
         self._write_skill(root, "Reproduce the template in full — substitute [[detect:KEY]] markers.\n")
         self._write_template(root, "Copy this section — do not abridge.")
         validate.check_workflow_full_fidelity_mandate()
-        assert any("verbatim" in f for f in validate.FAILURES), (
-            "Expected a failure naming 'verbatim' when that token is missing from Mode A"
+        assert any("full-fidelity mandate" in f for f in validate.FAILURES), (
+            "Expected a failure containing 'full-fidelity mandate' when 'verbatim' token is absent"
         )
 
     def test_skill_md_missing_in_full_fails(self, reset_validate):
@@ -2442,6 +2442,5 @@ class TestCheckWorkflowFullFidelityMandate:
         import validate as val
         real_root = Path(__file__).parent.parent
         monkeypatch.setattr(val, "ROOT", real_root)
-        val.FAILURES.clear()
         val.check_workflow_full_fidelity_mandate()
         assert val.FAILURES == [], f"validate.py failures on real repo: {val.FAILURES}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2383,6 +2383,13 @@ class TestCheckWorkflowFullFidelityMandate:
         content = header + "\n\n````markdown\n## Workflow\n````\n"
         (tmpl_dir / "plan-workflow-section.md").write_text(content, encoding="utf-8")
 
+    def test_both_files_correct_passes(self, reset_validate):
+        root = reset_validate
+        self._write_skill(root, "Reproduce in full and verbatim — substitute [[detect:KEY]] markers.\n")
+        self._write_template(root, "Copy this section — do not abridge.")
+        validate.check_workflow_full_fidelity_mandate()
+        assert validate.FAILURES == [], f"Expected no failures but got: {validate.FAILURES}"
+
     def test_skill_md_file_absent_fails(self, reset_validate):
         root = reset_validate
         # Neither SKILL.md nor the template exists — the missing-file branch fires.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2383,13 +2383,21 @@ class TestCheckWorkflowFullFidelityMandate:
         content = header + "\n\n````markdown\n## Workflow\n````\n"
         (tmpl_dir / "plan-workflow-section.md").write_text(content, encoding="utf-8")
 
+    def test_skill_md_file_absent_fails(self, reset_validate):
+        root = reset_validate
+        # Neither SKILL.md nor the template exists — the missing-file branch fires.
+        validate.check_workflow_full_fidelity_mandate()
+        assert any("missing" in f for f in validate.FAILURES), (
+            "Expected a failure containing 'missing' when SKILL.md does not exist"
+        )
+
     def test_skill_md_missing_in_full_and_verbatim_fails(self, reset_validate):
         root = reset_validate
         self._write_skill(root, "Substitute [[detect:KEY]] markers only.\n")
         self._write_template(root, "Copy this section — do not abridge.")
         validate.check_workflow_full_fidelity_mandate()
-        assert any("in full" in f or "verbatim" in f for f in validate.FAILURES), (
-            "Expected a failure naming 'in full' or 'verbatim' when Mode A mandate is absent"
+        assert any("full-fidelity mandate" in f for f in validate.FAILURES), (
+            "Expected a failure containing 'full-fidelity mandate' when Mode A mandate tokens are absent"
         )
 
     def test_skill_md_missing_verbatim_fails(self, reset_validate):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2410,6 +2410,17 @@ class TestCheckWorkflowFullFidelityMandate:
             "Expected a failure naming 'verbatim' when that token is missing from Mode A"
         )
 
+    def test_skill_md_missing_in_full_fails(self, reset_validate):
+        root = reset_validate
+        # Has "verbatim" but NOT "in full" — mirrors test_skill_md_missing_verbatim_fails
+        # to guard both halves of the `or` in the guard condition independently.
+        self._write_skill(root, "Reproduce verbatim — substitute [[detect:KEY]] markers.\n")
+        self._write_template(root, "Copy this section — do not abridge.")
+        validate.check_workflow_full_fidelity_mandate()
+        assert any("full-fidelity mandate" in f for f in validate.FAILURES), (
+            "Expected a failure when 'in full' is absent from Mode A paragraph"
+        )
+
     def test_template_missing_no_abridge_fails(self, reset_validate):
         root = reset_validate
         self._write_skill(root, "Reproduce in full and verbatim — substitute [[detect:KEY]] markers.\n")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2358,3 +2358,64 @@ class TestE2eTestVerifierAgent:
         val.check_agents(cache=cache)
         val.check_agent_skill_refs(cache=cache)
         assert val.FAILURES == [], f"validate.py failures: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────
+# check_workflow_full_fidelity_mandate
+# ──────────────────────────────────────────────
+
+class TestCheckWorkflowFullFidelityMandate:
+    """Guards the Mode A full-fidelity mandate in SKILL.md and the template header (#455)."""
+
+    def _write_skill(self, root, mode_a_body):
+        skill_dir = root / "skills" / "workflow-development"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = (
+            "## Plan-Time Behavior (Mode A)\n"
+            + mode_a_body
+            + "\n## Implementation-Time Behavior (Mode B)\n"
+        )
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+    def _write_template(self, root, header):
+        tmpl_dir = root / "skills" / "workflow-development" / "templates"
+        tmpl_dir.mkdir(parents=True, exist_ok=True)
+        content = header + "\n\n````markdown\n## Workflow\n````\n"
+        (tmpl_dir / "plan-workflow-section.md").write_text(content, encoding="utf-8")
+
+    def test_skill_md_missing_in_full_and_verbatim_fails(self, reset_validate):
+        root = reset_validate
+        self._write_skill(root, "Substitute [[detect:KEY]] markers only.\n")
+        self._write_template(root, "Copy this section — do not abridge.")
+        validate.check_workflow_full_fidelity_mandate()
+        assert any("in full" in f or "verbatim" in f for f in validate.FAILURES), (
+            "Expected a failure naming 'in full' or 'verbatim' when Mode A mandate is absent"
+        )
+
+    def test_skill_md_missing_verbatim_fails(self, reset_validate):
+        root = reset_validate
+        # Has "in full" but NOT "verbatim"
+        self._write_skill(root, "Reproduce the template in full — substitute [[detect:KEY]] markers.\n")
+        self._write_template(root, "Copy this section — do not abridge.")
+        validate.check_workflow_full_fidelity_mandate()
+        assert any("verbatim" in f for f in validate.FAILURES), (
+            "Expected a failure naming 'verbatim' when that token is missing from Mode A"
+        )
+
+    def test_template_missing_no_abridge_fails(self, reset_validate):
+        root = reset_validate
+        self._write_skill(root, "Reproduce in full and verbatim — substitute [[detect:KEY]] markers.\n")
+        self._write_template(root, "Copy this section into your plan.")
+        validate.check_workflow_full_fidelity_mandate()
+        assert any("do not abridge" in f for f in validate.FAILURES), (
+            "Expected a failure naming 'do not abridge' when that phrase is missing from template header"
+        )
+
+    def test_real_repo_passes(self, reset_validate, monkeypatch):
+        """After applying changes #1 and #2, the real files must pass cleanly."""
+        import validate as val
+        real_root = Path(__file__).parent.parent
+        monkeypatch.setattr(val, "ROOT", real_root)
+        val.FAILURES.clear()
+        val.check_workflow_full_fidelity_mandate()
+        assert val.FAILURES == [], f"validate.py failures on real repo: {val.FAILURES}"


### PR DESCRIPTION
## Summary
- Add explicit full-fidelity mandate to `skills/workflow-development/SKILL.md` Mode A paragraph: "Reproduce the template's `## Workflow` body **in full and verbatim**" — the only permitted edit is substituting `[[detect:KEY]]` markers.
- Add two guardrail table rows to SKILL.md reinforcing the mandate (Common Mistakes + If You Catch Yourself Thinking…).
- Strengthen `skills/workflow-development/templates/plan-workflow-section.md` header with "do not abridge, summarize, or collapse steps" so the instruction travels with the template itself.
- Add `check_workflow_full_fidelity_mandate()` to `scripts/validate.py` + register in `main()` — static guard that fails if either mandate phrase is ever stripped, locking the fix against regression.

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` → `All checks passed.`
- [x] `pytest tests/test_validate.py::TestCheckWorkflowFullFidelityMandate -v` → 4/4 pass
- [x] `pytest tests/test_plan_workflow_section.py::TestFullFidelityHeader -v` → 1/1 pass
- [x] `pytest tests/ -v` → 1362/1362 pass
- [x] Acceptance spot-check: strip mandate phrase from SKILL.md → `validate.sh` FAILS with `#455` message → restore → passes

### Type-tailored checks ([fix])
- [x] Reproduce bug: before the fix, Mode A paragraph contained no "in full"/"verbatim" → `check_workflow_full_fidelity_mandate` would have reported a failure (confirmed by RED phase — all new tests failed before implementation).
- [x] Verify fix: after the fix, all 5 new tests pass and the guard bites on stripped files.

Closes #455
