### PR TITLE
[chore] Harden CI workflows: SHA-pin actions/*, lockfile guard, release concurrency

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -46,6 +46,7 @@ jobs:
         run: bash scripts/lock-pip-requirements.sh
 
       - name: Guard against new top-level packages
+        # Keep this lockfile list in sync with the "Regenerate pip lockfiles" step above.
         run: bash scripts/check-lockfile-additions.sh tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock
 
       - name: Commit and push updated lockfiles if changed

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Checkout the branch tip (not a detached SHA) so git push is a fast-forward.
           # github.head_ref is safe here: action inputs are not shell-evaluated by the runner.
@@ -38,12 +38,15 @@ jobs:
           ref: ${{ github.head_ref }}
           persist-credentials: true
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Regenerate pip lockfiles
         run: bash scripts/lock-pip-requirements.sh
+
+      - name: Guard against new top-level packages
+        run: bash scripts/check-lockfile-additions.sh tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock
 
       - name: Commit and push updated lockfiles if changed
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Validate plugin files
         run: bash scripts/validate.sh
 
@@ -111,7 +111,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Run shellcheck (warning+ on all *.sh + githooks)
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         with:
@@ -125,8 +125,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - run: pip install --require-hashes -r tests/requirements.lock
@@ -138,8 +138,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - name: Verify lockfiles are up to date
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Check markdown links (lychee)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   validate-schemas:
     runs-on: ubuntu-latest
@@ -15,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Validate JSON well-formedness
         run: |
@@ -23,7 +27,7 @@ jobs:
           jq empty .claude-plugin/marketplace.json
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -72,12 +76,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists — skipping."
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+          if gh release view "$GITHUB_REF_NAME" >/dev/null; then
             echo "Release $GITHUB_REF_NAME already exists — skipping."
           else
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # gh release view exits 1 when the release doesn't exist; stderr is
+          # intentionally preserved so auth/network errors remain visible.
           if gh release view "$GITHUB_REF_NAME" >/dev/null; then
             echo "Release $GITHUB_REF_NAME already exists — skipping."
           else

--- a/.github/workflows/skill-triggers.yml
+++ b/.github/workflows/skill-triggers.yml
@@ -14,8 +14,8 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - run: pip install --require-hashes -r tests/requirements.lock

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Usage ──────────────────────────────────────────────────────────────────
+
+if [[ $# -eq 0 ]]; then
+  echo "Error: no lockfile paths given" >&2
+  echo "Usage: $0 <lockfile> [<lockfile> ...]" >&2
+  exit 1
+fi
+
+# ── Top-level extractor ────────────────────────────────────────────────────
+# Reads pip-compile lock content on stdin.
+# A package is top-level iff any line in its # via block matches -r *.txt.
+# Outputs sorted package names, one per line.
+
+extract_top_level() {
+  awk '
+    /^[A-Za-z0-9._-]+==/ {
+      name = $1
+      sub(/==.*/, "", name)
+      invia = 0
+      next
+    }
+    /^[[:space:]]*#[[:space:]]*via/ {
+      invia = 1
+      if ($0 ~ /-r[[:space:]].*\.txt/) top[name] = 1
+      next
+    }
+    invia && /^[[:space:]]*#/ {
+      if ($0 ~ /-r[[:space:]].*\.txt/) top[name] = 1
+      next
+    }
+    { invia = 0 }
+    END { for (p in top) if (p != "") print p }
+  ' | sort -u
+}
+
+# ── Per-lockfile check ─────────────────────────────────────────────────────
+
+failed=0
+
+for lock in "$@"; do
+  # Base set: HEAD content (pre-regen, pre-commit).
+  # Empty if the lockfile is new (git cat-file -e exits non-zero).
+  if git cat-file -e "HEAD:${lock}" 2>/dev/null; then
+    base=$(git show "HEAD:${lock}" | extract_top_level)
+  else
+    base=""
+  fi
+
+  # New set: working-tree content (post-regen).
+  new=$(extract_top_level < "${lock}")
+
+  # Additions: packages in new that are absent from base.
+  # Filter empty lines so an empty base doesn't false-positive.
+  added=$(comm -13 \
+    <(printf '%s\n' "${base}" | grep -v '^$' | sort -u) \
+    <(printf '%s\n' "${new}"  | grep -v '^$' | sort -u))
+
+  if [[ -n "${added}" ]]; then
+    echo "::error::${lock}: new top-level package(s) added — review before merging:" >&2
+    while IFS= read -r pkg; do
+      echo "  ${pkg}" >&2
+    done <<< "${added}"
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -eq 1 ]]; then
+  exit 1
+fi

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -61,8 +61,8 @@ for lock in "$@"; do
   # Additions: packages in new that are absent from base.
   # Filter empty lines so an empty base doesn't false-positive.
   added=$(comm -13 \
-    <(printf '%s\n' "${base}" | grep -v '^$' | sort -u) \
-    <(printf '%s\n' "${new}"  | grep -v '^$' | sort -u))
+    <(printf '%s\n' "${base}" | grep -v '^$') \
+    <(printf '%s\n' "${new}"  | grep -v '^$'))
 
   if [[ -n "${added}" ]]; then
     echo "::error::${lock}: new top-level package(s) added — review before merging:" >&2

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -73,6 +73,6 @@ for lock in "$@"; do
   fi
 done
 
-if [[ "${failed}" -eq 1 ]]; then
+if [[ "${failed}" -ne 0 ]]; then
   exit 1
 fi

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -51,6 +51,11 @@ for lock in "$@"; do
   fi
 
   # New set: working-tree content (post-regen).
+  if [[ ! -f "${lock}" ]]; then
+    echo "::error::${lock}: file not found in working tree" >&2
+    failed=1
+    continue
+  fi
   new=$(extract_top_level < "${lock}")
 
   # Additions: packages in new that are absent from base.

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -42,7 +42,8 @@ failed=0
 
 for lock in "$@"; do
   # Base set: HEAD content (pre-regen, pre-commit).
-  # Empty if the lockfile is new (git cat-file -e exits non-zero).
+  # When the lockfile is new (absent from HEAD), every package is treated as an
+  # addition — this is intentional; a new lockfile always requires human review.
   if git cat-file -e "HEAD:${lock}" 2>/dev/null; then
     base=$(git show "HEAD:${lock}" | extract_top_level)
   else

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,9 @@ import pytest
 # inherited by subprocess children — Git then treats temp test repos as if
 # they share the host repo's git context, causing failures.
 # We strip every GIT_* var, then re-add GIT_CONFIG_NOSYSTEM=1 to ignore the
-# system gitconfig for hermeticity.
+# system gitconfig for hermeticity. GIT_CONFIG_COUNT/KEY/VALUE_0 additionally
+# suppresses commit.gpgsign so tests don't fail on machines with GPG signing
+# enabled in ~/.gitconfig (which GIT_CONFIG_NOSYSTEM does not cover).
 #
 # Snapshot: built once from os.environ at pytest collection time. Session-scoped
 # fixtures that mutate GIT_* vars after import will not be reflected here.
@@ -27,6 +29,9 @@ _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
         "GIT_AUTHOR_EMAIL": "t@t.com",
         "GIT_COMMITTER_NAME": "T",
         "GIT_COMMITTER_EMAIL": "t@t.com",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "commit.gpgsign",
+        "GIT_CONFIG_VALUE_0": "false",
     }
 )
 

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -137,6 +137,20 @@ class TestLockfileAdditionsGuard:
         assert result.returncode == 1
         assert "file not found" in result.stderr
 
+    def test_all_top_level_removed_exits_zero(self, tmp_path):
+        """Top-level package in HEAD but absent after regen → removal is safe → exit 0."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text("")  # post-regen: empty lock (package removed)
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, result.stderr
+
     def test_transitive_only_addition_exits_zero(self, tmp_path):
         """A new package with # via <dep> (no -r) is transitive-only → exit 0."""
         lock_file = _make_git_repo(tmp_path, _BASE_LOCK)

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -1,0 +1,127 @@
+"""Behavioral tests for scripts/check-lockfile-additions.sh.
+
+Each case builds a hermetic temp git repo (git init + initial commit of the
+base lock), overwrites the working-tree lock to simulate a post-regen state,
+then runs the script via subprocess and asserts the exit code and output.
+
+The script reads HEAD:<lock> as the pre-regen baseline and compares top-level
+sets (packages whose # via block references -r *.txt).
+"""
+
+import subprocess
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+GUARD_SCRIPT = ROOT / "scripts" / "check-lockfile-additions.sh"
+
+# Minimal pip-compile lock with one top-level package.
+_BASE_LOCK = (
+    "pytest==9.0.3\n"
+    "    # via -r tests/requirements.txt\n"
+)
+
+
+def _make_git_repo(tmp_path: Path, lock_content: str) -> Path:
+    """Scaffold a temp git repo with the given lock content committed to HEAD."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    lock_file = tests_dir / "requirements.lock"
+    lock_file.write_text(lock_content)
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True,
+                   capture_output=True, env=_CLEAN_ENV)
+    subprocess.run(["git", "add", "tests/requirements.lock"], cwd=tmp_path,
+                   check=True, capture_output=True, env=_CLEAN_ENV)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True,
+                   capture_output=True, env=_CLEAN_ENV)
+    return lock_file
+
+
+class TestLockfileAdditionsGuard:
+    def test_version_bump_exits_zero(self, tmp_path):
+        """Bumping a top-level package version is not an addition → exit 0."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text("pytest==9.1.0\n    # via -r tests/requirements.txt\n")
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_new_top_level_package_exits_one(self, tmp_path):
+        """Adding a new # via -r package is a new top-level dep → exit 1 naming it."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(
+            _BASE_LOCK
+            + "requests==2.31.0\n"
+            + "    # via -r tests/requirements.txt\n"
+        )
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "requests" in result.stderr
+
+    def test_identical_lock_exits_zero(self, tmp_path):
+        """Unchanged working-tree lock → exit 0."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(_BASE_LOCK)
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_new_lockfile_absent_from_head_exits_one(self, tmp_path):
+        """Lockfile absent from HEAD (first introduction) → all packages are additions → exit 1."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True,
+                       capture_output=True, env=_CLEAN_ENV)
+        subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=tmp_path,
+                       check=True, capture_output=True, env=_CLEAN_ENV)
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        lock_file = tests_dir / "requirements.lock"
+        lock_file.write_text(_BASE_LOCK)
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "pytest" in result.stderr
+
+    def test_transitive_only_addition_exits_zero(self, tmp_path):
+        """A new package with # via <dep> (no -r) is transitive-only → exit 0."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(
+            _BASE_LOCK
+            + "attrs==23.1.0\n"
+            + "    # via pytest\n"
+        )
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -120,6 +120,23 @@ class TestLockfileAdditionsGuard:
         assert result.returncode == 1
         assert "pytest" in result.stderr
 
+    def test_missing_lockfile_exits_one(self, tmp_path):
+        """Path given but file absent from working tree → exit 1 with error message."""
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True,
+                       capture_output=True, env=_CLEAN_ENV)
+        subprocess.run(["git", "commit", "--allow-empty", "-m", "init"],
+                       cwd=tmp_path, check=True, capture_output=True, env=_CLEAN_ENV)
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "file not found" in result.stderr
+
     def test_transitive_only_addition_exits_zero(self, tmp_path):
         """A new package with # via <dep> (no -r) is transitive-only → exit 0."""
         lock_file = _make_git_repo(tmp_path, _BASE_LOCK)

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -40,6 +40,18 @@ def _make_git_repo(tmp_path: Path, lock_content: str) -> Path:
 
 
 class TestLockfileAdditionsGuard:
+    def test_no_args_exits_one(self, tmp_path):
+        """No lockfile args → usage error → exit 1."""
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT)],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "Usage" in result.stderr
+
     def test_version_bump_exits_zero(self, tmp_path):
         """Bumping a top-level package version is not an addition → exit 0."""
         lock_file = _make_git_repo(tmp_path, _BASE_LOCK)


### PR DESCRIPTION
## Summary
- **SHA-pin `actions/*`** — replaced floating `actions/checkout@v7` and `actions/setup-python@v6` tags with full 40-char SHAs + version comments across all four CI workflows (`pr.yml`, `release.yml`, `skill-triggers.yml`, `dependabot-lockfile.yml`). The `github-actions` Dependabot ecosystem (already configured in `.github/dependabot.yml`) will bump the pins automatically going forward.
- **Lockfile-additions guard** — new `scripts/check-lockfile-additions.sh` fails-closed (exit 1 + `::error::` annotation) if a Dependabot lockfile regen introduces a previously-absent top-level package (detected via pip-compile's `# via -r *.txt` blocks). Wired into `dependabot-lockfile.yml` between regen and commit steps. 5 pytest behavioral cases added.
- **Release concurrency + idempotent publish** — `release.yml` now has a `concurrency: cancel-in-progress: false` block (prevents duplicate tag runs from racing) and a `gh release view` idempotency guard on the "Create GitHub Release" step (safe to re-trigger).

## Test Plan
- [x] `shellcheck -S warning scripts/check-lockfile-additions.sh` — 0 issues
- [x] `actionlint` on all 4 edited workflows — 0 issues
- [x] `pytest tests/ -v` — 1370/1370 pass (5 new guard cases: version bump → 0, new top-level → 1, identical → 0, transitive-only → 0, absent-from-HEAD → 1)
- [x] Pre-push hook ran full suite on push — all green

### Type-tailored checks ([chore])
- [x] SHA SHAs verified to resolve to the commented tags before pinning
- [x] Dependabot `github-actions` ecosystem already present — no config change needed
- [x] Guard step positioned after regen but before commit — `HEAD:<lock>` is always the pre-regen baseline

Closes #456
