### PR TITLE
[docs] Document per-language formatter/import/lint/test tooling in language skills

### DIFF
--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -104,7 +104,7 @@ fi
 
 ## Tooling
 - **Format:** `shfmt -w .`
-- **Lint:** `shellcheck **/*.sh` (or `shellcheck $(git ls-files '*.sh')`)
+- **Lint:** `shellcheck $(git ls-files '*.sh')` (or `shellcheck **/*.sh` with `shopt -s globstar` on bash 4+)
 - **Test:** `bats` (see Testing below)
 
 ## Testing

--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -104,7 +104,7 @@ fi
 
 ## Tooling
 - **Format:** `shfmt -w .`
-- **Lint:** `shellcheck $(git ls-files '*.sh')` (or `shellcheck **/*.sh` with `shopt -s globstar` on bash 4+)
+- **Lint:** `git ls-files -z '*.sh' '*.bash' | xargs -0 shellcheck` (null-delimited — handles filenames with spaces; covers both `.sh` and `.bash` extensions)
 - **Test:** `bats` (see Testing below)
 
 ## Testing

--- a/skills/language-bash/SKILL.md
+++ b/skills/language-bash/SKILL.md
@@ -102,6 +102,11 @@ fi
 - `#!/bin/sh` only when strict POSIX portability is required — drop all bash-isms.
 - Run `shellcheck --shell=bash` (or `--shell=sh`) to enforce the declared contract.
 
+## Tooling
+- **Format:** `shfmt -w .`
+- **Lint:** `shellcheck **/*.sh` (or `shellcheck $(git ls-files '*.sh')`)
+- **Test:** `bats` (see Testing below)
+
 ## Testing
 - `bats-core` for non-trivial scripts: one assertion per test, temp dirs for isolation.
 - For inline assertions in one-shot scripts:

--- a/skills/language-csharp/SKILL.md
+++ b/skills/language-csharp/SKILL.md
@@ -104,6 +104,11 @@ var activeEmails = users
     .ToArray();
 ```
 
+## Tooling
+- **Imports/Format:** `dotnet format`
+- **Lint:** Roslyn analyzers (`<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>` in csproj); `dotnet format --verify-no-changes` as formatting gate in CI
+- **Test:** `dotnet test` (see Testing below)
+
 ## Testing
 - xUnit, NUnit, and MSTest are all fine; follow the repository's existing framework.
 - Use fluent assertions when already present, and keep tests behavior-focused.

--- a/skills/language-go/SKILL.md
+++ b/skills/language-go/SKILL.md
@@ -42,6 +42,12 @@ if err := g.Wait(); err != nil { return err }
 - Never store `context.Context` in a struct field.
 - Don't use `context.Value` for required parameters — only cross-cutting concerns like request IDs.
 
+## Tooling
+- **Imports:** `goimports -w .`
+- **Format:** `gofmt -w .` (redundant if running goimports; keep for explicit CI parity)
+- **Lint:** `go vet ./...` + `golangci-lint run`
+- **Test:** `go test ./...` (see Testing below)
+
 ## Testing
 - Table-driven tests are the default.
 - `t.Run(name, ...)` for subtests.

--- a/skills/language-java/SKILL.md
+++ b/skills/language-java/SKILL.md
@@ -84,6 +84,11 @@ List<String> emails = users.stream()
 - Gradle: `build.gradle` (Groovy) or `build.gradle.kts` (Kotlin DSL — preferred for IDE support).
 - JPMS (`module-info.java`): adopt only when publishing a library that needs strong encapsulation.
 
+## Tooling
+- **Imports/Format:** `mvn spotless:apply` / `./gradlew spotlessApply`
+- **Lint:** `mvn checkstyle:check` / `./gradlew checkstyleMain`
+- **Test:** `mvn test` / `./gradlew test` (see Testing below)
+
 ## Testing
 - JUnit 5 (`@Test`, `@ParameterizedTest`, `@MethodSource`) — not JUnit 4.
 - AssertJ for fluent assertions: `assertThat(actual).isEqualTo(expected)`.

--- a/skills/language-kotlin/SKILL.md
+++ b/skills/language-kotlin/SKILL.md
@@ -89,6 +89,11 @@ val prices: Flow<BigDecimal> = priceRepo.watch(symbol)
     .distinctUntilChanged()
 ```
 
+## Tooling
+- **Imports/Format:** `./gradlew ktlintFormat` / `ktlint -F` (standalone binary)
+- **Lint:** `detekt` / `./gradlew detekt`
+- **Test:** `./gradlew test` (see Testing below)
+
 ## Testing
 - JUnit 5 or Kotest for test structure; MockK for Kotlin-friendly mocking.
 - `runTest { }` from `kotlinx-coroutines-test` for coroutine tests — no manual dispatchers.

--- a/skills/language-python/SKILL.md
+++ b/skills/language-python/SKILL.md
@@ -93,6 +93,12 @@ match command:
 - Pin transitive deps via lockfile (`uv.lock`, `poetry.lock`) in applications; use version ranges in libraries.
 - Always isolate with a virtualenv — never install into the system Python.
 
+## Tooling
+- **Imports:** `ruff check --select I --fix`
+- **Format:** `ruff format` / `black .`
+- **Lint:** `ruff check` (+ `mypy` for types)
+- **Test:** `pytest` (see Testing below)
+
 ## Testing
 - `pytest` over `unittest` — fixtures, parametrize, and plugins make it richer.
 - `@pytest.mark.parametrize` instead of loops inside tests.

--- a/skills/language-ruby/SKILL.md
+++ b/skills/language-ruby/SKILL.md
@@ -80,6 +80,11 @@ end
 - Use Bundler for dependency boundaries, Rake for project tasks, and gemspecs only when shipping a library.
 - Rails-adjacent names like service objects, jobs, serializers, and presenters should describe ordinary Ruby objects first.
 
+## Tooling
+- **Format:** `rubocop -a` (safe autocorrect; no dedicated import tool in Ruby)
+- **Lint:** `rubocop`
+- **Test:** `rspec` / `rake test` (see Testing below)
+
 ## Testing
 - RSpec favors expressive examples, matchers, and shared context; keep examples behavior-focused and avoid over-nesting.
 - Minitest favors small stdlib tests with direct assertions; use it when simplicity and low dependency weight matter.

--- a/skills/language-rust/SKILL.md
+++ b/skills/language-rust/SKILL.md
@@ -64,8 +64,8 @@ let total: u32 = orders.iter()
 - Reserve `unwrap`/`expect` for truly unreachable cases; always prefer `expect("why")` over `unwrap` in production.
 
 ## Tooling
-- **Imports:** `cargo fix --allow-dirty` (removes unused imports; review diff before staging)
-- **Format:** `cargo fmt` (`cargo fmt --check` in CI)
+- **Unused imports:** `cargo fix --allow-dirty` (applies all auto-fixable Cargo lints — review the full diff before staging; not suitable as an unattended CI step)
+- **Format:** `cargo fmt` (set `imports_granularity` in `rustfmt.toml` for import grouping; `cargo fmt --check` in CI)
 - **Lint:** `cargo clippy -- -D warnings`
 - **Test:** `cargo test` (see Testing below)
 

--- a/skills/language-rust/SKILL.md
+++ b/skills/language-rust/SKILL.md
@@ -64,7 +64,7 @@ let total: u32 = orders.iter()
 - Reserve `unwrap`/`expect` for truly unreachable cases; always prefer `expect("why")` over `unwrap` in production.
 
 ## Tooling
-- **Unused imports:** `cargo fix --allow-dirty` (applies all auto-fixable Cargo lints — review the full diff before staging; not suitable as an unattended CI step)
+- **Imports/Auto-fix:** `cargo fix --allow-dirty` (applies all auto-fixable rustc/Clippy lints — review the full diff before staging; not suitable as an unattended CI step)
 - **Format:** `cargo fmt` (set `imports_granularity` in `rustfmt.toml` for import grouping; `cargo fmt --check` in CI)
 - **Lint:** `cargo clippy -- -D warnings`
 - **Test:** `cargo test` (see Testing below)

--- a/skills/language-rust/SKILL.md
+++ b/skills/language-rust/SKILL.md
@@ -63,11 +63,16 @@ let total: u32 = orders.iter()
 - `ok_or_else`, `map_err`, `and_then`, `unwrap_or_else` — chain, don't match.
 - Reserve `unwrap`/`expect` for truly unreachable cases; always prefer `expect("why")` over `unwrap` in production.
 
+## Tooling
+- **Imports:** `cargo fix --allow-dirty` (removes unused imports; review diff before staging)
+- **Format:** `cargo fmt` (`cargo fmt --check` in CI)
+- **Lint:** `cargo clippy -- -D warnings`
+- **Test:** `cargo test` (see Testing below)
+
 ## Testing
 - `#[cfg(test)] mod tests { ... }` at the bottom of each file for unit tests.
 - Integration tests in `tests/`.
 - `#[should_panic(expected = "...")]` for panic paths.
-- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` in CI.
 
 ## Async
 - Pick one runtime (usually `tokio`) and stay there.

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -70,7 +70,7 @@ LIMIT 50;
 ```
 
 ## Tooling
-- **Format:** `sqlfluff fix --dialect <dialect> .`
+- **Format:** `sqlfluff fix --dialect <dialect> .` (replace `<dialect>` with e.g. `ansi`, `postgres`, `bigquery` — check `.sqlfluff` config or project README)
 - **Lint:** `sqlfluff lint --dialect <dialect> .`
 - **Test:** engine-specific (pgTAP for PostgreSQL, `dbt test` if using dbt)
 

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -69,6 +69,11 @@ ORDER BY created_at DESC, id DESC
 LIMIT 50;
 ```
 
+## Tooling
+- **Format:** `sqlfluff fix --dialect <dialect> .`
+- **Lint:** `sqlfluff lint --dialect <dialect> .`
+- **Test:** engine-specific (pgTAP for PostgreSQL, `dbt test` if using dbt)
+
 ## Avoid
 - Schema changes without rollback or compatibility planning.
 - Unbounded queries in production paths.

--- a/skills/language-swift/SKILL.md
+++ b/skills/language-swift/SKILL.md
@@ -93,6 +93,11 @@ button.onTap = { [weak self] in
 - One target per logical module. Keep `Sources/` layout mirroring the module name.
 - Pin dependencies via `Package.resolved` in version control for reproducible builds.
 
+## Tooling
+- **Format:** `swiftformat .` / `swift-format format -i -r .`
+- **Lint:** `swiftlint lint`
+- **Test:** `swift test` (see Testing below)
+
 ## Testing
 - XCTest: `XCTAssertEqual`, `XCTUnwrap` (throws if nil, cleaner than force-unwrap in tests).
 - Swift Testing (`@Test`, `#expect`) for new projects on Swift 6.0+ (Xcode 16+).

--- a/skills/language-swift/SKILL.md
+++ b/skills/language-swift/SKILL.md
@@ -94,7 +94,7 @@ button.onTap = { [weak self] in
 - Pin dependencies via `Package.resolved` in version control for reproducible builds.
 
 ## Tooling
-- **Format:** `swiftformat .` / `swift-format format -i -r .`
+- **Format:** `swiftformat .` (nicklockwood/SwiftFormat) **or** `swift-format format -i -r .` (Apple — incompatible config; pick one per project)
 - **Lint:** `swiftlint lint`
 - **Test:** `swift test` (see Testing below)
 

--- a/skills/language-typescript/SKILL.md
+++ b/skills/language-typescript/SKILL.md
@@ -97,7 +97,7 @@ TypeScript types are shapes, not identities. Two unrelated types with the same f
 - `useEffect` only for synchronizing with external systems. Derived state belongs in render.
 
 ## Tooling
-- **Imports:** `eslint --fix` / `organize-imports-cli`
+- **Imports:** `organize-imports-cli` (reliable regardless of ESLint config); or `eslint --fix` if `eslint-plugin-import` / `@typescript-eslint/consistent-type-imports` is configured
 - **Format:** `prettier --write .`
 - **Lint:** `eslint .` + `tsc --noEmit`
 - **Test:** `vitest` / `jest` (see Testing below)

--- a/skills/language-typescript/SKILL.md
+++ b/skills/language-typescript/SKILL.md
@@ -96,6 +96,12 @@ TypeScript types are shapes, not identities. Two unrelated types with the same f
 - Avoid `FC<Props>` — it adds implicit `children` and breaks generic components. Prefer `function Thing(props: Props) { ... }`.
 - `useEffect` only for synchronizing with external systems. Derived state belongs in render.
 
+## Tooling
+- **Imports:** `eslint --fix` / `organize-imports-cli`
+- **Format:** `prettier --write .`
+- **Lint:** `eslint .` + `tsc --noEmit`
+- **Test:** `vitest` / `jest` (see Testing below)
+
 ## Testing
 - Vitest or Jest — pick one.
 - `tsd` or `expectType` for type-level tests of public APIs.

--- a/skills/language-typescript/SKILL.md
+++ b/skills/language-typescript/SKILL.md
@@ -97,7 +97,7 @@ TypeScript types are shapes, not identities. Two unrelated types with the same f
 - `useEffect` only for synchronizing with external systems. Derived state belongs in render.
 
 ## Tooling
-- **Imports:** `organize-imports-cli` (reliable regardless of ESLint config); or `eslint --fix` if `eslint-plugin-import` / `@typescript-eslint/consistent-type-imports` is configured
+- **Imports:** `npx organize-imports-cli` (reliable regardless of ESLint config); or `eslint --fix` if `eslint-plugin-import` / `@typescript-eslint/consistent-type-imports` is configured
 - **Format:** `prettier --write .`
 - **Lint:** `eslint .` + `tsc --noEmit`
 - **Test:** `vitest` / `jest` (see Testing below)

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -74,6 +74,8 @@ Also check CLAUDE.md for project-specific conventions.
 | `pom.xml` | `mvn spotless:apply` (requires import-ordering rules in Spotless config; for unused-import removal add `impsort-maven-plugin`) | `mvn spotless:apply` | `mvn checkstyle:check` (requires plugin) | `mvn test` |
 | `build.gradle` / `build.gradle.kts` | `./gradlew spotlessApply` (Spotless: importOrder + removeUnusedImports) | `./gradlew spotlessApply` (or ktlint / google-java-format) | `./gradlew check` (Kotlin: `detekt`; Java: `checkstyleMain`) | `./gradlew test` |
 
+> **Authoritative per-language tool list:** this table covers manifest-detected projects (Go, JS/TS, Rust, Python, Java, Kotlin). For the full, canonical command set for any language — including languages without a manifest row (C#, Ruby, Swift, SQL, Bash) — consult the matching `swe-workbench:language-<lang>` skill (e.g. `swe-workbench:language-csharp`).
+
 > **`quality-command` fallback** is in the table below — intentionally separate because Quality is multi-tool by nature and a single cell would be unreadably wide.
 
 **Quality stage fallback (multi-tool — wire whichever subset the project enforces):**


### PR DESCRIPTION
## Summary
- Add a `## Tooling` section to all 11 `language-*` skills (`bash`, `csharp`, `go`, `java`, `kotlin`, `python`, `ruby`, `rust`, `sql`, `swift`, `typescript`) with canonical import/format/lint/test commands
- Each language skill is now the authoritative source for its tooling commands; the `workflow-development` marker table gains an explicit pointer to the `swe-workbench:language-<lang>` skills
- Folds the existing `cargo fmt --check` / `cargo clippy` CI line out of `language-rust`'s `## Testing` into the new `## Tooling` section to eliminate duplication

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] `bash scripts/validate.sh` — All checks passed (frontmatter valid, all files ≤150 lines, triggers intact)
- [x] `pytest tests/` — 1387/1387 pass
- [x] Line-cap spot check: `language-bash` 135 lines, `language-python` 126 lines (both under 150)
- [x] All 11 language skills confirmed to contain `## Tooling` section
- [x] `## Tooling` placement: before `## Testing` in 10 skills; before `## Avoid` in `language-sql`

Closes #460
