### PR TITLE
[fix] Phase 4 dispatches both reviewers in parallel (#458)

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -33,7 +33,11 @@ Isolate this work in a worktree when the scope warrants it (non-trivial changes,
 Run `superpowers:verification-before-completion` before claiming any phase done. Do not advance to Phase 4 until this passes clean.
 
 **Phase 4 — Review**
-Dispatch both reviewers: `superpowers:requesting-code-review` (plan-alignment) and the `reviewer` subagent (diff correctness/security/design). Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
+Dispatch **BOTH** reviewers **IN PARALLEL** — in a single batch (same turn), as two distinct required invocations, **neither optional**:
+- `superpowers:requesting-code-review` (a **Skill**) — plan-alignment, standards
+- `swe-workbench:reviewer` (a **subagent**) — diff correctness/security/design in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+
+Running the Skill inline and skipping the `swe-workbench:reviewer` subagent (or vice-versa) does **not** satisfy this phase. Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
 
 **Phase 5 — Deliver**
 Use the PR template path recorded in Project Detection: pass it to `gh pr create --body-file <path>` and substitute the `Closes #` placeholder (with `Closes #123` or `Issue: N/A — <reason>`) before invoking. Only emit the heredoc body shown in Phase 5 of `templates/plan-workflow-section.md` if no template was found — do not re-invoke the template skill as a fallback. Then invoke `swe-workbench:workflow-commit-and-pr` to complete the delivery. After the PR is merged (by you or a reviewer), run `/swe-workbench:cleanup-merged <N>` to remove the worktree and local + remote branch.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -271,8 +271,8 @@ def check_agent_skill_refs(cache=None):
             if not _artifact_exists(artifact_id):
                 fail(
                     agent_md.relative_to(ROOT),
-                    f"references 'swe-workbench:{artifact_id}' but skills/{artifact_id}/ does not exist "
-                    f"(also checked agents/{artifact_id}.md and commands/{artifact_id}.md)",
+                    f"references 'swe-workbench:{artifact_id}' but no matching artifact found "
+                    f"(checked skills/{artifact_id}/, agents/{artifact_id}.md, commands/{artifact_id}.md)",
                 )
 
 
@@ -287,8 +287,8 @@ def check_command_skill_refs():
             if not _artifact_exists(artifact_id):
                 fail(
                     cmd_md.relative_to(ROOT),
-                    f"references 'swe-workbench:{artifact_id}' but skills/{artifact_id}/ does not exist "
-                    f"(also checked agents/{artifact_id}.md and commands/{artifact_id}.md)",
+                    f"references 'swe-workbench:{artifact_id}' but no matching artifact found "
+                    f"(checked skills/{artifact_id}/, agents/{artifact_id}.md, commands/{artifact_id}.md)",
                 )
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -254,9 +254,9 @@ def check_commands():
 
 
 def check_agent_skill_refs(cache=None):
-    """Every `swe-workbench:<id>` in agents/*.md must resolve to skills/<id>/ on disk."""
+    """Every `swe-workbench:<id>` in agents/*.md must resolve to a skill dir,
+    agent file, or command file on disk."""
     agents_dir = ROOT / "agents"
-    skills_dir = ROOT / "skills"
     agents_cache = cache[0] if cache is not None else None
     pattern = re.compile(r'`swe-workbench:([\w-]+)`')
     for agent_md in sorted(agents_dir.glob("*.md")):
@@ -267,26 +267,28 @@ def check_agent_skill_refs(cache=None):
                 continue
         else:
             text = agent_md.read_text(encoding="utf-8")
-        for skill_id in set(pattern.findall(text)):
-            if not (skills_dir / skill_id).is_dir():
+        for artifact_id in set(pattern.findall(text)):
+            if not _artifact_exists(artifact_id):
                 fail(
                     agent_md.relative_to(ROOT),
-                    f"references 'swe-workbench:{skill_id}' but skills/{skill_id}/ does not exist",
+                    f"references 'swe-workbench:{artifact_id}' but skills/{artifact_id}/ does not exist "
+                    f"(also checked agents/{artifact_id}.md and commands/{artifact_id}.md)",
                 )
 
 
 def check_command_skill_refs():
-    """Every `swe-workbench:<id>` in commands/*.md must resolve to skills/<id>/ on disk."""
+    """Every `swe-workbench:<id>` in commands/*.md must resolve to a skill dir,
+    agent file, or command file on disk."""
     commands_dir = ROOT / "commands"
-    skills_dir = ROOT / "skills"
     pattern = re.compile(r'`swe-workbench:([\w-]+)`')
     for cmd_md in sorted(commands_dir.glob("*.md")):
         text = cmd_md.read_text(encoding="utf-8")
-        for skill_id in set(pattern.findall(text)):
-            if not (skills_dir / skill_id).is_dir():
+        for artifact_id in set(pattern.findall(text)):
+            if not _artifact_exists(artifact_id):
                 fail(
                     cmd_md.relative_to(ROOT),
-                    f"references 'swe-workbench:{skill_id}' but skills/{skill_id}/ does not exist",
+                    f"references 'swe-workbench:{artifact_id}' but skills/{artifact_id}/ does not exist "
+                    f"(also checked agents/{artifact_id}.md and commands/{artifact_id}.md)",
                 )
 
 

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -31,8 +31,9 @@ Mode B — Single Implementation:
                           └─ swe-workbench:principle-tdd (per unit)
                           └─ swe-workbench:workflow-delegated-implementation (scope/complexity warrants isolation)
   Phase 3 (Verify)    → superpowers:verification-before-completion
-  Phase 4 (Review)    → superpowers:requesting-code-review (plan-alignment)
-                          └─ swe-workbench:reviewer (diff correctness/security/design)
+  Phase 4 (Review)    → BOTH in parallel (neither optional):
+                          ├─ superpowers:requesting-code-review (Skill — plan-alignment)
+                          └─ swe-workbench:reviewer (subagent — diff correctness/security/design)
   Phase 5 (Deliver)   → swe-workbench:workflow-commit-and-pr
 
 Mode C — Orchestration: see orchestration.md
@@ -199,15 +200,17 @@ Invoke `superpowers:verification-before-completion`.
 
 **Goal:** Catch design and quality issues before delivery.
 
-Dispatch both reviewers — they answer different questions:
-- `superpowers:requesting-code-review` — plan-alignment: does this match the plan and meet standards?
-- `swe-workbench:reviewer` subagent — diff review: correctness, security, design, test gaps in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+Dispatch **BOTH** reviewers **IN PARALLEL** — in a single batch (same turn), as two distinct required invocations, **neither optional**. They are different unit types:
+- `superpowers:requesting-code-review` (a **Skill**) — plan-alignment: does this match the plan and meet standards?
+- `swe-workbench:reviewer` (a **subagent**) — diff review: correctness, security, design, test gaps in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+
+Running the Skill inline and skipping the subagent (or vice-versa) does **not** satisfy this phase.
 
 Act on feedback:
 - **Critical/Important:** fix → re-verify (Phase 3) → re-review
 - **Minor:** note or fix inline, proceed
 
-**Skip condition:** If Phase 2 sub-skill already ran two-stage code review with evidence, mark as "completed by sub-skill" and proceed.
+**Skip condition:** Only skip with explicit named evidence that **both** stages already ran — a plan-alignment verdict from `superpowers:requesting-code-review` AND a `Severity | File:Line | …` diff review from `swe-workbench:reviewer`. Cite both when marking "completed by sub-skill". A single combined or one-sided review does not qualify.
 
 ---
 

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -60,9 +60,11 @@ Test: [[detect:test-command]] — N/N pass
 
 ### Phase 4: Review
 
-Dispatch both reviewers:
-- `superpowers:requesting-code-review` — plan-alignment, standards
-- `swe-workbench:reviewer` subagent — diff correctness/security/design in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+Dispatch **BOTH** reviewers **IN PARALLEL** — in a single batch (same turn), as two distinct required invocations, **neither optional**:
+- `superpowers:requesting-code-review` (a **Skill**) — plan-alignment, standards
+- `swe-workbench:reviewer` (a **subagent**) — diff correctness/security/design in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+
+Running the Skill inline and skipping the subagent (or vice-versa) does **not** satisfy this phase.
 
 Act on feedback:
 - **Critical/Important:** fix → re-verify → re-review

--- a/skills/workflow-extend/SKILL.md
+++ b/skills/workflow-extend/SKILL.md
@@ -68,11 +68,13 @@ Hand off to `swe-workbench:workflow-development` Mode B starting at **Phase 2 (I
 
 **Phase 3 (Verify):** Run `superpowers:verification-before-completion`. Do not advance until all format / lint / test steps pass with evidence.
 
-**Phase 4 (Review):** Dispatch both reviewers:
-- `superpowers:requesting-code-review` — plan-alignment and standards
-- `swe-workbench:reviewer` — diff correctness/security/design
+**Phase 4 (Review):** Dispatch **BOTH** reviewers **IN PARALLEL** — in a single batch (same turn), as two distinct required invocations, **neither optional**:
+- `superpowers:requesting-code-review` (a **Skill**) — plan-alignment and standards
+- `swe-workbench:reviewer` (a **subagent**) — diff correctness/security/design in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
 
-The reviewer must additionally check: **does the diff scope match the captured AC?** Flag scope creep as `Severity: High | scope-creep | <files>` and ask user to confirm or carve out before proceeding.
+Running the Skill inline and skipping the `swe-workbench:reviewer` subagent (or vice-versa) does **not** satisfy this phase.
+
+The `swe-workbench:reviewer` subagent must additionally check: **does the diff scope match the captured AC?** Flag scope creep as `Severity: High | scope-creep | <files>` and ask user to confirm or carve out before proceeding.
 
 Do not advance to Phase D until Phase C review passes clean or all issues are resolved.
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -662,7 +662,27 @@ class TestCheckAgentSkillRefs:
             encoding="utf-8",
         )
         validate.check_agent_skill_refs()
-        assert any("does not exist" in f for f in validate.FAILURES)
+        assert any("no matching artifact found" in f for f in validate.FAILURES)
+
+    def test_ref_to_existing_agent_file_passes(self, reset_validate):
+        """An agent referencing another agent via swe-workbench: must pass
+        when the target exists as agents/<id>.md (not just skills/<id>/)."""
+        root = reset_validate
+        make_plugin_tree(root)
+        agents_dir = root / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "bar.md").write_text(
+            "---\nname: bar\ndescription: d\ntools: Read\n---\n",
+            encoding="utf-8",
+        )
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Skill\n---\n"
+            "\nUse `swe-workbench:bar` subagent.\n"
+            "\n> See @./shared/principles.md\n",
+            encoding="utf-8",
+        )
+        validate.check_agent_skill_refs()
+        assert len(validate.FAILURES) == 0
 
 
 # ──────────────────────────────────────────────
@@ -691,7 +711,7 @@ class TestCheckCommandSkillRefs:
             encoding="utf-8",
         )
         validate.check_command_skill_refs()
-        assert any("nonexistent" in f and "does not exist" in f for f in validate.FAILURES)
+        assert any("nonexistent" in f and "no matching artifact found" in f for f in validate.FAILURES)
 
     def test_typoed_skill_id_among_valid_refs_fails(self, reset_validate):
         root = reset_validate
@@ -705,7 +725,7 @@ class TestCheckCommandSkillRefs:
         )
         validate.check_command_skill_refs()
         assert len(validate.FAILURES) == 1
-        assert "fooo" in validate.FAILURES[0] and "does not exist" in validate.FAILURES[0]
+        assert "fooo" in validate.FAILURES[0] and "no matching artifact found" in validate.FAILURES[0]
         assert "swe-workbench:foo'" not in validate.FAILURES[0]
 
     def test_command_with_no_skill_refs_passes_silently(self, reset_validate):
@@ -713,6 +733,22 @@ class TestCheckCommandSkillRefs:
         make_plugin_tree(root)
         (root / "commands" / "my-cmd.md").write_text(
             "---\ndescription: d\n---\n\nNo plugin references here.\n",
+            encoding="utf-8",
+        )
+        validate.check_command_skill_refs()
+        assert len(validate.FAILURES) == 0
+
+    def test_ref_to_existing_agent_file_passes(self, reset_validate):
+        """A command referencing an agent via swe-workbench: must pass
+        when the target exists as agents/<id>.md (not just skills/<id>/)."""
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "agents" / "reviewer.md").write_text(
+            "---\nname: reviewer\ndescription: d\ntools: Read\n---\n",
+            encoding="utf-8",
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nDispatch `swe-workbench:reviewer` subagent.\n",
             encoding="utf-8",
         )
         validate.check_command_skill_refs()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2444,3 +2444,80 @@ class TestCheckWorkflowFullFidelityMandate:
         monkeypatch.setattr(val, "ROOT", real_root)
         val.check_workflow_full_fidelity_mandate()
         assert val.FAILURES == [], f"validate.py failures on real repo: {val.FAILURES}"
+
+
+# ──────────────────────────────────────────────────────────────
+# Phase 4 dispatches BOTH reviewers in parallel (#458)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestPhase4DispatchesBothReviewers:
+    """Every Phase 4 dispatch site must name both reviewers AND the word
+    'parallel', ensuring neither can be omitted and they run concurrently.
+
+    Regression guard for issue #458.
+    """
+
+    REAL_ROOT = Path(__file__).parent.parent
+
+    # (file_path_relative, phase4_start_marker, terminator_prefix)
+    SITES = [
+        (
+            "skills/workflow-development/SKILL.md",
+            "### Phase 4: Review",
+            "### Phase 5",
+        ),
+        (
+            "commands/implement.md",
+            "**Phase 4 — Review**",
+            "**Phase 5",
+        ),
+        (
+            "skills/workflow-development/templates/plan-workflow-section.md",
+            "### Phase 4: Review",
+            "### Phase 5",
+        ),
+        (
+            "skills/workflow-extend/SKILL.md",
+            "**Phase 4 (Review):**",
+            "## Phase D",
+        ),
+    ]
+
+    REQUIRED_TOKENS = [
+        "superpowers:requesting-code-review",
+        "swe-workbench:reviewer",
+        "parallel",
+    ]
+
+    def _extract_phase4_section(self, text: str, start_marker: str, terminator: str) -> str:
+        """Return the text from start_marker up to (but not including) terminator."""
+        start = text.find(start_marker)
+        if start == -1:
+            raise ValueError(f"Phase-4 start marker {start_marker!r} not found in text")
+        end = text.find(terminator, start + len(start_marker))
+        if end == -1:
+            return text[start:]
+        return text[start:end]
+
+    def test_all_dispatch_sites_name_both_reviewers_and_parallel(self):
+        """Each Phase 4 section must contain both reviewer identifiers and 'parallel'."""
+        failures = []
+        for rel_path, start_marker, terminator in self.SITES:
+            full_path = self.REAL_ROOT / rel_path
+            text = full_path.read_text(encoding="utf-8")
+            section = self._extract_phase4_section(text, start_marker, terminator)
+            section_lower = section.lower()
+            missing = [
+                token
+                for token in self.REQUIRED_TOKENS
+                if token.lower() not in section_lower
+            ]
+            if missing:
+                failures.append(
+                    f"{rel_path}: missing {missing} in Phase 4 section"
+                )
+        assert not failures, (
+            "Phase 4 dispatch sites are missing required tokens (#458):\n"
+            + "\n".join(f"  {f}" for f in failures)
+        )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -669,13 +669,11 @@ class TestCheckAgentSkillRefs:
         when the target exists as agents/<id>.md (not just skills/<id>/)."""
         root = reset_validate
         make_plugin_tree(root)
-        agents_dir = root / "agents"
-        agents_dir.mkdir(parents=True, exist_ok=True)
-        (agents_dir / "bar.md").write_text(
+        (root / "agents" / "bar.md").write_text(
             "---\nname: bar\ndescription: d\ntools: Read\n---\n",
             encoding="utf-8",
         )
-        (agents_dir / "my-agent.md").write_text(
+        (root / "agents" / "my-agent.md").write_text(
             "---\nname: my-agent\ndescription: d\ntools: Read, Skill\n---\n"
             "\nUse `swe-workbench:bar` subagent.\n"
             "\n> See @./shared/principles.md\n",
@@ -2530,7 +2528,7 @@ class TestPhase4DispatchesBothReviewers:
         """Return the text from start_marker up to (but not including) terminator."""
         start = text.find(start_marker)
         if start == -1:
-            raise ValueError(f"Phase-4 start marker {start_marker!r} not found in text")
+            return ""  # all required tokens register as missing → clear assertion failure
         end = text.find(terminator, start + len(start_marker))
         if end == -1:
             return text[start:]


### PR DESCRIPTION
## Summary

- Fixes issue #458: Phase 4 review step now unambiguously dispatches **both** reviewers **in parallel**, as two distinct required invocations, **neither optional**
- Adds `TestPhase4DispatchesBothReviewers` regression guard in `tests/test_validate.py` — slices each file's Phase 4 section and asserts it contains `superpowers:requesting-code-review`, `swe-workbench:reviewer`, and `parallel` (TDD red → green)
- Updates all 4 dispatch sites with explicit Skill-vs-subagent type labels and parallel-dispatch wording: `skills/workflow-development/SKILL.md`, `commands/implement.md`, `skills/workflow-development/templates/plan-workflow-section.md`, `skills/workflow-extend/SKILL.md`
- Updates flow diagram in `workflow-development/SKILL.md` to show `BOTH in parallel (neither optional)` with `├─` / `└─` ASCII branches
- Tightens skip-condition to require named evidence from **both** stages; one-sided review no longer qualifies
- Fixes `check_command_skill_refs` and `check_agent_skill_refs` in `scripts/validate.py` to use `_artifact_exists()` (resolves skill dirs, agent files, and command files), consistent with how `check_skill_skill_refs` already works

## Test Plan

- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — passes
- [x] `pytest tests/ -v` — 1366/1366 pass (including new `TestPhase4DispatchesBothReviewers`)
- [x] Confirmed test goes RED before doc edits, GREEN after (TDD discipline)

### Type-tailored checks ([fix])
- [x] Root defect reproduced: no `parallel` token at any Phase 4 site before the fix
- [x] All 3 contributing defects addressed: ambiguous wording, missing `parallel`, over-broad skip-condition
- [x] No regression in `TestCheckAgentSkillRefs` / `TestCheckCommandSkillRefs` after validator fix

Closes #458
