### PR TITLE
[feat] Enforce tell-don't-ask and member-ordering conventions

### DIFF
--- a/agents/code-impl.md
+++ b/agents/code-impl.md
@@ -70,3 +70,4 @@ Invoke these skills via the Skill tool when relevant:
 - `swe-workbench:principle-testing` — test pyramid, mocking discipline, coverage audit
 - `swe-workbench:principle-clean-code` — naming, DRY, function length, abstraction level
 - `swe-workbench:principle-clean-architecture` — boundaries and layering for the type-placement fallback when sibling structure is incoherent or violates norms
+- `swe-workbench:principle-ddd` — tell-don't-ask: place behaviour on the entity that owns the data; avoid anemic models

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -101,3 +101,4 @@ Invoke these skills via the Skill tool when the review surfaces a concern in the
 - `swe-workbench:principle-testing` — missing coverage on new branches, brittle tests, tests that mirror implementation rather than behavior, flaky tests, mock overuse
 - `swe-workbench:principle-cost-awareness` — chatty service calls, log volume / cardinality, missed storage-tier opportunities
 - `swe-workbench:principle-version-control` — atomic commits, mixed formatting + logic in one diff, commit-message quality, missing PR test plan, force-push smells
+- `swe-workbench:principle-ddd` — anemic domain models, behaviour that belongs on the owning entity, tell-don't-ask violations

--- a/skills/principle-clean-code/SKILL.md
+++ b/skills/principle-clean-code/SKILL.md
@@ -25,6 +25,11 @@ description: Clean code, DRY, KISS, YAGNI, function length, naming, abstraction 
 - **One word per concept in a module** — `fetch`, `retrieve`, and `get` create false distinctions; pick one and apply it consistently.
 - **Positive booleans** — `isActive`, `hasExpired`, `canDelete`; negated names (`isNotLoaded`, `notActive`) invert reader expectations and compose poorly.
 
+## Member ordering
+*The public contract should read first.*
+- **Order by visibility** — in languages with explicit access modifiers (Java, C#, TypeScript, C++, Swift, Kotlin), declare members `public → protected → private` so readers meet the public surface before implementation detail.
+- **Same spirit, no modifiers** — Go (exported identifiers first), Rust (`pub` items first), and Python (public names before `_internal`) lead with the public surface even though the keywords differ.
+
 ## DRY — Rule of Three
 
 Don't abstract on first duplication. Extract on the third occurrence. Two is coincidence; three is pattern.

--- a/skills/principle-ddd/SKILL.md
+++ b/skills/principle-ddd/SKILL.md
@@ -26,6 +26,8 @@ Document how contexts relate: Partnership, Customer/Supplier, Conformist, Antico
 ### Entity
 Identity persists through change. `User{id, name}` — renaming doesn't change the user.
 
+Entities own their behaviour — **tell, don't ask**. Logic that enforces an entity's invariants belongs on the entity, not in a service that reads its fields and mutates them from outside. An entity that is pure data with all logic elsewhere is an **anemic domain model** — an anti-pattern. (See `principle-solid` § "If You Catch Yourself Thinking…" for the reflection-table form.)
+
 ### Value object
 Identity-less, immutable, compared by value. `Money{amount, currency}`, `EmailAddress`, `DateRange`. Prefer aggressively — eliminates primitive obsession bugs.
 

--- a/tests/test_behaviour_and_ordering_conventions.py
+++ b/tests/test_behaviour_and_ordering_conventions.py
@@ -53,7 +53,7 @@ def test_ddd_skill_file_exists():
 def test_ddd_skill_names_tell_dont_ask():
     """Entity subsection must explicitly use the tell-don't-ask idiom."""
     body = DDD_SKILL.read_text()
-    assert re.search(r"tell[,\-]?\s*don\W?t\s*ask", body, re.IGNORECASE), (
+    assert re.search(r"tell\W?\s*don\W?t\W?\s*ask", body, re.IGNORECASE), (
         "skills/principle-ddd/SKILL.md must mention the 'tell, don't ask' principle "
         "so reviewers and implementers can surface the anti-pattern"
     )

--- a/tests/test_behaviour_and_ordering_conventions.py
+++ b/tests/test_behaviour_and_ordering_conventions.py
@@ -1,0 +1,146 @@
+"""Structural tests for tell-don't-ask + member-ordering conventions (closes #459).
+
+Acceptance criteria:
+- skills/principle-ddd/SKILL.md body names both 'tell' (don't-ask) and 'anemic' domain.
+- skills/principle-clean-code/SKILL.md has a '## Member ordering' section that states
+  'public → protected → private' and mentions modifier-less languages (Go, Rust, or Python).
+- agents/reviewer.md Principle consultation list references swe-workbench:principle-ddd.
+- agents/code-impl.md Principle consultation list references swe-workbench:principle-ddd.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+DDD_SKILL = ROOT / "skills" / "principle-ddd" / "SKILL.md"
+CLEAN_CODE_SKILL = ROOT / "skills" / "principle-clean-code" / "SKILL.md"
+REVIEWER_AGENT = ROOT / "agents" / "reviewer.md"
+CODE_IMPL_AGENT = ROOT / "agents" / "code-impl.md"
+
+
+def _section(body: str, heading: str) -> str:
+    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks)."""
+    marker = f"## {heading}"
+    assert marker in body, f"Expected '{marker}' section not found"
+    start = body.index(marker) + len(marker)
+    rest = body[start:]
+    fence_open = False
+    lines = []
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~~"):
+            fence_open = not fence_open
+        if not fence_open and line.startswith("## "):
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — principle-ddd names tell-don't-ask and anemic domain
+# ---------------------------------------------------------------------------
+
+
+def test_ddd_skill_file_exists():
+    assert DDD_SKILL.exists(), "skills/principle-ddd/SKILL.md must exist"
+
+
+def test_ddd_skill_names_tell_dont_ask():
+    """Entity subsection must explicitly use 'tell' (covering tell-don't-ask)."""
+    body = DDD_SKILL.read_text()
+    assert "tell" in body.lower(), (
+        "skills/principle-ddd/SKILL.md must mention 'tell' (tell-don't-ask principle) "
+        "so reviewers and implementers can surface the anti-pattern"
+    )
+
+
+def test_ddd_skill_names_anemic_domain():
+    """Skill body must explicitly name 'anemic' domain model as an anti-pattern."""
+    body = DDD_SKILL.read_text()
+    assert "anemic" in body.lower(), (
+        "skills/principle-ddd/SKILL.md must mention 'anemic' (anemic domain model) "
+        "so reviewers and implementers can surface the anti-pattern"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — principle-clean-code has a Member ordering section
+# ---------------------------------------------------------------------------
+
+
+def test_clean_code_skill_file_exists():
+    assert CLEAN_CODE_SKILL.exists(), "skills/principle-clean-code/SKILL.md must exist"
+
+
+def test_clean_code_has_member_ordering_section():
+    body = CLEAN_CODE_SKILL.read_text()
+    assert "## Member ordering" in body, (
+        "skills/principle-clean-code/SKILL.md must contain a '## Member ordering' section "
+        "so the convention has a canonical normative home"
+    )
+
+
+def test_member_ordering_states_public_protected_private():
+    """The section must name the canonical order: public → protected → private."""
+    body = CLEAN_CODE_SKILL.read_text()
+    section = _section(body, "Member ordering")
+    # Accept arrow variants and plain text describing the order
+    has_order = (
+        "public" in section.lower()
+        and "protected" in section.lower()
+        and "private" in section.lower()
+    )
+    assert has_order, (
+        "'## Member ordering' must state the ordering of public, protected, and private members"
+    )
+
+
+def test_member_ordering_mentions_modifier_less_languages():
+    """The section must acknowledge languages without access modifiers (Go, Rust, or Python)."""
+    body = CLEAN_CODE_SKILL.read_text()
+    section = _section(body, "Member ordering")
+    section_lower = section.lower()
+    has_modifier_less = (
+        bool(re.search(r"\bgo\b", section_lower))
+        or bool(re.search(r"\brust\b", section_lower))
+        or bool(re.search(r"\bpython\b", section_lower))
+    )
+    assert has_modifier_less, (
+        "'## Member ordering' must mention at least one modifier-less language "
+        "(Go, Rust, or Python) so the rule is clear for those ecosystems"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — agents/reviewer.md Principle consultation references principle-ddd
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_agent_file_exists():
+    assert REVIEWER_AGENT.exists(), "agents/reviewer.md must exist"
+
+
+def test_reviewer_references_principle_ddd():
+    body = REVIEWER_AGENT.read_text()
+    assert "swe-workbench:principle-ddd" in body, (
+        "agents/reviewer.md Principle consultation must reference 'swe-workbench:principle-ddd' "
+        "so the reviewer catches anemic domain models and tell-don't-ask violations"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — agents/code-impl.md Principle consultation references principle-ddd
+# ---------------------------------------------------------------------------
+
+
+def test_code_impl_agent_file_exists():
+    assert CODE_IMPL_AGENT.exists(), "agents/code-impl.md must exist"
+
+
+def test_code_impl_references_principle_ddd():
+    body = CODE_IMPL_AGENT.read_text()
+    assert "swe-workbench:principle-ddd" in body, (
+        "agents/code-impl.md Principle consultation must reference 'swe-workbench:principle-ddd' "
+        "so implementers place behaviour on entities and avoid anemic models"
+    )

--- a/tests/test_behaviour_and_ordering_conventions.py
+++ b/tests/test_behaviour_and_ordering_conventions.py
@@ -20,9 +20,13 @@ CODE_IMPL_AGENT = ROOT / "agents" / "code-impl.md"
 
 
 def _section(body: str, heading: str) -> str:
-    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks)."""
+    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks).
+
+    Returns "" when the heading is absent so callers can assert with their own message.
+    """
     marker = f"## {heading}"
-    assert marker in body, f"Expected '{marker}' section not found"
+    if marker not in body:
+        return ""
     start = body.index(marker) + len(marker)
     rest = body[start:]
     fence_open = False
@@ -47,10 +51,10 @@ def test_ddd_skill_file_exists():
 
 
 def test_ddd_skill_names_tell_dont_ask():
-    """Entity subsection must explicitly use 'tell' (covering tell-don't-ask)."""
+    """Entity subsection must explicitly use the tell-don't-ask idiom."""
     body = DDD_SKILL.read_text()
-    assert "tell" in body.lower(), (
-        "skills/principle-ddd/SKILL.md must mention 'tell' (tell-don't-ask principle) "
+    assert re.search(r"tell[,\-]?\s*don\W?t\s*ask", body, re.IGNORECASE), (
+        "skills/principle-ddd/SKILL.md must mention the 'tell, don't ask' principle "
         "so reviewers and implementers can surface the anti-pattern"
     )
 
@@ -85,7 +89,7 @@ def test_member_ordering_states_public_protected_private():
     """The section must name the canonical order: public → protected → private."""
     body = CLEAN_CODE_SKILL.read_text()
     section = _section(body, "Member ordering")
-    # Accept arrow variants and plain text describing the order
+    assert section, "'## Member ordering' section is empty or missing"
     has_order = (
         "public" in section.lower()
         and "protected" in section.lower()
@@ -100,6 +104,7 @@ def test_member_ordering_mentions_modifier_less_languages():
     """The section must acknowledge languages without access modifiers (Go, Rust, or Python)."""
     body = CLEAN_CODE_SKILL.read_text()
     section = _section(body, "Member ordering")
+    assert section, "'## Member ordering' section is empty or missing"
     section_lower = section.lower()
     has_modifier_less = (
         bool(re.search(r"\bgo\b", section_lower))


### PR DESCRIPTION
## Summary
- Add normative tell-don't-ask / anemic-domain rule to `skills/principle-ddd/SKILL.md` Entity subsection — names both **tell-don't-ask** and **anemic domain model** explicitly so reviewer and implementer agents can surface the anti-pattern without a manual follow-up prompt
- Add new `## Member ordering` section to `skills/principle-clean-code/SKILL.md` with a modifier-aware `public → protected → private` rule, plus a note covering Go, Rust, and Python (modifier-less languages)
- Wire `swe-workbench:principle-ddd` into the `## Principle consultation` list of both `agents/reviewer.md` and `agents/code-impl.md` so the skill is conditionally invoked when entity-related code is in scope
- Add `tests/test_behaviour_and_ordering_conventions.py` (TDD red→green): 11 tests asserting all 4 acceptance criteria

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_behaviour_and_ordering_conventions.py -v` → RED before changes, GREEN after (7 failures → 0)
- [x] `pytest tests/ -v` → 1376/1376 pass, no regression in `test_review_routing.py` / `test_skill_triggers.py`

### Type-tailored checks ([feat])
- [x] New rule text verified against the plan's normative phrasing requirements (both `tell` and `anemic` present in DDD skill)
- [x] `grep -n "principle-ddd" agents/reviewer.md agents/code-impl.md` confirms both bullets present
- [x] `grep -n "Member ordering" skills/principle-clean-code/SKILL.md` confirms section added after `## Naming reveals intent`
- [x] Cross-reference to `principle-solid` § "If You Catch Yourself Thinking…" updated per code review (medium finding)
- [x] Word-boundary regex fix applied in test for modifier-less language check (low finding)

Closes #459
