### PR TITLE
[feat] Add language-dart skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What it is
 
-`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principle and language skills auto-hint by trigger (a non-blocking hint fires when a matching file is touched); commands and subagents are there when you want explicit help.
+`swe-workbench` bundles the reasoning a careful senior engineer does every day: architectural judgement (Clean Architecture, DDD, SOLID), test discipline (TDD, F.I.R.S.T.), pattern fluency (GoF and beyond), and idiomatic expertise in Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, and TypeScript. Principle and language skills auto-hint by trigger (a non-blocking hint fires when a matching file is touched); commands and subagents are there when you want explicit help.
 
 ## Install
 
@@ -29,7 +29,7 @@ cd swe-workbench
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:sync`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge`, `/swe-workbench:doctor` — see [docs/catalog.md](docs/catalog.md).
 - **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `code-impl`, `conflict-resolver`, `contributor-auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-designer`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security, product design — auto-hint by trigger keyword.
-- **Languages** — Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-hint by file extension (subagents load deterministically via catalog injection).
+- **Languages** — Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-hint by file extension (subagents load deterministically via catalog injection).
 - **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle; `workflow-audit-emit-issues` files grouped GitHub issues from codebase audit findings.
 

--- a/agents/shared/languages.md
+++ b/agents/shared/languages.md
@@ -4,6 +4,7 @@ All `swe-workbench` language skills available in this plugin. Use the `Skill` to
 
 - `swe-workbench:language-bash` — Bash idioms: strict mode, quoting, parameter expansion, arrays, pipefail, trap cleanup, idempotency, heredocs, and POSIX portability.
 - `swe-workbench:language-csharp` — C#/.NET idioms: .NET 8 LTS, nullable reference types, records, pattern matching, async/await, dependency injection, options, LINQ, and performance.
+- `swe-workbench:language-dart` — Dart idioms: null safety, async, Futures/Streams, widget composition, Riverpod/Bloc app architecture.
 - `swe-workbench:language-go` — Go idioms: error handling, concurrency, and standard library usage.
 - `swe-workbench:language-java` — Java idioms: records, sealed types, virtual threads, streams, JDK 21+ patterns.
 - `swe-workbench:language-kotlin` — Kotlin idioms: null safety, coroutines, sealed interfaces, scope functions, Flow.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -88,6 +88,7 @@
 |---|---|
 | `language-bash` | `.sh`, `.bash` files; keywords: bash, shell, sh, shellcheck, set -e, pipefail. |
 | `language-csharp` | `.cs` files, `.csproj`, `.sln`, `Directory.Build.props`, keywords: C#, .NET, dotnet, nullable reference types, records, pattern matching, async/await, cancellation tokens, ConfigureAwait, IOptions, LINQ. |
+| `language-dart` | `.dart` files, `pubspec.yaml`, keywords: Dart, Flutter, widget, Riverpod, Bloc, Stream, null safety. |
 | `language-go` | `.go` files, `go.mod`, `go.sum`, keywords: Go, Golang, goroutine, channel, context. |
 | `language-java` | `.java` files, `pom.xml`, `build.gradle`, keywords: Java, JVM, Spring, Maven, Gradle, records, sealed classes, virtual threads. |
 | `language-kotlin` | `.kt` files, `build.gradle.kts`, keywords: Kotlin, coroutines, suspend, StateFlow, sealed interface, Kotlin DSL. |

--- a/hooks/skill_autoload_hint.sh
+++ b/hooks/skill_autoload_hint.sh
@@ -22,6 +22,7 @@ ext_to_skill() {
         sh|bash)              echo "language-bash" ;;
         sql)                  echo "language-sql" ;;
         cs)                   echo "language-csharp" ;;
+        dart)                 echo "language-dart" ;;
         *)                    echo "" ;;
     esac
 }

--- a/skills/language-dart/SKILL.md
+++ b/skills/language-dart/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: language-dart
+description: Dart idioms — null safety, async/await, Futures and Streams, widget composition, and Riverpod/Bloc app architecture. Auto-load when working with .dart files, pubspec.yaml, or when the user mentions Dart, Flutter, widgets, Riverpod, Bloc, Streams, or null safety.
+---
+
+# Dart
+
+## Null safety
+- Sound null safety is on by default (Dart ≥2.12) — no unsound nulls sneak through.
+- Non-nullable is the default; append `?` only when a value can genuinely be absent (`String? name`).
+- `late` defers initialization for values assigned before first read (DI fields, `initState` fields) — a `late` field read before assignment throws.
+- `!` (null-assertion) asserts non-null; prefer narrowing (`if (x != null)`) or `?.`/`??` over `!`, since `!` throws at runtime.
+- `??=` for lazy default assignment; `??` for fallback expressions.
+
+```dart
+String greet(String? name) => 'Hello, ${name ?? 'stranger'}';
+```
+
+## Async — Futures and Streams
+- `Future<T>` wraps a value that arrives later; `async`/`await` reads like sync code.
+- Unhandled Future errors surface as unhandled exceptions — always `try`/`catch` around `await`, or attach `.catchError`.
+- `Stream<T>` models a sequence over time; `await for` consumes it, `StreamController` produces it.
+- `Completer<T>` bridges callback-based APIs into a `Future`.
+- `Future.wait([...])` for concurrent futures; don't `await` sequentially in a loop when the work is independent.
+
+```dart
+Future<User> fetchUser(String id) async {
+  try {
+    final res = await api.get('/users/$id');
+    return User.fromJson(res.data);
+  } on DioException catch (e) {
+    throw UserFetchException(id, e);
+  }
+}
+```
+
+## Widget composition
+- `StatelessWidget` is the default; reach for `StatefulWidget` only when the widget owns mutable state across rebuilds.
+- `build()` must be pure and fast — no side effects, no I/O; it can run many times per frame.
+- Compose small widgets instead of deep inheritance — extract a widget class, not a private `_buildX()` method, when it needs its own `const` or rebuild boundary.
+- `const` constructors on leaf widgets let Flutter skip rebuilding subtrees whose inputs didn't change.
+- Pass a `Key` (`ValueKey`, `ObjectKey`) when reordering or diffing a list of like-typed widgets, or state attaches to the wrong element.
+
+## State management — Riverpod and Bloc
+- **Riverpod**: `Provider`/`NotifierProvider` declares state outside the widget tree; `ref.watch(p)` subscribes and rebuilds, `ref.read(p)` reads once (event handlers, not `build`).
+- **Bloc**: a `Cubit` exposes methods that `emit` new states; a `Bloc` maps incoming `Event`s to `State`s via `on<Event>`. Widgets react via `BlocBuilder`/`BlocListener`.
+- Both push state out of widgets and make it unit-testable without pumping a widget tree — pick per-team convention, don't mix them within the same feature.
+
+```dart
+final counterProvider = NotifierProvider<Counter, int>(Counter.new);
+
+class Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+  void increment() => state++;
+}
+```
+
+## Testing
+- `flutter_test`: `testWidgets('description', (tester) async { ... })` drives a widget in an isolated binding.
+- `tester.pumpWidget(...)` mounts; `tester.pump()` advances one frame, `tester.pumpAndSettle()` drains animations/microtasks.
+- `find.text(...)`, `find.byType(...)`, `find.byKey(...)` locate widgets; assert with `expect(find.text('X'), findsOneWidget)`.
+- `integration_test` runs the same API on a real device/emulator for end-to-end flows.
+- Unit-test `Notifier`/`Cubit`/`Bloc` logic directly — no widget tree needed.
+
+## Tooling
+- **Format:** `dart format .`
+- **Lint/analyze:** `dart analyze` (package) or `flutter analyze` (app) — configured via `analysis_options.yaml`.
+- **Dependencies:** declared in `pubspec.yaml`; resolved with `dart pub get` / `flutter pub get`.
+- **Test:** `flutter test` (widget/unit), `flutter test integration_test` (e2e).
+
+## Idioms cheat sheet
+- `final` over `var` when the reference won't be reassigned; `const` when the value is compile-time constant.
+- Cascades (`obj..a()..b()`) for fluent multi-call setup.
+- Named constructors (`User.fromJson(...)`) beat factory functions with boolean flags.
+- Extension methods add behavior to existing types without subclassing.
+- Records (`(int, String)`, `({int id, String name})`) for small ad-hoc multi-value returns, in place of a throwaway class.
+
+## Avoid
+- `!` as a habitual fix for the analyzer instead of proving non-null.
+- Business logic inside `build()` — extract it into the state-management layer.
+- Deeply nested `setState` widgets when a `Notifier`/`Cubit` would isolate the rebuild.
+- Blocking synchronous work on the UI isolate — use `compute()` or a separate isolate for CPU-heavy work.

--- a/skills/language-dart/triggers.txt
+++ b/skills/language-dart/triggers.txt
@@ -1,0 +1,7 @@
+# Representative trigger prompts for language-dart
+how do I manage state in Flutter using Riverpod providers and ref.watch
+what is the idiomatic way to structure a Bloc with events and states in Dart
+review this Dart code for null safety and proper use of late and nullable types
+how should I compose StatelessWidget and StatefulWidget for a Flutter widget tree
+how do I use async await with Futures and Streams in Dart for network calls
+what goes in pubspec.yaml and how do I run flutter test for a widget test


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Adds `skills/language-dart/SKILL.md` and `triggers.txt`, a new `language-dart` skill covering null safety, async/await (Futures/Streams), widget composition, Riverpod/Bloc, `flutter_test`, and tooling — mirroring the `language-go` recipe.
- Registers the skill across every enforced touchpoint: `agents/shared/languages.md` catalog entry, `docs/catalog.md` Languages table row, `hooks/skill_autoload_hint.sh` `ext_to_skill()` case arm, and `README.md` prose lists.
- Tuned the `SKILL.md` description ("Riverpod/Bloc app architecture" instead of "state management") to avoid a BM25 near-tie with an unrelated `language-swift` trigger fixture in the nightly harness — mirrored the same wording in `languages.md` for consistency.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` passes (frontmatter, name==dir, ≤150-line cap, triggers.txt fixtures, catalog completeness)
- [x] `pytest tests/ -v` passes (1534/1534), including T4 (Auto-load clause), T5a (catalog row), T5b (hook case)
- [x] `pytest tests/test_skill_triggers.py -v` passes — `language-dart` ranks BM25 top-1 for all 6 of its own `triggers.txt` fixtures with no sibling-set escape hatch needed
- [x] `wc -l skills/language-dart/SKILL.md` → 83 lines (cap is 150)

### Type-tailored checks (feat)
- [x] New behavior (the skill and its auto-load hint) was exercised via the test suite above, not just added

Closes #351
