### PR TITLE
[fix] Bound runtime gh calls with a per-call timeout wrapper

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -19,6 +19,7 @@ the swe-workbench plugin and are invoked at runtime by skills, commands, and age
 | `clean-state-files.sh` | Safe `rm -f` for per-invocation `/tmp` state files |
 | `doctor.sh` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) |
 | `fetch-pr.sh` | Fetch a PR's metadata JSON via `gh pr view`; exits 1 if the PR is inaccessible |
+| `gh-timeout.sh` | Run a `gh` call under a per-call deadline (default 60s, override via `GH_TIMEOUT_SECS`); degrades to unbounded `gh` when neither `timeout` nor `gtimeout` is on PATH |
 | `preflight-pr.sh` | Consolidated pre-flight for PR-review skills: `gh auth` gate → `fetch-pr.sh` → emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as `printf %q`-quoted eval-able `KEY=VALUE` lines |
 | `reply-and-resolve.sh` | Post a PR review thread reply (REST) and optionally resolve it (GraphQL) |
 

--- a/runtime/fetch-pr.sh
+++ b/runtime/fetch-pr.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 PR="${1:?Usage: fetch-pr.sh <PR> <out_path> <json_fields>}"
 OUT="${2:?Usage: fetch-pr.sh <PR> <out_path> <json_fields>}"
 FIELDS="${3:?Usage: fetch-pr.sh <PR> <out_path> <json_fields>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$(dirname "$OUT")"
-gh pr view "$PR" --json "$FIELDS" > "$OUT" || { echo "PR #$PR not found or not accessible." >&2; exit 1; }
+bash "$SCRIPT_DIR/gh-timeout.sh" pr view "$PR" --json "$FIELDS" > "$OUT" || { echo "PR #$PR not found or not accessible." >&2; exit 1; }
 [ -s "$OUT" ] || { echo "PR #$PR returned empty JSON." >&2; exit 1; }

--- a/runtime/gh-timeout.sh
+++ b/runtime/gh-timeout.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run `gh` under a per-call timeout so a stalled GitHub API response can't hang
+# a PR-helper script. Override the deadline (seconds) with GH_TIMEOUT_SECS (default 60).
+# Degrades to plain `gh` when neither `timeout` nor `gtimeout` (macOS/coreutils) is present.
+# On timeout, exits 124 and prints a diagnostic to stderr so a stall is not misreported
+# by a caller (e.g. fetch-pr.sh's "PR not found" branch).
+set -euo pipefail
+
+secs="${GH_TIMEOUT_SECS:-60}"
+# Require >=1: a 0 duration means "disable the timer" to GNU timeout/gtimeout, which would
+# silently re-introduce an unbounded gh call — treat it the same as any other malformed override.
+[[ "$secs" =~ ^[1-9][0-9]*$ ]] || secs=60
+
+if command -v timeout >/dev/null 2>&1; then
+  timeout_bin=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+  timeout_bin=gtimeout
+else
+  exec gh "$@"   # no timeout binary available — degrade to unbounded gh
+fi
+
+rc=0
+"$timeout_bin" -k 5 "$secs" gh "$@" || rc=$?
+if [ "$rc" -eq 124 ]; then
+  echo "gh-timeout: 'gh $*' exceeded ${secs}s deadline (GH_TIMEOUT_SECS) and was terminated." >&2
+fi
+exit "$rc"

--- a/runtime/preflight-pr.sh
+++ b/runtime/preflight-pr.sh
@@ -18,7 +18,7 @@ FIELDS="${3:-state,number,headRefName,baseRefName,headRefOid,title,body,author,r
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-gh auth status >/dev/null || {
+bash "$SCRIPT_DIR/gh-timeout.sh" auth status >/dev/null || {
   echo "gh not authenticated. Run 'gh auth login'." >&2
   exit 1
 }
@@ -38,8 +38,8 @@ for _var in BASE HEAD_SHA AUTHOR_LOGIN STATE; do
   fi
 done
 
-OWNER=$(gh repo view --json owner -q .owner.login)
-REPO=$(gh repo view --json name   -q .name)
+OWNER=$(bash "$SCRIPT_DIR/gh-timeout.sh" repo view --json owner -q .owner.login)
+REPO=$(bash "$SCRIPT_DIR/gh-timeout.sh" repo view --json name   -q .name)
 if [ -z "$OWNER" ] || [ "$OWNER" = "null" ] || [ -z "$REPO" ] || [ "$REPO" = "null" ]; then
   echo "Could not determine base repo owner/name. Run 'gh repo view' to verify the current remote is set correctly." >&2
   exit 1

--- a/runtime/reply-and-resolve.sh
+++ b/runtime/reply-and-resolve.sh
@@ -12,11 +12,12 @@ if [ -z "${6:-}" ] && [ -z "${5:-}" ]; then exit 0; fi
 OWNER="${1:?}"; REPO="${2:?}"; PR="${3:?}"
 COMMENT_DATABASEID="${4:-}"; THREAD_ID="${5:-}"; REPLY_BODY="${6:-}"
 KIND="${7:-review}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 case "$KIND" in
   issue)
     [ -n "$REPLY_BODY" ] || exit 0
     # -f (raw), not -F: an @author-prefixed body would be @-file-expanded by -F. See docs/gh-api-field-flags.md
-    gh api "repos/${OWNER}/${REPO}/issues/${PR}/comments" -f body="$REPLY_BODY"
+    bash "$SCRIPT_DIR/gh-timeout.sh" api "repos/${OWNER}/${REPO}/issues/${PR}/comments" -f body="$REPLY_BODY"
     exit 0 ;;
   review) : ;;
   *) echo "reply-and-resolve: unknown KIND '$KIND'" >&2; exit 1 ;;
@@ -24,9 +25,9 @@ esac
 if [ -n "$REPLY_BODY" ]; then
   [ -n "$COMMENT_DATABASEID" ] || { echo "reply-and-resolve: REPLY_BODY set but COMMENT_DATABASEID is empty" >&2; exit 1; }
   # -f (raw), not -F: an @author-prefixed body would be @-file-expanded by -F. See docs/gh-api-field-flags.md
-  gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments/${COMMENT_DATABASEID}/replies" -f body="$REPLY_BODY"
+  bash "$SCRIPT_DIR/gh-timeout.sh" api "repos/${OWNER}/${REPO}/pulls/${PR}/comments/${COMMENT_DATABASEID}/replies" -f body="$REPLY_BODY"
 fi
 if [ -n "$THREAD_ID" ]; then
-  gh api graphql -F threadId="$THREAD_ID" -f query='
+  bash "$SCRIPT_DIR/gh-timeout.sh" api graphql -F threadId="$THREAD_ID" -f query='
     mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id isResolved } } }'
 fi

--- a/runtime/sync-pr-metadata.sh
+++ b/runtime/sync-pr-metadata.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 PR="${1:?sync-pr-metadata: PR number required}"
 NEW_TITLE="${2:-}"; BODY_FILE="${3:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 args=()
 [ -n "$NEW_TITLE" ] && args+=(--title "$NEW_TITLE")
 if [ -n "$BODY_FILE" ]; then
@@ -12,4 +13,4 @@ if [ -n "$BODY_FILE" ]; then
   args+=(--body-file "$BODY_FILE")
 fi
 [ ${#args[@]} -gt 0 ] || { echo "sync-pr-metadata: nothing to update (no title, no body)" >&2; exit 1; }
-gh pr edit "$PR" "${args[@]}"
+bash "$SCRIPT_DIR/gh-timeout.sh" pr edit "$PR" "${args[@]}"

--- a/tests/test_gh_timeout_script.py
+++ b/tests/test_gh_timeout_script.py
@@ -1,0 +1,216 @@
+"""Tests for runtime/gh-timeout.sh — per-call timeout wrapper for `gh` (issue #504).
+
+Each test invokes the script as a subprocess with fake `timeout`/`gtimeout`/`gh`
+stubs prepended to a PATH that is tightly scoped per test, mirroring the
+test_doctor_script.py / test_reply_and_resolve_script.py stub conventions.
+
+Stubs record their full argv NUL-delimited to a log file so assertions can
+recover exact argument boundaries even when an argument (e.g. a GraphQL query)
+contains spaces or newlines.
+
+Behavioral paths under test:
+  - Applies the deadline: `timeout -k 5 <secs> gh <args...>`, args forwarded verbatim
+  - GH_TIMEOUT_SECS override changes the deadline
+  - Invalid GH_TIMEOUT_SECS falls back to the 60s default
+  - No timeout/gtimeout on PATH: degrades to calling `gh` directly
+  - gtimeout is used when `timeout` is absent but `gtimeout` is present (macOS/coreutils)
+  - A 124 exit from the timeout binary propagates and prints a stderr diagnostic
+  - Multi-arg calls (e.g. `gh api graphql -F ... -f query=...`) forward every arg intact
+"""
+
+import subprocess
+from pathlib import Path
+from shutil import which
+
+from conftest import _CLEAN_ENV
+
+SCRIPT = Path(__file__).parent.parent / "runtime" / "gh-timeout.sh"
+ROOT = Path(__file__).parent.parent
+
+BASH_BIN = which("bash") or "/bin/bash"
+
+
+def _write_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _recording_stub(log: Path, *, exit_code: int = 0) -> str:
+    """Stub body that NUL-delimits its full argv to `log`, then exits `exit_code`."""
+    return f"#!/bin/sh\nprintf '%s\\0' \"$@\" > '{log}'\nexit {exit_code}\n"
+
+
+def _fixed_exit_stub(exit_code: int) -> str:
+    """Stub body that ignores its args and exits `exit_code` unconditionally."""
+    return f"#!/bin/sh\nexit {exit_code}\n"
+
+
+def _read_argv(log: Path) -> list[str]:
+    """Decode a NUL-delimited argv log back into a list of strings."""
+    if not log.exists():
+        return []
+    raw = log.read_bytes()
+    parts = raw.split(b"\0")
+    if parts and parts[-1] == b"":
+        parts = parts[:-1]
+    return [p.decode() for p in parts]
+
+
+def _run(args: list[str], *, bin_dir: Path, extra_env: dict | None = None):
+    env = dict(_CLEAN_ENV)
+    env["PATH"] = str(bin_dir)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [BASH_BIN, str(SCRIPT), *args],
+        capture_output=True, text=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+
+
+# ── Existence ────────────────────────────────────────────────────────────────
+
+def test_script_exists_and_executable():
+    """runtime/gh-timeout.sh must exist and be executable."""
+    import os
+    assert SCRIPT.exists(), "runtime/gh-timeout.sh must exist"
+    assert os.access(SCRIPT, os.X_OK), "runtime/gh-timeout.sh must be executable (chmod +x)"
+
+
+# ── Applies the deadline (default 60s), forwards args verbatim ────────────────
+
+def test_applies_default_deadline_and_forwards_args(tmp_path):
+    """With a `timeout` stub present, deadline defaults to 60s and gh args are forwarded verbatim."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "timeout.log"
+    _write_stub(bin_dir / "timeout", _recording_stub(log))
+    result = _run(["pr", "view", "42", "--json", "state"], bin_dir=bin_dir)
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "60"], f"expected '-k 5 60' prefix, got: {argv}"
+    assert argv[3:] == ["gh", "pr", "view", "42", "--json", "state"], (
+        f"expected forwarded gh call verbatim, got: {argv}"
+    )
+
+
+# ── GH_TIMEOUT_SECS override ───────────────────────────────────────────────────
+
+def test_env_override_changes_deadline(tmp_path):
+    """GH_TIMEOUT_SECS=15 → the timeout binary is invoked with a 15s deadline."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "timeout.log"
+    _write_stub(bin_dir / "timeout", _recording_stub(log))
+    result = _run(["api", "rate_limit"], bin_dir=bin_dir, extra_env={"GH_TIMEOUT_SECS": "15"})
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "15"], f"expected '-k 5 15' prefix, got: {argv}"
+
+
+# ── Invalid GH_TIMEOUT_SECS falls back to 60 ───────────────────────────────────
+
+def test_invalid_override_falls_back_to_60(tmp_path):
+    """A malformed GH_TIMEOUT_SECS (non-numeric) falls back to the 60s default without failing hard."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "timeout.log"
+    _write_stub(bin_dir / "timeout", _recording_stub(log))
+    result = _run(["api", "rate_limit"], bin_dir=bin_dir, extra_env={"GH_TIMEOUT_SECS": "abc"})
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "60"], f"expected fallback to 60s, got: {argv}"
+
+
+def test_zero_override_falls_back_to_60(tmp_path):
+    """GH_TIMEOUT_SECS=0 must NOT be forwarded as-is: GNU timeout/gtimeout treat a 0 duration as
+    'disable the timer', so passing 0 through would silently re-introduce an unbounded gh call —
+    the exact hang this wrapper exists to prevent. It must fall back to the 60s default instead."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "timeout.log"
+    _write_stub(bin_dir / "timeout", _recording_stub(log))
+    result = _run(["api", "rate_limit"], bin_dir=bin_dir, extra_env={"GH_TIMEOUT_SECS": "0"})
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "60"], f"expected fallback to 60s (not 0/unbounded), got: {argv}"
+
+
+# ── Degrades gracefully when no timeout binary is present ─────────────────────
+
+def test_degrades_to_plain_gh_when_no_timeout_binary(tmp_path):
+    """Neither timeout nor gtimeout on PATH → gh is called directly, exit 0."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "gh.log"
+    _write_stub(bin_dir / "gh", _recording_stub(log))
+    result = _run(["pr", "view", "42"], bin_dir=bin_dir)
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    assert _read_argv(log) == ["pr", "view", "42"], (
+        "gh must be called directly with args forwarded verbatim when no timeout binary exists"
+    )
+
+
+def test_uses_gtimeout_when_timeout_absent(tmp_path):
+    """`gtimeout` (macOS/coreutils) is used when `timeout` is absent but `gtimeout` is present."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "gtimeout.log"
+    _write_stub(bin_dir / "gtimeout", _recording_stub(log))
+    result = _run(["pr", "view", "42"], bin_dir=bin_dir)
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "60"], f"expected '-k 5 60' prefix, got: {argv}"
+    assert argv[3:] == ["gh", "pr", "view", "42"], f"expected forwarded gh call, got: {argv}"
+
+
+# ── Timeout exit (124) propagates with a stderr diagnostic ────────────────────
+
+def test_timeout_exit_propagates_and_prints_diagnostic(tmp_path):
+    """A 124 exit from the timeout binary propagates as-is, with a clear stderr diagnostic."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir / "timeout", _fixed_exit_stub(124))
+    result = _run(["pr", "view", "42"], bin_dir=bin_dir)
+    assert result.returncode == 124, f"expected exit 124, got {result.returncode}: {result.stderr!r}"
+    assert "gh-timeout" in result.stderr, f"expected a gh-timeout diagnostic on stderr: {result.stderr!r}"
+    assert "gh pr view 42" in result.stderr, (
+        f"diagnostic must name the timed-out gh call: {result.stderr!r}"
+    )
+    assert "60s deadline" in result.stderr, f"diagnostic must name the deadline: {result.stderr!r}"
+    assert "GH_TIMEOUT_SECS" in result.stderr, (
+        f"diagnostic must name the override env var: {result.stderr!r}"
+    )
+
+
+def test_non_timeout_failure_propagates_without_diagnostic(tmp_path):
+    """A non-124 gh failure (e.g. a real error) propagates its exit code without the timeout diagnostic."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir / "timeout", _fixed_exit_stub(1))
+    result = _run(["pr", "view", "999"], bin_dir=bin_dir)
+    assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+    assert "gh-timeout" not in result.stderr, (
+        f"non-timeout failures must not print the timeout diagnostic: {result.stderr!r}"
+    )
+
+
+# ── Multi-arg forwarding (guards the reply-and-resolve GraphQL call) ──────────
+
+def test_multi_arg_graphql_call_forwarded_intact(tmp_path):
+    """A `gh api graphql -F ... -f query=...` style call forwards every argv element intact."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "timeout.log"
+    _write_stub(bin_dir / "timeout", _recording_stub(log))
+    query = (
+        "mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) "
+        "{ thread { id isResolved } } }"
+    )
+    args = ["api", "graphql", "-F", "threadId=THREAD_abc123", "-f", f"query={query}"]
+    result = _run(args, bin_dir=bin_dir)
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    argv = _read_argv(log)
+    assert argv[:3] == ["-k", "5", "60"]
+    assert argv[3:] == ["gh", *args], f"expected every argv element forwarded intact, got: {argv}"

--- a/tests/test_reply_and_resolve_script.py
+++ b/tests/test_reply_and_resolve_script.py
@@ -11,6 +11,7 @@ Behavioral paths under test:
   - Missing COMMENT_DATABASEID when REPLY_BODY set: exit 1, error on stderr, gh not called
 """
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -230,9 +231,16 @@ def test_body_flag_is_lowercase_f_not_uppercase_f():
     reviewer's handle. The recording gh stub used elsewhere in this file only
     logs "$1 $2" (sub-command + URL), not flags, so it can't catch a regression
     here — this test reads the script source directly instead.
+
+    Call sites go through the gh-timeout.sh wrapper (issue #504), so the
+    literal substring "gh api" no longer appears on these lines — match the
+    wrapper invocation pattern instead.
     """
     text = SCRIPT.read_text()
-    body_lines = [ln for ln in text.splitlines() if "body=" in ln and "gh api" in ln]
+    body_lines = [
+        ln for ln in text.splitlines()
+        if "body=" in ln and re.search(r'gh-timeout\.sh"\s+api\b', ln)
+    ]
     assert len(body_lines) == 2, f"expected exactly 2 gh api body= call sites, found {len(body_lines)}: {body_lines}"
     for ln in body_lines:
         assert "-f body=" in ln, f"expected -f body= (raw string), got: {ln!r}"

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -14,6 +14,7 @@ RUNTIME_SCRIPTS = [
     "clean-state-files.sh",
     "doctor.sh",
     "fetch-pr.sh",
+    "gh-timeout.sh",
     "preflight-pr.sh",
     "reply-and-resolve.sh",
     "sync-pr-metadata.sh",


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Every `gh` CLI call in the 4 `runtime/` PR-helper scripts (`fetch-pr.sh`, `reply-and-resolve.sh`, `sync-pr-metadata.sh`, `preflight-pr.sh`) ran unbounded — a stalled GitHub API response never returns and never errors, which can leave `reply-and-resolve.sh` mid-loop with a review thread partially replied/resolved.
- Adds `runtime/gh-timeout.sh`, a subprocess wrapper (matches the repo's existing sibling-subprocess resolution convention, not a sourced helper) that runs `gh` under `timeout -k 5 <secs>` (default 60s, overridable via `GH_TIMEOUT_SECS`), falls back to `gtimeout` (macOS/coreutils) if `timeout` is absent, and degrades to unbounded `gh` if neither exists.
- Rejects `GH_TIMEOUT_SECS=0` (falls back to 60s) — GNU `timeout`/`gtimeout` treat a `0` duration as "disable the timer", so a `0` override would otherwise silently reintroduce an unbounded call.
- On a 124 (timeout) exit, prints a stderr diagnostic naming the timed-out `gh` call so a stall isn't misreported as e.g. "PR not found".
- Rewrites all `gh` call sites in the 4 scripts to go through the wrapper; no behavior change for callers.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `shellcheck --severity=warning runtime/gh-timeout.sh runtime/*.sh` — 0 issues
- [x] `pytest tests/ -v` — 1567/1567 pass, including 10 new `test_gh_timeout_script.py` cases
- [x] Manual smoke: `GH_TIMEOUT_SECS=2 bash runtime/gh-timeout.sh api rate_limit` succeeds against the real GitHub API; on a host with neither `timeout` nor `gtimeout` installed, a slow stubbed `gh` ran unbounded to completion, confirming the degrade path

### Type-tailored checks (fix)
- [x] Reproduced the root cause: unbounded `gh` calls with no application-level deadline (Go `net/http` sets none on the response-body read)
- [x] Verified the fix bounds every call site in scope and a regression test (`GH_TIMEOUT_SECS=0`) guards the exact foot-gun both reviewers independently flagged

Closes #504
