### PR TITLE
[chore] Bump version to 0.1.22

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "swe-workbench",
       "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "source": "./",
       "author": {
         "name": "Lugas Septiawan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",


### PR DESCRIPTION
## Summary
- Bump version: `0.1.21` → `0.1.22`
- Tag `v0.1.22` will be pushed automatically once this merges, triggering `.github/workflows/release.yml` to publish a GitHub Release.

## Test Plan
- [x] CI (pr.yml) passes
- [x] Tag-triggered release workflow publishes `v0.1.22`

N/A