### PR TITLE
[chore] Add scheduled lockfile-refresh workflow

### DIFF
--- a/.github/workflows/lockfile-refresh.yml
+++ b/.github/workflows/lockfile-refresh.yml
@@ -1,0 +1,88 @@
+name: Lockfile Refresh
+
+on:
+  schedule:
+    # Weekly, offset a day from Dependabot's default Monday run (see
+    # .github/dependabot.yml) so a Monday transitive release has already
+    # landed on PyPI by the time this job re-resolves.
+    - cron: '0 6 * * 2'  # Tuesday 06:00 UTC
+  workflow_dispatch: {}
+
+# Default to least-privilege; the one job that writes elevates explicitly.
+permissions:
+  contents: read
+
+# A stable group (not keyed on github.ref, since schedule/workflow_dispatch
+# both resolve to the same ref) so overlapping runs queue instead of both
+# racing to push the same stable branch.
+concurrency:
+  group: lockfile-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh-lockfiles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # Pin explicitly: workflow_dispatch can be triggered from any branch via the
+          # GitHub UI, and we always want the drift check to run against main.
+          ref: main
+          persist-credentials: true
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Regenerate pip lockfiles
+        run: bash scripts/lock-pip-requirements.sh
+
+      - name: Guard against new top-level packages
+        # Keep this lockfile list in sync with the "Regenerate pip lockfiles" step above.
+        run: bash scripts/check-lockfile-additions.sh tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock
+
+      - name: Check for an already-open refresh PR
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh pr list --head chore/lockfile-refresh --state open --json number --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Commit, push, and open PR if lockfiles drifted
+        if: steps.existing_pr.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock; then
+            echo "Lockfiles are already up to date — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B chore/lockfile-refresh
+          git add tests/requirements.lock tests/release-requirements.lock tests/build-requirements.lock
+          git commit -m "[chore] Refresh pip lockfiles (transitive drift)"
+          git push --force origin chore/lockfile-refresh
+
+          # shellcheck disable=SC2016  # backticks below are markdown code spans, not command substitution
+          BODY=$(printf '%s\n' \
+            '## Summary' \
+            '- Scheduled drift check found one or more `tests/*.lock` files out of date against a transitive dependency release — a package pinned indirectly (not listed in any `tests/*-requirements.txt`) published a new version, which would otherwise silently fail the next unrelated PR'"'"'s `lockfile-check`.' \
+            '- Opened automatically by `.github/workflows/lockfile-refresh.yml`.' \
+            '' \
+            '## Test Plan' \
+            '- [x] `scripts/check-lockfile-additions.sh` passed — no new top-level packages.' \
+            '- [ ] `scripts/lock-pip-requirements.sh --check` will re-verify on this PR'"'"'s own `lockfile-check` run.' \
+            '- [ ]' \
+            '' \
+            'Issue: N/A — recurring automated lockfile drift, no specific issue')
+
+          gh pr create \
+            --title "[chore] Refresh pip lockfiles (transitive drift)" \
+            --body "$BODY"


### PR DESCRIPTION
## Summary
- `.github/workflows/dependabot-lockfile.yml` only regenerates the pip lockfiles on PRs that touch a `tests/*-requirements.txt` source file (a `paths:` filter). A transitive-only dependency release — a new version of a package pinned indirectly, not listed in any `.txt` — never triggers it.
- This is exactly what broke `lockfile-check` on every open PR (including innocent Dependabot PR #505) and required a reactive fix in #506: `build==1.5.1` was published to PyPI with no `.txt` change to trigger a regen, so the drift sat on `main` silently until the next PR's `--check` step failed against live PyPI.
- Adds `.github/workflows/lockfile-refresh.yml`: a scheduled workflow (weekly cron, offset a day from Dependabot's Monday run, + `workflow_dispatch` for on-demand runs) that regenerates all three lockfiles independently of the `.txt` paths filter and opens a PR when they've drifted — making transitive-dep drift self-healing instead of a silent landmine for the next unrelated PR.
- Mirrors `dependabot-lockfile.yml`'s conventions: same SHA-pinned `actions/checkout`/`actions/setup-python`, same `contents: read` permissions floor with per-job elevation, same regen + `check-lockfile-additions.sh` guard steps. No new third-party actions — uses `gh` CLI + git scripting instead of `peter-evans/create-pull-request`, keeping the action attack surface unchanged.
- New logic beyond the sibling workflow: a `gh pr list --head chore/lockfile-refresh --state open` guard so a second run never opens a duplicate PR while one is already open; on drift, commits to a stable branch (`chore/lockfile-refresh`, force-pushed — safe because the guard means this only happens when no PR is open) and opens a PR whose body uses `Issue: N/A — recurring automated lockfile drift, no specific issue` (each weekly run is a fresh drift event, not tied to one tracked issue).

## Test Plan
- [x] `actionlint .github/workflows/lockfile-refresh.yml` passes clean (including embedded shellcheck).
- [x] `bash scripts/validate.sh` (plugin file validation) passes.
- [x] `python3 -m pytest tests/ -q` — 1537 passed.
- [x] Locally simulated the PR-guard logic end-to-end against a fake git remote + a stubbed `gh` CLI (deliberately avoided a real `workflow_dispatch` run, which would have pushed to a shared branch and opened a real duplicate PR against this repo while #506 was still open). All three scenarios passed: (a) drift present + no open PR → regenerates, commits, pushes, opens exactly one PR; (b) locks fresh + no open PR → no-ops ("nothing to commit"); (c) PR already open → step skipped entirely, no duplicate.
- [x] Two required reviews (plan-alignment + diff-correctness) ran in parallel; both returned "Ready to merge: With fixes" on the first pass. Fixes applied: (1) the auto-generated PR body no longer hardcodes `Closes #507` on every future weekly run — that keyword belongs only on this delivery PR, not baked into the recurring template; (2) pinned `ref: main` on the checkout step so a manual `workflow_dispatch` from a non-default branch can't accidentally check out the wrong ref; (3) un-checked a Test Plan checkbox in the generated body that described a future action as already done.

**Optional follow-up for a maintainer:** since live `workflow_dispatch` testing was deliberately skipped (see above), consider running `gh workflow run lockfile-refresh.yml` for a real smoke test once this and #506 are both merged (so there's no leftover drift to duplicate). Not a merge blocker.

Closes #507
