### PR TITLE
[docs] Update README/catalog for agent and manifest drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "swe-workbench",
-      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
+      "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
       "version": "0.1.22",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
   "version": "0.1.22",
-  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
+  "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",
     "email": "11341007+lugassawan@users.noreply.github.com",
@@ -22,6 +22,7 @@
     "bash",
     "csharp",
     "dotnet",
+    "dart",
     "golang",
     "java",
     "kotlin",

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ cd swe-workbench
 ## What's inside
 
 - **Commands** — `/swe-workbench:review`, `/swe-workbench:design`, `/swe-workbench:architect`, `/swe-workbench:document`, `/swe-workbench:refactor`, `/swe-workbench:migrate`, `/swe-workbench:debug`, `/swe-workbench:implement`, `/swe-workbench:extend`, `/swe-workbench:test`, `/swe-workbench:security-review`, `/swe-workbench:capture`, `/swe-workbench:report-issue`, `/swe-workbench:cleanup-merged`, `/swe-workbench:sync`, `/swe-workbench:address-feedback`, `/swe-workbench:audit-codebase`, `/swe-workbench:codebase-knowledge`, `/swe-workbench:doctor` — see [docs/catalog.md](docs/catalog.md).
-- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `code-impl`, `conflict-resolver`, `contributor-auditor`, `debugger`, `dependency-auditor`, `migrator`, `performance-tuner`, `product-designer`, `product-manager`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
+- **Subagents** — `accessibility-auditor`, `architect`, `auditor`, `code-impl`, `conflict-resolver`, `contributor-auditor`, `debugger`, `dependency-auditor`, `e2e-test-verifier`, `e2e-test-writer`, `migrator`, `performance-tuner`, `product-designer`, `product-manager`, `redundancy-assessor`, `refactorer`, `reviewer`, `security-auditor`, `senior-engineer`, `tech-writer`, `test-reviewer`, `test-writer` — see [docs/catalog.md](docs/catalog.md).
 - **Principles** — Clean Architecture, DDD, SOLID, TDD, design patterns, clean code, observability, API design, concurrency, data modeling, error handling, security, product design — auto-hint by trigger keyword.
 - **Languages** — Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript — auto-hint by file extension (subagents load deterministically via catalog injection).
-- **Integrations** — `ticket-context` — auto-loads on ticket references (Jira, Confluence, GitHub) to feed the full spec into commands.
+- **Integrations** — external-service context skills (`ticket-context`, `observability-context`, `comms-context`) — auto-load on ticket references, Sentry links, Slack/PagerDuty links to feed the full context into commands — see [docs/catalog.md](docs/catalog.md).
 - **Workflows** — `development` orchestrator wrapping the full 5-phase implementation lifecycle; `workflow-audit-emit-issues` files grouped GitHub issues from codebase audit findings.
 
 Full reference tables → [docs/catalog.md](docs/catalog.md). Extending guide and philosophy → [docs/extending.md](docs/extending.md). Runtime dependencies → [docs/dependencies.md](docs/dependencies.md).
@@ -48,10 +48,12 @@ full pattern list, suppression options, and security notes.
 
 When Claude Code auto-compacts a long conversation, any in-progress `workflow-development`,
 `workflow-bug-triage`, or `workflow-pr-review` state is saved to a sidecar JSON file under
-`.claude/cache/workflow-state/`. A `SessionStart` hook detects this file after compaction
-and injects a resume preamble so the workflow continues at the correct phase — no manual
-restart needed. See [docs/workflow-state.md](docs/workflow-state.md) for the schema,
-lifecycle table, and a manual smoke test.
+`.claude/cache/workflow-state/`. A `SessionStart` hook detects this file and injects a
+resume preamble so the workflow continues at the correct phase — no manual restart needed.
+The hook fires on compaction as well as on plain session startup/resume, and also nudges a
+worktree re-anchor when the session's cwd has drifted from a linked worktree. See
+[docs/workflow-state.md](docs/workflow-state.md) for the schema, lifecycle table, and a
+manual smoke test.
 
 ## Skill-usage telemetry
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -21,7 +21,7 @@
 | `/swe-workbench:audit-codebase [--time-box <dur>] [--scope <list>] [--depth <quick\|standard\|deep>]` | Cold-start, time-boxed, multi-domain defect sweep — ranked findings with reasoning chains. Use for take-home assessments, post-acquisition reviews, and tech-debt sweeps. |
 | `/swe-workbench:codebase-knowledge [path]` | Present a structured knowledge document (architecture overview, module map, public API surfaces, patterns). Read-only, understanding-oriented. Distinct from `/swe-workbench:audit-codebase` (defect detection) and `/swe-workbench:document` (prose-doc generation). |
 | `/swe-workbench:cleanup-merged [PR number]` | Remove the worktree, local branch, and remote branch for a merged PR. Defaults to the current branch. Squash-merge safe. |
-| `/swe-workbench:sync [--rebase]` | Bring the current branch up to date with the default branch — delegates the mechanical merge/rebase to rimba (or git), then walks through any conflicts file-by-file with a `conflict-resolver` recommendation and rationale before applying. Never auto-pushes; push is a separate, prompted step. Default strategy is merge; pass `--rebase` to rebase instead. |
+| `/swe-workbench:sync [--rebase] [--check-redundancy]` | Bring the current branch up to date with the default branch — delegates the mechanical merge/rebase to rimba (or git), then walks through any conflicts file-by-file with a `conflict-resolver` recommendation and rationale before applying. Never auto-pushes; push is a separate, prompted step. Default strategy is merge; pass `--rebase` to rebase instead. `--check-redundancy` runs an opt-in `redundancy-assessor` pass surfacing functional duplication the default branch already provides. |
 | `/swe-workbench:doctor` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) plus gh auth status. Prints a green/red table; never modifies state. Exit 0 regardless of findings. |
 
 ## Subagents
@@ -36,10 +36,13 @@
 | `contributor-auditor` | Triaging external PRs for author signal, diff-shape coherence, repo posture, and pattern-risk signals before merge. Advisory only — never posts to the PR. Invoked by `/swe-workbench:review --mode contributor-trust`. |
 | `debugger` | Bug diagnosis and minimal fix — composes `superpowers:systematic-debugging`, layers principle lens. |
 | `dependency-auditor` | Supply-chain hygiene audit — outdated versions, license conflicts, transitive bloat, lockfile drift. Invoked by `/swe-workbench:review --mode deps`. |
+| `e2e-test-verifier` | Runs newly-authored E2E specs via the project's detected command, distrusts false-green passes, confirms each spec exercises the stated behaviour. Invoked by `/swe-workbench:test --mode e2e` after the writer. |
+| `e2e-test-writer` | Explores a live app via Playwright MCP, authors durable spec files, mandates browser teardown with per-step deadlines. Invoked by `/swe-workbench:test --mode e2e`. |
 | `migrator` | Plan and execute a multi-deployment migration: DB schema, framework upgrade, runtime, API/contract, or event-schema. Produces a five-phase (Expand → Backfill → Dual-write → Switch → Contract) plan with rollback gates. Invoked by `/swe-workbench:migrate`. |
 | `performance-tuner` | Profile-driven hotspot triage — ranks bottlenecks from a flame graph or benchmark and recommends targeted optimizations. Refuses speculative optimization without profiling evidence. |
 | `product-designer` | Depth-first UX and design quality review of frontend diffs — usability heuristics, visual hierarchy, information architecture, interaction design, design-system compliance. Invoked by `/swe-workbench:review --mode ux`. |
 | `product-manager` | Drafts a well-framed GitHub issue from a raw idea — product framing (problem, value, RICE-lite), template detection, duplicate scan, and confirm gate. Invoked by `/swe-workbench:capture`. |
+| `redundancy-assessor` | Reads whole-file candidates the branch added against what the default branch grew independently, recommends auto-apply/escalate/none per candidate; never removes a file itself. Invoked by `/swe-workbench:sync --check-redundancy`. |
 | `refactorer` | Cleaning up smells before adding a feature. |
 | `reviewer` | PR review, diff audit, post-feature sanity check. |
 | `security-auditor` | Depth-first security audit of a diff or file (OWASP Top 10, secrets, dependency CVEs). |

--- a/tests/test_agent_catalog_coverage.py
+++ b/tests/test_agent_catalog_coverage.py
@@ -1,0 +1,52 @@
+"""Structural test — agent-to-docs coverage.
+
+Mirrors the T5a pattern in test_agent_language_catalog.py::test_language_skill_in_catalog,
+but for agents/*.md instead of skills/language-*: every top-level agent must be
+discoverable from both docs/catalog.md (canonical reference table) and README.md
+(roster bullet). Prevents a shipped agent from going undocumented, as happened with
+e2e-test-verifier, e2e-test-writer, and redundancy-assessor.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+AGENTS_DIR = ROOT / "agents"
+README_MD = ROOT / "README.md"
+CATALOG_MD = ROOT / "docs" / "catalog.md"
+
+
+def _agent_names():
+    """Top-level agents/*.md files only — excludes agents/shared/ include fragments."""
+    return sorted(p.stem for p in AGENTS_DIR.glob("*.md"))
+
+
+def _readme_subagents_bullet() -> str:
+    text = README_MD.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if line.strip().startswith("- **Subagents**"):
+            return line
+    raise AssertionError("README.md is missing a '- **Subagents**' bullet")
+
+
+@pytest.mark.parametrize("agent_name", _agent_names())
+def test_agent_in_catalog(agent_name):
+    """Every top-level agent must have a row marker in docs/catalog.md."""
+    catalog_text = CATALOG_MD.read_text(encoding="utf-8")
+    row_marker = f"| `{agent_name}` |"
+    assert row_marker in catalog_text, (
+        f"docs/catalog.md is missing a row for '{agent_name}'. "
+        "Add the agent to the Subagents table."
+    )
+
+
+@pytest.mark.parametrize("agent_name", _agent_names())
+def test_agent_in_readme(agent_name):
+    """Every top-level agent must be backtick-wrapped in README.md's Subagents bullet."""
+    bullet = _readme_subagents_bullet()
+    marker = f"`{agent_name}`"
+    assert marker in bullet, (
+        f"README.md's Subagents bullet is missing '{agent_name}'. "
+        "Add it to the roster."
+    )


### PR DESCRIPTION
## Summary
- Add `tests/test_agent_catalog_coverage.py`, a regression test mirroring the existing T5a language-skill/catalog pattern: every top-level `agents/*.md` must have a row in `docs/catalog.md`'s Subagents table and a backtick-wrapped mention in README's Subagents bullet.
- Sync `README.md` and `docs/catalog.md` to close the drift the new test caught: add the three undocumented agents (`e2e-test-verifier`, `e2e-test-writer`, `redundancy-assessor`), document `/sync`'s `--check-redundancy` flag, broaden the Integrations line to the full external-service-context category, and note the workflow-state resume hook now also fires on session startup/resume.
- Add the already-shipped Dart language to both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` description strings, plus `plugin.json`'s `keywords` array.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1771/1771 pass (new coverage test RED before the doc sync, GREEN after)
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `lychee --config .lychee.toml './**/*.md'` — 0 broken links

### Type-tailored checks (docs)
- [x] All new/changed links resolve (verified via lychee above)
- [x] Manifest JSON (`plugin.json`, `marketplace.json`) still parses (`python3 -m json.tool`)

Issue: N/A — routine doc-freshness sweep, no tracking issue filed
