### PR TITLE
[fix] Clarify debugger design-fork escalation (orchestrator-mediated consult)

### DIFF
--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -52,6 +52,7 @@ Call this out even when the minimal fix does not address it. Silence signals the
 - Minimal fix (diff summary + what it deliberately does NOT touch + placement choice if a new type was introduced)
 - Regression test (name + location)
 - SOLID / Clean-Arch risks (or "none — principle is clean")
+- Design fork (if any) — surfaced for the orchestrator; you have no `Agent` tool and do not consult subagents yourself
 
 ## Principle consultation
 
@@ -73,5 +74,5 @@ See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 - No fix without a failing test first.
 - No behavior change beyond what the failing test demands.
 - No "while I'm here" refactors — note them, defer to `/swe-workbench:refactor`.
-- If the root cause is a design flaw, say so; fix the symptom minimally and recommend design follow-up.
+- If the root cause is a design flaw, fix the symptom minimally and surface the design fork in your output for the orchestrator to act on. You do not hold the `Agent` tool and cannot consult other subagents yourself — flagging the fork is your responsibility; deciding and running any advisory consult is the orchestrator's.
 - If a fix genuinely requires a new type: (1) scan sibling source files — if empty/absent, apply `swe-workbench:principle-clean-architecture` layering directly; if coherent, match the observed convention; if incoherent, apply best practice via `swe-workbench:principle-clean-architecture`. (2) Note the placement choice in the Minimal-fix output line. (3) Never let placement reasoning widen the diff.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -91,4 +91,6 @@ Delegate to the `debugger` subagent. Its output must include:
 
 Absolute rule: no fix without a failing test first. This command changes behavior to match spec — it is not a refactor.
 
+**Design-fork escalation.** The debugger has no `Agent` tool and cannot consult subagents itself — if its diagnosis surfaces a design fork, it surfaces the fork in its output instead. When that happens, you (the orchestrator) consult the `senior-engineer` subagent before finalizing the plan, per the worker→orchestrator consult contract in `swe-workbench:workflow-development`'s SKILL.md (Phase 2). Fold its read into the plan; do not invent the architectural answer yourself.
+
 **Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `[[detect:…]]`. Since `/swe-workbench:debug` always produces a fix (file edits), Mode A always applies here.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -88,6 +88,7 @@ Delegate to the `debugger` subagent. Its output must include:
 4. **Minimal fix** — smallest behavior-changing patch that resolves the root cause; call out what it deliberately does NOT touch.
 5. **Regression test** — the test that fails before the fix and passes after. Name it and its location.
 6. **SOLID / Clean-Arch risks** — whether the bug's shape signals a principle violation, and whether the minimal fix papers over it.
+7. **Design fork (if any)** — surfaced for the orchestrator to act on; see the design-fork escalation note below.
 
 Absolute rule: no fix without a failing test first. This command changes behavior to match spec — it is not a refactor.
 

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -178,6 +178,8 @@ Commit logically grouped changes as you go. Never bundle unrelated changes.
 | Tests | Test files and test utilities |
 | Wiring | Integration, routing, CLI registration |
 
+**Design-fork consult contract.** Worker subagents — `debugger`, `code-impl`, and every other worker — hold no `Agent` tool, so none can consult a peer subagent itself. When a worker's diagnosis surfaces a design fork, it surfaces the fork in its output rather than attempting the consult. The orchestrator (this skill, which does hold `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
+
 ---
 
 ### Phase 3: Verify

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -178,7 +178,7 @@ Commit logically grouped changes as you go. Never bundle unrelated changes.
 | Tests | Test files and test utilities |
 | Wiring | Integration, routing, CLI registration |
 
-**Design-fork consult contract.** Worker subagents — `debugger`, `code-impl`, and every other worker — hold no `Agent` tool, so none can consult a peer subagent itself. When a worker's diagnosis surfaces a design fork, it surfaces the fork in its output rather than attempting the consult. The orchestrator (this skill, which does hold `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
+**Design-fork consult contract.** Worker subagents — `debugger`, `code-impl`, and every other worker — hold no `Agent` tool, so none can consult a peer subagent itself. When a worker's diagnosis surfaces a design fork, it surfaces the fork in its output rather than attempting the consult. The orchestrator (the top-level context activating this skill, which holds `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
 
 ---
 

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -178,7 +178,7 @@ Commit logically grouped changes as you go. Never bundle unrelated changes.
 | Tests | Test files and test utilities |
 | Wiring | Integration, routing, CLI registration |
 
-**Design-fork consult contract.** Worker subagents — `debugger`, `code-impl`, and every other worker — hold no `Agent` tool, so none can consult a peer subagent itself. When a worker's diagnosis surfaces a design fork, it surfaces the fork in its output rather than attempting the consult. The orchestrator (the top-level context activating this skill, which holds `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
+**Design-fork consult contract.** Worker subagents hold no `Agent` tool (verified: 0 of 21) — none can consult a peer subagent itself, regardless of what an individual agent's prompt text says. `debugger` follows this contract: it surfaces a design fork in its output rather than attempting the consult. (Other worker prompts may still self-instruct to consult a subagent directly — that is a pre-existing instance of the same bug class, not a license to violate the tool grant; fix on sight.) The orchestrator (the top-level context activating this skill, which holds `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
 
 ---
 

--- a/tests/test_debugger_agent.py
+++ b/tests/test_debugger_agent.py
@@ -1,6 +1,5 @@
 """Structural tests for agents/debugger.md (closes #404, #498)."""
 
-import re
 from pathlib import Path
 
 import validate
@@ -151,20 +150,17 @@ def test_output_contract_has_design_fork_slot():
     )
 
 
-def test_debugger_never_names_senior_engineer_as_consult_target():
-    """Regression guard: debugger.md must not instruct itself to consult/invoke senior-engineer.
+def test_debugger_never_names_senior_engineer():
+    """Regression guard: debugger.md must never name senior-engineer at all.
 
     The debugger has no `Agent` tool and cannot invoke subagents. Naming
-    senior-engineer as something the debugger consults/invokes re-opens the
-    impossible worker->peer consult that issue #498 reports. Only the
-    orchestrator (commands/debug.md, SKILL.md) may name senior-engineer as a
-    consult target.
+    senior-engineer anywhere in this file — as a consult target, an "escalate
+    to" pointer, or a bare reference — re-opens the impossible worker->peer
+    consult that issue #498 reports. Only the orchestrator (commands/debug.md,
+    SKILL.md) may name senior-engineer as a consult target.
     """
     body = _read()
-    pattern = re.compile(r"(consult|invoke)s?\s+.{0,20}senior-engineer", re.IGNORECASE)
-    match = pattern.search(body)
-    assert match is None, (
-        f"agents/debugger.md must not tell the debugger to consult/invoke "
-        f"senior-engineer directly (found: {match.group(0)!r} if it did) — "
+    assert "senior-engineer" not in body.lower(), (
+        "agents/debugger.md must not name senior-engineer anywhere — "
         "the debugger has no Agent tool; only the orchestrator may own that consult"
     )

--- a/tests/test_debugger_agent.py
+++ b/tests/test_debugger_agent.py
@@ -1,5 +1,6 @@
-"""Structural tests for agents/debugger.md (closes #404)."""
+"""Structural tests for agents/debugger.md (closes #404, #498)."""
 
+import re
 from pathlib import Path
 
 import validate
@@ -95,4 +96,75 @@ def test_principle_clean_architecture_referenced():
     assert "swe-workbench:principle-clean-architecture" in body, (
         "agents/debugger.md must reference 'swe-workbench:principle-clean-architecture' "
         "for the placement fallback when sibling structure is incoherent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Design-fork escalation (closes #498)
+# ---------------------------------------------------------------------------
+
+
+def test_design_flaw_rule_surfaces_not_consults():
+    """The design-flaw rule must use surface/output wording, not 'consult'."""
+    body = _read()
+    section = _section(body, "Absolute rules")
+    lines = section.splitlines()
+    design_flaw_line = next(
+        (ln for ln in lines if "design flaw" in ln.lower()), ""
+    )
+    assert design_flaw_line, "'## Absolute rules' must have a design-flaw rule"
+    assert "surface" in design_flaw_line.lower(), (
+        "the design-flaw rule must tell the agent to surface the fork in its "
+        "output, not to consult a peer subagent it has no tool access to"
+    )
+    assert "design fork" in design_flaw_line.lower(), (
+        "the design-flaw rule must name the concept 'design fork' so it lines "
+        "up with the Output-contract slot and the orchestrator-side contract"
+    )
+
+
+def test_design_flaw_rule_states_no_agent_tool():
+    """The design-flaw rule must state the debugger cannot consult subagents itself."""
+    body = _read()
+    section = _section(body, "Absolute rules")
+    lines = section.splitlines()
+    design_flaw_line = next(
+        (ln for ln in lines if "design flaw" in ln.lower()), ""
+    )
+    assert "`Agent`" in design_flaw_line or "Agent tool" in design_flaw_line, (
+        "the design-flaw rule must state the structural fact that the debugger "
+        "does not hold the Agent tool"
+    )
+    assert "cannot consult" in design_flaw_line.lower(), (
+        "the design-flaw rule must state the debugger cannot consult other "
+        "subagents itself — deciding/running a consult is the orchestrator's job"
+    )
+
+
+def test_output_contract_has_design_fork_slot():
+    """The Output contract must carry a 'Design fork' slot."""
+    body = _read()
+    section = _section(body, "Output contract")
+    assert "design fork" in section.lower(), (
+        "'## Output contract' must include a 'Design fork' line so orchestrators "
+        "know to look for a surfaced fork in the debugger's output"
+    )
+
+
+def test_debugger_never_names_senior_engineer_as_consult_target():
+    """Regression guard: debugger.md must not instruct itself to consult/invoke senior-engineer.
+
+    The debugger has no `Agent` tool and cannot invoke subagents. Naming
+    senior-engineer as something the debugger consults/invokes re-opens the
+    impossible worker->peer consult that issue #498 reports. Only the
+    orchestrator (commands/debug.md, SKILL.md) may name senior-engineer as a
+    consult target.
+    """
+    body = _read()
+    pattern = re.compile(r"(consult|invoke)s?\s+.{0,20}senior-engineer", re.IGNORECASE)
+    match = pattern.search(body)
+    assert match is None, (
+        f"agents/debugger.md must not tell the debugger to consult/invoke "
+        f"senior-engineer directly (found: {match.group(0)!r} if it did) — "
+        "the debugger has no Agent tool; only the orchestrator may own that consult"
     )

--- a/tests/test_worker_orchestrator_consult.py
+++ b/tests/test_worker_orchestrator_consult.py
@@ -1,0 +1,89 @@
+"""Cross-file contract tests for the worker→orchestrator design-fork consult (closes #498).
+
+`debugger` (and every other worker subagent) holds no `Agent` tool, so it cannot
+itself "consult senior-engineer" the way the original #498 report assumed. The
+real fix is a documented contract: a worker *surfaces* a design fork in its
+output; the orchestrator — which does hold `Agent` — owns the `senior-engineer`
+consult. This module pins that contract at its two homes:
+
+- `skills/workflow-development/SKILL.md` — the canonical, fleet-wide statement
+  (Phase 2: Implement).
+- `commands/debug.md` — the orchestrator-side note giving `/swe-workbench:debug`
+  parity with the equivalent note already in `commands/implement.md`.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SKILL = ROOT / "skills" / "workflow-development" / "SKILL.md"
+DEBUG_COMMAND = ROOT / "commands" / "debug.md"
+
+
+def _skill_body() -> str:
+    assert SKILL.is_file(), "skills/workflow-development/SKILL.md must exist"
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _debug_body() -> str:
+    assert DEBUG_COMMAND.is_file(), "commands/debug.md must exist"
+    return DEBUG_COMMAND.read_text(encoding="utf-8")
+
+
+def _phase_2_section(body: str) -> str:
+    assert "### Phase 2: Implement" in body, (
+        "SKILL.md must have a '### Phase 2: Implement' section to anchor the "
+        "design-fork consult contract"
+    )
+    return body.split("### Phase 2: Implement")[1].split("### Phase 3")[0]
+
+
+# ---------------------------------------------------------------------------
+# skills/workflow-development/SKILL.md — canonical contract
+# ---------------------------------------------------------------------------
+
+
+def test_skill_phase_2_states_workers_hold_no_agent_tool():
+    section = _phase_2_section(_skill_body())
+    assert "no `Agent` tool" in section or "hold no `Agent` tool" in section, (
+        "Phase 2 must state the structural fact that worker subagents hold no "
+        "`Agent` tool — this is why a worker cannot consult a peer subagent itself"
+    )
+
+
+def test_skill_phase_2_states_worker_surfaces_fork():
+    section = _phase_2_section(_skill_body())
+    assert "surface" in section.lower() and "design fork" in section.lower(), (
+        "Phase 2 must state that a worker surfaces a design fork in its output "
+        "rather than attempting to consult a subagent itself"
+    )
+
+
+def test_skill_phase_2_names_orchestrator_owns_senior_engineer_consult():
+    section = _phase_2_section(_skill_body())
+    assert "senior-engineer" in section, (
+        "Phase 2 must name `senior-engineer` as the consult the orchestrator "
+        "owns once a worker has surfaced a design fork"
+    )
+    assert "orchestrator" in section.lower(), (
+        "Phase 2 must attribute ownership of the senior-engineer consult to "
+        "the orchestrator, not the worker"
+    )
+
+
+# ---------------------------------------------------------------------------
+# commands/debug.md — orchestrator-side parity with commands/implement.md:30
+# ---------------------------------------------------------------------------
+
+
+def test_debug_command_names_senior_engineer_for_design_fork():
+    body = _debug_body()
+    assert "senior-engineer" in body, (
+        "commands/debug.md must name `senior-engineer` as the orchestrator-owned "
+        "consult target for a design fork surfaced by the debugger, at parity "
+        "with commands/implement.md's mid-implementation-fork note"
+    )
+    assert "design fork" in body.lower(), (
+        "commands/debug.md must reference 'design fork' so the note is "
+        "discoverable and consistent with agents/debugger.md's Output contract "
+        "and the SKILL.md canonical contract"
+    )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Rewrite `agents/debugger.md`'s design-flaw Absolute Rule: the debugger surfaces the design fork in its output instead of "consulting" — it holds no `Agent` tool (tools: Read, Edit, Grep, Glob, Bash, Skill) and cannot invoke subagents itself.
- Add a "Design fork (if any)" line to the debugger's Output contract.
- Add a design-fork escalation note to `commands/debug.md` naming `senior-engineer` as the orchestrator-owned consult target, at parity with the existing pattern in `commands/implement.md`.
- State the canonical worker→orchestrator consult contract once in `skills/workflow-development/SKILL.md` (Phase 2: Implement) — workers hold no `Agent` tool, surface forks in their output, and the orchestrator owns the `senior-engineer` consult.
- Deliberately does **not** grant `debugger` the `Agent` tool — 0 of 21 subagents hold it; granting one would break a fleet-wide invariant.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1555 passed
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `lychee --config .lychee.toml './**/*.md'` — 0 broken links

### Type-tailored checks (fix)
- [x] Reproduced: wrote regression tests first, confirmed they fail against the pre-fix wording (RED)
- [x] Verified: same tests pass after the markdown edits (GREEN)
- [x] Regression guarded: negative-anchor test pins that `agents/debugger.md` never names `senior-engineer` anywhere
- [x] Independently reviewed twice (plan-alignment skill + `swe-workbench:reviewer` subagent, run in parallel) — both returned "Ready to merge: Yes", no Critical/Important issues; one shared Medium finding (regex too narrow) was addressed in a follow-up commit

Closes #498
