### PR TITLE
[feat] Add Testing section to language-sql skill

### DIFF
--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -72,7 +72,28 @@ LIMIT 50;
 ## Tooling
 - **Format:** `sqlfluff fix --dialect <dialect> .` (replace `<dialect>` with e.g. `ansi`, `postgres`, `bigquery` — check `.sqlfluff` config or project README)
 - **Lint:** `sqlfluff lint --dialect <dialect> .`
-- **Test:** engine-specific (pgTAP for PostgreSQL, `dbt test` if using dbt)
+- **Test:** engine-specific (pgTAP for PostgreSQL, `dbt test` if using dbt) — see Testing below
+
+## Testing
+- pgTAP for in-database assertions (`results_eq`, `throws_ok`), run via `pg_prove`; `dbt test` for `unique`/`not_null`/`relationships` in transformation projects.
+- Wrap each test in `BEGIN … ROLLBACK` for isolation — no shared state or leftover rows between tests.
+- Seed deterministic fixtures per test; don't depend on ambient row counts or implicit ordering.
+- Assert on `EXPLAIN` output (index scan vs seq scan) to catch query-plan regressions.
+
+```sql
+BEGIN;
+SELECT plan(1);
+
+INSERT INTO users (id, active) VALUES (1, true), (2, true), (3, false);
+
+SELECT results_eq(
+    'SELECT count(*) FROM users WHERE active',
+    ARRAY[2::bigint]
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
 
 ## Avoid
 - Schema changes without rollback or compatibility planning.

--- a/tests/test_behaviour_and_ordering_conventions.py
+++ b/tests/test_behaviour_and_ordering_conventions.py
@@ -6,6 +6,9 @@ Acceptance criteria:
   'public → protected → private' and mentions modifier-less languages (Go, Rust, or Python).
 - agents/reviewer.md Principle consultation list references swe-workbench:principle-ddd.
 - agents/code-impl.md Principle consultation list references swe-workbench:principle-ddd.
+
+Acceptance criteria (#329):
+- Every skills/language-*/SKILL.md has a '## Testing' section before '## Avoid'.
 """
 
 import re

--- a/tests/test_behaviour_and_ordering_conventions.py
+++ b/tests/test_behaviour_and_ordering_conventions.py
@@ -11,6 +11,8 @@ Acceptance criteria:
 import re
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).parent.parent
 
 DDD_SKILL = ROOT / "skills" / "principle-ddd" / "SKILL.md"
@@ -148,4 +150,35 @@ def test_code_impl_references_principle_ddd():
     assert "swe-workbench:principle-ddd" in body, (
         "agents/code-impl.md Principle consultation must reference 'swe-workbench:principle-ddd' "
         "so implementers place behaviour on entities and avoid anemic models"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 5 (#329) — every language-* skill has a '## Testing' section before '## Avoid'
+# ---------------------------------------------------------------------------
+
+LANGUAGE_SKILLS = sorted((ROOT / "skills").glob("language-*/SKILL.md"))
+
+
+@pytest.mark.parametrize("skill_path", LANGUAGE_SKILLS, ids=lambda p: p.parent.name)
+def test_language_skill_has_testing_section_before_avoid(skill_path):
+    """Every language-* skill must document a '## Testing' section ahead of '## Avoid'.
+
+    Exact heading match only: a prefix match would false-positive on
+    language-rust's '## Avoiding unnecessary clones' subsection.
+    """
+    lines = skill_path.read_text().splitlines()
+    stripped = [line.strip() for line in lines]
+
+    assert "## Testing" in stripped, (
+        f"{skill_path.relative_to(ROOT)} is missing a '## Testing' section"
+    )
+    assert "## Avoid" in stripped, (
+        f"{skill_path.relative_to(ROOT)} is missing an '## Avoid' section"
+    )
+
+    testing_index = stripped.index("## Testing")
+    avoid_index = stripped.index("## Avoid")
+    assert testing_index < avoid_index, (
+        f"{skill_path.relative_to(ROOT)}: '## Testing' must precede '## Avoid'"
     )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Added a `## Testing` section to `skills/language-sql/SKILL.md` — it was the only one of twelve `language-*` skills without one, leaving SQL authors without pgTAP/dbt guidance every sibling skill provides.
- Covers pgTAP (`results_eq`, `throws_ok` via `pg_prove`), `dbt test` for transformation projects, `BEGIN … ROLLBACK` transactional isolation, deterministic fixture seeding, and asserting on `EXPLAIN` output for query-plan regressions — plus one fenced pgTAP example.
- Added a `## Tooling` → `**Test:**` cross-reference ("see Testing below") to match sibling skills' convention.
- Added a family-wide regression test in `tests/test_behaviour_and_ordering_conventions.py` that parametrizes over all `skills/language-*/SKILL.md` files, asserting each has an exact `## Testing` heading before its exact `## Avoid` heading (exact match avoids false-positiving on `language-rust`'s `## Avoiding unnecessary clones` subsection).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest tests/ -v` — 1547/1547 pass (TDD: RED for language-sql only pre-change, GREEN for all 12 language skills post-change)

### Type-tailored checks (feat)
- [x] New `## Testing` section reviewed for SQL correctness (pgTAP example seeds its own fixture rows, matches its own "deterministic fixtures" guidance)
- [x] Reviewed by `swe-workbench:reviewer` (diff correctness) and a plan-alignment reviewer, both in parallel — no Critical/Important findings; two Minor/Low nitpicks addressed (fixture seeding, Tooling cross-reference)

<!-- Link to the GitHub issue this PR addresses.
     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>

     If no issue applies, DELETE the "Closes #" line and replace it with
     a standalone line:
         Issue: N/A
     Preferred (more useful for reviewers):
         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">

     The following WILL fail CI:
       - leaving "Closes #" empty with no replacement
       - deleting the line entirely with nothing in its place
       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
Closes #329
