### PR TITLE
[chore] Ignore all .rimba/*.local.toml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 scripts/__pycache__/
 *.pyc
 .venv/
-.rimba/settings.local.toml
 .claude/cache/
 .superpowers/
 docs/superpowers/
+.rimba/*.local.toml


### PR DESCRIPTION
## Summary
- Broaden the `.gitignore` pattern for local rimba config from `.rimba/settings.local.toml` to `.rimba/*.local.toml`, so any `*.local.toml` file under `.rimba/` is ignored, not just `settings.local.toml`.

## Test Plan
- [ ] Changed skills/commands/agents load without errors
- [x] Confirmed the new glob matches `.rimba/settings.local.toml` and other `*.local.toml` variants via `git check-ignore`

### Type-tailored checks (chore)
- [x] Repo builds/validates cleanly (`pre-push` hook test suite: 1727 passed)

Issue: N/A — trivial gitignore pattern broadening
