### PR TITLE
[chore] Regenerate pip lockfiles (build 1.5.0→1.5.1)

### DIFF
--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=tests/build-requirements.lock tests/build-requirements.txt
 #
-build==1.5.0 \
-    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
-    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
+build==1.5.1 \
+    --hash=sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb \
+    --hash=sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d
     # via pip-tools
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \


### PR DESCRIPTION
## Summary
- `lockfile-check` (in *PR Validation*) was failing on **every open PR** — including innocent Dependabot PR #505, which touches zero Python — because `tests/build-requirements.lock` had drifted from PyPI's live state.
- Root cause: `build==1.5.1` was published to PyPI on 2026-07-09, one day after the lock was last regenerated (`c4e4a7a`, 2026-07-08). The CI job's `--check` step re-resolves `tests/*-requirements.txt` against live PyPI, so the committed pin (`build==1.5.0`) no longer matched.
- Fix: ran `bash scripts/lock-pip-requirements.sh` to regenerate all three lockfiles via a full `--upgrade` re-resolution. Only `tests/build-requirements.lock` actually changed (`build==1.5.0 → 1.5.1`, refreshed `--hash` lines); `tests/requirements.lock` and `tests/release-requirements.lock` re-generated byte-identical to HEAD, confirming the drift was isolated to `build`.

## Test Plan
- [x] `bash scripts/check-lockfile-additions.sh tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock` — exits 0, no new top-level packages.
- [x] `bash scripts/lock-pip-requirements.sh --check` — exits 0 (previously failing; this is the regression this PR fixes).
- [x] Diff independently verified by two reviewers: hash values for `build==1.5.1` match PyPI's published sdist/wheel digests exactly; no other lines in the lockfile were touched.
- [ ]

Issue: N/A — routine dependency-lock maintenance, fixes CI without a tracked bug report. (A follow-up PR will file an issue + scheduled workflow for the structural gap that let this drift accumulate.)
