### PR TITLE
[feat] Fire worktree re-anchor nudge on startup/resume, not just compaction

### DIFF
--- a/docs/workflow-state.md
+++ b/docs/workflow-state.md
@@ -56,7 +56,7 @@ but different branches never share a checkpoint file.
 - `context` — flat free-form bag; `context.branch` is the resume-validation key. Skills pack skill-specific values here (`pr`, `head_sha`, `decision` for pr-review; project-detection values for workflow-development). `context.worktree_root` records the absolute path of the worktree where the session is doing its work — populate it with `git rev-parse --show-toplevel` at Phase 1 checkpoint, or omit it when working in the main checkout.
 - `updated_at` — ISO-8601 timestamp (informational — not used for staleness; the hook uses filesystem mtime instead).
 
-**Coverage limit for the worktree re-anchor nudge:** The resume hook is compaction-only (`SessionStart` with `matcher: "compact"`). As of issue #497, the nudge fires independently of the sidecar gate: it probes `git rev-parse --git-dir --git-common-dir` directly and fires whenever cwd resolves to a linked worktree — including the *same-path* case (a fresh sidecar's `worktree_root` already matches the live root) and the *sidecar-less* case (no checkpoint exists at all, e.g. a workflow that never wrote one). Only when cwd is **not** a linked worktree does the hook stay silent. It **cannot** redirect to a *foreign* worktree it has no checkpoint for (e.g. a session that was always anchored in the wrong dir but never compacted) — path mismatch still only produces the `REQUIRED` variant when a sidecar records a differing `worktree_root`. It also does not fire on a cold fresh launch or session "continuation" (a non-compaction resume) — this remains a residual coverage limit, since the hook's `matcher: "compact"` only targets compaction-triggered `SessionStart` events. The worktree_root nudge is defense-in-depth; the primary guidance lives in `skills/workflow-worktree-session/SKILL.md` and the plan template.
+**Coverage limit for the worktree re-anchor nudge:** As of issue #497, the nudge fires independently of the sidecar gate: it probes `git rev-parse --git-dir --git-common-dir` directly and fires whenever cwd resolves to a linked worktree — including the *same-path* case (a fresh sidecar's `worktree_root` already matches the live root) and the *sidecar-less* case (no checkpoint exists at all, e.g. a workflow that never wrote one). Only when cwd is **not** a linked worktree does the hook stay silent. As of issue #524, the hook also fires on `startup` (cold launch) and `resume` (`--continue`/`--resume`/`/resume`), not only `compact` — closing the gap where a non-compaction session resume left `EnterWorktree` tracking silently unrecovered. Wording is source-aware: a `startup`/`resume` firing never claims "this session was compacted" (see `context.worktree_root` note below and the Hook registration table). Two intentional gaps remain: `clear` (`/clear`) is not covered, since anchoring generally survives it (same process, same cwd); and the hook still **cannot** redirect to a *foreign* worktree it has no checkpoint for (e.g. a session that was always anchored in the wrong dir) — path mismatch still only produces the `REQUIRED` variant when a sidecar records a differing `worktree_root`. The worktree_root nudge is defense-in-depth; the primary guidance lives in `skills/workflow-worktree-session/SKILL.md` and the plan template.
 
 ### Lifecycle
 
@@ -64,9 +64,9 @@ but different branches never share a checkpoint file.
 |---|---|---|
 | **Model** | Phase/step transition | Write (overwrite) the state file with the new phase |
 | **Model** | Terminal phase success | Delete the state file |
-| **Hook** | SessionStart(compact) | Read the file; inject resume preamble if fresh + valid |
-| **Hook** | SessionStart(compact), file >24h old | Delete the file; no injection (staleness sweep) |
-| **Hook** | SessionStart(compact), branch mismatch or version ≠ 1 | No injection (fail-open, file untouched) |
+| **Hook** | SessionStart(startup\|resume\|compact) | Read the file; inject resume preamble if fresh + valid |
+| **Hook** | SessionStart(startup\|resume\|compact), file >24h old | Delete the file; no injection (staleness sweep) |
+| **Hook** | SessionStart(startup\|resume\|compact), branch mismatch or version ≠ 1 | No injection (fail-open, file untouched) |
 
 The state file is a **fail-soft cache, not a source of truth**. The model owns the semantic
 lifecycle (write/delete at phase boundaries). The hook owns the mechanical lifecycle
@@ -77,10 +77,20 @@ to "ask", because a wrong resume is worse than no resume.
 
 | Event | Matcher | Script |
 |---|---|---|
+| `SessionStart` | `"startup"` | `hooks/workflow_resume_hint.sh` |
+| `SessionStart` | `"resume"` | `hooks/workflow_resume_hint.sh` |
 | `SessionStart` | `"compact"` | `hooks/workflow_resume_hint.sh` |
 
-`SessionStart` requires a `matcher` string (not a lifecycle event in `validate.py`); the
-`"compact"` matcher targets only compaction-triggered session starts.
+`SessionStart` requires a `matcher` string (not a lifecycle event in `validate.py`); each
+matcher is registered as its own explicit single-matcher entry (rather than one piped
+`"startup|resume|compact"` entry) so a silent non-match on unsupported piped-matcher
+regex support would be visible rather than invisible. Together the three matchers cover
+cold launch (`startup`), continuation via `--continue`/`--resume`/`/resume` (`resume`),
+and auto-compaction (`compact`). `"clear"` (`/clear`) is intentionally not registered —
+`/clear` keeps the same process and cwd, so `EnterWorktree` anchoring generally survives
+it. The injected wording is conditioned on the SessionStart `.source` field (see
+`hooks/workflow_resume_hint.sh`'s `set_framing`) so a `startup`/`resume` firing never
+falsely claims "this session was compacted".
 
 The hook always exits 0 — it never blocks session startup.
 
@@ -129,6 +139,25 @@ echo '{"cwd":"'"$(git rev-parse --show-toplevel)"'"}' \
   | bash hooks/workflow_resume_hint.sh
 
 # Expected: JSON with hookSpecificOutput.additionalContext containing the skill name and phase.
+# No .source field → neutral wording ("[Workflow auto-resume]" / "This session resumed.").
+
+# 2b. Reproduce each source-aware framing by adding a `.source` field.
+# `source` selects the wording: compact | resume | startup | (absent/other → neutral).
+for src in compact resume startup; do
+  echo "--- source=$src ---"
+  jq -cn --arg cwd "$(git rev-parse --show-toplevel)" --arg source "$src" \
+    '{cwd: $cwd, source: $source}' \
+    | bash hooks/workflow_resume_hint.sh \
+    | jq -r '.hookSpecificOutput.additionalContext' | head -3
+done
+
+# Expected headers, respectively:
+#   [Workflow auto-resume after compaction]   / "This session was compacted."
+#   [Workflow auto-resume after continuation] / "This session was resumed/continued."
+#   [Workflow auto-resume on startup]         / "This is a fresh session start."
+# None but the `compact` case may contain the word "compacted". The startup intro is
+# worktree-agnostic by design — the worktree-specific claim (is this cwd a linked
+# worktree?) belongs to the separately gated reanchor_line/format_advisory, not the intro.
 
 # 3. Test the no-op path (no file)
 rm "$STATEDIR/${SAFE}.json"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -61,6 +61,24 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+          }
+        ]
+      },
+      {
         "matcher": "compact",
         "hooks": [
           {

--- a/hooks/workflow_resume_hint.sh
+++ b/hooks/workflow_resume_hint.sh
@@ -1,20 +1,50 @@
 #!/usr/bin/env bash
-# workflow_resume_hint.sh — SessionStart(compact) hook
+# workflow_resume_hint.sh — SessionStart(startup|resume|compact) hook
 #
-# Fires after auto-compaction. Detects a fresh, branch-matching workflow
-# checkpoint and injects a resume preamble so the model re-enters the
-# interrupted workflow at the correct phase.
+# Fires on cold launch, session continuation (--continue/--resume), and
+# auto-compaction. Detects a fresh, branch-matching workflow checkpoint and
+# injects a resume preamble so the model re-enters the interrupted workflow
+# at the correct phase. Wording is conditioned on the SessionStart `.source`
+# field so a non-compaction resume never falsely claims "this session was
+# compacted".
 #
 # Fail-open: exit 0 unconditionally. A broken hook must never block startup.
 
+# Sets advisory_lead/preamble_header/preamble_intro from $session_source.
+# Reads $session_source and writes into main()'s locals via dynamic scoping.
+set_framing() {
+    case "$session_source" in
+        compact)
+            advisory_lead="WORKTREE RE-ANCHOR ADVISORY: Compaction may have dropped EnterWorktree tracking"
+            preamble_header="[Workflow auto-resume after compaction]"
+            preamble_intro="This session was compacted."
+            ;;
+        resume)
+            advisory_lead="WORKTREE RE-ANCHOR ADVISORY: Resuming this session may have dropped EnterWorktree tracking"
+            preamble_header="[Workflow auto-resume after continuation]"
+            preamble_intro="This session was resumed/continued."
+            ;;
+        startup)
+            advisory_lead="WORKTREE RE-ANCHOR ADVISORY: This session is not EnterWorktree-anchored"
+            preamble_header="[Workflow auto-resume on startup]"
+            preamble_intro="This is a fresh session start."
+            ;;
+        *)
+            advisory_lead="WORKTREE RE-ANCHOR ADVISORY: EnterWorktree tracking may not be active"
+            preamble_header="[Workflow auto-resume]"
+            preamble_intro="This session resumed."
+            ;;
+    esac
+}
+
 # Shared advisory wording; $1 is the clause explaining why cwd is suspect.
-# Reads $root via dynamic scoping from main().
+# Reads $advisory_lead/$root via dynamic scoping from main().
 format_advisory() {
     local clause="$1"
     # Backticks below are literal markdown ticks, not command substitution.
     # shellcheck disable=SC2016
-    printf 'WORKTREE RE-ANCHOR ADVISORY: Compaction may have dropped EnterWorktree tracking even though your cwd (`%s`) %s. Call `EnterWorktree(path=%s)` to be safe — idempotent and harmless if you'"'"'re still anchored. A later `ExitWorktree` no-op is consistent with this, though not proof — cd-entry looks identical.' \
-        "$root" "$clause" "$root"
+    printf '%s even though your cwd (`%s`) %s. Call `EnterWorktree(path=%s)` to be safe — idempotent and harmless if you'"'"'re still anchored. A later `ExitWorktree` no-op is consistent with this, though not proof — cd-entry looks identical.' \
+        "$advisory_lead" "$root" "$clause" "$root"
 }
 
 # Nudges when cwd is a linked worktree but there's no usable checkpoint to
@@ -34,10 +64,13 @@ main() {
     local worktree_root real_wt_root real_live_root cmp_wt_root cmp_live_root reanchor_line
     local git_dir git_common_dir real_git_dir real_common_dir cmp_git_dir cmp_common_dir
     local is_linked_worktree
+    local session_source advisory_lead preamble_header preamble_intro
 
     input=$(cat)
     cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || return 0
     [ -n "$cwd" ] || cwd="$PWD"
+    session_source=$(printf '%s' "$input" | jq -r '.source // empty' 2>/dev/null) || session_source=""
+    set_framing
 
     # Resolve git root — absent in non-git directories, which is fine
     root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || return 0
@@ -153,9 +186,9 @@ $(format_advisory "is a linked worktree")
     fi
 
     # Build preamble
-    preamble="[Workflow auto-resume after compaction]
+    preamble="${preamble_header}
 
-This session was compacted. A workflow checkpoint was found for branch: ${branch}.
+${preamble_intro} A workflow checkpoint was found for branch: ${branch}.
 
 Skill:            ${skill}
 Current phase:    Phase ${phase}${phase_label:+ — ${phase_label}}${mode:+ (Mode ${mode})}

--- a/tests/test_workflow_resume_hook.py
+++ b/tests/test_workflow_resume_hook.py
@@ -1,9 +1,10 @@
-"""Tests for hooks/workflow_resume_hint.sh — SessionStart compact hook.
+"""Tests for hooks/workflow_resume_hint.sh — SessionStart(startup|resume|compact) hook.
 
 Each test invokes hooks/workflow_resume_hint.sh directly with a JSON payload on
-stdin, mirroring how Claude Code calls the SessionStart hook after auto-compaction.
-Exit 0 always (fail-open). Injection only when a fresh, branch-matching v1 state
-file exists.
+stdin, mirroring how Claude Code calls the SessionStart hook on cold launch,
+continuation, or auto-compaction. Exit 0 always (fail-open). Injection only when
+a fresh, branch-matching v1 state file exists (or, for the standalone advisory,
+when cwd is a linked worktree).
 """
 
 import json
@@ -81,8 +82,11 @@ def _write_state(repo_dir: Path, state: dict, branch: str = _BRANCH) -> Path:
     return path
 
 
-def _run(script, cwd: str) -> subprocess.CompletedProcess:
-    payload = json.dumps({"cwd": cwd})
+def _run(script, cwd: str, source: str | None = None) -> subprocess.CompletedProcess:
+    payload_dict = {"cwd": cwd}
+    if source is not None:
+        payload_dict["source"] = source
+    payload = json.dumps(payload_dict)
     return subprocess.run(
         [str(script)],
         input=payload, text=True, capture_output=True,
@@ -95,28 +99,30 @@ def _run(script, cwd: str) -> subprocess.CompletedProcess:
 # ---------------------------------------------------------------------------
 
 class TestHookWiring:
-    """hooks.json has the right SessionStart entry; script exists and is executable."""
+    """hooks.json has the right SessionStart entries; script exists and is executable."""
 
     def test_session_start_entry_present(self):
         data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         entries = data["hooks"].get("SessionStart", [])
         assert entries, "SessionStart event missing from hooks.json"
 
-    def test_compact_matcher_present(self):
+    @pytest.mark.parametrize("matcher", ["startup", "resume", "compact"])
+    def test_matcher_present(self, matcher):
         data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         entries = data["hooks"].get("SessionStart", [])
-        compact = [e for e in entries if e.get("matcher") == "compact"]
-        assert compact, "No SessionStart entry with matcher='compact' in hooks.json"
+        matched = [e for e in entries if e.get("matcher") == matcher]
+        assert matched, f"No SessionStart entry with matcher='{matcher}' in hooks.json"
 
-    def test_hook_script_referenced(self):
+    @pytest.mark.parametrize("matcher", ["startup", "resume", "compact"])
+    def test_hook_script_referenced(self, matcher):
         data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
         entries = data["hooks"].get("SessionStart", [])
-        compact = [e for e in entries if e.get("matcher") == "compact"]
+        matched = [e for e in entries if e.get("matcher") == matcher]
         assert any(
             "workflow_resume_hint.sh" in hook["command"]
-            for e in compact
+            for e in matched
             for hook in e.get("hooks", [])
-        ), "workflow_resume_hint.sh not referenced in SessionStart compact entry"
+        ), f"workflow_resume_hint.sh not referenced in SessionStart {matcher} entry"
 
     def test_hook_script_exists_and_executable(self):
         assert HOOK.exists(), f"Missing hook script: {HOOK}"
@@ -494,6 +500,26 @@ class TestLinkedWorktreeReanchor:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
+    def test_standalone_nudge_source_compact_wording(self, hook_script, linked_worktree):
+        """No state file, cwd IS a linked worktree, source=compact → standalone
+        nudge uses the compaction-specific advisory_lead wording."""
+        result = _run(hook_script, str(linked_worktree), source="compact")
+
+        assert result.returncode == 0
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Compaction may have dropped EnterWorktree tracking" in ctx
+        assert "not EnterWorktree-anchored" not in ctx
+
+    def test_standalone_nudge_source_resume_wording(self, hook_script, linked_worktree):
+        """No state file, cwd IS a linked worktree, source=resume → standalone
+        nudge uses the resume-specific advisory_lead wording, not compaction's."""
+        result = _run(hook_script, str(linked_worktree), source="resume")
+
+        assert result.returncode == 0
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "Resuming this session may have dropped EnterWorktree tracking" in ctx
+        assert "Compaction may have dropped" not in ctx
+
     def test_standalone_nudge_when_sidecar_stale(self, hook_script, linked_worktree):
         """Stale (>24h) same-branch sidecar in a linked worktree → still nudge.
 
@@ -544,3 +570,95 @@ class TestLinkedWorktreeReanchor:
         assert result.stdout.strip(), "Expected a nudge despite the branch mismatch"
         ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
         assert "WORKTREE RE-ANCHOR" in ctx
+
+    def test_standalone_nudge_source_startup_no_dropped_claim(self, hook_script, linked_worktree):
+        """source=startup, no sidecar, linked worktree → standalone nudge fires but
+        must not claim tracking was 'dropped' or that the session was 'compacted' —
+        a fresh cold-launch process never had a prior EnterWorktree session to lose."""
+        result = _run(hook_script, str(linked_worktree), source="startup")
+
+        assert result.returncode == 0
+        assert result.stdout.strip(), "Expected a standalone nudge on cold startup"
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "WORKTREE RE-ANCHOR" in ctx
+        assert "dropped" not in ctx.lower()
+        assert "compacted" not in ctx.lower()
+        assert "not EnterWorktree-anchored" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Source-aware framing (#524): startup/resume never falsely claim compaction
+# ---------------------------------------------------------------------------
+
+class TestSourceAwareFraming:
+    """The full resume preamble's wording is conditioned on SessionStart's
+    `.source` field so a non-compaction resume never claims 'this session was
+    compacted'."""
+
+    def test_source_compact_wording_unchanged(self, hook_script, git_repo):
+        """source=compact must preserve the original compaction wording exactly."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo), source="compact")
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume after compaction]" in ctx
+        assert "This session was compacted." in ctx
+
+    def test_source_resume_wording(self, hook_script, git_repo):
+        """source=resume (--continue/--resume) must say 'resumed/continued', never
+        claim compaction happened."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo), source="resume")
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume after continuation]" in ctx
+        assert "This session was resumed/continued." in ctx
+        assert "compacted" not in ctx.lower()
+
+    def test_source_startup_wording(self, hook_script, git_repo):
+        """source=startup (cold launch) must not claim compaction or a dropped
+        session — there was no prior session to drop. `git_repo` is a plain
+        checkout, not a linked worktree, so the intro must not assert
+        worktree-specific facts either (that claim belongs to the separately
+        is_linked_worktree-gated reanchor_line/format_advisory, not the intro)."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo), source="startup")
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume on startup]" in ctx
+        assert "This is a fresh session start." in ctx
+        assert "compacted" not in ctx.lower()
+        assert "linked worktree" not in ctx.lower()
+
+    def test_absent_source_neutral_wording(self, hook_script, git_repo):
+        """No `.source` field at all (older harness payload) must default to
+        neutral wording, never asserting compaction happened."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo))
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume]" in ctx
+        assert "This session resumed." in ctx
+        assert "compacted" not in ctx.lower()
+
+    def test_unknown_source_value_falls_back_to_neutral(self, hook_script, git_repo):
+        """An unrecognized `.source` value must degrade to the neutral framing
+        rather than crashing or leaking the raw value into the preamble."""
+        _write_state(git_repo, VALID_STATE)
+        result = _run(hook_script, str(git_repo), source="some-future-source")
+        assert result.returncode == 0
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume]" in ctx
+        assert "This session resumed." in ctx
+        assert "compacted" not in ctx.lower()
+
+    def test_non_scalar_source_falls_back_to_neutral(self, hook_script, git_repo):
+        """A `.source` that is a JSON object/array (malformed payload) must still
+        degrade to neutral wording, not crash or leak raw JSON into the preamble."""
+        _write_state(git_repo, VALID_STATE)
+        payload = json.dumps({"cwd": str(git_repo), "source": {"a": 1}})
+        result = subprocess.run(
+            [str(hook_script)], input=payload, text=True, capture_output=True, env=_CLEAN_ENV,
+        )
+        assert result.returncode == 0
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        assert "[Workflow auto-resume]" in ctx
+        assert "This session resumed." in ctx
+        assert "compacted" not in ctx.lower()
+        assert '{"a"' not in ctx


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Extend `hooks/workflow_resume_hint.sh`'s `SessionStart` registration to fire on cold launch (`startup`) and continuation (`--continue`/`--resume`, matcher `resume`), not only auto-compaction (`compact`) — closing the residual coverage gap left by #497/PR #523.
- Registered as three explicit single-matcher `SessionStart` entries in `hooks/hooks.json` (not one piped `"startup|resume|compact"` matcher), since piped-matcher regex support for `SessionStart` was unconfirmed and a silent non-match would be invisible.
- Wording is now source-aware: the hook reads `.source` from the SessionStart payload and branches phrasing (`compact` → "compacted", `resume` → "resumed/continued", `startup` → no dropped/compacted claim since a fresh process had no prior session to lose, absent/unknown → neutral). The underlying gating logic (linked-worktree probe, sidecar/staleness/version/branch gates, `worktree_root` compare) is unchanged — only human-facing strings are conditioned on source.
- `docs/workflow-state.md` updated: coverage-limit note (gap closed for `startup`/`resume`; `clear` and foreign-worktree-with-no-checkpoint gaps remain and are now explicitly named), lifecycle table, hook registration table, and manual smoke-test snippet extended to reproduce all three framings.
- `clear` (`/clear`) is intentionally NOT registered — it keeps the same process/cwd, so `EnterWorktree` anchoring generally survives it.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — hooks.json schema-valid with 3 SessionStart entries
- [x] `shellcheck hooks/workflow_resume_hint.sh` — clean

### Type-tailored checks (feat)
- [x] New behavior verified directly: drove `hooks/workflow_resume_hint.sh` with `source=compact|resume|startup` payloads and confirmed each framing's exact wording (see `docs/workflow-state.md`'s manual smoke-test snippet, which reproduces this)
- [x] `pytest tests/test_workflow_resume_hook.py -v` — 45/45 passed (wiring, source-aware framing, standalone-advisory-per-source, non-scalar `.source` fallback)
- [x] Full suite: `pytest tests/ -v` — 1705/1705 passed, no regressions
- [x] Two independent parallel reviews (plan-alignment + diff correctness/security/design) both returned "Ready to merge: Yes" after one real finding (startup intro falsely claiming "linked worktree" even in a plain checkout) was found, fixed, and re-verified

Closes #524
