### PR TITLE
[feat] Embed workflow phases 2-5 inline in extend.md

### DIFF
--- a/commands/extend.md
+++ b/commands/extend.md
@@ -33,6 +33,24 @@ If `PR_STATE` is `"OPEN"`: capture PR_NUM, HEAD_REF, PR_URL, and IS_DRAFT into c
 
 Then activate `swe-workbench:workflow-extend` with all four values.
 
+The list below is a visible contract of the phases `workflow-extend` runs — it does **not** replace the skill activation above. Execute phases 2–5 in order. **Phase 1 (Branch) is intentionally skipped** — the open PR branch is reused, so no new branch or worktree is created.
+
+**Phase 2 — Implement**
+Execute the plan via `superpowers:executing-plans` or `superpowers:subagent-driven-development`. Apply `swe-workbench:principle-tdd` per unit: red → green → refactor.
+
+**Phase 3 — Verify**
+Run `superpowers:verification-before-completion` before claiming any phase done. Do not advance to Phase 4 until format / lint / test pass with evidence.
+
+**Phase 4 — Review**
+Dispatch **BOTH** reviewers **IN PARALLEL** — in a single batch (same turn), as two distinct required invocations, **neither optional**:
+- `superpowers:requesting-code-review` (a **Skill**) — plan-alignment, standards
+- `swe-workbench:reviewer` (a **subagent**) — diff correctness/security/design in `Severity | File:Line | Issue | Why it matters | Suggested fix` format
+
+Running the Skill inline and skipping the `swe-workbench:reviewer` subagent (or vice-versa) does **not** satisfy this phase. Do not advance to Phase 5 until review passes clean or all raised issues are resolved.
+
+**Phase 5 — Deliver**
+Invoke `swe-workbench:workflow-commit-and-pr` to update the **existing** PR — never `gh pr create`, never a second PR.
+
 If `PR_STATE` is not `"OPEN"` (empty, `"CLOSED"`, `"MERGED"`, or `gh` error): surface the following `AskUserQuestion` and **return** — do **not** activate `workflow-extend`:
 
 ```json

--- a/tests/test_extend_command.py
+++ b/tests/test_extend_command.py
@@ -157,6 +157,35 @@ def test_extend_command_no_open_pr_fallback():
     )
 
 
+def test_extend_command_inline_phases_2_through_5():
+    """extend.md must show Phases 2-5 inline (issue #476), mirroring implement.md.
+
+    Phase 1 (Branch) is intentionally skipped — the open PR branch is reused.
+    Phase 5 must update the existing PR via workflow-commit-and-pr, never gh pr create.
+    """
+    text = EXTEND_CMD.read_text()
+    for marker in (
+        "**Phase 2 — Implement**",
+        "**Phase 3 — Verify**",
+        "**Phase 4 — Review**",
+        "**Phase 5 — Deliver**",
+    ):
+        assert marker in text, f"extend.md must contain inline marker {marker!r}"
+
+    assert re.search(r'Phase 1.{0,80}\b(skipped|reused)\b', text, re.IGNORECASE | re.DOTALL), (
+        "extend.md must note that Phase 1 (Branch) is skipped/reused"
+    )
+
+    assert "swe-workbench:workflow-commit-and-pr" in text, (
+        "extend.md Phase 5 must invoke swe-workbench:workflow-commit-and-pr to update the existing PR"
+    )
+
+    assert "swe-workbench:workflow-extend" in text, (
+        "extend.md must still activate swe-workbench:workflow-extend — "
+        "the inline block is a visible contract, not a replacement"
+    )
+
+
 def test_extend_commit_format_sub_idea_prefix():
     """SKILL.md and template must both mandate the 'sub-idea:' commit prefix."""
     assert "sub-idea:" in SKILL_MD.read_text(), (

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2516,6 +2516,11 @@ class TestPhase4DispatchesBothReviewers:
             "**Phase 4 (Review):**",
             "## Phase D",
         ),
+        (
+            "commands/extend.md",
+            "**Phase 4 — Review**",
+            "**Phase 5",
+        ),
     ]
 
     REQUIRED_TOKENS = [


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `commands/extend.md` previously only activated `swe-workbench:workflow-extend`, leaving the Implement → Verify → Review → Deliver phase contract two skill-activation hops away from the reader.
- Insert an inline **Phase 2 — Implement / Phase 3 — Verify / Phase 4 — Review / Phase 5 — Deliver** block, mirroring the existing inline Phase 1–5 block in `commands/implement.md`. Phase 1 (Branch) is intentionally omitted — `/extend` reuses the existing open PR's branch, so no new branch or worktree is created.
- Phase 5 wording deliberately diverges from `implement.md`: "update the **existing** PR via `swe-workbench:workflow-commit-and-pr` — never `gh pr create`, never a second PR."
- The inline block is a visible contract only — it does not replace the `workflow-extend` skill activation, and the existing "Absolute rules" block (including the no-skip-Phase-3/4 rule) is left untouched.
- Add a regression test (`tests/test_extend_command.py::test_extend_command_inline_phases_2_through_5`) asserting the four inline phase headers, the Phase 1 skip note, the Phase 5 delivery target, and that `workflow-extend` activation is still present.
- Extend the existing Phase-4 dual-reviewer regression guard (issue #458) in `tests/test_validate.py::TestPhase4DispatchesBothReviewers.SITES` to also cover the new inline block in `commands/extend.md`.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_extend_command.py tests/test_validate.py -v` — 243/243 pass
- [x] `pytest tests/ -v` — full suite, 1434/1434 pass
- [x] Manual read of `commands/extend.md`: Phases 2–5 visible inline after the `workflow-extend` activation line; Phase 1 noted as skipped/reused; Phase 5 says update existing PR (no `gh pr create`); `swe-workbench:workflow-extend` still activated; "Absolute rules" block unchanged

### Type-tailored checks (feat)
- [x] New behaviour verified: the inline block renders correctly and the two new regression tests fail red before the `extend.md` edit and pass green after (TDD red → green confirmed)

Closes #476
