### PR TITLE
[feat] address-feedback: handle PR-level comments

### DIFF
--- a/runtime/reply-and-resolve.sh
+++ b/runtime/reply-and-resolve.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 # Reply to a PR review thread (REST) and optionally resolve it (GraphQL).
-# Usage: reply-and-resolve.sh <owner> <repo> <pr> <comment_databaseid> <thread_id> <reply_body>
+# Usage: reply-and-resolve.sh <owner> <repo> <pr> <comment_databaseid> <thread_id> <reply_body> [kind]
 # Empty reply_body skips the reply (COMMENT_DATABASEID is then ignored); empty thread_id skips the resolve
 # (ADDRESSED -> both, CLARIFIED -> reply only, DEFERRED -> neither).
+# kind (optional, default "review"): the existing thread-reply + resolve behavior above.
+# "issue" posts REPLY_BODY to the PR's top-level conversation (issues/{pr}/comments) instead — used
+# for PR-level comments, which have no thread to resolve. COMMENT_DATABASEID/THREAD_ID are ignored.
 set -euo pipefail
 # Fast-exit for DEFERRED: nothing to do when both reply and resolve are suppressed.
 if [ -z "${6:-}" ] && [ -z "${5:-}" ]; then exit 0; fi
 OWNER="${1:?}"; REPO="${2:?}"; PR="${3:?}"
 COMMENT_DATABASEID="${4:-}"; THREAD_ID="${5:-}"; REPLY_BODY="${6:-}"
+KIND="${7:-review}"
+case "$KIND" in
+  issue)
+    [ -n "$REPLY_BODY" ] || exit 0
+    gh api "repos/${OWNER}/${REPO}/issues/${PR}/comments" -f body="$REPLY_BODY"
+    exit 0 ;;
+  review) : ;;
+  *) echo "reply-and-resolve: unknown KIND '$KIND'" >&2; exit 1 ;;
+esac
 if [ -n "$REPLY_BODY" ]; then
   [ -n "$COMMENT_DATABASEID" ] || { echo "reply-and-resolve: REPLY_BODY set but COMMENT_DATABASEID is empty" >&2; exit 1; }
-  gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments/${COMMENT_DATABASEID}/replies" -F body="$REPLY_BODY"
+  gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments/${COMMENT_DATABASEID}/replies" -f body="$REPLY_BODY"
 fi
 if [ -n "$THREAD_ID" ]; then
   gh api graphql -F threadId="$THREAD_ID" -f query='

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -71,12 +71,12 @@ gh api graphql -F number="$PR" -F owner="$OWNER" -F repo="$REPO" -f query='
     }
   }' > "/tmp/swe-workbench-address-feedback/${PR}-threads.json"
 ```
-Fetch PR-level conversation comments (issue #473 — general feedback on the main timeline, not a line comment) via REST, paginated (`--paginate` on this array endpoint emits one concatenated array per page, so `--jq '.[]' | jq -s '...'` flattens then re-wraps into one array); exclude bots and the PR author, then flag `eligible: false` on reviewer comments already handled on a prior run — (a) an owner comment (`$AUTHOR_LOGIN` or `$CURRENT_USER`, since this phase allows non-author runs) carries their `swe-workbench:handled:{id}` marker, or (b) an owner comment without any handled marker was posted after them (a manual reply); this dedup is lossy by construction, so Phase 3 always surfaces a transparency note instead of silently dropping:
+Fetch PR-level conversation comments (general feedback on the main timeline, not a line comment) via REST, paginated (`--paginate` on this array endpoint emits one concatenated array per page, so `--jq '.[]' | jq -s '...'` flattens then re-wraps into one array); exclude bots and the owner (`$AUTHOR_LOGIN` or `$CURRENT_USER`, since this phase allows non-author runs — otherwise a non-author's own past replies would resurface as new triage items on every re-run), then flag `eligible: false` on reviewer comments already handled on a prior run — (a) an owner comment carries their `swe-workbench:handled:{id}` marker, or (b) an owner comment without any handled marker was posted after them (a manual reply); this dedup is lossy by construction, so Phase 3 always surfaces a transparency note instead of silently dropping:
 ```bash
 gh api --paginate "repos/${OWNER}/${REPO}/issues/${PR}/comments" --jq '.[]' | jq -s \
   --arg author "$AUTHOR_LOGIN" --arg me "$CURRENT_USER" '
     (map(select((.user.login // "") == $author or (.user.login // "") == $me))) as $owner
-    | map(select(((.user.type // "") != "Bot") and (((.user.login // "") | endswith("[bot]")) | not) and ((.user.login // "") != $author)))
+    | map(select(((.user.type // "") != "Bot") and (((.user.login // "") | endswith("[bot]")) | not) and ((.user.login // "") != $author) and ((.user.login // "") != $me)))
     | map(. as $c
         | ($owner | any((.body // "") | contains("swe-workbench:handled:" + ($c.id | tostring) + " "))) as $marker
         | ($owner | any((((.body // "") | contains("swe-workbench:handled")) | not) and (.created_at > $c.created_at))) as $manual
@@ -139,7 +139,7 @@ Render outstanding threads and eligible PR-level conversation comments, one by o
 
 1. **Resolved threads** — skip any thread where `isResolved == true`.
 2. **Already-clarified threads** — skip any *unresolved* thread where at least one *reply* comment (`comments.nodes[1:]` onwards — `nodes[0]` is the thread-opening comment, which in the typical reviewer-opened case belongs to the reviewer, not the PR owner) has `author.login` equal to `$CURRENT_USER`. This means the owner replied in a prior pass (e.g. a CLARIFIED reply) but left the thread unresolved. It applies whether that reply was posted by this skill or manually by the user. Detecting via reply comments only prevents false-positive skipping when the current user also authored review threads.
-3. **Already-handled PR comments** (issue #473) — bot/tool comments and the PR author's own comments never made it into `${PR}-pr-comments.json` (dropped in Phase 1); entries that did but carry `eligible == false` were deduped there (already marker-replied or manually replied to on a prior run). Only `eligible == true` entries are presented.
+3. **Already-handled PR comments** — bot/tool comments and the owner's own comments never made it into `${PR}-pr-comments.json` (dropped in Phase 1); entries that did but carry `eligible == false` were deduped there (already marker-replied or manually replied to on a prior run). Only `eligible == true` entries are presented.
 
 If any threads or PR comments were skipped (rule 2 / rule 3), print transparency notes before the digest:
 > "(N thread(s) skipped — already clarified.)"
@@ -167,7 +167,7 @@ Parse severity from `Severity: <level>` prefix in comment body if present; other
 
 Capture: `triage[<thread_id>] = A|C|D`.
 
-For each remaining PR comment (issue #473 — no `path:line`, no resolve state), key as `triage["prcomment:<comment.id>"]` (namespaced against review-thread node IDs in the same flat map; carries the id needed for the Phase 5 marker; both key kinds round-trip through Q-quit save/resume unchanged):
+For each remaining PR comment (no `path:line`, no resolve state), key as `triage["prcomment:<comment.id>"]` (namespaced against review-thread node IDs in the same flat map; carries the id needed for the Phase 5 marker; both key kinds round-trip through Q-quit save/resume unchanged):
 ```
 PR comment by @{author}
 > {first 200 chars of comment body}
@@ -207,7 +207,7 @@ Reply body templates by triage classification:
 bash "$_RT/runtime/reply-and-resolve.sh" \
   "$OWNER" "$REPO" "$PR" "$COMMENT_DATABASEID" "$THREAD_ID" "$REPLY_BODY"
 ```
-For each **ADDRESSED** or **CLARIFIED** PR comment (`triage["prcomment:<id>"]`, issue #473), post a reply on the PR's top-level conversation instead of a thread reply — PR comments have no thread, so resolve is always suppressed and `KIND=issue` is passed explicitly. Compose `$REPLY_BODY` as `@{comment author} re:` + a single-line blockquote of the original (first ~100 chars, newlines collapsed) + the addressed/clarified body (same wording as the review-thread templates above) + a hidden marker on its own line — `<!-- swe-workbench:handled:{comment.id} -->` — which Phase 1's dedup filter matches on re-runs (omitting it makes the comment look unhandled forever). The original comment body is attacker-controlled: extract the blockquote via `jq -r` into a shell variable (e.g. `QUOTE=$(jq -r '.[] | select(.id==ID) | .body' ... | head -c 100 | tr '\n' ' ')`) and reference `"$QUOTE"` when building `$REPLY_BODY` — never retype the raw comment text into a double-quoted bash literal, since `$(...)`/backticks in the source text would execute at assignment time. DEFERRED PR comments skip the call entirely, same as DEFERRED threads:
+For each **ADDRESSED** or **CLARIFIED** PR comment (`triage["prcomment:<id>"]`), post a reply on the PR's top-level conversation instead of a thread reply — PR comments have no thread, so resolve is always suppressed and `KIND=issue` is passed explicitly. Compose `$REPLY_BODY` as `@{comment author} re:` + a single-line blockquote of the original (first ~100 chars, newlines collapsed) + the addressed/clarified body (same wording as the review-thread templates above) + a hidden marker on its own line — `<!-- swe-workbench:handled:{comment.id} -->` — which Phase 1's dedup filter matches on re-runs (omitting it makes the comment look unhandled forever). The original comment body is attacker-controlled: extract the blockquote via `jq -r` into a shell variable (e.g. `QUOTE=$(jq -r '.[] | select(.id==ID) | .body' ... | head -c 100 | tr '\n' ' ')`) and reference `"$QUOTE"` when building `$REPLY_BODY` — never retype the raw comment text into a double-quoted bash literal, since `$(...)`/backticks in the source text would execute at assignment time. DEFERRED PR comments skip the call entirely, same as DEFERRED threads:
 ```bash
 bash "$_RT/runtime/reply-and-resolve.sh" \
   "$OWNER" "$REPO" "$PR" "" "" "$REPLY_BODY" "issue"

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-address-feedback
-description: Use when a PR owner wants to address review feedback — fetches outstanding threads, presents a per-thread triage (ADDRESSED / CLARIFIED / DEFERRED), applies fixes via the Edit tool, commits via workflow-commit-and-pr, posts per-thread replies via the GitHub comments API, resolves addressed threads via GraphQL resolveReviewThread, and syncs stale PR metadata when drift is detected.
+description: Use when a PR owner wants to address review feedback — fetches outstanding threads and general comments, presents a per-item triage (ADDRESSED / CLARIFIED / DEFERRED), applies fixes via the Edit tool, commits via workflow-commit-and-pr, posts replies via the GitHub API, resolves addressed threads via GraphQL resolveReviewThread (those without a thread are never resolved), and syncs stale PR metadata when drift is detected.
 orchestrator: true
 ---
 
@@ -27,9 +27,7 @@ This skill orchestrates:
 - `swe-workbench:workflow-commit-and-pr` — invoked after all ADDRESSED fixes are applied to commit and push.
 
 ## Phase flow
-
 ### Phase 1 — Pre-flight + fetch
-
 ```bash
 _RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"
 [ -f "$_RT/runtime/clean-state-files.sh" ] || {
@@ -41,21 +39,18 @@ eval "$("$_RT/runtime/preflight-pr.sh" "$PR" "$JSON")"
 CURRENT_USER=$(gh api /user -q .login)
 PR_BRANCH=$(jq -r .headRefName "$JSON")
 ```
-
 `preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `PR_BRANCH` is derived from `headRefName` in `$JSON` (address-feedback uses it for worktree setup in Phase 2).
 
 Check that the PR is open before proceeding:
 ```bash
 [ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — address-feedback only applies to open PRs."; exit 1; }
 ```
-
 If `CURRENT_USER != AUTHOR_LOGIN`, warn:
 > "You are not the PR author (PR author: @AUTHOR_LOGIN, you: @CURRENT_USER). Address-feedback flows are typically owner-side. Continue anyway? Reply `yes` to proceed."
 
 Wait for confirmation before continuing.
 
 Fetch outstanding review threads via GraphQL:
-
 ```bash
 gh api graphql -F number="$PR" -F owner="$OWNER" -F repo="$REPO" -f query='
   query($owner: String!, $repo: String!, $number: Int!) {
@@ -76,8 +71,21 @@ gh api graphql -F number="$PR" -F owner="$OWNER" -F repo="$REPO" -f query='
     }
   }' > "/tmp/swe-workbench-address-feedback/${PR}-threads.json"
 ```
-
-If all threads are resolved (or no threads exist), print:
+Fetch PR-level conversation comments (issue #473 — general feedback on the main timeline, not a line comment) via REST, paginated (`--paginate` on this array endpoint emits one concatenated array per page, so `--jq '.[]' | jq -s '...'` flattens then re-wraps into one array); exclude bots and the PR author, then flag `eligible: false` on reviewer comments already handled on a prior run — (a) an owner comment (`$AUTHOR_LOGIN` or `$CURRENT_USER`, since this phase allows non-author runs) carries their `swe-workbench:handled:{id}` marker, or (b) an owner comment without any handled marker was posted after them (a manual reply); this dedup is lossy by construction, so Phase 3 always surfaces a transparency note instead of silently dropping:
+```bash
+gh api --paginate "repos/${OWNER}/${REPO}/issues/${PR}/comments" --jq '.[]' | jq -s \
+  --arg author "$AUTHOR_LOGIN" --arg me "$CURRENT_USER" '
+    (map(select((.user.login // "") == $author or (.user.login // "") == $me))) as $owner
+    | map(select(((.user.type // "") != "Bot") and (((.user.login // "") | endswith("[bot]")) | not) and ((.user.login // "") != $author)))
+    | map(. as $c
+        | ($owner | any((.body // "") | contains("swe-workbench:handled:" + ($c.id | tostring) + " "))) as $marker
+        | ($owner | any((((.body // "") | contains("swe-workbench:handled")) | not) and (.created_at > $c.created_at))) as $manual
+        | $c + {eligible: (($marker or $manual) | not)})
+  ' > "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json"
+ELIGIBLE_PR_COMMENTS=$(jq '[.[] | select(.eligible)] | length' "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json")
+SKIPPED_PR_COMMENTS=$(jq '[.[] | select(.eligible | not)] | length' "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json")
+```
+If all threads are resolved (or no threads exist) **and** `$ELIGIBLE_PR_COMMENTS` is zero, print:
 > "No open threads — nothing to address."
 Then exit cleanly.
 
@@ -86,7 +94,6 @@ If a prior triage save exists at `/tmp/swe-workbench-address-feedback/${PR}-tria
 ### Phase 2 — Worktree
 
 First, check whether the current branch already matches the PR head — if so, reuse the current worktree instead of creating a new one:
-
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
@@ -97,9 +104,7 @@ if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
   [ -n "$DIRTY" ] && echo "Note: working tree has uncommitted changes; the user may stash before Phase 4 commits to avoid sweeping unrelated edits into the feedback commit."
 fi
 ```
-
 If `$WT` is not yet set, check whether a worktree for `$PR_BRANCH` already exists elsewhere on disk (e.g. the session is on `main` but the branch was checked out previously):
-
 ```bash
 if [ -z "$WT" ]; then
   EXISTING_WT=$(git worktree list --porcelain \
@@ -111,46 +116,42 @@ if [ -z "$WT" ]; then
   fi
 fi
 ```
-
 If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree:
 
 **When rimba is available** (preferred):
-
 ```bash
 RIMBA_OUT=$(rimba add "pr:$PR" --task "address-feedback-$PR" --skip-deps --skip-hooks 2>&1)
 WT=$(echo "$RIMBA_OUT" | awk '/Path:/{print $2}')
 [ -d "$WT" ] || { echo "rimba add failed: $RIMBA_OUT"; exit 1; }
 ```
-
 **When rimba is absent** (fallback):
-
 ```bash
 WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
 mkdir -p "$(dirname "$WT")"
 git fetch origin "${PR_BRANCH}"
 git worktree add "$WT" "${PR_BRANCH}"
 ```
-
 This worktree is **disposable** — fixes are committed and pushed to the PR branch in Phase 4, so the work lives on the remote, not the worktree. Phase 7 removes it on every exit (success, Q-quit, or error). If removal fails, a fallback is attempted; see Phase 7 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 7 before stopping.
 
 ### Phase 3 — Triage digest
 
-Render outstanding threads, one by one. **Filter out two kinds of thread before presenting:**
+Render outstanding threads and eligible PR-level conversation comments, one by one. **Filter out before presenting:**
 
 1. **Resolved threads** — skip any thread where `isResolved == true`.
 2. **Already-clarified threads** — skip any *unresolved* thread where at least one *reply* comment (`comments.nodes[1:]` onwards — `nodes[0]` is the thread-opening comment, which in the typical reviewer-opened case belongs to the reviewer, not the PR owner) has `author.login` equal to `$CURRENT_USER`. This means the owner replied in a prior pass (e.g. a CLARIFIED reply) but left the thread unresolved. It applies whether that reply was posted by this skill or manually by the user. Detecting via reply comments only prevents false-positive skipping when the current user also authored review threads.
+3. **Already-handled PR comments** (issue #473) — bot/tool comments and the PR author's own comments never made it into `${PR}-pr-comments.json` (dropped in Phase 1); entries that did but carry `eligible == false` were deduped there (already marker-replied or manually replied to on a prior run). Only `eligible == true` entries are presented.
 
-If any threads were skipped under rule 2, print a one-line transparency note before the digest:
+If any threads or PR comments were skipped (rule 2 / rule 3), print transparency notes before the digest:
 > "(N thread(s) skipped — already clarified.)"
+> "(N PR comment(s) skipped — already handled.)"
 
-If no threads remain after filtering:
-- When N ≥ 1 (threads were skipped under rule 2): print "No new threads to triage — N already clarified."
-- When N = 0 (only resolved threads filtered): print "No new threads to triage."
+If no threads and no eligible PR comments (`$ELIGIBLE_PR_COMMENTS == 0`) remain after filtering:
+- When any items were skipped under rule 2 or rule 3: print "No new items to triage — N already clarified/handled."
+- When nothing was skipped (only resolved threads filtered, and no PR comments existed): print "No new items to triage."
 
 Then run **Phase 7 — Cleanup** and exit cleanly.
 
 For each remaining thread:
-
 ```
 ─────────────────────────────────────────────────
 Thread #ID — {path}:{line}  by @{author}  [{Severity if parseable}]
@@ -162,18 +163,27 @@ Thread #ID — {path}:{line}  by @{author}  [{Severity if parseable}]
 [D]eferred — skip this thread
 [Q]uit — save progress and exit
 ```
-
 Parse severity from `Severity: <level>` prefix in comment body if present; otherwise label `Unknown`.
 
 Capture: `triage[<thread_id>] = A|C|D`.
 
-If the owner replies `Q`, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, then run **Phase 7 — Cleanup**, and exit. Re-invocation resumes from this file (Phase 2 re-creates the worktree).
+For each remaining PR comment (issue #473 — no `path:line`, no resolve state), key as `triage["prcomment:<comment.id>"]` (namespaced against review-thread node IDs in the same flat map; carries the id needed for the Phase 5 marker; both key kinds round-trip through Q-quit save/resume unchanged):
+```
+PR comment by @{author}
+> {first 200 chars of comment body}
+
+[A]ddressed — fix + commit + reply (PR comments have no thread to resolve)
+[C]larified — reply only
+[D]eferred — skip this comment
+[Q]uit — save progress and exit
+```
+If the owner replies `Q` at any point in either loop, save triage state to `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, then run **Phase 7 — Cleanup**, and exit. Re-invocation resumes from this file (Phase 2 re-creates the worktree).
 
 ### Phase 4 — Implement + commit
 
-For each `ADDRESSED` thread (in order):
+For each `ADDRESSED` review thread or PR comment (in order — both sources share this loop, since the commit step is source-agnostic):
 
-1. Show the finding and the relevant file/line context.
+1. Show the finding and the relevant file/line context (PR comments have no `path:line`; show the comment body instead).
 2. Ask the owner for the fix approach (free-text). If the comment already contains a `### Suggested fix` block, offer to apply it automatically via the Edit tool.
 3. Apply edits using the Edit tool.
 
@@ -181,50 +191,52 @@ After all `ADDRESSED` fixes are applied, invoke `swe-workbench:workflow-commit-a
 > "commit and push these fixes addressing review feedback on PR #N"
 
 This reuses the existing `[type]` commit format, branch-naming check, and push logic. After the skill returns, capture the resulting commit SHA:
-
 ```bash
 FIX_SHA=$(git -C "$WT" rev-parse HEAD)
 ```
 
 ### Phase 5 — Reply + resolve
 
-For each **ADDRESSED** or **CLARIFIED** thread, post a reply via REST then conditionally resolve (DEFERRED threads skip this call entirely). Use `comments.nodes[0].databaseId` (the thread root comment) as `$COMMENT_DATABASEID` — replies must target the first comment in the thread, not a subsequent reply.
+For each **ADDRESSED** or **CLARIFIED** review thread, post a reply via REST then conditionally resolve (DEFERRED threads skip this call entirely). Use `comments.nodes[0].databaseId` (the thread root comment) as `$COMMENT_DATABASEID` — replies must target the first comment in the thread, not a subsequent reply.
 
 Reply body templates by triage classification:
 - **ADDRESSED**: `"Addressed in ${FIX_SHA}: <one-line summary of fix>."` — pass both `$REPLY_BODY` and `$THREAD_ID`.
 - **CLARIFIED**: free-text owner-authored reply (asked interactively) — pass `$REPLY_BODY` with empty `$THREAD_ID` (reply only, no resolve).
 - **DEFERRED**: pass empty `$REPLY_BODY` and empty `$THREAD_ID` (neither reply nor resolve).
-
 ```bash
 bash "$_RT/runtime/reply-and-resolve.sh" \
   "$OWNER" "$REPO" "$PR" "$COMMENT_DATABASEID" "$THREAD_ID" "$REPLY_BODY"
 ```
-
+For each **ADDRESSED** or **CLARIFIED** PR comment (`triage["prcomment:<id>"]`, issue #473), post a reply on the PR's top-level conversation instead of a thread reply — PR comments have no thread, so resolve is always suppressed and `KIND=issue` is passed explicitly. Compose `$REPLY_BODY` as `@{comment author} re:` + a single-line blockquote of the original (first ~100 chars, newlines collapsed) + the addressed/clarified body (same wording as the review-thread templates above) + a hidden marker on its own line — `<!-- swe-workbench:handled:{comment.id} -->` — which Phase 1's dedup filter matches on re-runs (omitting it makes the comment look unhandled forever). The original comment body is attacker-controlled: extract the blockquote via `jq -r` into a shell variable (e.g. `QUOTE=$(jq -r '.[] | select(.id==ID) | .body' ... | head -c 100 | tr '\n' ' ')`) and reference `"$QUOTE"` when building `$REPLY_BODY` — never retype the raw comment text into a double-quoted bash literal, since `$(...)`/backticks in the source text would execute at assignment time. DEFERRED PR comments skip the call entirely, same as DEFERRED threads:
+```bash
+bash "$_RT/runtime/reply-and-resolve.sh" \
+  "$OWNER" "$REPO" "$PR" "" "" "$REPLY_BODY" "issue"
+```
 After all replies and resolutions land, emit the follow-up CTA:
 
 > "Want me to ping the reviewer to re-check? Reply `yes` to run `/review --check-followup <N>`."
 
 On the Phase 5 success path, delete the address-feedback state files. The reap runs foreground; failures surface (no `2>/dev/null`):
-
 ```bash
 bash "$_RT/runtime/clean-state-files.sh" \
   "/tmp/swe-workbench-address-feedback/${PR}.json" \
   "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+  "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json" \
   "/tmp/swe-workbench-address-feedback/${PR}-triage.json"
 for f in "/tmp/swe-workbench-address-feedback/${PR}.json" \
          "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+         "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json" \
          "/tmp/swe-workbench-address-feedback/${PR}-triage.json"; do
   [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
 done
 ```
-
 Then run **Phase 6 — Sync PR metadata**.
 
 ### Phase 6 — Sync PR metadata (when fixes were committed)
 
 Skip this phase entirely if `$FIX_SHA` is unset (no fixes were committed in Phase 4).
 
-Fetch: `gh pr view "$PR" --json title,body`; commit subjects via `git -C "$WT" log "$BASE"..HEAD --format='%s'`; diff stat via `git -C "$WT" diff "$BASE"..HEAD --stat`. No new state file — the reap already ran in Phase 5.
+Fetch: `gh pr view "$PR" --json title,body`; commit subjects via `git -C "$WT" log "$BASE"..HEAD --format='%s'`; diff stat via `git -C "$WT" diff "$BASE"..HEAD --stat`. No new state file — the reap already ran in Phase 5 (covers `${PR}-pr-comments.json` too).
 
 **Judge drift** by comparing the live title and `## Summary` section of the PR body against the commit subjects and diff stat. If aligned, emit "PR metadata is up to date — no changes needed." and fall through to Phase 7 — Cleanup.
 
@@ -233,7 +245,6 @@ Fetch: `gh pr view "$PR" --json title,body`; commit subjects via `git -C "$WT" l
 > Reply `yes` to apply these changes to PR #N.
 
 On `yes`:
-
 ```bash
 NEW_BODY_FILE=$(mktemp)
 trap 'rm -f "$NEW_BODY_FILE"' EXIT
@@ -241,13 +252,11 @@ printf '%s' "$NEW_BODY" > "$NEW_BODY_FILE"
 bash "$_RT/runtime/sync-pr-metadata.sh" "$PR" "$NEW_TITLE" "$NEW_BODY_FILE" \
   || echo "Warning: PR metadata update failed — continuing to cleanup." >&2
 ```
-
 Then run **Phase 7 — Cleanup**.
 
 ### Phase 7 — Cleanup (always)
 
 Run on every exit that occurs after a worktree was **created** in Phase 2 (success, Q-quit, or error). Skip on Phase 1 early-exits (before any worktree exists) and when the reuse-guard fired (`REUSED_WT=1`) — the reuse path sets `$WT` to an existing checkout, never creates a worktree, so there is nothing to remove.
-
 ```bash
 if [ "${REUSED_WT:-0}" = "1" ]; then
   echo "Reused existing worktree at $WT — skipping cleanup (nothing was created)."
@@ -262,7 +271,6 @@ else
   fi
 fi
 ```
-
 Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a warning and do not block completion. The fallback removes only the worktree directory — never delete `$PR_BRANCH` directly (e.g. via `git branch -D`), which would destroy the owner's actual PR head branch.
 
 ## Failure modes

--- a/tests/test_reply_and_resolve_script.py
+++ b/tests/test_reply_and_resolve_script.py
@@ -32,11 +32,14 @@ def _make_recording_gh_stub(stub_dir: Path, log_file: Path) -> None:
     stub.chmod(0o755)
 
 
-def _run(owner, repo, pr, comment_id, thread_id, reply_body, *, stub_dir: Path):
+def _run(owner, repo, pr, comment_id, thread_id, reply_body, kind=None, *, stub_dir: Path):
     env = dict(_CLEAN_ENV)
     env["PATH"] = f"{stub_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+    args = ["bash", str(SCRIPT), owner, repo, pr, comment_id, thread_id, reply_body]
+    if kind is not None:
+        args.append(kind)
     return subprocess.run(
-        ["bash", str(SCRIPT), owner, repo, pr, comment_id, thread_id, reply_body],
+        args,
         capture_output=True, text=True,
         cwd=str(ROOT),
         env=env,
@@ -147,3 +150,106 @@ def test_reply_without_comment_id_exits_nonzero(tmp_path):
         f"Expected COMMENT_DATABASEID error on stderr; got: {result.stderr!r}"
     )
     assert _gh_calls(log) == [], "gh must NOT be called when COMMENT_DATABASEID is missing"
+
+
+# ── KIND=issue (PR-level conversation comments) ───────────────────────────────
+
+def test_issue_kind_posts_to_issues_comments(tmp_path):
+    """KIND=issue posts the reply to the issues/{pr}/comments endpoint, not a review reply."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run(
+        "owner", "repo", "123", "", "", "@reviewer re: thanks, fixed.", "issue",
+        stub_dir=stub_dir,
+    )
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 1, f"Expected 1 gh call for issue KIND, got {len(calls)}: {calls}"
+    assert "issues/123/comments" in calls[0], (
+        f"Expected the issues/{{pr}}/comments endpoint; got: {calls[0]!r}"
+    )
+
+
+def test_issue_kind_never_calls_graphql(tmp_path):
+    """KIND=issue never resolves — PR-level comments have no thread to resolve."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    _run("owner", "repo", "123", "", "", "@reviewer re: noted.", "issue", stub_dir=stub_dir)
+    calls = _gh_calls(log)
+    assert all("graphql" not in c for c in calls), (
+        f"KIND=issue must not call graphql; calls: {calls}"
+    )
+
+
+def test_issue_kind_ignores_nonempty_comment_databaseid(tmp_path):
+    """KIND=issue ignores a stray COMMENT_DATABASEID — no missing-id error, still posts."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run(
+        "owner", "repo", "123", "999", "", "@reviewer re: thanks.", "issue",
+        stub_dir=stub_dir,
+    )
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 1
+    assert "issues/123/comments" in calls[0]
+
+
+def test_issue_kind_empty_body_exits_zero_without_calling_gh(tmp_path):
+    """KIND=issue with an empty REPLY_BODY is a no-op: exit 0, gh never invoked."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run("owner", "repo", "123", "", "", "", "issue", stub_dir=stub_dir)
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    assert _gh_calls(log) == [], "gh must NOT be called when REPLY_BODY is empty"
+
+
+def test_unknown_kind_exits_nonzero(tmp_path):
+    """An unrecognized KIND value fails loudly instead of silently falling through."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run(
+        "owner", "repo", "123", "456", "THREAD_abc", "Addressed.", "bogus",
+        stub_dir=stub_dir,
+    )
+    assert result.returncode != 0, "Expected non-zero exit for an unknown KIND value"
+    assert _gh_calls(log) == [], "gh must NOT be called for an unknown KIND value"
+
+
+def test_body_flag_is_lowercase_f_not_uppercase_f():
+    """Both gh api body= call sites must use -f (raw string), never -F.
+
+    Reply bodies always start with @{author} — `gh api -F body=@x` treats an
+    @-prefixed value as a file path to read rather than a literal string, so
+    every reply would silently try to read a nonexistent file named after the
+    reviewer's handle. The recording gh stub used elsewhere in this file only
+    logs "$1 $2" (sub-command + URL), not flags, so it can't catch a regression
+    here — this test reads the script source directly instead.
+    """
+    text = SCRIPT.read_text()
+    body_lines = [ln for ln in text.splitlines() if "body=" in ln and "gh api" in ln]
+    assert len(body_lines) == 2, f"expected exactly 2 gh api body= call sites, found {len(body_lines)}: {body_lines}"
+    for ln in body_lines:
+        assert "-f body=" in ln, f"expected -f body= (raw string), got: {ln!r}"
+        assert "-F body=" not in ln, f"-F body= would @-file-expand an @-prefixed reply: {ln!r}"
+
+
+def test_six_arg_call_still_behaves_as_review(tmp_path):
+    """Omitting the 7th KIND arg preserves the existing review-reply behavior (back-compat)."""
+    stub_dir = tmp_path / "stubs"
+    log = tmp_path / "gh.log"
+    _make_recording_gh_stub(stub_dir, log)
+    result = _run(
+        "owner", "repo", "123", "456", "THREAD_abc", "Addressed in abc123: fix typo.",
+        stub_dir=stub_dir,
+    )
+    assert result.returncode == 0, f"Expected exit 0\nstderr: {result.stderr!r}"
+    calls = _gh_calls(log)
+    assert len(calls) == 2, f"Expected 2 gh calls, got {len(calls)}: {calls}"
+    assert "comments/456/replies" in calls[0]
+    assert "graphql" in calls[1]

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -629,6 +629,25 @@ def test_pr_comments_jq_filter_drops_bots_and_author():
 
 
 @pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_drops_current_user_on_non_author_run():
+    """Regression test: on a non-author run, the runner's own past marker-bearing
+    reply must not resurface as a fresh triage candidate (duplicate-reply spam)."""
+    comments = [
+        {"id": 20, "user": {"login": "reviewer6", "type": "User"}, "body": "please fix V", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 21, "user": {"login": "maintainer-x", "type": "User"}, "body": "done <!-- swe-workbench:handled:20 -->", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="maintainer-x")
+    by_id = {c["id"]: c for c in result}
+    assert 21 not in by_id, (
+        "comment 21 was authored by $me (the non-author runner) and must be dropped "
+        "as a candidate entirely, not resurface with eligible: false"
+    )
+    assert by_id[20]["eligible"] is False, (
+        "comment 20 must still be marker-deduped via owner comment 21's marker"
+    )
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
 def test_pr_comments_jq_filter_marker_dedup():
     comments = [
         {"id": 5, "user": {"login": "reviewer2", "type": "User"}, "body": "please fix Y", "created_at": "2026-01-01T00:00:00Z"},

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -2,10 +2,16 @@
 
 """Tests for the workflow-address-feedback skill (closes #218)."""
 
+import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
+
 import validate
+from conftest import _CLEAN_ENV
 
 ROOT = Path(__file__).parent.parent
 SKILL_DIR = ROOT / "skills" / "workflow-address-feedback"
@@ -460,4 +466,224 @@ def test_address_feedback_skill_phase5_reap_has_post_check():
     assert re.search(r'✓ state file reaped:', text), (
         "SKILL.md Phase 5 must include a post-reap report line "
         "'✓ state file reaped: ...' so operators can verify cleanup completed"
+    )
+
+
+# --- PR-level conversation comments (issue #473) ---
+
+
+def test_address_feedback_skill_fetches_pr_comments_paginated():
+    """Phase 1 must fetch PR-level conversation comments via the paginated issues comments endpoint."""
+    text = SKILL_MD.read_text()
+    assert "issues/${PR}/comments" in text, (
+        "SKILL.md Phase 1 must fetch repos/{owner}/{repo}/issues/${PR}/comments "
+        "(PR-level conversation comments, distinct from review-thread comments)"
+    )
+    assert "--paginate" in text, (
+        "SKILL.md Phase 1 must paginate the issues/comments fetch (--paginate) — "
+        "a PR can have more than one page of conversation comments"
+    )
+
+
+def test_address_feedback_skill_early_exit_accounts_for_pr_comments():
+    """Phase 1 early-exit must also gate on eligible PR comments, not just unresolved threads."""
+    text = SKILL_MD.read_text()
+    assert "ELIGIBLE_PR_COMMENTS" in text, (
+        "SKILL.md Phase 1 must compute $ELIGIBLE_PR_COMMENTS so the early-exit can "
+        "account for PR-level comments, not only review threads"
+    )
+    early_exit_idx = text.find("No open threads — nothing to address")
+    assert early_exit_idx != -1, "SKILL.md must contain the early-exit message"
+    preceding = text[:early_exit_idx]
+    assert "ELIGIBLE_PR_COMMENTS" in preceding[-600:], (
+        "SKILL.md early-exit gate must reference $ELIGIBLE_PR_COMMENTS just before "
+        "the 'No open threads — nothing to address' message"
+    )
+
+
+def test_address_feedback_skill_excludes_bots_and_author_from_pr_comments():
+    """Phase 1's PR-comment filter must exclude bot comments and the PR author's own comments."""
+    text = SKILL_MD.read_text()
+    assert "Bot" in text and "[bot]" in text, (
+        "SKILL.md must describe excluding bot comments (user.type == Bot or a "
+        "login ending in [bot]) from PR-level comment triage"
+    )
+    assert "AUTHOR_LOGIN" in text and "eligible" in text, (
+        "SKILL.md must describe excluding the PR author's own comments "
+        "(user.login == $AUTHOR_LOGIN) via the eligible filter"
+    )
+
+
+def test_address_feedback_skill_renders_pr_comment_block():
+    """Phase 3 must render a distinct 'PR comment by @{author}' block with an [A] menu that skips resolve."""
+    text = SKILL_MD.read_text()
+    assert "PR comment by @{author}" in text, (
+        "SKILL.md Phase 3 must render PR-level comments in a distinct "
+        "'PR comment by @{author}' block (no path:line)"
+    )
+    pr_block_idx = text.find("PR comment by @{author}")
+    assert pr_block_idx != -1
+    following = text[pr_block_idx:pr_block_idx + 600]
+    assert re.search(r"\[A\]ddressed.*no.*resolve|\[A\]ddressed.*no thread to resolve", following, re.IGNORECASE), (
+        "SKILL.md PR comment menu's [A]ddressed option must state that PR comments "
+        "have no thread to resolve — resolve must be suppressed"
+    )
+
+
+def test_address_feedback_skill_keys_pr_comments_namespaced():
+    """Phase 3 must key PR comments as triage["prcomment:<id>"], namespaced from thread node IDs."""
+    text = SKILL_MD.read_text()
+    assert 'triage["prcomment:' in text, (
+        'SKILL.md Phase 3 must key PR comments as triage["prcomment:<comment.id>"] — '
+        "namespaced so they cannot collide with GraphQL review-thread node IDs in the same map"
+    )
+
+
+def test_address_feedback_skill_phase5_dispatches_issue_kind():
+    """Phase 5 must dispatch reply-and-resolve.sh with KIND=issue and empty comment-id/thread-id for PR comments."""
+    text = SKILL_MD.read_text()
+    assert re.search(r'reply-and-resolve\.sh.*\n.*"\$OWNER" "\$REPO" "\$PR" "" "" "\$REPLY_BODY" "issue"', text), (
+        'SKILL.md Phase 5 must call reply-and-resolve.sh with '
+        '"$OWNER" "$REPO" "$PR" "" "" "$REPLY_BODY" "issue" for PR comments — '
+        "empty COMMENT_DATABASEID/THREAD_ID (PR comments have no thread) and explicit issue KIND"
+    )
+
+
+def test_address_feedback_skill_reply_body_embeds_handled_marker():
+    """Phase 5 PR-comment reply body must embed the swe-workbench:handled:{id} marker used for re-run dedup."""
+    text = SKILL_MD.read_text()
+    assert "swe-workbench:handled:" in text, (
+        "SKILL.md Phase 5 must compose the PR-comment reply body with a hidden "
+        "<!-- swe-workbench:handled:{comment.id} --> marker — Phase 1's dedup filter "
+        "matches on this marker to skip already-replied comments on re-runs"
+    )
+
+
+def test_address_feedback_skill_pr_comments_state_file_in_reap():
+    """Phase 5 reap must include ${PR}-pr-comments.json in both the clean-state-files.sh call and the report loop."""
+    text = SKILL_MD.read_text()
+    assert "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json" in text, (
+        "SKILL.md must reference /tmp/swe-workbench-address-feedback/${PR}-pr-comments.json "
+        "for state-file cleanup"
+    )
+    lines_with_path = [ln for ln in text.splitlines() if "${PR}-pr-comments.json" in ln]
+    assert len(lines_with_path) >= 2, (
+        "SKILL.md must reference ${PR}-pr-comments.json at least twice — once in the "
+        "clean-state-files.sh call and once in the post-reap report loop"
+    )
+
+
+def test_address_feedback_skill_pr_comment_skipped_transparency_note():
+    """Phase 3 must emit a transparency note for PR comments skipped as already-handled."""
+    text = SKILL_MD.read_text()
+    assert "PR comment(s) skipped" in text, (
+        "SKILL.md Phase 3 must emit a transparency note like "
+        "'(N PR comment(s) skipped — already handled.)' since the marker/manual-reply "
+        "dedup is lossy by construction"
+    )
+
+
+# --- Executable coverage of the embedded Phase 1 jq filter (issue #473) ---
+#
+# The filter's exclusion/dedup logic lives inside a jq program embedded in SKILL.md
+# prose, not in a standalone script. Regex assertions on the surrounding text can't
+# catch a logic bug inside that program (e.g. an unanchored substring match). These
+# tests extract the actual program text and run it through real jq, so a regression
+# in the embedded logic fails here instead of shipping silently.
+
+_JQ_AVAILABLE = shutil.which("jq") is not None
+
+
+def _extract_pr_comments_jq_program() -> str:
+    text = SKILL_MD.read_text()
+    block = re.search(r"```bash\ngh api --paginate.*?\n```", text, re.DOTALL)
+    assert block, "Phase 1 PR-comments fetch code block not found in SKILL.md"
+    program = re.search(r'--arg me "\$CURRENT_USER" \'\n(.*?)\n  \' >', block.group(0), re.DOTALL)
+    assert program, "jq program not found within the Phase 1 fetch code block"
+    return program.group(1)
+
+
+def _run_pr_comments_filter(comments: list[dict], author: str, me: str) -> list[dict]:
+    program = _extract_pr_comments_jq_program()
+    result = subprocess.run(
+        ["jq", "--arg", "author", author, "--arg", "me", me, program],
+        input=json.dumps(comments), capture_output=True, text=True,
+        env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 0, f"jq filter failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_drops_bots_and_author():
+    comments = [
+        {"id": 1, "user": {"login": "some-bot", "type": "Bot"}, "body": "lgtm", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 2, "user": {"login": "renovate[bot]", "type": "User"}, "body": "bump", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 3, "user": {"login": "pr-author", "type": "User"}, "body": "self note", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 4, "user": {"login": "reviewer1", "type": "User"}, "body": "please fix X", "created_at": "2026-01-01T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="pr-author")
+    ids = {c["id"] for c in result}
+    assert ids == {4}, f"bot/[bot]/author comments must be dropped entirely; got ids {ids}"
+    assert result[0]["eligible"] is True
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_marker_dedup():
+    comments = [
+        {"id": 5, "user": {"login": "reviewer2", "type": "User"}, "body": "please fix Y", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 6, "user": {"login": "pr-author", "type": "User"}, "body": "done <!-- swe-workbench:handled:5 -->", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="pr-author")
+    by_id = {c["id"]: c for c in result}
+    assert by_id[5]["eligible"] is False, "a comment whose own marker is present must be ineligible"
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_marker_match_is_anchored():
+    """Regression test: a marker for id 1234 must not dedup-suppress unrelated id 123
+    via an unanchored substring match (id 123 is a numeric prefix of 1234)."""
+    comments = [
+        {"id": 123, "user": {"login": "reviewer3", "type": "User"}, "body": "please fix Z", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 999, "user": {"login": "pr-author", "type": "User"}, "body": "done <!-- swe-workbench:handled:1234 -->", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="pr-author")
+    by_id = {c["id"]: c for c in result}
+    assert by_id[123]["eligible"] is True, (
+        "comment 123 must stay eligible — the owner's marker is for a different "
+        "comment (1234) that merely shares a numeric prefix; an unanchored "
+        "contains() match would incorrectly suppress it"
+    )
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_manual_reply_dedup():
+    comments = [
+        {"id": 7, "user": {"login": "reviewer4", "type": "User"}, "body": "please fix W", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 8, "user": {"login": "pr-author", "type": "User"}, "body": "thanks, will look", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="pr-author")
+    by_id = {c["id"]: c for c in result}
+    assert by_id[7]["eligible"] is False, (
+        "a marker-less owner comment posted after the reviewer comment counts as a "
+        "manual reply and must dedup-suppress it"
+    )
+
+
+@pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
+def test_pr_comments_jq_filter_own_marker_replies_excluded_from_manual_heuristic():
+    """A prior marker-bearing tool reply must not itself count as a 'manual reply' that
+    over-suppresses a different, still-open reviewer comment posted before it."""
+    comments = [
+        {"id": 9, "user": {"login": "reviewer5", "type": "User"}, "body": "issue A", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": 10, "user": {"login": "reviewer5", "type": "User"}, "body": "issue B", "created_at": "2026-01-01T01:00:00Z"},
+        {"id": 11, "user": {"login": "pr-author", "type": "User"}, "body": "done <!-- swe-workbench:handled:10 -->", "created_at": "2026-01-02T00:00:00Z"},
+    ]
+    result = _run_pr_comments_filter(comments, author="pr-author", me="pr-author")
+    by_id = {c["id"]: c for c in result}
+    assert by_id[10]["eligible"] is False, "comment 10's own marker must dedup-suppress it"
+    assert by_id[9]["eligible"] is True, (
+        "comment 9 must stay eligible — the only later owner comment is a "
+        "marker-bearing tool reply for a different comment, which the manual-reply "
+        "heuristic must ignore (it only counts marker-less owner comments)"
     )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `runtime/reply-and-resolve.sh` gains an optional 7th `KIND` arg (default `review`, back-compat unchanged); `KIND=issue` posts a reply to the PR's top-level conversation (`issues/{pr}/comments`) instead of a review thread, and never resolves. Also fixes a latent `-F`→`-f` bug: reply bodies start with `@{reviewer}`, and `gh api -F body=@x` treats an `@`-prefixed value as a file path to read rather than a literal string.
- `skills/workflow-address-feedback/SKILL.md` (Phase 1) now also fetches PR-level conversation comments via a paginated REST call, filtering out bots/the PR author and flagging already-handled comments via a `swe-workbench:handled:{id}` marker or a manual-reply heuristic (both surfaced via a transparency note, since PR-level comments aren't threaded so the dedup is lossy by construction).
- Phase 3 renders eligible PR comments in a distinct "PR comment by @{author}" digest block (no `path:line`), keyed as `triage["prcomment:<id>"]`; `[A]ddressed` runs the same fix→commit→reply flow as review threads, minus the resolve mutation.
- Phase 4/5 route ADDRESSED/CLARIFIED PR comments through the same fix→commit flow, then dispatch `reply-and-resolve.sh` with `KIND=issue`; the composed reply body embeds a hidden `swe-workbench:handled:{id}` marker for re-run dedup.
- New tests: KIND-branch coverage for `reply-and-resolve.sh` (including a static `-f`/`-F` regression guard), SKILL.md contract assertions, and executable tests that run the actual embedded jq filter against fixtures (bot/author exclusion, marker dedup, manual-reply dedup, and a regression test for a marker-substring-anchoring bug caught during review).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1426 passed
- [x] `bash scripts/validate.sh` — all checks passed
- [x] `shellcheck --severity=warning runtime/reply-and-resolve.sh` — clean
- [x] Reviewed in parallel by `superpowers:requesting-code-review` (plan-alignment) and `swe-workbench:reviewer` (diff correctness/security/design); all Critical/Important findings fixed (marker-anchoring bug, injection-safe reply composition, `-f`/`-F` regression guard, docs inconsistency)

Closes #473
