### PR TITLE
[fix] Hooks: close rm/force-push guard gaps + throttle telemetry sweep (#501)

### DIFF
--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -11,6 +11,13 @@
 # per-call grep tax flagged in #233.
 #
 # Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal; compound cd (cwd not in hook payload).
+# --force-with-lease/--force-if-includes intentionally unblocked (#163); force-push after a shell
+# separator (`&& echo main`) may over-block via the folded input (accepted fail-safe); a remote
+# literally named main/master over-blocks. Block 2's push-token scan trusts a small allowlist of
+# known BOOLEAN-only push flags and defensively consumes the next token for any other `-*` flag
+# (assumes it takes a separate-word value, e.g. `-o ci.skip`) so an unknown flag's value can never
+# be miscounted as the remote/refspec (#501 senior-engineer consult); an unrecognized flag that
+# actually takes NO value will over-block by one token (fail-safe direction, not a bypass).
 
 set -u
 
@@ -19,8 +26,35 @@ if ! cmd=$(jq -r '.tool_input.command // ""'); then
   exit 2
 fi
 
-# Normalise shell separators to spaces so rm/git after ; | & are still detected.
-_norm=$(printf '%s' "$cmd" | tr ';|&' '   ')
+# Strip shell comments per-line BEFORE folding newlines. A `#` comment ends at
+# its line's newline; folding first would let an early comment swallow a
+# destructive command on a later line (e.g. "echo hi # note\nrm -rf ~").
+# Quote-aware: a `#` inside a single- or double-quoted string (e.g. a commit
+# message referencing an issue number, `-m "fix #501"`) is NOT a real shell
+# comment and must not truncate real command text after it (#501 review).
+# Quote state is tracked in a BEGIN block (not reset per-line) so it persists
+# across an embedded newline inside a still-open quote — e.g. a multi-line -m
+# commit message — otherwise a '#'-starting continuation line would swallow
+# real command text that follows the closing quote on the SAME line (#501
+# re-review finding).
+_nc=$(printf '%s' "$cmd" | awk '
+BEGIN { in_sq = 0; in_dq = 0 }
+{
+  line = $0; out = ""; n = length(line)
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (c == "\x27" && !in_dq) { in_sq = !in_sq; out = out c; continue }
+    if (c == "\"" && !in_sq)  { in_dq = !in_dq; out = out c; continue }
+    if (c == "#" && !in_sq && !in_dq && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) break
+    out = out c
+  }
+  print out
+}')
+
+# Normalise separators AND newlines/tabs to spaces so rm/git after ; | & \n \t
+# are still detected — the fast-gate `case` and the grep detectors must share
+# ONE separator alphabet (the bug in #501: gate saw ';|&', grep saw [[:space:]]).
+_norm=$(printf '%s' "$_nc" | tr ';|&\n\t' '     ')
 
 case "$_norm" in
   rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;
@@ -42,6 +76,59 @@ if echo "$norm" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:s
    && echo "$norm" | grep -Eq '(^|[[:space:]]|:)(main|master|release/[^[:space:]:]*)([[:space:]]|:|$)'; then
   echo 'BLOCKED: force push to protected branch (main/master/release/*)' >&2
   exit 2
+fi
+
+# Block 2: implicit-branch force-push from a protected branch — additive to the
+# explicit-refspec block above. Force detection reuses the SAME anchored pattern,
+# so --force-with-lease stays unblocked (settled: #163). Fires ONLY when no
+# explicit refspec is present (push relies on push.default/upstream); an explicit
+# non-protected refspec (`origin feat`) must stay allowed even from a protected
+# branch — Block 1 already owns explicit protected refspecs.
+if echo "$norm" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))'; then
+  # Isolate the FORCE-flagged push invocation from the comment-stripped raw
+  # command ($_nc keeps real separators). Fold the SAME separator alphabet as
+  # $_norm (;|&\n\t, not just ;|&) so a tab/newline-prefixed command doesn't
+  # leak extra tokens onto the push line, and filter to lines that actually
+  # match the force pattern — a chained non-force `git push` (e.g. `git push
+  # origin x && git push --force`) must not be the one inspected for a
+  # refspec, or the real force-push line is skipped entirely (#501 review).
+  push_cmd=$(printf '%s' "$_nc" | tr ';|&\n\t' '\n\n\n\n\n' \
+    | grep -E 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' \
+    | tr -d "'\"" | head -n1)
+  has_refspec=0; seen_positional=0; consume_next=0
+  read -ra _toks <<<"$push_cmd"
+  if (( ${#_toks[@]} )); then                 # guard: bash 3.2 + set -u errors on empty "${arr[@]}"
+    for _t in "${_toks[@]}"; do
+      if (( consume_next )); then             # swallow an unrecognized flag's separate-word value
+        consume_next=0
+        continue
+      fi
+      case "$_t" in
+        git|push) ;;                          # command words
+        # Known BOOLEAN-only push flags — safe to skip outright. An
+        # unrecognized `-*` flag (senior-engineer consult, #501: `-o <val>`
+        # miscounted as a positional and silently allowed the push through)
+        # is assumed to take a separate-word value and that value is
+        # consumed too, so it can never be mistaken for the remote/refspec.
+        --force|-f|--force-with-lease*|--force-if-includes|--all|--tags|--follow-tags|\
+        --prune|--thin|--atomic|--no-verify|--dry-run|--porcelain|-q|--quiet|-v|--verbose|\
+        --progress|--no-progress|-u|--set-upstream|-d|--delete|--signed|--no-signed|\
+        --mirror|-n) ;;
+        -*) consume_next=1 ;;                 # unrecognized flag — assume it takes a value
+        *:*) has_refspec=1; break ;;          # src:dst refspec
+        *) if (( seen_positional )); then has_refspec=1; break; fi; seen_positional=1 ;;  # 1st bareword = remote
+      esac
+    done
+  fi
+  if (( has_refspec == 0 )); then             # relies on push.default / upstream
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    case "$branch" in
+      main|master|release/*)
+        echo "BLOCKED: force push of current protected branch '$branch' (implicit upstream)" >&2
+        exit 2
+        ;;
+    esac
+  fi
 fi
 
 if echo "$norm" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then

--- a/hooks/skill_usage_record.sh
+++ b/hooks/skill_usage_record.sh
@@ -41,8 +41,14 @@ buffer="$cache_dir/$(date +%Y%m%d)-$agent_id.txt"
 # Append skill name. Dedup happens at flush time so this path stays fast.
 printf '%s\n' "$skill" >>"$buffer" 2>>"$cache_dir/.errors.log" || true
 
-# Opportunistic sweep: drop buffers older than 24h (-mmin +1440 is portable to
-# both GNU and BSD find and gives a true 24h sliding window).
-find "$cache_dir" -maxdepth 1 \( -name '*-*.txt' -o -name '.errors.log' \) -mmin +1440 -delete 2>/dev/null || true
+# Opportunistic sweep: drop buffers older than 24h. Throttled to ~1 in 50 calls
+# so this maintenance traversal doesn't ride every Skill dispatch on the telemetry
+# hot path (#501); orphans are still reaped within ~50 calls. SKILL_SWEEP_EVERY is
+# a test seam: 1 forces every call, 0 disables it deterministically (a large
+# divisor only makes firing improbable — RANDOM can still draw exactly 0).
+sweep_every="${SKILL_SWEEP_EVERY:-50}"
+if (( sweep_every > 0 )) && (( RANDOM % sweep_every == 0 )); then
+  find "$cache_dir" -maxdepth 1 \( -name '*-*.txt' -o -name '.errors.log' \) -mmin +1440 -delete 2>/dev/null || true
+fi
 
 exit 0

--- a/hooks/worktree_permission_grant.sh
+++ b/hooks/worktree_permission_grant.sh
@@ -106,18 +106,15 @@ while IFS= read -r entry; do
                     P="**"
                     ;;
                 "$parent"/*)
-                    # Sibling worktree grant — remap to the current worktree.
+                    # Sibling worktree grant — remap the sub-path to THIS worktree.
+                    # A bare grant (no sub-path) or empty remainder grants NOTHING:
+                    # collapsing to "**" would broaden a *different* worktree's root
+                    # grant to the entire current worktree (fail-open, #501).
                     remainder="${abs_glob#"$parent"/}"
-                    # remainder = "<sibling-name>/rest" or "<sibling-name>"
                     case "$remainder" in
-                        */*)
-                            P="${remainder#*/}"
-                            ;;
-                        *)
-                            P="**"
-                            ;;
+                        */?*) P="${remainder#*/}" ;;
+                        *)    continue ;;
                     esac
-                    [ -z "$P" ] && P="**"
                     ;;
                 *)
                     # Unrelated absolute path (e.g. //tmp/x/**) — skip.
@@ -137,16 +134,13 @@ while IFS= read -r entry; do
                     P="**"
                     ;;
                 "$parent"/*)
+                    # Sibling worktree grant — see the //* branch above for rationale
+                    # on why a bare/empty remainder must fail closed (grant nothing).
                     remainder="${abs_glob#"$parent"/}"
                     case "$remainder" in
-                        */*)
-                            P="${remainder#*/}"
-                            ;;
-                        *)
-                            P="**"
-                            ;;
+                        */?*) P="${remainder#*/}" ;;
+                        *)    continue ;;
                     esac
-                    [ -z "$P" ] && P="**"
                     ;;
                 *)
                     continue

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -71,6 +71,27 @@ class TestRmRfBlocker:
         "ls;rm -rf /",
         "ls;rm -rf /Users/foo",
         "ls&&rm -rf /home/foo",
+        # newline/tab-separated rm — the fast-exit case gate must fold the
+        # same separator alphabet as the grep detector (issue #501)
+        "echo hi\nrm -rf ~",
+        "echo hi\trm -rf /",
+        "true;\nrm -Rf $HOME",
+        # comment-strip must run BEFORE the newline fold, else an early
+        # comment on line 1 would swallow a destructive rm on line 2
+        "git push --force  # note\nrm -rf /",
+        # a trailing comment on the SAME line as rm must not hide it —
+        # the rm precedes the comment marker
+        "rm -rf / # cleanup",
+        # a '#' INSIDE a quoted string is not a real shell comment — the
+        # comment-strip must be quote-aware, or it silently truncates real
+        # command text after it (issue #501 review finding)
+        'echo "note # nope" && rm -rf ~',
+        # quote state must persist ACROSS an embedded newline inside a still-
+        # open quoted string (e.g. a multi-line -m commit message) — resetting
+        # quote tracking per-line would let a '#'-starting continuation line
+        # swallow real command text that follows on the SAME physical line
+        # (issue #501 re-review finding)
+        'git commit -m "line one\n# note" && rm -rf ~',
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)
@@ -123,6 +144,10 @@ class TestForcePushBlocker:
         "git push --force origin HEAD:release/1.2",
         "git push --force origin release/1.2:release/1.2",
         "git push --force origin release/x:main",
+        # quote state spanning an embedded newline inside an open quote must
+        # not let a '#'-starting continuation line swallow the real force-push
+        # that follows on the same physical line (issue #501 re-review finding)
+        'git commit -m "line one\n# note" && git push --force origin main',
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)
@@ -149,6 +174,162 @@ class TestForcePushBlocker:
         result = run_guard(guard_script, cmd)
         assert result.returncode == 0, (
             f"Expected exit 0 (ALLOWED) for {cmd!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+
+# ──────────────────────────────────────────────
+# implicit-branch force-push — branch-aware (requires temp git repo)
+# ──────────────────────────────────────────────
+
+class TestImplicitForcePushBlocker:
+    """git push --force/-f with NO explicit refspec, relying on
+    push.default/upstream, from a protected branch (issue #501 Block 2).
+    """
+
+    @pytest.mark.parametrize("branch", ["main", "master", "release/2025-01"])
+    @pytest.mark.parametrize("cmd", ["git push --force", "git push -f"])
+    def test_blocked_on_protected_branch(self, guard_script, repo_on, branch, cmd):
+        repo = repo_on(branch)
+        result = run_guard(guard_script, cmd, cwd=str(repo))
+        assert result.returncode == 2, (
+            f"Expected BLOCKED for {cmd!r} on branch {branch!r}, got exit "
+            f"{result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    @pytest.mark.parametrize("cmd", ["git push --force", "git push -f"])
+    def test_allowed_on_feature_branch(self, guard_script, repo_on, cmd):
+        repo = repo_on("feature/x")
+        result = run_guard(guard_script, cmd, cwd=str(repo))
+        assert result.returncode == 0, (
+            f"Expected ALLOWED for {cmd!r} on feature/x, got exit "
+            f"{result.returncode}\nstderr: {result.stderr!r}"
+        )
+
+    def test_explicit_nonprotected_refspec_still_allowed(self, guard_script, repo_on):
+        """An explicit non-protected refspec must not regress — Block 1
+        already owns explicit protected refspecs, Block 2 only fires when
+        no refspec is present at all.
+        """
+        repo = repo_on("main")
+        result = run_guard(guard_script, "git push --force origin feat", cwd=str(repo))
+        assert result.returncode == 0, (
+            f"Expected ALLOWED, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_trailing_comment_false_positive_still_allowed(self, guard_script):
+        """A protected token in a trailing shell comment must not over-block
+        (no repo fixture needed — this never reaches the branch check).
+        """
+        result = run_guard(guard_script, "git push -f origin feat # rebased onto main")
+        assert result.returncode == 0, (
+            f"Expected ALLOWED, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_quoted_hash_does_not_hide_implicit_force_push(self, guard_script, repo_on):
+        """A '#' inside a quoted string (e.g. a commit message referencing an
+        issue number) must not be treated as a comment — it must not hide a
+        chained implicit force-push from a protected branch.
+        """
+        repo = repo_on("main")
+        result = run_guard(
+            guard_script, 'echo "see issue #501" && git push --force', cwd=str(repo)
+        )
+        assert result.returncode == 2, (
+            f"Expected BLOCKED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_chained_nonforce_push_does_not_hide_forced_push(self, guard_script, repo_on):
+        """An explicit, innocuous push chained BEFORE an implicit force-push
+        must not cause Block 2 to inspect the wrong invocation and miss the
+        dangerous one.
+        """
+        repo = repo_on("main")
+        result = run_guard(
+            guard_script, "git push origin feature && git push --force", cwd=str(repo)
+        )
+        assert result.returncode == 2, (
+            f"Expected BLOCKED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_tab_separated_prefix_does_not_hide_forced_push(self, guard_script, repo_on):
+        """A tab-separated command prefix before the force-push must not leak
+        into the isolated push invocation and miscount positionals.
+        """
+        repo = repo_on("main")
+        result = run_guard(guard_script, "echo hi\tgit push --force", cwd=str(repo))
+        assert result.returncode == 2, (
+            f"Expected BLOCKED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_separate_word_push_option_does_not_hide_implicit_force_push(
+        self, guard_script, repo_on
+    ):
+        """A separate-word push option (`-o ci.skip`) must not be miscounted
+        as the first positional (remote) — that would let the real remote
+        token flip has_refspec and silently allow the implicit force-push
+        (senior-engineer consult, issue #501).
+        """
+        repo = repo_on("main")
+        result = run_guard(guard_script, "git push -o ci.skip --force origin", cwd=str(repo))
+        assert result.returncode == 2, (
+            f"Expected BLOCKED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_separate_word_push_option_repeated_still_blocked(self, guard_script, repo_on):
+        """Multiple unrecognized separate-word flags must each consume their
+        own value token, not accumulate into a false explicit-refspec read.
+        """
+        repo = repo_on("main")
+        result = run_guard(
+            guard_script,
+            "git push -o ci.skip -o merge_request.create --force origin",
+            cwd=str(repo),
+        )
+        assert result.returncode == 2, (
+            f"Expected BLOCKED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_separate_word_push_option_with_explicit_branch_still_allowed(
+        self, guard_script, repo_on
+    ):
+        """An explicit remote+branch after a separate-word option must still
+        count as an explicit refspec — the consume-next fix must not
+        over-block a genuinely explicit, non-protected destination.
+        """
+        repo = repo_on("main")
+        result = run_guard(
+            guard_script,
+            "git push -o ci.skip --force origin feat-branch",
+            cwd=str(repo),
+        )
+        assert result.returncode == 0, (
+            f"Expected ALLOWED, got exit {result.returncode}\nstderr: {result.stderr!r}"
+        )
+
+    @pytest.mark.parametrize("flag", ["-u", "--set-upstream", "-d", "--delete"])
+    def test_known_boolean_push_flag_does_not_over_block_explicit_refspec(
+        self, guard_script, repo_on, flag
+    ):
+        """A common boolean-only push flag (-u/--set-upstream/-d/--delete)
+        must not be mistaken for a value-taking flag — that would swallow the
+        real remote token and misclassify an explicit, non-protected refspec
+        as implicit, over-blocking legitimate work (re-review finding).
+        """
+        repo = repo_on("main")
+        result = run_guard(
+            guard_script, f"git push {flag} origin feature-branch --force", cwd=str(repo)
+        )
+        assert result.returncode == 0, (
+            f"Expected ALLOWED for flag {flag!r}, got exit {result.returncode}\n"
             f"stderr: {result.stderr!r}"
         )
 

--- a/tests/test_skill_usage_telemetry.py
+++ b/tests/test_skill_usage_telemetry.py
@@ -64,13 +64,18 @@ def _env(plugin_root: Path, cache_dir: Path) -> dict:
     return env
 
 
-def _run_record(stdin_json: dict, plugin_root: Path, cache_dir: Path) -> subprocess.CompletedProcess:
+def _run_record(
+    stdin_json: dict, plugin_root: Path, cache_dir: Path, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    env = _env(plugin_root, cache_dir)
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         ["bash", str(RECORD_SH)],
         input=json.dumps(stdin_json),
         capture_output=True,
         text=True,
-        env=_env(plugin_root, cache_dir),
+        env=env,
     )
 
 
@@ -201,7 +206,10 @@ class TestRecordHook:
         assert _buffer_files(cache_dir) == []
 
     def test_sweep_removes_old_buffers(self, plugin_root, cache_dir):
-        """Files older than 24h are swept on each hook invocation."""
+        """Files older than 24h are swept when the throttle fires (issue #501:
+        the sweep is throttled to ~1-in-50 calls; force it here with
+        SKILL_SWEEP_EVERY=1 so the assertion stays deterministic).
+        """
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         old_file = skill_cache / "20240101-old-agent.txt"
@@ -218,11 +226,14 @@ class TestRecordHook:
             },
             plugin_root,
             cache_dir,
+            extra_env={"SKILL_SWEEP_EVERY": "1"},
         )
         assert not old_file.exists(), "Old buffer should have been swept"
 
     def test_sweep_removes_old_errors_log(self, plugin_root, cache_dir):
-        """Stale .errors.log older than 24h is swept alongside old buffer files."""
+        """Stale .errors.log older than 24h is swept alongside old buffer
+        files when the throttle fires (forced via SKILL_SWEEP_EVERY=1).
+        """
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         errors_log = skill_cache / ".errors.log"
@@ -238,11 +249,14 @@ class TestRecordHook:
             },
             plugin_root,
             cache_dir,
+            extra_env={"SKILL_SWEEP_EVERY": "1"},
         )
         assert not errors_log.exists(), "Stale .errors.log should have been swept"
 
     def test_sweep_retains_fresh_errors_log(self, plugin_root, cache_dir):
-        """A recent .errors.log (< 24h old) must NOT be swept."""
+        """A recent .errors.log (< 24h old) must NOT be swept, even when the
+        throttle is forced to fire on every call.
+        """
         skill_cache = _skill_cache(cache_dir)
         skill_cache.mkdir(parents=True)
         errors_log = skill_cache / ".errors.log"
@@ -259,8 +273,55 @@ class TestRecordHook:
             },
             plugin_root,
             cache_dir,
+            extra_env={"SKILL_SWEEP_EVERY": "1"},
         )
         assert errors_log.exists(), "Fresh .errors.log must be retained"
+
+    def test_sweep_suppressed_by_throttle(self, plugin_root, cache_dir):
+        """SKILL_SWEEP_EVERY=0 deterministically disables the sweep — an old
+        buffer survives the call every time (issue #501 finding #4). A large
+        divisor like 999999 would only make firing *improbable* (RANDOM can
+        still draw exactly 0), so 0 is the seam that guarantees suppression.
+        """
+        skill_cache = _skill_cache(cache_dir)
+        skill_cache.mkdir(parents=True)
+        old_file = skill_cache / "20240101-old-agent.txt"
+        old_file.write_text("old-skill\n")
+        old_mtime = time.time() - 25 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        result = _run_record(
+            {
+                "agent_id": "new-999",
+                "agent_type": "reviewer",
+                "tool_input": {"skill": "swe-workbench:principle-code-review"},
+            },
+            plugin_root,
+            cache_dir,
+            extra_env={"SKILL_SWEEP_EVERY": "0"},
+        )
+        assert old_file.exists(), "Throttle should have suppressed the sweep"
+        assert result.stderr == "", f"SKILL_SWEEP_EVERY=0 must not error: {result.stderr!r}"
+
+    def test_append_path_unaffected_by_throttle(self, plugin_root, cache_dir):
+        """The current-day buffer append must happen regardless of whether
+        the sweep throttle fires on this particular call.
+        """
+        for sweep_every in ("1", "999999"):
+            result = _run_record(
+                {
+                    "agent_id": f"append-{sweep_every}",
+                    "agent_type": "reviewer",
+                    "tool_input": {"skill": "swe-workbench:principle-code-review"},
+                },
+                plugin_root,
+                cache_dir,
+                extra_env={"SKILL_SWEEP_EVERY": sweep_every},
+            )
+            assert result.returncode == 0
+            matches = [b for b in _buffer_files(cache_dir) if b.name.endswith(f"-append-{sweep_every}.txt")]
+            assert len(matches) == 1, f"Expected buffer for SKILL_SWEEP_EVERY={sweep_every}"
+            assert "swe-workbench:principle-code-review" in matches[0].read_text()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_worktree_permission_grant.py
+++ b/tests/test_worktree_permission_grant.py
@@ -284,6 +284,54 @@ class TestWorktreePermissionGrant:
         assert result.returncode == 0
         assert json.loads(result.stdout) == _ALLOW_JSON
 
+    def test_bare_sibling_grant_denies_current_worktree_root(self, wt_env):
+        """A sibling grant with NO sub-path must fail closed — it must not
+        remap to '**' and silently broaden to the current worktree's own
+        root (issue #501 finding #3).
+        """
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)})"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_trailing_slash_sibling_grant_denies_current_worktree_root(self, wt_env):
+        """Same fail-closed behavior for a bare sibling grant with a
+        trailing slash and no further sub-path.
+        """
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/)"])
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "README")},
+            }
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_sibling_subpath_grant_still_remaps(self, wt_env):
+        """A sibling grant WITH a sub-path must still remap correctly —
+        the fail-closed fix must not regress the existing remap behavior.
+        """
+        wt, other = wt_env["wt"], wt_env["other"]
+        _settings(wt, [f"Read({_cc_abs(other)}/src/**)"])
+        (wt / "src").mkdir()
+        (wt / "src" / "y.md").write_text("content")
+        result = _run(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(wt / "src" / "y.md")},
+            }
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == _ALLOW_JSON
+
     def test_single_slash_abs_glob_matches(self, wt_env):
         wt = wt_env["wt"]
         _settings(wt, [f"Read({str(wt)}/**)"])


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `hooks/bash_guard.sh`: the destructive-`rm` guard's fast-exit `case` gate folded only `;|&`, narrower than the grep detector's `[[:space:]]`, so a newline/tab-separated `rm -rf ~` could bypass it. Comment-stripping is now quote-aware (tracks single/double-quote state in an `awk` `BEGIN` block so it persists across an embedded newline inside a still-open quote) and runs before folding `;|&\n\t` to one shared separator alphabet across the fast-gate and both detectors.
- `hooks/bash_guard.sh`: added an additive Block 2 for `git push --force`/`-f` with **no** explicit refspec (relying on `push.default`/upstream) from a protected branch (main/master/release/*) — previously a false negative. The push-invocation token scan isolates the force-flagged `git push` line specifically (not just the first `git push` line, so a chained non-force push can't hide the real one), and treats any unrecognized flag as taking a separate-word value it defensively consumes, so it can never be miscounted as the remote/refspec. `--force-with-lease` and Block 1's destination-refspec matching are untouched (settled behavior from #163/#199/#382).
- `hooks/worktree_permission_grant.sh`: a bare sibling-worktree grant with no sub-path (or a trailing slash and empty remainder) was remapping to `P="**"`, silently broadening a *different* worktree's root grant into a grant of the **entire current worktree**. Now fails closed (grants nothing) for bare/empty-remainder sibling grants in both the `//*` and `/*` glob branches.
- `hooks/skill_usage_record.sh`: the 24h orphan-buffer `find` sweep ran on every Skill dispatch, riding the telemetry hot path. Throttled to ~1-in-50 calls via an env-seamed modulo (`SKILL_SWEEP_EVERY`), with `0` as a deterministic "disable" value (avoids a `RANDOM % 0` division error and an inherent test flake from relying on a large-but-not-infinite divisor).

All four fixes are covered by failing-first tests. This PR went through two rounds of independent code review plus a senior-engineer consult on the force-push token-parsing edge case (`-o <value>`-style separate-word push options); both review rounds surfaced real bypasses that are fixed here (a quote-unaware comment strip, wrong-invocation selection when multiple `git push` calls are chained, and a multi-line quoted string not preserving quote state across the embedded newline).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually

### Type-tailored checks (fix)
- [x] Reproduced each of the four original defects against the pre-fix code (manual hook invocation with crafted payloads), confirming they were real
- [x] Reproduced the fix closing each defect via the same manual invocation
- [x] Full regression suite: `pytest tests/ -v` — 1590 passed
- [x] `shellcheck -S warning hooks/bash_guard.sh hooks/worktree_permission_grant.sh hooks/skill_usage_record.sh` — clean
- [x] `bash scripts/validate.sh` — clean
- [x] Confirmed no regression to settled behavior: `--force-with-lease`/`--force-if-includes` still unblocked, Block 1's destination-refspec (`HEAD:main`, `main:main`, `release/*`) matching byte-for-byte unchanged, `worktree_permission_grant.sh`'s own-root (`wt_root`/`wt_root/*`) fallback unchanged

Closes #501
