### PR TITLE
[fix] Recognize `fix/` branch prefix + document rimba `--fix` alias

### DIFF
--- a/skills/workflow-branch-sync/SKILL.md
+++ b/skills/workflow-branch-sync/SKILL.md
@@ -45,7 +45,7 @@ If the rimba MCP server is active in the session, invoke its `conflict-check` to
 
 **Resolve strategy** from the invoking command into `SYNC_STRATEGY=merge|rebase` — default is **merge**; `--rebase` selects **rebase**. Keep `SYNC_STRATEGY` separate from `OPERATION` (Step 4): `OPERATION` means "conflict resolution currently in progress" (and is `none` on a clean sync — the common case), not "which strategy was used." Step 6's push branching reads `SYNC_STRATEGY`, never `OPERATION`.
 
-**Derive the task identifier** for rimba from `CURRENT_BRANCH` by stripping a known type prefix (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`) if present; otherwise use `CURRENT_BRANCH` as-is.
+**Derive the task identifier** for rimba from `CURRENT_BRANCH` by stripping a known type prefix (`feature/`, `bugfix/`, `fix/`, `hotfix/`, `docs/`, `test/`, `chore/`) if present — `fix/` is accepted as an input alias for hand-named branches even though rimba's canonical output prefix is `bugfix/`; otherwise use `CURRENT_BRANCH` as-is.
 
 **Provider detection** (mirror the rimba MCP → binary → shell ordering of `skills/workflow-development/SKILL.md`):
 

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -82,7 +82,7 @@ Detect the host repo's branch convention via 3-tier probe. **Tier 1:** run `git 
 
 **Current-branch evaluation:**
 - `main`/`master` → warn: "You're on `main`. Switch to a feature branch first."
-- `worktree-*` pattern (EnterWorktree-mangled) → non-conforming; pointer: "Use `rimba add <task> [--bugfix|--hotfix|--docs|--test|--chore]` for canonical prefixes (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`)." Stop evaluation here; do not offer a rename.
+- `worktree-*` pattern (EnterWorktree-mangled) → non-conforming; pointer: "Use `rimba add <task> [--bugfix|--fix|--hotfix|--docs|--test|--chore]` for canonical prefixes (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`); `--fix` is an alias for `--bugfix` — both produce `bugfix/`." Stop evaluation here; do not offer a rename.
 - Mismatch with detected convention → offer rename (see below). Matches → silent.
 
 **Rename offer:** Before `git branch -m`, check safety: `git rev-parse @{upstream} 2>/dev/null` (exit 0 = already pushed / has upstream); `gh pr view --json state` (open PR check). When pushed or open PR → suggest-only (print compliant name, skip rename). Otherwise call `AskUserQuestion` with **Rename** (`git branch -m <current> <compliant>`) / **Keep as-is** options.

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -123,7 +123,7 @@ RIMBA=$(command -v rimba 2>/dev/null \
 | Work type | rimba flag | Branch prefix | Commit-tag |
 |---|---|---|---|
 | New feature *(default)* | *(none)* | `feature/<task>` | `[feat]` |
-| Bug fix | `--bugfix` | `bugfix/<task>` | `[fix]` |
+| Bug fix | `--bugfix` (alias `--fix`) | `bugfix/<task>` | `[fix]` |
 | Hotfix | `--hotfix` | `hotfix/<task>` | `[hotfix]` |
 | Documentation | `--docs` | `docs/<task>` | `[docs]` |
 | Tests | `--test` | `test/<task>` | `[test]` |

--- a/skills/workflow-development/templates/plan-workflow-section.md
+++ b/skills/workflow-development/templates/plan-workflow-section.md
@@ -14,7 +14,7 @@ Copy this `## Workflow` section into your plan **in full — do not abridge, sum
   | Work type | rimba flag | Branch prefix | Commit-tag |
   |---|---|---|---|
   | New feature *(default)* | *(none)* | `feature/<task>` | `[feat]` |
-  | Bug fix | `--bugfix` | `bugfix/<task>` | `[fix]` |
+  | Bug fix | `--bugfix` (alias `--fix`) | `bugfix/<task>` | `[fix]` |
   | Hotfix | `--hotfix` | `hotfix/<task>` | `[hotfix]` |
   | Documentation | `--docs` | `docs/<task>` | `[docs]` |
   | Tests | `--test` | `test/<task>` | `[test]` |

--- a/tests/test_branch_sync_skill.py
+++ b/tests/test_branch_sync_skill.py
@@ -190,11 +190,13 @@ def test_when_to_invoke_references_sync_command():
 def test_step3_task_id_derivation_documents_known_prefixes():
     """Regression: the task-ID derivation logic must pin the exact prefix
     list so it can't silently drift from workflow-development's branch-prefix
-    taxonomy (feature/, bugfix/, hotfix/, docs/, test/, chore/)."""
+    taxonomy (feature/, bugfix/, hotfix/, docs/, test/, chore/), plus the
+    `fix/` input alias — accepted here for hand-named branches even though it
+    is not part of workflow-development's output taxonomy."""
     body = _body()
     step3 = body.split("### Step 3")[1].split("### Step 4")[0]
     assert "task identifier" in step3.lower()
-    for prefix in ("feature/", "bugfix/", "hotfix/", "docs/", "test/", "chore/"):
+    for prefix in ("feature/", "bugfix/", "fix/", "hotfix/", "docs/", "test/", "chore/"):
         assert f"`{prefix}`" in step3, f"Step 3 must document stripping the `{prefix}` prefix"
 
 

--- a/tests/test_workflow_commit_and_pr_convention_detection.py
+++ b/tests/test_workflow_commit_and_pr_convention_detection.py
@@ -123,6 +123,7 @@ def test_worktree_mangled_pattern_guard():
     1. 'worktree-' pattern is explicitly mentioned.
     2. 'rimba' is referenced as the canonical branch-creation tool.
     3. All six canonical rimba prefixes are listed: feature/, bugfix/, hotfix/, docs/, test/, chore/.
+    4. The '--fix' flag alias for '--bugfix' is listed alongside the other flags.
     """
     body = SKILL_PATH.read_text()
     section = _section_body(body, BRANCH_SECTION_HEADING)
@@ -140,6 +141,10 @@ def test_worktree_mangled_pattern_guard():
         assert prefix in section, (
             f"Canonical rimba prefix '{prefix}' must be listed in the branch section"
         )
+
+    assert "--fix" in section, (
+        "Branch section's rimba flag list must include '--fix' (alias for '--bugfix')"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow_development_rimba_flags.py
+++ b/tests/test_workflow_development_rimba_flags.py
@@ -57,6 +57,41 @@ def test_skill_documents_all_five_branch_prefix_flags():
         )
 
 
+def test_skill_documents_fix_alias_for_bugfix():
+    """SKILL.md Phase 1 must document `--fix` as a flag alias for `--bugfix`.
+
+    rimba 1.10.0 added `--fix` as a documented alias for `--bugfix` (issue #495).
+    It must be surfaced as a flag alias only — never as a `fix/` branch prefix,
+    which rimba does not produce (see test_skill_no_longer_uses_wrong_feat_fix_prefixes).
+    """
+    body = SKILL.read_text()
+    phase1 = _phase1_section(body)
+
+    assert "--fix" in phase1, (
+        "SKILL.md Phase 1 must document the `--fix` alias for `--bugfix`"
+    )
+    assert "alias" in phase1.lower(), (
+        "SKILL.md Phase 1 must describe `--fix` as an alias, not a separate flag"
+    )
+
+
+def test_template_documents_fix_alias_for_bugfix():
+    """plan-workflow-section.md Phase 1 must document `--fix` as a flag alias for `--bugfix`.
+
+    Mirrors test_skill_documents_fix_alias_for_bugfix — the template is rendered
+    verbatim into every generated plan.
+    """
+    body = TEMPLATE.read_text()
+    phase1 = _phase1_section(body)
+
+    assert "--fix" in phase1, (
+        "plan-workflow-section.md Phase 1 must document the `--fix` alias for `--bugfix`"
+    )
+    assert "alias" in phase1.lower(), (
+        "plan-workflow-section.md Phase 1 must describe `--fix` as an alias, not a separate flag"
+    )
+
+
 def test_skill_no_longer_uses_wrong_feat_fix_prefixes():
     """SKILL.md Phase 1 must not claim rimba produces `feat/` or `fix/` prefixes.
 


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `skills/workflow-branch-sync/SKILL.md`: Step 3 now strips `fix/` as an accepted *input* alias when deriving a rimba task id from `CURRENT_BRANCH`, alongside the existing six canonical prefixes — hand-named `fix/*` branches now sync correctly instead of falling through unrecognized.
- `skills/workflow-development/SKILL.md` and `templates/plan-workflow-section.md`: annotate the "Bug fix" row's flag cell as `` `--bugfix` (alias `--fix`) `` — rimba 1.10.0 ships `--fix` as a documented alias for `--bugfix`, producing `bugfix/`. Deliberately does **not** introduce a `fix/` branch-prefix string (pinned by an existing test that forbids it).
- `skills/workflow-commit-and-pr/SKILL.md`: surfaces `--fix` in the `worktree-*` non-conforming-branch pointer message, with a one-clause note that it's an alias collapsing into `bugfix/`.
- No changes to the `rimba` binary — it's an external dependency and already ships the `--fix` alias upstream (confirmed via `rimba add --help` on the installed 1.10.0).
- Test coverage added/extended test-first (TDD red→green) in `tests/test_branch_sync_skill.py`, `tests/test_workflow_development_rimba_flags.py`, and `tests/test_workflow_commit_and_pr_convention_detection.py`.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples exercised — `rimba add --fix` verified against rimba 1.10.0 (`rimba add recognize-fix-branch-prefix --fix` → `bugfix/recognize-fix-branch-prefix`, confirmed via `rimba add --help`)
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest tests/ -v` — 1549/1549 pass (incl. BM25 trigger harness, no self-ranking regression)

### Type-tailored checks ([fix])
- [x] Reproduced the gap (branch-sync's strip list didn't recognize `fix/`; workflow-development's flag table didn't document `--fix`) and verified the fix closes it via the new pinning tests
- [x] Confirmed `test_skill_no_longer_uses_wrong_feat_fix_prefixes` still passes — no `fix/` branch-prefix leaked into workflow-development's output taxonomy

Closes #495
