### PR TITLE
[feat] Inject CLAUDE_PLUGIN_ROOT into Bash tool calls via PreToolUse hook

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,11 +1,16 @@
 ---
-description: Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) plus gh auth status. Prints a green/red table; never modifies state. Exit 0 regardless of findings.
+description: Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) plus gh auth status. Prints a green/red table; never modifies state. Exit 0 regardless of dependency findings; exits 1 only if CLAUDE_PLUGIN_ROOT cannot be resolved.
 ---
 
 Run the preflight diagnostic and print the results verbatim:
 
 ```
-bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"
+_RT="${CLAUDE_PLUGIN_ROOT:-}"
+[ -n "$_RT" ] || {
+  echo "CLAUDE_PLUGIN_ROOT not set; cannot locate runtime scripts (see swe-workbench runtime/README.md)" >&2
+  exit 1
+}
+bash "$_RT/runtime/doctor.sh"
 ```
 
 Print the full stdout output exactly as produced — do not summarise, truncate, or reformat it.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -22,7 +22,7 @@
 | `/swe-workbench:codebase-knowledge [path]` | Present a structured knowledge document (architecture overview, module map, public API surfaces, patterns). Read-only, understanding-oriented. Distinct from `/swe-workbench:audit-codebase` (defect detection) and `/swe-workbench:document` (prose-doc generation). |
 | `/swe-workbench:cleanup-merged [PR number]` | Remove the worktree, local branch, and remote branch for a merged PR. Defaults to the current branch. Squash-merge safe. |
 | `/swe-workbench:sync [--rebase] [--check-redundancy]` | Bring the current branch up to date with the default branch — delegates the mechanical merge/rebase to rimba (or git), then walks through any conflicts file-by-file with a `conflict-resolver` recommendation and rationale before applying. Never auto-pushes; push is a separate, prompted step. Default strategy is merge; pass `--rebase` to rebase instead. `--check-redundancy` runs an opt-in `redundancy-assessor` pass surfacing functional duplication the default branch already provides. |
-| `/swe-workbench:doctor` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) plus gh auth status. Prints a green/red table; never modifies state. Exit 0 regardless of findings. |
+| `/swe-workbench:doctor` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude) plus gh auth status. Prints a green/red table; never modifies state. Exit 0 regardless of dependency findings; exits 1 only if CLAUDE_PLUGIN_ROOT cannot be resolved. |
 
 ## Subagents
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,15 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/inject_plugin_root.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Skill",
         "hooks": [
           {

--- a/hooks/inject_plugin_root.sh
+++ b/hooks/inject_plugin_root.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PreToolUse:Bash hook — inject CLAUDE_PLUGIN_ROOT into Bash commands that
+# reference it (issue #530).
+#
+# Claude Code injects CLAUDE_PLUGIN_ROOT for hooks/MCP/LSP but NOT into Bash
+# tool calls, so a command like `bash "$CLAUDE_PLUGIN_ROOT/runtime/foo.sh"`
+# resolves to an empty prefix and fails. This hook's OWN environment does
+# have the authoritative value (proven by the fact that hooks.json invokes
+# every hook via $CLAUDE_PLUGIN_ROOT/hooks/<script>), so it reads it and
+# re-injects it into the command about to run.
+#
+# Surgical scope: only rewrites commands that reference CLAUDE_PLUGIN_ROOT
+# and don't already assign it. Never blocks — exit 0 in every branch.
+# Emits ONLY updatedInput, never permissionDecision, so bash_guard.sh's
+# exit-2 block is untouched and composes cleanly with this hook.
+set -u
+
+root="${CLAUDE_PLUGIN_ROOT:-}"
+[ -n "$root" ] || exit 0
+
+input=$(cat)
+
+# Cheap pre-check on the raw payload before paying the jq tax, mirroring
+# bash_guard.sh's short-circuit for the common (non-matching) case.
+case "$input" in
+  *CLAUDE_PLUGIN_ROOT*) ;;
+  *)                    exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$cmd" ] || exit 0
+
+# Word-boundary aware so an unrelated identifier that merely contains
+# CLAUDE_PLUGIN_ROOT as a substring (e.g. MY_CLAUDE_PLUGIN_ROOT=, or the
+# distinct var CLAUDE_PLUGIN_ROOTS) is never mistaken for a real reference
+# or assignment of the actual variable.
+# Out of scope: execution order — a reference BEFORE a later assignment in
+# the same command (e.g. `echo "$CLAUDE_PLUGIN_ROOT"; CLAUDE_PLUGIN_ROOT=x`)
+# is still treated as "already assigned" and skipped, since this hook does
+# not parse shell execution order (same class of scope gap bash_guard.sh
+# documents in its own header comment).
+if printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_])CLAUDE_PLUGIN_ROOT='; then
+  exit 0  # already assigns it — idempotent no-op
+fi
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_])CLAUDE_PLUGIN_ROOT([^A-Za-z0-9_]|$)'; then
+  exit 0  # doesn't reference it — nothing to do
+fi
+
+jq -n --arg root "$root" --arg cmd "$cmd" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: {command: ("export CLAUDE_PLUGIN_ROOT=" + ($root|@sh) + "; " + $cmd)}}}' \
+  2>/dev/null || exit 0
+
+exit 0

--- a/hooks/inject_plugin_root.sh
+++ b/hooks/inject_plugin_root.sh
@@ -30,19 +30,28 @@ esac
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -n "$cmd" ] || exit 0
 
-# Word-boundary aware so an unrelated identifier that merely contains
-# CLAUDE_PLUGIN_ROOT as a substring (e.g. MY_CLAUDE_PLUGIN_ROOT=, or the
-# distinct var CLAUDE_PLUGIN_ROOTS) is never mistaken for a real reference
-# or assignment of the actual variable.
-# Out of scope: execution order — a reference BEFORE a later assignment in
-# the same command (e.g. `echo "$CLAUDE_PLUGIN_ROOT"; CLAUDE_PLUGIN_ROOT=x`)
-# is still treated as "already assigned" and skipped, since this hook does
-# not parse shell execution order (same class of scope gap bash_guard.sh
-# documents in its own header comment).
-if printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_])CLAUDE_PLUGIN_ROOT='; then
+# Assignment check is anchored to an actual command-start position (start
+# of a line — grep is line-oriented, so this also covers "after a newline"
+# for free — or after a ; & | separator, optionally with leading
+# whitespace) — NOT a bare word-boundary substring match. A word-boundary
+# check alone still mis-fires on CLAUDE_PLUGIN_ROOT= appearing inside a URL
+# query string or --data payload (e.g. `curl ".../?CLAUDE_PLUGIN_ROOT=x"`),
+# which would wrongly read as "already assigned" and skip injection of a
+# genuine $CLAUDE_PLUGIN_ROOT reference elsewhere in the same command —
+# reproducing the exact #530 failure mode in that case. [;&|] alone covers
+# && and || too, since each is still built from ; & | characters.
+# Reference check requires an actual sigil ($ or ${) so a bare mention of
+# the literal text (e.g. in an echo or comment, with no $) doesn't trigger
+# an unnecessary rewrite.
+# Out of scope: execution order — a reference BEFORE a later real
+# assignment in the same command (e.g. `echo "$CLAUDE_PLUGIN_ROOT";
+# CLAUDE_PLUGIN_ROOT=x`) is still treated as "already assigned" and
+# skipped, since this hook does not parse shell execution order (same
+# class of scope gap bash_guard.sh documents in its own header comment).
+if printf '%s' "$cmd" | grep -Eq '(^|[;&|])[[:space:]]*(export[[:space:]]+)?CLAUDE_PLUGIN_ROOT='; then
   exit 0  # already assigns it — idempotent no-op
 fi
-if ! printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_])CLAUDE_PLUGIN_ROOT([^A-Za-z0-9_]|$)'; then
+if ! printf '%s' "$cmd" | grep -Eq '\$\{?CLAUDE_PLUGIN_ROOT([^A-Za-z0-9_]|$)'; then
   exit 0  # doesn't reference it — nothing to do
 fi
 

--- a/hooks/inject_plugin_root.sh
+++ b/hooks/inject_plugin_root.sh
@@ -48,6 +48,13 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) |
 # CLAUDE_PLUGIN_ROOT=x`) is still treated as "already assigned" and
 # skipped, since this hook does not parse shell execution order (same
 # class of scope gap bash_guard.sh documents in its own header comment).
+# Out of scope: quoted/heredoc content — a `;`/`&`/`|` or line-start
+# inside a quoted string or heredoc body (e.g. a `.env` file written via
+# `cat > .env <<EOF` containing a literal `CLAUDE_PLUGIN_ROOT=` line, or
+# an `echo "...; CLAUDE_PLUGIN_ROOT=x"` argument) is indistinguishable
+# from a real command boundary without a real shell tokenizer. Worst
+# case this reverts to pre-hook behavior (silent no-op) for that command,
+# not a new failure mode.
 if printf '%s' "$cmd" | grep -Eq '(^|[;&|])[[:space:]]*(export[[:space:]]+)?CLAUDE_PLUGIN_ROOT='; then
   exit 0  # already assigns it — idempotent no-op
 fi

--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=tests/build-requirements.lock tests/build-requirements.txt
 #
-build==1.5.1 \
-    --hash=sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb \
-    --hash=sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
     # via pip-tools
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -73,10 +73,16 @@ def test_doctor_in_readme():
 
 
 def test_doctor_invokes_script_portably():
-    """doctor.md must invoke the script via $CLAUDE_PLUGIN_ROOT (portable for plugin installs, #328)."""
+    """doctor.md must invoke the script via a CLAUDE_PLUGIN_ROOT-derived path
+    (portable for plugin installs, #328), guarded so an empty
+    CLAUDE_PLUGIN_ROOT fails loudly instead of silently resolving to a bare
+    relative path (#530)."""
     text = DOCTOR_CMD.read_text()
-    assert "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh" in text, (
-        "doctor.md must invoke the script via $CLAUDE_PLUGIN_ROOT for plugin-install portability"
+    assert "CLAUDE_PLUGIN_ROOT" in text, (
+        "doctor.md must reference CLAUDE_PLUGIN_ROOT for plugin-install portability"
+    )
+    assert "$_RT/runtime/doctor.sh" in text, (
+        "doctor.md must invoke the script via $_RT (bound from CLAUDE_PLUGIN_ROOT) after the guard"
     )
     assert "bash scripts/doctor.sh" not in text, (
         "doctor.md must not invoke the script via a non-portable bare relative path"

--- a/tests/test_inject_plugin_root.py
+++ b/tests/test_inject_plugin_root.py
@@ -185,6 +185,53 @@ class TestWordBoundaryGate:
 
 
 # ──────────────────────────────────────────────
+# Assignment-position anchoring (regression: a bare word-boundary check
+# still mis-fired on CLAUDE_PLUGIN_ROOT= appearing inside a URL query
+# string or --data payload, not a real shell assignment — reviewer finding)
+# ──────────────────────────────────────────────
+
+
+class TestAssignmentPositionAnchoring:
+    def test_url_query_string_does_not_suppress_injection(self, hook_script):
+        """CLAUDE_PLUGIN_ROOT= inside a URL query string is not a real
+        assignment — the real $CLAUDE_PLUGIN_ROOT reference elsewhere in
+        the same command must still get injected."""
+        cmd = 'curl "https://example.com/?CLAUDE_PLUGIN_ROOT=x"; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT=")
+        assert "/fake/root" in updated
+
+    def test_data_payload_does_not_suppress_injection(self, hook_script):
+        cmd = 'curl --data "CLAUDE_PLUGIN_ROOT=x" example.com && bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT=")
+
+    def test_assignment_after_semicolon_still_suppresses(self, hook_script):
+        cmd = 'echo hi; CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_assignment_after_and_operator_still_suppresses(self, hook_script):
+        cmd = 'echo hi && CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_export_assignment_after_semicolon_still_suppresses(self, hook_script):
+        cmd = 'echo hi; export CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ──────────────────────────────────────────────
 # Fail-open on malformed input
 # ──────────────────────────────────────────────
 

--- a/tests/test_inject_plugin_root.py
+++ b/tests/test_inject_plugin_root.py
@@ -1,0 +1,301 @@
+"""Tests for hooks/inject_plugin_root.sh — PreToolUse:Bash CLAUDE_PLUGIN_ROOT
+injector (issue #530).
+
+CLAUDE_PLUGIN_ROOT is empty in the Bash tool's own environment even though
+it's present in the hook process's environment. This hook reads the
+authoritative value from its own env and rewrites `tool_input.command` to
+export it, ONLY for commands that reference the var and don't already assign
+it. It must never emit `permissionDecision` (composability with
+bash_guard.sh) and must never exit non-zero (fail-open).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+HOOK = Path(__file__).parent.parent / "hooks" / "inject_plugin_root.sh"
+HOOKS_JSON = Path(__file__).parent.parent / "hooks" / "hooks.json"
+DOCTOR_CMD = Path(__file__).parent.parent / "commands" / "doctor.md"
+
+
+@pytest.fixture(scope="module")
+def hook_script():
+    assert HOOK.exists(), f"missing {HOOK}"
+    assert os.access(HOOK, os.X_OK), f"{HOOK} must be executable"
+    return HOOK
+
+
+def run_hook(script, cmd, *, plugin_root="/fake/root", extra_env=None):
+    payload = json.dumps({"tool_input": {"command": cmd}})
+    env = dict(_CLEAN_ENV)
+    if plugin_root is None:
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+    else:
+        env["CLAUDE_PLUGIN_ROOT"] = plugin_root
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(script)], input=payload, text=True, capture_output=True, env=env,
+    )
+
+
+# ──────────────────────────────────────────────
+# Wiring
+# ──────────────────────────────────────────────
+
+
+class TestWiring:
+    def test_hook_script_exists_and_executable(self):
+        assert HOOK.exists(), f"Missing hook script: {HOOK}"
+        assert os.access(HOOK, os.X_OK), f"Hook script not executable: {HOOK}"
+
+    def test_hooks_json_has_bash_entry(self):
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = [
+            e for e in data["hooks"]["PreToolUse"]
+            if e.get("matcher") == "Bash"
+        ]
+        assert entries, "No PreToolUse Bash entries in hooks.json"
+        assert any(
+            "inject_plugin_root.sh" in h["command"]
+            for e in entries
+            for h in e["hooks"]
+        ), f"No Bash entry references inject_plugin_root.sh; entries: {entries}"
+
+    def test_bash_guard_entry_still_present(self):
+        """The new entry must be additive — bash_guard.sh must remain wired."""
+        data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+        entries = [
+            e for e in data["hooks"]["PreToolUse"]
+            if e.get("matcher") == "Bash"
+        ]
+        assert any(
+            "bash_guard.sh" in h["command"]
+            for e in entries
+            for h in e["hooks"]
+        ), "bash_guard.sh entry must remain wired alongside the injector"
+
+
+# ──────────────────────────────────────────────
+# Inject
+# ──────────────────────────────────────────────
+
+
+class TestInject:
+    def test_injects_export_for_referencing_command(self, hook_script):
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT="), updated
+        assert "/fake/root" in updated
+        assert cmd in updated, "original command must be preserved verbatim"
+
+    def test_injects_for_braced_reference(self, hook_script):
+        cmd = 'bash "${CLAUDE_PLUGIN_ROOT}/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT=")
+        assert cmd in updated
+
+    def test_hook_event_name_is_pretooluse(self, hook_script):
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        out = json.loads(result.stdout)
+        assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+
+
+# ──────────────────────────────────────────────
+# Pass-through / idempotency / empty-env
+# ──────────────────────────────────────────────
+
+
+class TestPassThrough:
+    def test_no_reference_passes_through(self, hook_script):
+        result = run_hook(hook_script, "ls -la", plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_already_assigned_is_idempotent(self, hook_script):
+        cmd = 'CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_already_exported_is_idempotent(self, hook_script):
+        cmd = 'export CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_plugin_root_env_passes_through(self, hook_script):
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root=None)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_blank_plugin_root_env_passes_through(self, hook_script):
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ──────────────────────────────────────────────
+# Word-boundary gate (regression: bare substring match previously
+# mis-fired on unrelated identifiers containing CLAUDE_PLUGIN_ROOT)
+# ──────────────────────────────────────────────
+
+
+class TestWordBoundaryGate:
+    def test_unrelated_var_assignment_does_not_suppress_injection(self, hook_script):
+        """MY_CLAUDE_PLUGIN_ROOT= must NOT be mistaken for a real assignment
+        of $CLAUDE_PLUGIN_ROOT — the real var still needs injection."""
+        cmd = 'MY_CLAUDE_PLUGIN_ROOT=/other/value; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT=")
+        assert "/fake/root" in updated
+
+    def test_unrelated_var_reference_does_not_trigger_injection(self, hook_script):
+        """$CLAUDE_PLUGIN_ROOTS (a different, longer var name) must NOT be
+        mistaken for a reference to $CLAUDE_PLUGIN_ROOT."""
+        cmd = 'echo "$CLAUDE_PLUGIN_ROOTS"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_real_assignment_still_suppresses_injection(self, hook_script):
+        """A genuine assignment (word-boundary correct) must still be
+        idempotent — no regression from the boundary tightening."""
+        cmd = 'CLAUDE_PLUGIN_ROOT=/already/set; bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ──────────────────────────────────────────────
+# Fail-open on malformed input
+# ──────────────────────────────────────────────
+
+
+class TestFailOpen:
+    @pytest.mark.parametrize("payload", [
+        "",
+        "not json at all",
+        "{",
+        '{"tool_input": {}}',
+        '{"tool_input": {"command": null}}',
+        "null",
+    ])
+    def test_malformed_or_empty_input_never_blocks(self, hook_script, payload):
+        env = dict(_CLEAN_ENV)
+        env["CLAUDE_PLUGIN_ROOT"] = "/fake/root"
+        result = subprocess.run(
+            [str(hook_script)], input=payload, text=True, capture_output=True, env=env,
+        )
+        assert result.returncode == 0, (
+            f"Expected exit 0 for payload {payload!r}, got {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+
+# ──────────────────────────────────────────────
+# Security: permission-neutral, guard-token preservation, JSON-escaping
+# ──────────────────────────────────────────────
+
+
+class TestSecurity:
+    def test_never_emits_permission_decision(self, hook_script):
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert "permissionDecision" not in result.stdout, (
+            "Injector must never emit permissionDecision — that would bypass "
+            "bash_guard.sh's exit-2 block"
+        )
+
+    def test_destructive_tokens_preserved_verbatim_for_guard(self, hook_script):
+        """A destructive command that also references the var must still
+        carry the rm/git tokens unchanged so bash_guard.sh (which reads the
+        ORIGINAL tool_input.command, not this hook's output) still detects
+        them."""
+        cmd = 'rm -rf "$CLAUDE_PLUGIN_ROOT/tmp" && echo done'
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert 'rm -rf "$CLAUDE_PLUGIN_ROOT/tmp" && echo done' in updated
+
+    @pytest.mark.parametrize("cmd", [
+        'echo "quote\\"s" && echo "$CLAUDE_PLUGIN_ROOT"',
+        'echo \'$CLAUDE_PLUGIN_ROOT\' && echo "$CLAUDE_PLUGIN_ROOT/x"',
+        'echo "line one\nline two $CLAUDE_PLUGIN_ROOT"',
+        'echo "$CLAUDE_PLUGIN_ROOT" "$(pwd)"',
+    ])
+    def test_json_escaping_round_trips(self, hook_script, cmd):
+        result = run_hook(hook_script, cmd, plugin_root="/fake/root")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)  # must parse as valid JSON
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert cmd in updated
+
+    def test_plugin_root_value_shell_quoted(self, hook_script):
+        """A plugin root path containing a space or quote must be safely
+        shell-quoted in the export prefix."""
+        cmd = 'bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"'
+        result = run_hook(hook_script, cmd, plugin_root="/fake root/with'quote")
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        updated = out["hookSpecificOutput"]["updatedInput"]["command"]
+        assert updated.startswith("export CLAUDE_PLUGIN_ROOT=")
+
+    def test_bash_guard_still_blocks_original_stdin_when_both_hooks_wired(self, hook_script):
+        """Chained-hooks integration: both PreToolUse:Bash entries receive
+        the SAME original tool_input independently (Claude Code does not
+        pipe one hook's updatedInput into the next hook's stdin). Feed a
+        destructive command that also references CLAUDE_PLUGIN_ROOT through
+        BOTH scripts and confirm bash_guard.sh still blocks on the original,
+        unmodified stdin regardless of what the injector produces."""
+        guard = Path(__file__).parent.parent / "hooks" / "bash_guard.sh"
+        cmd = 'rm -rf ~ "$CLAUDE_PLUGIN_ROOT/tmp"'
+        payload = json.dumps({"tool_input": {"command": cmd}})
+        env = dict(_CLEAN_ENV)
+        env["CLAUDE_PLUGIN_ROOT"] = "/fake/root"
+
+        guard_result = subprocess.run(
+            [str(guard)], input=payload, text=True, capture_output=True, env=env,
+        )
+        injector_result = subprocess.run(
+            [str(hook_script)], input=payload, text=True, capture_output=True, env=env,
+        )
+
+        assert guard_result.returncode == 2, guard_result.stderr
+        assert "BLOCKED" in guard_result.stderr
+        assert injector_result.returncode == 0
+        assert "permissionDecision" not in injector_result.stdout
+
+
+# ──────────────────────────────────────────────
+# doctor.md guard (static)
+# ──────────────────────────────────────────────
+
+
+class TestDoctorGuard:
+    def test_doctor_has_hard_fail_guard(self):
+        text = DOCTOR_CMD.read_text()
+        assert '[ -n "$_RT" ]' in text, (
+            "doctor.md must contain the hard-fail guard checking $_RT"
+        )
+        assert '$_RT/runtime/doctor.sh' in text, (
+            "doctor.md must invoke doctor.sh via $_RT after the guard"
+        )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Bash tool calls in Claude Code don't inherit `CLAUDE_PLUGIN_ROOT` (only hooks/MCP/LSP get it), so runtime scripts invoked like `bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"` silently resolve to an empty prefix and fail with an opaque "No such file or directory" (#530, reported failure at `commands/doctor.md:8`).
- New `hooks/inject_plugin_root.sh` (PreToolUse:Bash) reads `CLAUDE_PLUGIN_ROOT` from its own environment — which does have the authoritative value, since Claude Code invokes every hook via `$CLAUDE_PLUGIN_ROOT/hooks/<script>` — and rewrites `tool_input.command` to prepend `export CLAUDE_PLUGIN_ROOT=<value>; `. Surgically scoped: only fires on commands that reference the var and don't already assign it (word-boundary aware, so `MY_CLAUDE_PLUGIN_ROOT=` or `$CLAUDE_PLUGIN_ROOTS` are never mistaken for the real variable).
- Fail-open and permission-neutral by design: every branch exits 0, and the hook emits ONLY `updatedInput` — never `permissionDecision` — so `hooks/bash_guard.sh`'s destructive-command block composes cleanly and can't be bypassed.
- Wired as a second `PreToolUse` `Bash` entry in `hooks/hooks.json`, additive to the existing `bash_guard.sh` entry.
- Belt-and-suspenders: `commands/doctor.md` now hard-fails loudly (`exit 1` with an actionable message) if `CLAUDE_PLUGIN_ROOT` is ever still empty, instead of silently computing a broken path. Frontmatter description (and its `docs/catalog.md` mirror) updated to reflect the new exit-1 case.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually — piped a hook-input JSON with `bash "$CLAUDE_PLUGIN_ROOT/runtime/doctor.sh"` into `inject_plugin_root.sh`, confirmed the rewritten command carries the `export`, then ran the rewritten command directly and confirmed it prints the full preflight table (proves #530 is fixed end-to-end).
- [x] `bash_guard.sh` still blocks a destructive command (`rm -rf ~ "$CLAUDE_PLUGIN_ROOT/tmp"`) with the injector wired alongside it — confirmed exit 2 / `BLOCKED`, and confirmed the injector's own output never contains `permissionDecision`.

### Type-tailored checks (feat)
- [x] `tests/test_inject_plugin_root.py` (new, 32 tests): wiring, injection (plain + braced var forms), pass-through, idempotency (assignment/export), word-boundary gate regressions, fail-open on 6 malformed-stdin variants, security (no `permissionDecision`, destructive-token preservation, JSON-escaping round-trips, shell-quoting), chained-hooks integration, `doctor.md` static guard.
- [x] `pytest tests/ -v` — 1807/1807 passed (re-confirmed by the pre-push hook).
- [x] `bash scripts/validate.sh` — 0 issues.
- [x] `shellcheck hooks/inject_plugin_root.sh` — clean.

Closes #530
