### PR TITLE
[fix] cleanup-merged: internal timeout guard + partial-deletion detection in sync-and-verify.sh

### DIFF
--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -248,10 +248,12 @@ A `SYNC_TIMEOUT` firing (or an external tool-call kill) can land mid-`rm` inside
 ```bash
 cd "$MAIN_REPO"
 # Identify which registered worktree(s) have no directory on disk (same
-# check Block D performs internally — a plain grep on porcelain output
-# cannot answer this, since "worktree <path>" lines don't self-report state):
-git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r w; do
-  [ -d "$w" ] || echo "MISSING: $w"
+# check Block D performs internally). Line-based, not awk field-splitting —
+# a path containing a space would silently vanish under `awk '{print $2}'`:
+git worktree list --porcelain | while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) w=${line#worktree }; [ -d "$w" ] || echo "MISSING: $w" ;;
+  esac
 done
 git worktree prune                              # drops the stale registration(s) for the missing dir(s)
 git branch -D <stale-branch-name>                # the local ref that survived the interrupted rm

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -90,12 +90,17 @@ The script: derives `MAIN_REPO=` (main worktree root via `git worktree list --po
 
 When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast path)`), `git pull` fires the hook as a side-effect, which removes the merged worktree and local branch automatically. A sync failure on the fast path forces fall-through to the rimba-binary or shell strategy — it does NOT abort cleanup.
 
+**Internal timeout guard.** The checkout-then-pull sync step runs under a `SYNC_TIMEOUT` watchdog (`90` seconds by default, override via the `SYNC_TIMEOUT` env var) — a pure-bash `set -m` job-group backgrounding, not the `timeout` binary (absent on stock macOS). If the pull hangs, the watchdog `kill`s the whole process group at `SYNC_TIMEOUT` seconds. **Invariant the caller must hold:** `SYNC_TIMEOUT` must stay below the harness's external tool-call timeout (headroom for Block C/D plus a 2s kill grace) — the script cannot self-enforce this. **What the guard does and does not do:** it does NOT prevent corruption — an external kill can still land mid-`rm` inside the rimba post-merge hook. It converts an otherwise-uncontrolled external kill (which would also SIGKILL this script mid-hook, leaving the failure silent) into a controlled in-script timeout that still runs Block D's detection below. Firing at 90s, below the common 120s external tool-call limit, usually lands during the network pull itself (a clean kill, no hook involved) rather than mid-hook.
+
+**Hook-interruption detection (stateless, not event-based).** After the sync, the script probes `git worktree list --porcelain` for any registered worktree whose directory is missing on disk — the canonical signal that a `post-merge` hook `rm` (this run's or a prior one's) was interrupted mid-deletion, leaving the worktree registration and branch ref alive in `.git` while the files are gone. This is state-based rather than event-based on purpose: an external kill takes down this script too, so it cannot reliably observe its own interruption — but a stale registration on the next run always tells the truth.
+
 ### Step 4 — Remove Worktree
 
-`sync-and-verify.sh` (Step 3) emits `WORKTREE_GONE=0|1` into the shell environment via `eval`.
+`sync-and-verify.sh` (Step 3) emits two `KEY=VALUE` lines into the shell environment via `eval`: `WORKTREE_GONE=0|1` and `HOOK_INTERRUPTED=0|1`.
 
 - **`WORKTREE_GONE=1`**: both the worktree and local branch are already gone — the hook did its job. No further action is needed in Step 4; proceed to Step 5. The script reports `LOCAL_DELETED=0` (local already gone) and still attempts the remote delete.
 - **`WORKTREE_GONE=0`**: hook did not fire (or rimba refused due to dirty/unpushed state). Select a removal strategy from `## Worktree Removal Strategies` below. Execute only the first strategy whose preconditions hold.
+- **`HOOK_INTERRUPTED=1`**: independent of `WORKTREE_GONE` — a registered worktree exists in `.git` with no directory on disk, i.e. the timeout guard (or an external kill on a prior run) caught a hook mid-`rm`. The probe scans **all** registered worktrees, not just `$HEAD_REF`'s — the flagged entry may be `$HEAD_REF`'s own half-deleted worktree, or an unrelated stray left over from a different branch's interrupted cleanup. Either way, run `git worktree prune` first (always safe — see the Recovery Example below); if the missing entry was `$HEAD_REF`'s own, its worktree is now fully gone and only its branch remains (skip straight to Step 5). If it was an unrelated stray, pruning clears the signal and the normal Step 4 removal strategies proceed for `$HEAD_REF` as usual. The script is verify-only here: it signals and documents, it never auto-remediates.
 
 ### Step 5 — Delete Branches
 
@@ -234,6 +239,25 @@ git worktree remove "$WORKTREE"
 | Hook ran but did not clean | `WORKTREE_GONE=0` after sync despite hook active | Fall through to rimba-binary or shell strategy. No abort. |
 | cwd deleted mid-flow by hook | `fatal: not a git repository` on next command | Step 3a `ExitWorktree action=keep` (or the `cd`-to-main-root fallback for `cd`-entered worktrees) prevents this when followed. If observed, re-run from the main repo root. |
 | rimba `remove` removes worktree but fails branch delete | Non-zero exit after worktree directory is gone | Partial success — fall through to Step 5 from `$MAIN_REPO`. Worktree is gone; only branch remains. |
+| Partial worktree deletion (interrupted hook) | `HOOK_INTERRUPTED=1` — a registered worktree is missing on disk (may be `$HEAD_REF`'s own, or an unrelated stray from an earlier interrupted cleanup) | Run `git worktree prune` from `$MAIN_REPO` first — always safe, never touches a live worktree — then delete the stale branch (`delete-branches.sh` or `git branch -D <ref>`). Only skip the normal Step 4 removal strategies for `$HEAD_REF` if the missing entry turns out to be `$HEAD_REF`'s own worktree; otherwise proceed with Step 4 as usual once the stray is pruned. |
+
+### Recovery Example — Interrupted Hook
+
+A `SYNC_TIMEOUT` firing (or an external tool-call kill) can land mid-`rm` inside the rimba post-merge hook, leaving a worktree registered in `.git` with its directory already gone from disk. `sync-and-verify.sh` reports this as `HOOK_INTERRUPTED=1` and prints a recovery hint to stderr. The probe scans **all** registered worktrees, not just `$HEAD_REF`'s — `HOOK_INTERRUPTED=1` can point at an unrelated stray left over from a different branch's interrupted cleanup, so identify the specific entry before assuming it's the one you're cleaning up:
+
+```bash
+cd "$MAIN_REPO"
+# Identify which registered worktree(s) have no directory on disk (same
+# check Block D performs internally — a plain grep on porcelain output
+# cannot answer this, since "worktree <path>" lines don't self-report state):
+git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r w; do
+  [ -d "$w" ] || echo "MISSING: $w"
+done
+git worktree prune                              # drops the stale registration(s) for the missing dir(s)
+git branch -D <stale-branch-name>                # the local ref that survived the interrupted rm
+```
+
+`git worktree prune` only removes registrations whose directories are gone — it never touches a live worktree, so it is safe to run unconditionally once `HOOK_INTERRUPTED=1` is observed. This does not need `--force`: prune has no dirty/unpushed concept because the directory it would check is already gone. If the missing entry turns out to be an unrelated stray (not `$HEAD_REF`), pruning it clears the signal and Step 4's normal removal strategies proceed for `$HEAD_REF` as usual.
 
 ## Common Mistakes
 

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Anchors cwd to the main repo, syncs local main, and checks whether the
 # rimba post-merge hook already cleaned up the given branch.
-# Usage: sync-and-verify.sh <head_ref>
-# Stdout contract: WORKTREE_GONE=0|1
+# Usage: sync-and-verify.sh <head_ref> [default_branch]
+# Stdout contract: WORKTREE_GONE=0|1 <newline> HOOK_INTERRUPTED=0|1
 # Exit non-zero only if $MAIN_REPO cannot be resolved.
 set -euo pipefail
 
@@ -15,8 +15,44 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 cd "$MAIN_REPO"
 
 # Block B: sync local default branch (best-effort — failure warns, does not abort)
-(git checkout "$DEFAULT_BRANCH" && git pull --ff-only origin "$DEFAULT_BRANCH") >/dev/null 2>&1 \
-  || echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually (run git pull to see the underlying error)" >&2
+# Backgrounded under an internal watchdog so an external tool-call kill can
+# never hit this step uncontrolled: firing before that external timeout turns
+# an unrecoverable process-tree kill into a controlled in-script exit that
+# still runs Block D's detection. This does NOT prevent corruption — a kill
+# can still land during the hook's rm — it makes it detectable and recoverable.
+# SYNC_TIMEOUT must be < the external tool-call timeout (headroom for Block C/D
+# plus the 2s kill grace below) — the script cannot self-enforce this invariant.
+SYNC_TIMEOUT="${SYNC_TIMEOUT:-90}"
+case "$SYNC_TIMEOUT" in
+  ''|*[!0-9]*)
+    echo "sync-and-verify: invalid SYNC_TIMEOUT='$SYNC_TIMEOUT' (must be a non-negative integer) — falling back to 90" >&2
+    SYNC_TIMEOUT=90
+    ;;
+esac
+TIMED_OUT=0
+set -m # give the backgrounded job its own process group
+( git checkout "$DEFAULT_BRANCH" \
+    && git pull --ff-only origin "$DEFAULT_BRANCH" ) >/dev/null 2>&1 &
+job=$!
+elapsed=0
+while kill -0 "$job" 2>/dev/null; do
+  if [ "$elapsed" -ge "$SYNC_TIMEOUT" ]; then
+    kill -TERM -"$job" 2>/dev/null || true # negative PID = whole group: git + orphaned rimba hook child
+    sleep 2
+    kill -KILL -"$job" 2>/dev/null || true
+    TIMED_OUT=1
+    break
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1)) # NOT ((elapsed++)) — returns 1 (falsy) at 0, trips set -e
+done
+pull_rc=0
+wait "$job" 2>/dev/null || pull_rc=$? # `wait; pull_rc=$?` on separate lines is unreachable under set -e
+set +m
+
+if [ "$TIMED_OUT" -eq 0 ] && [ "$pull_rc" -ne 0 ]; then
+  echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually (run git pull to see the underlying error)" >&2
+fi
 
 # Block C: verification gate — check whether hook already cleaned up
 # Use awk string comparison (-v) to avoid regex metachar injection from HEAD_REF
@@ -31,4 +67,25 @@ fi
 WORKTREE_GONE=0
 [ -z "${WORKTREE_FOUND:-}" ] && [ -z "${BRANCH_FOUND:-}" ] && WORKTREE_GONE=1
 
+# Block D: partial-deletion probe — canonical state-based signal that the
+# rimba post-merge hook (or a prior cleanup run) was interrupted mid-rm: a
+# worktree still registered in .git but whose directory is gone from disk.
+# State, not event: robust to external kills that also took down this script
+# on a prior run, not just to a timeout caught by Block B on this run.
+HOOK_INTERRUPTED=0
+while IFS= read -r _line; do
+  case "$_line" in
+    "worktree "*) _wt=${_line#worktree }; [ -d "$_wt" ] || HOOK_INTERRUPTED=1 ;;
+  esac
+done < <(git worktree list --porcelain)
+
+if [ "$HOOK_INTERRUPTED" -eq 1 ]; then
+  if [ "$TIMED_OUT" -eq 1 ]; then
+    echo "sync-and-verify: internal timeout (${SYNC_TIMEOUT}s) interrupted the post-merge hook — partial worktree deletion detected. Recover: run 'git worktree prune' from the main repo, then delete the stale branch." >&2
+  else
+    echo "sync-and-verify: partial worktree deletion detected (a registered worktree is missing on disk — a prior cleanup was likely interrupted). Recover: run 'git worktree prune' from the main repo." >&2
+  fi
+fi
+
 printf 'WORKTREE_GONE=%s\n' "$WORKTREE_GONE"
+printf 'HOOK_INTERRUPTED=%s\n' "$HOOK_INTERRUPTED"

--- a/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
+++ b/skills/workflow-cleanup-merged/scripts/sync-and-verify.sh
@@ -50,7 +50,9 @@ pull_rc=0
 wait "$job" 2>/dev/null || pull_rc=$? # `wait; pull_rc=$?` on separate lines is unreachable under set -e
 set +m
 
-if [ "$TIMED_OUT" -eq 0 ] && [ "$pull_rc" -ne 0 ]; then
+if [ "$TIMED_OUT" -eq 1 ]; then
+  echo "sync-and-verify: internal timeout (${SYNC_TIMEOUT}s) killed the checkout/pull — $DEFAULT_BRANCH sync may be incomplete, verify manually" >&2
+elif [ "$pull_rc" -ne 0 ]; then
   echo "sync-main: best-effort failed — reconcile $DEFAULT_BRANCH manually (run git pull to see the underlying error)" >&2
 fi
 

--- a/tests/test_cleanup_merged_skill.py
+++ b/tests/test_cleanup_merged_skill.py
@@ -132,6 +132,33 @@ def test_phase1_template_rimba_is_primary_not_peer():
         )
 
 
+def test_cleanup_merged_documents_hook_interrupted_recovery():
+    """SKILL.md must document the HOOK_INTERRUPTED signal and its recovery (issue #496).
+
+    sync-and-verify.sh now emits a second stdout field, HOOK_INTERRUPTED=0|1, detecting
+    a registered worktree whose directory is missing on disk (a timeout or external kill
+    landed mid-rm inside the rimba post-merge hook). The skill must document the signal,
+    the Failure Mode Table row, and the manual `git worktree prune` recovery — the script
+    is verify-only and never auto-remediates.
+    """
+    body = SKILL.read_text()
+
+    assert "HOOK_INTERRUPTED" in body, (
+        "SKILL.md must mention the HOOK_INTERRUPTED stdout field"
+    )
+
+    assert "## Failure Mode Table" in body, "Failure Mode Table section must exist"
+    failure_table = body.split("## Failure Mode Table")[1].split("## Common Mistakes")[0]
+
+    assert "HOOK_INTERRUPTED=1" in failure_table, (
+        "Failure Mode Table must have a row keyed on HOOK_INTERRUPTED=1"
+    )
+    assert "git worktree prune" in failure_table, (
+        "Failure Mode Table's partial-deletion row must name the recovery command "
+        "git worktree prune"
+    )
+
+
 def test_cleanup_merged_step5_delegates_to_delete_branches_script():
     """Step 5 must delegate branch deletion to delete-branches.sh via eval.
 

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -11,8 +11,11 @@ Both were eval'd by the caller, causing "command not found" errors.
 This test pins the contract: stdout must be exactly one line.
 """
 
+import os
 import re
+import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -104,14 +107,18 @@ def _run_script(repo: Path, head_ref: str, default_branch: str = "main"):
     )
 
 
-def _assert_contract(result, expected: str) -> None:
+def _assert_contract(result, expected: str, hook_interrupted: str = "0") -> None:
     assert result.returncode == 0, (
         f"Script exited {result.returncode}\n"
         f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
     )
     lines = result.stdout.strip().splitlines()
-    assert lines == [f"WORKTREE_GONE={expected}"], (
-        f"Expected stdout=['WORKTREE_GONE={expected}'], got {lines!r}\n"
+    expected_lines = [
+        f"WORKTREE_GONE={expected}",
+        f"HOOK_INTERRUPTED={hook_interrupted}",
+    ]
+    assert lines == expected_lines, (
+        f"Expected stdout={expected_lines!r}, got {lines!r}\n"
         f"Full stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
     )
     assert not SHA_PATTERN.search(result.stdout), (
@@ -166,6 +173,117 @@ class TestSyncAndVerifyNonMainDefaultBranch:
         )
         result = _run_script(git_repo_trunk, BRANCH, default_branch="trunk")
         _assert_contract(result, "1")
+
+
+class TestSyncAndVerifyHookInterruptedDetection:
+    """State-based detection (issue #496): a registered worktree whose directory
+    is missing on disk is the canonical signal that the rimba post-merge hook
+    (or a prior cleanup run) was interrupted mid-deletion — the worktree entry
+    and branch ref survive in .git, but the directory is gone from disk."""
+
+    def test_partial_deletion_detected(self, git_repo, tmp_path):
+        stray_path = tmp_path / "wt-stray"
+        subprocess.run(
+            ["git", "worktree", "add", str(stray_path), "-b", "stray-branch"],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        shutil.rmtree(stray_path)
+
+        result = _run_script(git_repo, BRANCH, default_branch="main")
+        _assert_contract(result, "0", hook_interrupted="1")
+
+
+class TestSyncAndVerifyWatchdog:
+    """The internal SYNC_TIMEOUT guard (issue #496) must reap a hung `git pull`
+    within the configured window — headless (no tty, no job control) — without
+    polluting stdout and without leaking the killed subprocess."""
+
+    def test_watchdog_kills_hung_pull_and_stays_clean(self, git_repo, tmp_path):
+        real_git = shutil.which("git")
+        assert real_git, "git must be resolvable on PATH for this test"
+
+        stub_dir = tmp_path / "stub_bin"
+        stub_dir.mkdir()
+        stub_git = stub_dir / "git"
+        marker = tmp_path / "pull_started"
+        stub_git.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "pull" ]; then\n'
+            f'  touch "{marker}"\n'
+            "  sleep 30\n"
+            "fi\n"
+            f'exec "{real_git}" "$@"\n'
+        )
+        stub_git.chmod(0o755)
+
+        env = {
+            **_CLEAN_ENV,
+            "PATH": f"{stub_dir}{os.pathsep}{_CLEAN_ENV['PATH']}",
+            "SYNC_TIMEOUT": "1",
+        }
+
+        start = time.monotonic()
+        result = subprocess.run(
+            ["bash", str(SCRIPT), BRANCH, "main"],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=20,
+        )
+        elapsed = time.monotonic() - start
+
+        assert marker.exists(), "stub git pull was never invoked — test is vacuous"
+        assert result.returncode == 0, (
+            f"Script exited {result.returncode}\n"
+            f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+        assert elapsed < 10, (
+            f"watchdog (SYNC_TIMEOUT=1) should reap the hung pull well under "
+            f"10s, took {elapsed:.1f}s"
+        )
+
+        lines = result.stdout.strip().splitlines()
+        assert lines == ["WORKTREE_GONE=0", "HOOK_INTERRUPTED=0"], (
+            f"Expected clean two-line contract, got {lines!r}\n"
+            f"Full stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+        )
+
+        # Confirm the stubbed sleep was actually reaped, not merely orphaned
+        # after the parent exited (process-group kill, not just job kill).
+        time.sleep(0.5)
+        ps = subprocess.run(
+            ["pgrep", "-f", "sleep 30"], capture_output=True, text=True, env=_CLEAN_ENV
+        )
+        assert ps.returncode != 0, f"orphaned stub sleep process still running: {ps.stdout}"
+
+
+class TestSyncAndVerifySyncTimeoutValidation:
+    """A malformed SYNC_TIMEOUT must not silently disable the watchdog.
+
+    `[ "$elapsed" -ge "$SYNC_TIMEOUT" ]` errors on non-numeric input, which
+    evaluates as false under set -e inside an if condition — the loop would
+    never time out, reproducing the exact bug #496 exists to fix. The script
+    must fall back to the 90s default and warn on stderr instead.
+    """
+
+    def test_non_numeric_sync_timeout_falls_back_to_default(self, git_repo):
+        env = {**_CLEAN_ENV, "SYNC_TIMEOUT": "90s"}
+        result = subprocess.run(
+            ["bash", str(SCRIPT), BRANCH, "main"],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        _assert_contract(result, "0")
+        assert "invalid SYNC_TIMEOUT" in result.stderr, (
+            f"Expected a fallback warning on stderr, got: {result.stderr!r}"
+        )
 
 
 class TestSyncAndVerifyEvalSafety:

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -253,6 +253,14 @@ class TestSyncAndVerifyWatchdog:
             f"Full stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
         )
 
+        # TIMED_OUT=1 with HOOK_INTERRUPTED=0 (this case: no worktree was mid-
+        # deletion) must still surface a diagnostic — a killed checkout/pull is
+        # not silently indistinguishable from a fully successful sync.
+        assert "internal timeout" in result.stderr, (
+            f"A watchdog timeout with no hook interruption must still warn on "
+            f"stderr, got: {result.stderr!r}"
+        )
+
         # Confirm the stubbed sleep was actually reaped, not merely orphaned
         # after the parent exited (process-group kill, not just job kill).
         time.sleep(0.5)

--- a/tests/test_sync_and_verify.py
+++ b/tests/test_sync_and_verify.py
@@ -261,6 +261,66 @@ class TestSyncAndVerifyWatchdog:
         )
         assert ps.returncode != 0, f"orphaned stub sleep process still running: {ps.stdout}"
 
+    def test_watchdog_timeout_concurrent_with_hook_interruption(self, git_repo, tmp_path):
+        """The exact scenario issue #496 was filed for: SYNC_TIMEOUT fires while a
+        registered worktree is simultaneously missing its directory on disk. Must
+        emit the timeout-specific stderr message (corroborated wording), not the
+        generic partial-deletion one — this exercises the `TIMED_OUT=1` branch of
+        Block D's message selection, which the non-combined tests above never hit
+        (one triggers only TIMED_OUT, the other only HOOK_INTERRUPTED)."""
+        real_git = shutil.which("git")
+        assert real_git, "git must be resolvable on PATH for this test"
+
+        stray_path = tmp_path / "wt-stray-timeout"
+        subprocess.run(
+            ["git", "worktree", "add", str(stray_path), "-b", "stray-timeout-branch"],
+            cwd=str(git_repo),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_CLEAN_ENV,
+        )
+        shutil.rmtree(stray_path)
+
+        stub_dir = tmp_path / "stub_bin_combined"
+        stub_dir.mkdir()
+        stub_git = stub_dir / "git"
+        marker = tmp_path / "pull_started_combined"
+        stub_git.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "pull" ]; then\n'
+            f'  touch "{marker}"\n'
+            "  sleep 30\n"
+            "fi\n"
+            f'exec "{real_git}" "$@"\n'
+        )
+        stub_git.chmod(0o755)
+
+        env = {
+            **_CLEAN_ENV,
+            "PATH": f"{stub_dir}{os.pathsep}{_CLEAN_ENV['PATH']}",
+            "SYNC_TIMEOUT": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", str(SCRIPT), BRANCH, "main"],
+            cwd=str(git_repo),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=20,
+        )
+
+        assert marker.exists(), "stub git pull was never invoked — test is vacuous"
+        _assert_contract(result, "0", hook_interrupted="1")
+        assert "internal timeout" in result.stderr, (
+            f"Expected the TIMED_OUT-corroborated message, got: {result.stderr!r}"
+        )
+        assert "a prior cleanup was likely interrupted" not in result.stderr, (
+            "Got the generic (non-timeout) partial-deletion message instead of "
+            f"the timeout-specific one: {result.stderr!r}"
+        )
+
 
 class TestSyncAndVerifySyncTimeoutValidation:
     """A malformed SYNC_TIMEOUT must not silently disable the watchdog.


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `sync-and-verify.sh` ran a blocking `git pull --ff-only` that fires the rimba `post-merge` hook (`rimba clean --merged --force`) as a side effect; an external tool-call timeout (e.g. a 2-minute limit) could SIGKILL the whole process tree mid-hook, leaving a worktree registered in `.git` with its directory already deleted — a silent, hard-to-diagnose partial deletion.
- Adds a pure-bash `SYNC_TIMEOUT` watchdog (90s default, user-configurable) around the checkout-then-pull sync step: backgrounds it under `set -m` in its own process group, polls with `kill -0`, and on timeout sends `kill -TERM`/`kill -KILL` to the negative PID (whole group) to reap both git and any orphaned hook child.
- Adds a stateless partial-deletion probe: scans `git worktree list --porcelain` for any registered worktree whose directory is missing on disk and reports it via a new additive `HOOK_INTERRUPTED=0|1` stdout line (extends the existing `WORKTREE_GONE=0|1` one-line contract to two lines).
- The script stays **verify-only** — it signals via stdout/stderr and documents recovery, it never auto-remediates (no `git branch -D`, no `git worktree prune` inside the script).
- `SKILL.md` documents the new field, the `SYNC_TIMEOUT < external-timeout` invariant, a new Failure Mode Table row, and a manual recovery example (`git worktree prune` then delete the stale branch) — with explicit honest framing that the guard makes corruption *detectable and recoverable*, not *prevented*.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1561/1561 pass, including two new tests: a state-fixture test (`git worktree add` + `rm -rf` its dir → asserts `HOOK_INTERRUPTED=1`) and a watchdog test (`PATH`-shimmed slow `git` stub + `SYNC_TIMEOUT=1` → asserts exit 0, clean two-line stdout, and the stub subprocess actually reaped via `pgrep`)
- [x] `shellcheck -S warning` on all `*.sh`/`*.bash` — 0 issues
- [x] `bash scripts/validate.sh` — passes

### Type-tailored checks (fix)
- [x] Reproduced the original bug's failure mode locally (standalone `set -m` group-kill script against a `sleep 30 & sleep 30; wait` nested-child stand-in for git + orphaned hook child — confirmed the group kill reaps both, no orphan left via `pgrep`)
- [x] Verified the fix resolves it without regressing the existing one-line `WORKTREE_GONE` contract (all 8 pre-existing `test_sync_and_verify.py` tests still pass unchanged)

Closes #496
