### PR TITLE
[fix] Close newline/tab rm bypass in bash_guard.sh

### DIFF
--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -19,8 +19,9 @@ if ! cmd=$(jq -r '.tool_input.command // ""'); then
   exit 2
 fi
 
-# Normalise shell separators to spaces so rm/git after ; | & are still detected.
-_norm=$(printf '%s' "$cmd" | tr ';|&' '   ')
+# Normalise shell separators (incl. newline/tab) to spaces so rm/git after
+# ; | & ␊ ␉ are still detected.
+_norm=$(printf '%s' "$cmd" | tr ';|&\n\t' '     ')
 
 case "$_norm" in
   rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -71,6 +71,8 @@ class TestRmRfBlocker:
         "ls;rm -rf /",
         "ls;rm -rf /Users/foo",
         "ls&&rm -rf /home/foo",
+        "echo hi\nrm -rf ~",
+        "true\trm -rf /",
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)
@@ -91,6 +93,7 @@ class TestRmRfBlocker:
         "rm -r ./dist",
         "rm -rf /UsersHome",
         "rm -rf /homestead",
+        "echo hi\nrm -rf ./build",
     ])
     def test_allowed(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -94,6 +94,7 @@ class TestRmRfBlocker:
         "rm -rf /UsersHome",
         "rm -rf /homestead",
         "echo hi\nrm -rf ./build",
+        "true\trm -rf ./build",
     ])
     def test_allowed(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `hooks/bash_guard.sh`'s separator normalization (`tr`) only folded `;|&` to spaces before the fast-exit `case` gate checked for `rm`/`git`. A newline or tab before `rm` slipped past the case gate entirely and never reached the capable grep check below it — e.g. `echo hi\nrm -rf ~` was silently allowed.
- Extended the `tr` set from `';|&'` (3 chars) to `';|&\n\t'` (5 chars), keeping SET1/SET2 equal length, so newline/tab now fold to spaces before the gate runs.
- Added 4 regression tests to `tests/test_hooks.py::TestRmRfBlocker`: two BLOCKED cases (newline- and tab-separated `rm -rf`) and two ALLOWED cases (newline- and tab-separated safe commands) proving the fix does not over-block, for either separator.
- Also resolves finding #1 of #501 (the `tr` multiline bypass); findings #4/#6/#8 of #501 remain open and are intentionally out of scope for this PR.
- Note: as a side effect of folding newlines to spaces, a *literal* multi-line mention of a blocked pattern (e.g. `rm -rf /` appearing as text inside a heredoc or a multi-line commit message) is now also blocked, even when `rm` isn't actually invoked. This is an accepted fail-closed trade-off for a security guard, consistent with the hook's existing "parse error blocks by default" posture.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/test_hooks.py -v` — RED confirmed (2 new BLOCKED cases failed pre-fix), GREEN confirmed (all pass post-fix)
- [x] `pytest tests/ -v` — 1560/1560 pass
- [x] `shellcheck hooks/bash_guard.sh` — 0 issues
- [x] `bash scripts/validate.sh` — all checks passed
- [x] Manual guard invocation via stdin JSON for both new BLOCKED cases and the ALLOWED case — behavior matches expectations

### Type-tailored checks (fix)
- [x] Bug reproduced pre-fix (RED), fix verified to close it (GREEN)

Closes #502
