### PR TITLE
[feat] Document Go codegen/wire convention in language-go skill

### DIFF
--- a/skills/language-go/SKILL.md
+++ b/skills/language-go/SKILL.md
@@ -42,6 +42,25 @@ if err := g.Wait(); err != nil { return err }
 - Never store `context.Context` in a struct field.
 - Don't use `context.Value` for required parameters — only cross-cutting concerns like request IDs.
 
+## Code generation
+- A `// Code generated ... DO NOT EDIT.` header means the file is output, not source. Never hand-edit it — edits are clobbered on the next run and drift from their input.
+- Edit the generator's input, then regenerate with `go generate ./...` (or the tool directly). Commit the regenerated file with the source change.
+- Applies to `stringer`, `mockgen`, `sqlc`, `protoc-gen-go`, and **google/wire**.
+
+**google/wire** — detected by a `wire.go` tagged `//go:build wireinject` plus a `wire_gen.go` carrying the Wire `DO NOT EDIT.` header. To change dependency injection:
+- Edit provider sets / injectors in `wire.go` only — never `wire_gen.go`.
+- Regenerate with `go generate ./...` (or `wire ./...`), then stage the updated `wire_gen.go`. If `go generate ./...` produces no diff, `wire.go` likely lacks a `//go:generate wire` directive — run `wire ./...` directly.
+
+```go
+//go:build wireinject
+
+// wire.go — edit here: provider sets and injector signatures.
+func InitApp(ctx context.Context) (*App, error) {
+    wire.Build(configSet, storeSet, NewApp)
+    return nil, nil // wire fills the body in wire_gen.go
+}
+```
+
 ## Tooling
 - **Imports:** `goimports -w .`
 - **Format:** `gofmt -w .` (redundant if running goimports; keep for explicit CI parity)

--- a/tests/test_language_go_codegen.py
+++ b/tests/test_language_go_codegen.py
@@ -1,0 +1,88 @@
+"""Structural tests for the Go code-generation / google/wire convention (closes #477).
+
+Acceptance criteria:
+- skills/language-go/SKILL.md has a '## Code generation' section, non-empty.
+- The section mentions wire.go, wire_gen.go, and a DO NOT EDIT / generated signal.
+- The section references regeneration via `go generate` (and/or `wire ./...`).
+- The section states the source-of-truth rule: edit wire.go, not wire_gen.go.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+GO_SKILL = ROOT / "skills" / "language-go" / "SKILL.md"
+
+
+def _section(body: str, heading: str) -> str:
+    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks).
+
+    Returns "" when the heading is absent so callers can assert with their own message.
+    """
+    marker = f"## {heading}"
+    if marker not in body:
+        return ""
+    start = body.index(marker) + len(marker)
+    rest = body[start:]
+    fence_open = False
+    lines = []
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~~"):
+            fence_open = not fence_open
+        if not fence_open and line.startswith("## "):
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def test_go_skill_file_exists():
+    assert GO_SKILL.exists(), "skills/language-go/SKILL.md must exist"
+
+
+def test_has_code_generation_section():
+    body = GO_SKILL.read_text()
+    section = _section(body, "Code generation")
+    assert section.strip(), (
+        "skills/language-go/SKILL.md must contain a non-empty '## Code generation' section"
+    )
+
+
+def test_code_generation_mentions_wire_files():
+    body = GO_SKILL.read_text()
+    section = _section(body, "Code generation")
+    assert section.strip(), "'## Code generation' section is empty or missing"
+    assert "wire.go" in section, (
+        "'## Code generation' must reference 'wire.go' as the editable injector source"
+    )
+    assert "wire_gen.go" in section, (
+        "'## Code generation' must reference 'wire_gen.go' as the generated output"
+    )
+
+
+def test_code_generation_mentions_generated_signal():
+    body = GO_SKILL.read_text()
+    section = _section(body, "Code generation")
+    assert section.strip(), "'## Code generation' section is empty or missing"
+    assert re.search(r"DO NOT EDIT", section, re.IGNORECASE), (
+        "'## Code generation' must call out the literal 'DO NOT EDIT' generated-file signal"
+    )
+
+
+def test_code_generation_mentions_regeneration_command():
+    body = GO_SKILL.read_text()
+    section = _section(body, "Code generation")
+    assert section.strip(), "'## Code generation' section is empty or missing"
+    assert re.search(r"go generate|wire\s+\./\.\.\.", section), (
+        "'## Code generation' must reference regenerating via `go generate` or `wire ./...`"
+    )
+
+
+def test_code_generation_states_source_of_truth_rule():
+    body = GO_SKILL.read_text()
+    section = _section(body, "Code generation")
+    assert section.strip(), "'## Code generation' section is empty or missing"
+    assert re.search(r"wire\.go.{0,80}never.{0,40}wire_gen\.go", section, re.IGNORECASE | re.DOTALL), (
+        "'## Code generation' must state, in one place, the rule: edit wire.go, never wire_gen.go"
+    )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Add a `## Code generation` section to `skills/language-go/SKILL.md`: never hand-edit a `DO NOT EDIT` generated file — edit the generator's input, then regenerate.
- Use google/wire as the worked example: detect via `wire.go` tagged `//go:build wireinject` + `wire_gen.go` carrying the Wire `DO NOT EDIT.` header; edit `wire.go` only, regenerate with `go generate ./...` (or `wire ./...`), commit the regenerated `wire_gen.go`.
- Section is placed before `## Tooling`, keeping `## Avoid` as the closing section per the file's existing convention.
- Content-only change — `triggers.txt` and the frontmatter `description` are untouched; guidance rides on the skill's existing `.go`/`go.mod` triggers.
- Add `tests/test_language_go_codegen.py` (TDD, mirrors the `_section()` helper from `tests/test_behaviour_and_ordering_conventions.py`) asserting the section exists and pins down each acceptance criterion.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python -m pytest tests/ -q` — 1433 passed (1427 baseline + 6 new), no regressions
- [x] `bash scripts/validate.sh` — structural validation passes
- [x] Mutation-tested the two tightened assertions (source-of-truth rule, DO-NOT-EDIT signal) to confirm they fail when the guarded content is removed

### Type-tailored checks (feat)
- [x] New `## Code generation` section is reachable via the skill's existing `.go`/`go.mod` auto-load triggers (no trigger/description changes needed)
- [x] Reviewed by both `superpowers:requesting-code-review` (plan-alignment: Ready to merge — Yes) and `swe-workbench:reviewer` (diff review: APPROVE); both review findings addressed

Closes #477
