### PR TITLE
[fix] Use -f body= in PR-review Step 6 inline-comment POST

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@
 - [workflow-state.md](workflow-state.md) — SessionStart hook that persists workflow phase state across auto-compaction and injects a resume preamble.
 - [skill-usage-telemetry.md](skill-usage-telemetry.md) — how subagent skill invocations are surfaced in the transcript.
 - [worktree-permission-grant.md](worktree-permission-grant.md) — automatic permission grants for isolated worktree agents.
+- [gh-api-field-flags.md](gh-api-field-flags.md) — `-f` vs `-F` on `gh api`: avoid silent `@`-expansion when posting comment bodies.

--- a/docs/gh-api-field-flags.md
+++ b/docs/gh-api-field-flags.md
@@ -1,0 +1,45 @@
+# `gh api` field flags: `-f` vs `-F`
+
+`gh api` accepts request-body fields two ways, and mixing them up fails **silently** — no
+error, no warning, just the wrong content posted.
+
+| Flag | Long form | Semantics |
+|---|---|---|
+| `-f key=value` | `--raw-field` | Value is always sent as a literal string. |
+| `-F key=value` | `--field` | Value is typed: JSON `true`/`false`/numbers are converted; and if the value starts with `@`, it is treated as a **file path to read** (`@-` reads stdin) instead of a literal string. |
+
+## Two failure modes
+
+1. **`-f body=@/path/to/file.md`** — `-f` never does `@`-expansion, so this posts the *literal
+   string* `@/path/to/file.md`, not the file's contents. To post a body sourced from a file, use
+   `-F body=@/path/to/file.md` instead.
+2. **`-F body="@author, thanks for the review"`** — a free-form body that happens to start with
+   `@` gets `@`-expanded by `-F`: `gh` tries to open a file named `author, thanks for the review`
+   and the call fails (or, worse, reads an unrelated file that happens to exist at that path).
+
+Both are silent at the call site — the bug only surfaces later, as a garbled or missing comment.
+
+## Rule
+
+| Body source | Flag |
+|---|---|
+| Free-form string that may start with `@` (a reply, a reviewer finding) | `-f body="$VALUE"` |
+| Content that must be read from a file | `-F body=@/path/to/file.md` |
+| Typed scalar (e.g. `line` as an integer) | `-F line="$LINE"` |
+
+## Spot-check
+
+After posting, confirm the body landed as the literal string you intended:
+
+```bash
+gh api <endpoint>/<id> -q '.body'
+```
+
+## Where this is enforced
+
+- `runtime/reply-and-resolve.sh` uses `-f body=` for both reply call sites (reply bodies start
+  with `@{author}`); guarded by
+  `tests/test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f`.
+- `skills/workflow-pr-review/SKILL.md` and `skills/workflow-pr-review-followup/SKILL.md` use
+  `-f body="$BODY"` in the Step 6 inline-comment POST (a reviewer finding can also start with
+  `@author`); guarded by `tests/test_pr_review_skill_body_flag.py`.

--- a/runtime/reply-and-resolve.sh
+++ b/runtime/reply-and-resolve.sh
@@ -15,6 +15,7 @@ KIND="${7:-review}"
 case "$KIND" in
   issue)
     [ -n "$REPLY_BODY" ] || exit 0
+    # -f (raw), not -F: an @author-prefixed body would be @-file-expanded by -F. See docs/gh-api-field-flags.md
     gh api "repos/${OWNER}/${REPO}/issues/${PR}/comments" -f body="$REPLY_BODY"
     exit 0 ;;
   review) : ;;
@@ -22,6 +23,7 @@ case "$KIND" in
 esac
 if [ -n "$REPLY_BODY" ]; then
   [ -n "$COMMENT_DATABASEID" ] || { echo "reply-and-resolve: REPLY_BODY set but COMMENT_DATABASEID is empty" >&2; exit 1; }
+  # -f (raw), not -F: an @author-prefixed body would be @-file-expanded by -F. See docs/gh-api-field-flags.md
   gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments/${COMMENT_DATABASEID}/replies" -f body="$REPLY_BODY"
 fi
 if [ -n "$THREAD_ID" ]; then

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -150,12 +150,19 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
      ```bash
      gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
-       -F body="$BODY" \
+       -f body="$BODY" \
        -F path="$REPO_PATH" \
        -F line="$LINE" \
        -F side=RIGHT \
        -F commit_id="$HEAD_SHA"
      ```
+
+     **Why `-f body=`, not `-F body=`:** `gh`'s `-F`/`--field` treats a value beginning with `@` as a
+     file path to read (and `@-` as stdin); a finding body that starts with `@author…` would be
+     silently `@`-expanded into a file read and post garbage. Use `-f` (raw string) for any free-form
+     body. Conversely, `@file` expansion (reading a body *from* a file) requires `-F` — `-f body=@x`
+     posts the literal `@x`. See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md).
+     **Spot-check** any body sourced from a file: `gh api <endpoint>/{id} -q '.body'`.
 
 3. Track counts: `posted=N`, `deduped=M`. Initialise `DEFERRED_INFORMATIONAL=""` before the loop. On HTTP 422: out-of-diff informational findings → `DEFERRED_INFORMATIONAL` (not stale-SHA; expected for context-line refs); in-diff findings on 422 → skip/log, stale-SHA counted.
 
@@ -285,3 +292,4 @@ Match against ANY author. On match, skip posting AND add 👍 to the thread head
 | Apply the diff-scoping flip on self-review | The flip is gated on `IS_SELF_REVIEW = false`. A self-review with out-of-diff-only Critical/High findings stays `COMMENT`. See [Diff-scoping flip contract](#diff-scoping-flip-contract). |
 | Apply the diff-scoping flip when identity is unknown | `IDENTITY_KNOWN = false` when `$CURRENT_USER` or `$AUTHOR_LOGIN` is empty. The flip does NOT fire — stay COMMENT. Never auto-approve when you can't verify the authorship axis. |
 | Fire the CTA after the diff-scoping flip when `DECISION=APPROVE`, `posted=0`, `deduped=0` | CTA suppression is evaluated post-flip. After a flip to `APPROVE`, `posted=0`, `deduped=0` → suppress. The informational findings land in the summary body (not inline threads); there is nothing for `/swe-workbench:address-feedback` to act on. |
+| `-F body="$BODY"` on a finding that starts with `@` → silent `@`-file-expansion | Use `-f body=` (raw). See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -150,12 +150,19 @@ Also scan for `^\*\*Blocking Scope:\s+(NONE|OUT-OF-DIFF-ONLY|IN-DIFF)\*\*$`; par
 
      ```bash
      gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
-       -F body="$BODY" \
+       -f body="$BODY" \
        -F path="$REPO_PATH" \
        -F line="$LINE" \
        -F side=RIGHT \
        -F commit_id="$HEAD_SHA"
      ```
+
+     **Why `-f body=`, not `-F body=`:** `gh`'s `-F`/`--field` treats a value beginning with `@` as a
+     file path to read (and `@-` as stdin); a finding body that starts with `@author…` would be
+     silently `@`-expanded into a file read and post garbage. Use `-f` (raw string) for any free-form
+     body. Conversely, `@file` expansion (reading a body *from* a file) requires `-F` — `-f body=@x`
+     posts the literal `@x`. See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md).
+     **Spot-check** any body sourced from a file: `gh api <endpoint>/{id} -q '.body'`.
 
 3. Track counts: `posted=N`, `deduped=M`. Initialise `DEFERRED_INFORMATIONAL=""` before the loop. On HTTP 422: out-of-diff informational findings → `DEFERRED_INFORMATIONAL` (not stale-SHA; expected for context-line refs); in-diff findings on 422 → skip/log, stale-SHA counted.
 
@@ -287,3 +294,4 @@ Match against ANY author (User Decision 2). On match, skip posting AND add 👍 
 | Emit the CTA as plain text instead of `AskUserQuestion` | Always use the `AskUserQuestion` tool for the CTA — it gives the user a clickable button and eliminates the "type yes" friction. Never emit a free-text prompt asking the user to reply `yes`. |
 | Apply the diff-scoping flip on self-review | The flip is gated on `IS_SELF_REVIEW = false`. A self-review with out-of-diff-only Critical/High findings stays `COMMENT`. |
 | Fire the CTA after the diff-scoping flip when `DECISION=APPROVE`, `posted=0`, `deduped=0` | CTA suppression is evaluated post-flip. After a flip to `APPROVE`, `posted=0`, `deduped=0` → suppress. The informational findings land in the summary body (not inline threads); there is nothing for `/swe-workbench:address-feedback` to act on. |
+| `-F body="$BODY"` on a finding that starts with `@` → silent `@`-file-expansion | Use `-f body=` (raw). See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). |

--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -38,7 +38,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via pip-tools
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via pip-tools

--- a/tests/test_pr_review_skill_body_flag.py
+++ b/tests/test_pr_review_skill_body_flag.py
@@ -1,0 +1,50 @@
+"""Guards the Step 6 inline-comment POST in the PR-review skills against the
+`gh api -F body=` @-expansion hazard (issue #494).
+
+A reviewer finding body is free-form text that can legitimately start with
+`@author...`. `gh api -F body=` treats an @-prefixed value as a file path to
+read, so posting such a finding with `-F` would silently read (or fail to
+read) a bogus file instead of posting the literal text. `-f body=` forces a
+raw string and is the fix mirrored from `reply-and-resolve.sh` (see
+test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f).
+
+Unlike the runtime script, `gh api` and the `-F body=` flag sit on separate
+continuation lines inside the skill's fenced code block, so a single-line
+`"body=" in ln and "gh api" in ln` filter would match nothing and pass
+vacuously. This test extracts the fenced bash block containing the POST and
+asserts on the literal flag string within it — scoped to the code block, not
+the whole file, since the "Common mistakes" table also mentions `-F body=`
+in prose as the anti-pattern being warned against.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SKILL_PATHS = [
+    ROOT / "skills" / "workflow-pr-review" / "SKILL.md",
+    ROOT / "skills" / "workflow-pr-review-followup" / "SKILL.md",
+]
+
+CODE_BLOCK_RE = re.compile(r"```bash\n(.*?)\n\s*```", re.DOTALL)
+
+
+def _post_code_block(text: str) -> str:
+    for block in CODE_BLOCK_RE.findall(text):
+        if "pulls/${PR}/comments" in block:
+            return block
+    raise AssertionError("no fenced bash block found for the pulls/{PR}/comments POST")
+
+
+def test_step6_post_uses_lowercase_f_not_uppercase_f_for_body():
+    for path in SKILL_PATHS:
+        block = _post_code_block(path.read_text())
+        assert '-f body="$BODY"' in block, (
+            f"{path}: expected -f body=\"$BODY\" (raw string) in the Step 6 "
+            "inline-comment POST"
+        )
+        assert '-F body="$BODY"' not in block, (
+            f"{path}: -F body=\"$BODY\" would @-file-expand a finding body "
+            "that starts with @author"
+        )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Fix `gh api -F body="$BODY"` in the Step 6 inline-comment POST of `workflow-pr-review` and `workflow-pr-review-followup` — `-F` silently `@`-file-expands a reviewer finding that starts with `@author`, the inverse of the `-f body=@file` hazard reported in #494.
- Change to `-f body="$BODY"` in both skills (kept `-F` on `line`, `path`, `side`, `commit_id` — unaffected), matching the convention already test-guarded in `runtime/reply-and-resolve.sh`.
- Add a shared `docs/gh-api-field-flags.md` reference doc (indexed in `docs/README.md`) documenting the `-f`/`-F` distinction and both failure modes, linked from a new warning callout and "Common mistakes" row in each skill.
- Add clarifying inline comments at the two already-correct `reply-and-resolve.sh` call sites (no behavior change).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest -q` — 1535/1535 passing (includes the new guard test)

### Type-tailored checks (fix)
- [x] Reproduced the bug: wrote `tests/test_pr_review_skill_body_flag.py` first, confirmed it fails RED against the pre-fix `-F body="$BODY"` in both SKILL.md files.
- [x] Verified the fix: same test passes GREEN after the flag change; `tests/test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f` (the sibling runtime guard) still passes unchanged.
- [ ] Follow-up (not in this PR): a reviewer subagent independently flagged that `-F path="$REPO_PATH"` in the same Step 6 POST carries a smaller, pre-existing version of the same hazard (e.g. npm-scoped-package paths like `@scope/pkg/index.ts`). Left as-is per this PR's scoped fix — worth a follow-up issue if desired.

Closes #494
