### PR TITLE
[fix] Add macOS pytest CI + warn on transitive lockfile adds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,7 +120,11 @@ jobs:
           check_together: 'yes'
 
   pytest:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/scripts/check-lockfile-additions.sh
+++ b/scripts/check-lockfile-additions.sh
@@ -36,18 +36,38 @@ extract_top_level() {
   ' | sort -u
 }
 
+# ── All-packages extractor ─────────────────────────────────────────────────
+# Same package set, but ignores the -r *.txt predicate — every pinned
+# package (top-level or transitive) is included.
+
+extract_all_packages() {
+  awk '
+    /^[A-Za-z0-9._-]+==/ {
+      name = $1
+      sub(/==.*/, "", name)
+      if (name != "") print name
+    }
+  ' | sort -u
+}
+
 # ── Per-lockfile check ─────────────────────────────────────────────────────
 
 failed=0
 
 for lock in "$@"; do
   # Base set: HEAD content (pre-regen, pre-commit).
+  # NOTE: baseline is HEAD, not main — on a `synchronize` after the bot has
+  # already committed a regen to this branch, a transitive package warned on
+  # in an earlier push won't re-warn. Acceptable: this signal is non-blocking.
   # When the lockfile is new (absent from HEAD), every package is treated as an
   # addition — this is intentional; a new lockfile always requires human review.
   if git cat-file -e "HEAD:${lock}" 2>/dev/null; then
-    base=$(git show "HEAD:${lock}" | extract_top_level)
+    base_content=$(git show "HEAD:${lock}")
+    base=$(printf '%s\n' "${base_content}" | extract_top_level)
+    base_all=$(printf '%s\n' "${base_content}" | extract_all_packages)
   else
     base=""
+    base_all=""
   fi
 
   # New set: working-tree content (post-regen).
@@ -57,6 +77,7 @@ for lock in "$@"; do
     continue
   fi
   new=$(extract_top_level < "${lock}")
+  new_all=$(extract_all_packages < "${lock}")
 
   # Additions: packages in new that are absent from base.
   # Filter empty lines so an empty base doesn't false-positive.
@@ -70,6 +91,29 @@ for lock in "$@"; do
       echo "  ${pkg}" >&2
     done <<< "${added}"
     failed=1
+  fi
+
+  # Transitive additions: new packages (any provenance) minus new top-level
+  # additions already reported above. Non-blocking — surfaced for visibility
+  # only, so the Dependabot auto-commit step keeps running.
+  added_all=$(comm -13 \
+    <(printf '%s\n' "${base_all}" | grep -v '^$') \
+    <(printf '%s\n' "${new_all}"  | grep -v '^$'))
+  added_transitive=$(comm -23 \
+    <(printf '%s\n' "${added_all}" | grep -v '^$') \
+    <(printf '%s\n' "${added}"     | grep -v '^$'))
+
+  if [[ -n "${added_transitive}" ]]; then
+    # `paste -d` treats a multi-char delimiter as a per-gap cycling list, not a
+    # joint string (e.g. `paste -sd ', '` on 3 items yields "a,b c", not
+    # "a, b, c") — join on a single char, then expand to ", " afterwards.
+    names=$(paste -sd ',' - <<< "${added_transitive}")
+    names=${names//,/, }
+    echo "::warning::${lock}: new transitive package(s) pinned — review: ${names}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+      echo "- ⚠️ \`${lock}\`: new transitive package(s) pinned — review: ${names}" \
+        >> "${GITHUB_STEP_SUMMARY}"
+    fi
   fi
 done
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ import pytest
 # suppresses commit.gpgsign so tests don't fail on machines with GPG signing
 # enabled in ~/.gitconfig (which GIT_CONFIG_NOSYSTEM does not cover).
 #
+# GITHUB_STEP_SUMMARY is also stripped: GitHub Actions sets it for every step
+# of a job, not just steps that opt in. Without stripping it, tests that spawn
+# scripts writing to that path (e.g. check-lockfile-additions.sh) would leak
+# fabricated content into the real pytest job's Job Summary when this suite
+# runs in CI. Tests that want to exercise that write path opt back in via
+# env={**_CLEAN_ENV, "GITHUB_STEP_SUMMARY": str(tmp_file)}.
+#
 # Snapshot: built once from os.environ at pytest collection time. Session-scoped
 # fixtures that mutate GIT_* vars after import will not be reflected here.
 #
@@ -22,7 +29,11 @@ import pytest
 #   subprocess.run([...], env=_CLEAN_ENV, ...)
 #   subprocess.run([...], env={**_CLEAN_ENV, "KEY": "val"}, ...)
 _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
-    {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("GIT_") and k != "GITHUB_STEP_SUMMARY"
+    }
     | {
         "GIT_CONFIG_NOSYSTEM": "1",
         "GIT_AUTHOR_NAME": "T",

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -5,7 +5,9 @@ base lock), overwrites the working-tree lock to simulate a post-regen state,
 then runs the script via subprocess and asserts the exit code and output.
 
 The script reads HEAD:<lock> as the pre-regen baseline and compares top-level
-sets (packages whose # via block references -r *.txt).
+sets (packages whose # via block references -r *.txt). New top-level packages
+hard-fail (exit 1); new transitive packages (any other # via) are non-blocking
+and surfaced as a ::warning:: plus an optional $GITHUB_STEP_SUMMARY line.
 """
 
 import subprocess
@@ -152,7 +154,7 @@ class TestLockfileAdditionsGuard:
         assert result.returncode == 0, result.stderr
 
     def test_transitive_only_addition_exits_zero(self, tmp_path):
-        """A new package with # via <dep> (no -r) is transitive-only → exit 0."""
+        """A new package with # via <dep> (no -r) is transitive-only → exit 0, but warns."""
         lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
         lock_file.write_text(
             _BASE_LOCK
@@ -168,3 +170,73 @@ class TestLockfileAdditionsGuard:
             env=_CLEAN_ENV,
         )
         assert result.returncode == 0, result.stderr
+        assert "::warning::" in result.stdout
+        assert "attrs" in result.stdout
+
+    def test_transitive_and_top_level_addition_exits_one_and_warns(self, tmp_path):
+        """A new top-level package (hard-fail) alongside a new transitive package
+        (non-blocking warning) → exit 1 for the top-level addition, but the
+        transitive package is still named in a ::warning:: annotation."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(
+            _BASE_LOCK
+            + "requests==2.31.0\n"
+            + "    # via -r tests/requirements.txt\n"
+            + "attrs==23.1.0\n"
+            + "    # via pytest\n"
+        )
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "requests" in result.stderr
+        assert "::warning::" in result.stdout
+        assert "attrs" in result.stdout
+
+    def test_multiple_transitive_additions_warn_with_readable_separator(self, tmp_path):
+        """Two+ new transitive packages must be joined as a readable ", "-separated
+        list, not garbled by a delimiter that cycles per-gap (e.g. paste -d ', ')."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(
+            _BASE_LOCK
+            + "attrs==23.1.0\n"
+            + "    # via pytest\n"
+            + "iniconfig==2.0.0\n"
+            + "    # via pytest\n"
+        )
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "attrs, iniconfig" in result.stdout, result.stdout
+
+    def test_transitive_warning_written_to_step_summary(self, tmp_path):
+        """When GITHUB_STEP_SUMMARY is set, the transitive warning is also
+        appended there; when unset, the script still exits cleanly (set -u safe)."""
+        lock_file = _make_git_repo(tmp_path, _BASE_LOCK)
+        lock_file.write_text(
+            _BASE_LOCK
+            + "attrs==23.1.0\n"
+            + "    # via pytest\n"
+        )
+        summary_file = tmp_path / "step_summary.md"
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env={**_CLEAN_ENV, "GITHUB_STEP_SUMMARY": str(summary_file)},
+        )
+        assert result.returncode == 0, result.stderr
+        assert "attrs" in summary_file.read_text()

--- a/tests/test_check_lockfile_additions.py
+++ b/tests/test_check_lockfile_additions.py
@@ -198,6 +198,31 @@ class TestLockfileAdditionsGuard:
         assert "::warning::" in result.stdout
         assert "attrs" in result.stdout
 
+    def test_transitive_promoted_to_top_level_exits_one_no_warning(self, tmp_path):
+        """A package that was transitive-only in the base lock (# via pytest) and
+        becomes top-level in the new lock (# via -r ...) is a top-level addition
+        (hard-fail) and must not ALSO be double-reported as a transitive one."""
+        lock_file = _make_git_repo(
+            tmp_path,
+            _BASE_LOCK + "iniconfig==2.0.0\n    # via pytest\n",
+        )
+        lock_file.write_text(
+            _BASE_LOCK
+            + "iniconfig==2.0.0\n"
+            + "    # via -r tests/requirements.txt\n"
+        )
+
+        result = subprocess.run(
+            ["bash", str(GUARD_SCRIPT), "tests/requirements.lock"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        assert result.returncode == 1
+        assert "iniconfig" in result.stderr
+        assert "::warning::" not in result.stdout
+
     def test_multiple_transitive_additions_warn_with_readable_separator(self, tmp_path):
         """Two+ new transitive packages must be joined as a readable ", "-separated
         list, not garbled by a delimiter that cycles per-gap (e.g. paste -d ', ')."""


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `pr.yml`'s `pytest` job now runs a `[ubuntu-latest, macos-latest]` matrix (`fail-fast: false`) — every other job stays `ubuntu-latest`-only. Three hook scripts (`hooks/bash_guard.sh`, `hooks/worktree_permission_grant.sh`, `hooks/skill_usage_record.sh`) have deliberate BSD-only code paths that only the pytest job's `subprocess.run`-driven tests actually exercise; `shellcheck` output is platform-identical and `lockfile-check` risks pip-compile platform-resolution false-fails, so both stay ubuntu-only.
- `scripts/check-lockfile-additions.sh` now also flags new **transitive** pip packages (previously silent) via a non-blocking `::warning::` plus an optional `$GITHUB_STEP_SUMMARY` line. New **top-level** packages still hard-fail (exit 1) exactly as before, so Dependabot's lockfile auto-commit step in `dependabot-lockfile.yml` keeps running unaffected.
- Fixed two bugs surfaced during review: a `paste -d ', '` multi-char delimiter that garbled 2+ package names in the warning, and a `GITHUB_STEP_SUMMARY` env leak in `tests/conftest.py`'s `_CLEAN_ENV` that would have written fabricated warnings into the real `pytest` job's CI summary on every run.
- Added a regression test covering the case where a package is transitive-only in the base lock and gets promoted to top-level in the new lock — locks in that it still hard-fails (no duplicate `::warning::`), per follow-up review feedback.

⚠️ **Deploy-time note:** the matrix renames the `pytest` status check to `pytest (ubuntu-latest)` / `pytest (macos-latest)`. If branch protection requires a check literally named `pytest`, update the required-checks list or merges will hang.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1561/1561 pass (includes new/extended lockfile-guard tests)
- [x] `shellcheck scripts/check-lockfile-additions.sh` — 0 issues
- [x] `actionlint .github/workflows/pr.yml` — clean
- [x] `bash scripts/validate.sh` — clean
- [x] Manual smoke test: transitive-only addition → exit 0 + `::warning::`; `GITHUB_STEP_SUMMARY` set → warning line lands in the file; unset → no leak

### Type-tailored checks (fix)
- [x] Reproduced both pre-fix bugs locally (`paste -sd ', '` garbling multi-package names; `GITHUB_STEP_SUMMARY` leaking into `pytest` job output) before fixing
- [x] Verified the guard script's hard-fail path (new top-level package) is unchanged and cannot be miscategorized as transitive-only

Closes #503
