### PR TITLE
[feat] workflow-pr-review-post: pending-review posting, byline off inline, public-only remark

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -121,7 +121,7 @@ If the PR number was obtained via auto-detect (user replied `yes` to the prompt 
    - `PR`, `OWNER`, `REPO`, `HEAD_SHA`, `BASE`, `CURRENT_USER`, `AUTHOR_LOGIN` — from Step 1.
    - `DECISION` — as derived above.
    - `BLOCKING_SCOPE` — intentionally omitted; specialist auditors don't classify in-diff vs out-of-diff, so it falls back to the core's `IN-DIFF` fail-safe default and the diff-scoping flip never fires for specialist-mode reviews (unlike `workflow-pr-review`/`workflow-pr-review-followup`, which do set it from the reviewer agent's own classification).
-   - `BYLINE` — `` _Reviewed by `<auditor>` ([swe-workbench](https://github.com/lugassawan/swe-workbench))._ `` (the specific agent from the mode table, e.g. `security-auditor`).
+   - `BYLINE` — `` _Reviewed by `<auditor>`_ `` (identity-only — substitute the specific agent from the mode table, e.g. `security-auditor`; the core appends the swe-workbench remark itself, conditionally on public repos).
    - `CALLER_TAG` — the mode name (e.g. `security`).
    - `FINDINGS[]` — as normalized above.
 

--- a/docs/gh-api-field-flags.md
+++ b/docs/gh-api-field-flags.md
@@ -35,6 +35,29 @@ After posting, confirm the body landed as the literal string you intended:
 gh api <endpoint>/<id> -q '.body'
 ```
 
+## Arrays of objects: `-f`/`-F` field flags don't work, use `--input -`
+
+`gh api -f`/`-F` bracket notation (`key[]=value`) only builds arrays of **scalars**.
+Numeric-indexed bracket notation (`comments[0][path]=...`, `comments[1][path]=...`) does
+**not** build an array of objects — it builds a JSON *object* keyed by stringified indices
+(`{"comments":{"0":{...},"1":{...}}}`), which most array-typed API fields (e.g. GitHub's
+`POST /pulls/{n}/reviews` `comments` field) reject outright. Verified against a live `gh`
+install — this is not a theoretical gap.
+
+For an array-of-objects field, build the whole request body as JSON (`jq` is the natural
+tool) and post it via `gh api --input -`, which reads the request body verbatim from stdin.
+`jq --arg`/`--argjson` give the same raw-string safety `-f` gives a scalar field — a value
+starting with `@` is embedded as a literal JSON string, never file-expanded, because the
+payload never passes through `gh api`'s own field-flag parser at all:
+
+```bash
+PAYLOAD=$(jq -n --arg body "$BODY" '{body: $body, comments: $comments_array}')
+gh api --method POST <endpoint> --input - <<<"$PAYLOAD"
+```
+
+Never string-concatenate a free-form value directly into a JSON literal (`"body": "'"$BODY"'"`)
+— a value containing `"` or `\` breaks the JSON or injects fields. Always go through `jq --arg`.
+
 ## Where this is enforced
 
 - `runtime/reply-and-resolve.sh` uses `-f body=` for both reply call sites (reply bodies start
@@ -42,6 +65,7 @@ gh api <endpoint>/<id> -q '.body'
   `tests/test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f`.
 - `skills/workflow-pr-review-post/SKILL.md` (the shared posting core used by
   `workflow-pr-review`, `workflow-pr-review-followup`, and the `/swe-workbench:review`
-  specialist PR-mode sub-flow) uses `-f body="$BODY"` in its Step 2 inline-comment POST
-  (a reviewer finding can also start with `@author`); guarded by
-  `tests/test_pr_review_skill_body_flag.py`.
+  specialist PR-mode sub-flow) builds the Step 2 `comments[]` array via `jq --arg body`
+  and posts it with `gh api --input -` (see above), and uses `-f body="$BODY"` in the
+  Step 4 model-A fallback's single-comment POST (a reviewer finding can also start with
+  `@author`); both guarded by `tests/test_pr_review_skill_body_flag.py`.

--- a/skills/workflow-pr-review-followup/SKILL.md
+++ b/skills/workflow-pr-review-followup/SKILL.md
@@ -109,7 +109,7 @@ Parse Step 4's `reviewer` output into `FINDINGS[]` rows (`severity`, `path`, `li
 
 - `PR`, `OWNER`, `REPO`, `HEAD_SHA`, `BASE`, `CURRENT_USER`, `AUTHOR_LOGIN` — from Step 1.
 - `DECISION`, `BLOCKING_SCOPE` — parsed in Step 5.
-- `BYLINE` — `_Re-reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench))._`
+- `BYLINE` — `_Re-reviewed by \`reviewer\`_` (identity-only — the core appends the swe-workbench remark itself, conditionally on public repos; see `skills/workflow-pr-review-post/SKILL.md` Step 4).
 - `CALLER_TAG` — `followup` (scopes the core's own threads-cache filename so it never collides with a concurrent primary or specialist run on the same PR).
 - `FINDINGS[]` — as parsed above.
 

--- a/skills/workflow-pr-review-post/SKILL.md
+++ b/skills/workflow-pr-review-post/SKILL.md
@@ -200,8 +200,11 @@ if [ "$N" -gt 0 ]; then
 
     PAYLOAD=$(jq -n --arg commit_id "$HEAD_SHA" --arg event "$EVENT" --arg body "$SUMMARY" --argjson comments "$COMMENTS_JSON" \
       '{commit_id: $commit_id, event: $event, body: $body, comments: $comments}')
-    RESP2=$(gh api --method POST "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" --input - <<<"$PAYLOAD" 2>&1)
-    [ $? -eq 0 ] && { posted_inline=$N; SUBMITTED=true; }
+    RESP2=$(gh api --method POST "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" --input - <<<"$PAYLOAD" 2>&1); RESP2_OK=$?
+    # Retry failure is the same ambiguous class one level deeper — reuse the read-your-write check.
+    [ "$RESP2_OK" -ne 0 ] && LANDED=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" \
+      -q "[.[] | select(.user.login==\"$CURRENT_USER\" and .commit_id==\"$HEAD_SHA\")] | length")
+    { [ "$RESP2_OK" -eq 0 ] || [ "${LANDED:-0}" -gt 0 ]; } && { posted_inline=$N; SUBMITTED=true; }
   else
     # Network/5xx — ambiguous: the POST may have landed server-side even though the
     # client saw a failure. Never blind-retry (no idempotency key); instead confirm
@@ -283,18 +286,15 @@ This skill never touches the caller's own worktree or preflight state files (e.g
 | Failure | Signal | Action |
 |---|---|---|
 | A pre-validated finding goes out-of-diff at post time, or the atomic POST 422s outright (stale `commit_id`) | Line-in-diff check fails during assembly, or `gh api` non-zero exit with `422` | Demote to the pr-level batch (never drop silently); for a 422, re-fetch `HEAD_SHA`, re-validate/reassemble, retry **once** — still failing falls back to model-A (rebuild `$SUMMARY` from the actual landed count). |
-| Atomic review POST fails on network/5xx | Non-422 failure | **Never** blind-retry (no idempotency key). Confirm via a read-your-write check (list reviews, filter by `$CURRENT_USER` + `$HEAD_SHA`) before conceding to the model-A fallback. |
+| Atomic POST (first attempt or retry) fails on network/5xx | Non-422 failure | **Never** blind-retry (no idempotency key). Confirm via a read-your-write check (list reviews, filter by `$CURRENT_USER` + `$HEAD_SHA`) before conceding to the model-A fallback — applies symmetrically to both the first attempt and the retry. |
 | Self-review (`IS_SELF_REVIEW=true`), or `comments[]` is empty (`N == 0`) | `CURRENT_USER == AUTHOR_LOGIN`, or no inline survivors after dedup + pre-validate | Self-review: submit `EVENT=COMMENT` regardless of `$DECISION` (never `APPROVE`). Empty: fall through to `gh pr review --approve\|--comment` directly, no atomic POST attempted. |
-| All findings dedup-matched | `posted == 0` | Submit with body noting "no new findings — all previously raised". Decision unaffected. |
-| `gh pr comment` fails for a pr-level batch | Non-zero exit | Log and continue — inline findings from the same run must still post/submit; do not abort the whole flow over the pr-level fallback. |
+| All findings dedup-matched, or `gh pr comment` fails for a pr-level batch | `posted == 0`, or non-zero exit | Submit with body noting "no new findings — all previously raised" (decision unaffected). On a failed batch, log and continue — inline findings must still post/submit. |
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---|---|
 | Dedup pr-level findings against `reviewThreads` | `reviewThreads` only covers inline comment threads; a pr-level finding has no `path`/`line` to match against. Batch and post once; re-running the same specialist mode on an unchanged PR will re-post the batch (known v1 limitation — no pr-level dedup yet). |
-| Assemble `comments[]` via `gh api` bracket-indexed field flags, string-concatenate `$BODY` into a JSON literal, or post inline comments individually | Bracket indices (`comments[0][path]=...`) build a stringified-key *object*, not an array — GitHub's Reviews API rejects it. String concatenation breaks on `"`/`\`. Build `comments[]` as real JSON via `jq --arg`/`--argjson` and submit the whole batch atomically via `gh api --input -`; per-comment posting is the model-A fallback only, reachable after a confirmed double-422 (or `N=0`). |
-| `-F body=` on the fallback POST, or concatenating `$BYLINE`/`$BYLINE_FULL`/`$REMARK` into a `comments[]` body | Use `-f body="$BODY"` (raw) for the fallback POST — see [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). Inline comment bodies are `finding.body` verbatim; the byline/remark is a Step 4, review-level concern only (issue #531). |
-| Set `posted_pr_level` before checking whether `gh pr comment` succeeded, or report a dependency-mode (pr-level-only) run as "posted N inline comments" | Gate the assignment on exit status — a failed batch must leave `posted_pr_level=0`. The byline reports `posted_inline`/`posted_pr_level` separately so a zero-inline run doesn't misreport itself. |
-| Restate posted findings in the review `$SUMMARY` body, or block on this skill's own cleanup before returning control | Findings live in inline/pr-level comments; the summary is decision + byline only. Step 6 reap is foreground (fast) — unlike worktree teardown, which the caller backgrounds separately. |
-| Assume `$_RT` is inherited from the caller's Step 1 | This skill is its own skill boundary, not a `source`d shell fragment — re-derive `_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"` at the top of Step 6. |
+| Assemble `comments[]` via `gh api` bracket-indexed field flags, string-concatenate `$BODY` into a JSON literal, post inline comments individually, use `-F body=` on the fallback POST, or concatenate `$BYLINE`/`$BYLINE_FULL`/`$REMARK` into a `comments[]` body | Bracket indices build a stringified-key *object*, not an array — GitHub rejects it. Build `comments[]` as real JSON via `jq --arg`/`--argjson`, submit atomically via `gh api --input -` (per-comment is the model-A fallback only). Use `-f body="$BODY"` (raw) for the fallback POST — see [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). Inline bodies are `finding.body` verbatim; the byline/remark is Step 4-only (issue #531). |
+| Set `posted_pr_level` before checking whether `gh pr comment` succeeded, report a dependency-mode (pr-level-only) run as "posted N inline comments", or restate posted findings in `$SUMMARY` | Gate the assignment on exit status. The byline reports `posted_inline`/`posted_pr_level` separately. Findings live in inline/pr-level comments; the summary is decision + byline only. |
+| Block on this skill's own cleanup, or assume `$_RT` is inherited from the caller's Step 1 | Step 6 reap is foreground (fast) — unlike worktree teardown, backgrounded separately. This skill is its own skill boundary — re-derive `_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"` at the top of Step 6. |

--- a/skills/workflow-pr-review-post/SKILL.md
+++ b/skills/workflow-pr-review-post/SKILL.md
@@ -180,16 +180,19 @@ if [ "$N" -gt 0 ]; then
     # GENUINELY re-validate/reassemble (do NOT resubmit $COMMENTS_JSON
     # unchanged); demote anything newly out-of-diff to a pr-level comment.
     HEAD_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
-    COMMENTS_JSON="[]"; STILL_IN_DIFF=()
+    COMMENTS_JSON="[]"; STILL_IN_DIFF=(); DEMOTED_BODY=""; DEMOTED_N=0
     for row in "${INLINE_SURVIVORS[@]}"; do   # each row resolves REPO_PATH, LINE, BODY
       if line_is_in_diff "$REPO_PATH" "$LINE" "$HEAD_SHA"; then   # same predicate as Step 2's pre-validate pass
         COMMENTS_JSON=$(jq --arg path "$REPO_PATH" --argjson line "$LINE" --arg body "$BODY" \
           '. + [{path: $path, line: $line, side: "RIGHT", body: $body}]' <<<"$COMMENTS_JSON")
         STILL_IN_DIFF+=("$row")
       else
-        gh pr comment "$PR" --body "$BODY" && posted_pr_level=$((posted_pr_level + 1))
+        DEMOTED_BODY="${DEMOTED_BODY}${BODY}"$'\n\n---\n\n'; DEMOTED_N=$((DEMOTED_N + 1))
       fi
     done
+    # Batch every newly-demoted row into ONE pr-level comment — mirrors Step 2's own batching.
+    [ "$DEMOTED_N" -gt 0 ] && gh pr comment "$PR" --body "$DEMOTED_BODY" \
+      && posted_pr_level=$((posted_pr_level + DEMOTED_N))
     INLINE_SURVIVORS=("${STILL_IN_DIFF[@]}"); N=$(jq 'length' <<<"$COMMENTS_JSON")
     BYLINE_FULL="${BYLINE}${REMARK}. Posted ${N} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
     if [ "$IS_SELF_REVIEW" = true ]; then SUMMARY=$(printf '%s\n' "$BYLINE_FULL")
@@ -199,15 +202,20 @@ if [ "$N" -gt 0 ]; then
       '{commit_id: $commit_id, event: $event, body: $body, comments: $comments}')
     RESP2=$(gh api --method POST "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" --input - <<<"$PAYLOAD" 2>&1)
     [ $? -eq 0 ] && { posted_inline=$N; SUBMITTED=true; }
+  else
+    # Network/5xx — ambiguous: the POST may have landed server-side even though the
+    # client saw a failure. Never blind-retry (no idempotency key); instead confirm
+    # via a cheap read-your-write check before conceding to the model-A fallback.
+    LANDED=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" \
+      -q "[.[] | select(.user.login==\"$CURRENT_USER\" and .commit_id==\"$HEAD_SHA\")] | length")
+    [ "${LANDED:-0}" -gt 0 ] && { posted_inline=$N; SUBMITTED=true; }
   fi
-  # Any other failure (network, 5xx) is NOT retried — never blind-retry a POST
-  # with no idempotency key; SUBMITTED stays unset, falls through below.
 fi
 
 if [ "${SUBMITTED:-false}" != true ]; then
   # Reached when N=0 (nothing to batch — today's plain submit) OR the atomic
   # POST 422'd twice OR failed on network/5xx — model-A per-comment fallback.
-  posted_inline=0
+  posted_inline=0; DEMOTED_BODY=""; DEMOTED_N=0
   for row in "${INLINE_SURVIVORS[@]}"; do   # empty loop when N=0; each row resolves REPO_PATH, LINE, BODY
     if gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
          -f body="$BODY" \
@@ -217,12 +225,13 @@ if [ "${SUBMITTED:-false}" != true ]; then
          -F commit_id="$HEAD_SHA"; then
       posted_inline=$((posted_inline + 1))
     else
-      # Never drop a finding silently on a fallback POST failure — demote to
-      # a follow-up pr-level note (same treatment an out-of-diff finding gets).
-      echo "[warn] individual comment POST failed for $REPO_PATH:$LINE — demoting to pr-level." >&2
-      gh pr comment "$PR" --body "$BODY" && posted_pr_level=$((posted_pr_level + 1))
+      # Never drop a finding silently on a fallback POST failure — batch into ONE
+      # follow-up pr-level comment after the loop, not one gh pr comment per row.
+      DEMOTED_BODY="${DEMOTED_BODY}${BODY}"$'\n\n---\n\n'; DEMOTED_N=$((DEMOTED_N + 1))
     fi
   done
+  [ "$DEMOTED_N" -gt 0 ] && gh pr comment "$PR" --body "$DEMOTED_BODY" \
+    && posted_pr_level=$((posted_pr_level + DEMOTED_N))
   BYLINE_FULL="${BYLINE}${REMARK}. Posted ${posted_inline} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
   if [ "$IS_SELF_REVIEW" = true ]; then SUMMARY=$(printf '%s\n' "$BYLINE_FULL")
   else SUMMARY=$(printf '**Review Decision: %s**\n\n%s\n' "$DECISION" "$BYLINE_FULL"); fi
@@ -273,13 +282,10 @@ This skill never touches the caller's own worktree or preflight state files (e.g
 
 | Failure | Signal | Action |
 |---|---|---|
-| A pre-validated finding is out-of-diff at post time (`HEAD_SHA` advanced since the diff-scoping scan) | Line-in-diff check fails during Step 2 assembly | Demote to the pr-level batch — never drop a finding silently. |
-| Atomic review POST returns 422 — stale `commit_id`, since every row in `comments[]` was pre-validated in-diff before assembly | `gh api` non-zero exit, response contains `422` | Re-fetch `HEAD_SHA` (`gh pr view "$PR" --json headRefOid -q .headRefOid`), re-run pre-validate/assemble, retry the atomic POST **once**. Still failing → fall back to model-A per-comment posting (rebuild `$SUMMARY` from the actual landed count, submit the event via `gh pr review`). |
-| Atomic review POST fails on network/5xx | Non-422 failure | **Never** blind-retry — no idempotency key for this endpoint, so a retried call that already landed double-posts every comment. Fall straight to the model-A fallback. |
-| `comments[]` is empty (`N == 0`) | No inline survivors after dedup + pre-validate | Fall through to `gh pr review --approve\|--comment` directly — no atomic POST attempted (the existing pre-#531 path, unchanged). |
-| Self-review (`IS_SELF_REVIEW=true`) | `CURRENT_USER == AUTHOR_LOGIN` | Submit with `EVENT=COMMENT` regardless of `$DECISION` — GitHub blocks self-`APPROVE` but allows self-`COMMENT`, so this run's inline/pr-level comments still land instead of the whole submit being skipped. |
+| A pre-validated finding goes out-of-diff at post time, or the atomic POST 422s outright (stale `commit_id`) | Line-in-diff check fails during assembly, or `gh api` non-zero exit with `422` | Demote to the pr-level batch (never drop silently); for a 422, re-fetch `HEAD_SHA`, re-validate/reassemble, retry **once** — still failing falls back to model-A (rebuild `$SUMMARY` from the actual landed count). |
+| Atomic review POST fails on network/5xx | Non-422 failure | **Never** blind-retry (no idempotency key). Confirm via a read-your-write check (list reviews, filter by `$CURRENT_USER` + `$HEAD_SHA`) before conceding to the model-A fallback. |
+| Self-review (`IS_SELF_REVIEW=true`), or `comments[]` is empty (`N == 0`) | `CURRENT_USER == AUTHOR_LOGIN`, or no inline survivors after dedup + pre-validate | Self-review: submit `EVENT=COMMENT` regardless of `$DECISION` (never `APPROVE`). Empty: fall through to `gh pr review --approve\|--comment` directly, no atomic POST attempted. |
 | All findings dedup-matched | `posted == 0` | Submit with body noting "no new findings — all previously raised". Decision unaffected. |
-| GraphQL pagination needed (PR > 100 threads) | `hasNextPage == true` | Loop with `after: endCursor`. Known v1 limit if not hit/implemented. |
 | `gh pr comment` fails for a pr-level batch | Non-zero exit | Log and continue — inline findings from the same run must still post/submit; do not abort the whole flow over the pr-level fallback. |
 
 ## Common mistakes
@@ -287,14 +293,8 @@ This skill never touches the caller's own worktree or preflight state files (e.g
 | Mistake | Fix |
 |---|---|
 | Dedup pr-level findings against `reviewThreads` | `reviewThreads` only covers inline comment threads; a pr-level finding has no `path`/`line` to match against. Batch and post once; re-running the same specialist mode on an unchanged PR will re-post the batch (known v1 limitation — no pr-level dedup yet). |
-| Assemble `comments[]` via `gh api` bracket-indexed field flags, or string-concatenate `$BODY` into a JSON literal | Bracket indices (`comments[0][path]=...`) build a stringified-key *object*, not an array — GitHub's Reviews API rejects it. String concatenation breaks on `"`/`\`. Build `comments[]` as real JSON via `jq --arg`/`--argjson` and post with `gh api --input -`. |
-| `-F body=` on the fallback POST for a finding that starts with `@` → silent `@`-file-expansion | Use `-f body="$BODY"` (raw). See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). |
-| Concatenate `$BYLINE`/`$BYLINE_FULL`/`$REMARK` into a `comments[]` body | Inline comment bodies are `finding.body` verbatim — the byline/remark is a Step 4, review-level concern only (issue #531). |
-| Post inline comments individually while assembling `comments[]` | Assemble the whole batch and submit it atomically via `POST .../pulls/{n}/reviews`; per-comment posting is the model-A fallback, reachable only after a confirmed double-422 (or when `N=0`). |
-| Apply the diff-scoping flip on self-review or unknown identity | Gated on `IS_SELF_REVIEW=false` AND `IDENTITY_KNOWN=true`. Either false → no flip. |
-| Reuse the caller's own state-file names for the threads cache | This skill owns `${PR}-post-threads-${CALLER_TAG}.json` specifically so it never collides with a caller's `${PR}.json`/`${PR}-threads.json`/`${PR}-followup*.json`, nor with another caller's own tagged threads cache for the same PR. |
-| Set `posted_pr_level` before checking whether `gh pr comment` succeeded | Gate the assignment on the call's exit status — a failed batch must leave `posted_pr_level=0`, not the finding count, or the byline/CTA misreport what was actually posted. |
-| Restate posted findings in the review `$SUMMARY` body | Findings live in inline comments / the pr-level batch comment; the summary is decision + byline (+ informational) only. |
-| Block on this skill's own cleanup before returning control | Step 6 reap is foreground (fast, single small file) — unlike worktree teardown, which the caller backgrounds separately. |
-| Report a dependency-mode (pr-level-only) run as "posted N inline comments" | The byline reports `posted_inline` and `posted_pr_level` separately — a run with zero inline posts must not claim it posted inline comments just because `posted` (the combined total) is non-zero. |
+| Assemble `comments[]` via `gh api` bracket-indexed field flags, string-concatenate `$BODY` into a JSON literal, or post inline comments individually | Bracket indices (`comments[0][path]=...`) build a stringified-key *object*, not an array — GitHub's Reviews API rejects it. String concatenation breaks on `"`/`\`. Build `comments[]` as real JSON via `jq --arg`/`--argjson` and submit the whole batch atomically via `gh api --input -`; per-comment posting is the model-A fallback only, reachable after a confirmed double-422 (or `N=0`). |
+| `-F body=` on the fallback POST, or concatenating `$BYLINE`/`$BYLINE_FULL`/`$REMARK` into a `comments[]` body | Use `-f body="$BODY"` (raw) for the fallback POST — see [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). Inline comment bodies are `finding.body` verbatim; the byline/remark is a Step 4, review-level concern only (issue #531). |
+| Set `posted_pr_level` before checking whether `gh pr comment` succeeded, or report a dependency-mode (pr-level-only) run as "posted N inline comments" | Gate the assignment on exit status — a failed batch must leave `posted_pr_level=0`. The byline reports `posted_inline`/`posted_pr_level` separately so a zero-inline run doesn't misreport itself. |
+| Restate posted findings in the review `$SUMMARY` body, or block on this skill's own cleanup before returning control | Findings live in inline/pr-level comments; the summary is decision + byline only. Step 6 reap is foreground (fast) — unlike worktree teardown, which the caller backgrounds separately. |
 | Assume `$_RT` is inherited from the caller's Step 1 | This skill is its own skill boundary, not a `source`d shell fragment — re-derive `_RT="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}"` at the top of Step 6. |

--- a/skills/workflow-pr-review-post/SKILL.md
+++ b/skills/workflow-pr-review-post/SKILL.md
@@ -32,9 +32,9 @@ Before Step 1, verify every required field is present and well-formed. **Abort i
 | `BASE` | non-empty |
 | `CURRENT_USER`, `AUTHOR_LOGIN` | may be empty (identity-unknown is a valid state — see Step 3), but if provided must be plain login strings |
 | `DECISION` | exactly `APPROVE` or `COMMENT` |
-| `BYLINE` | non-empty, fully-formed markdown identity clause (e.g. `_Reviewed by \`reviewer\`_`) — **must NOT** embed `posted`/`deduped` counts; this skill appends its own stats clause in Step 4, since those counts aren't known until Step 2 runs |
+| `BYLINE` | non-empty, **identity-only** markdown clause (e.g. `_Reviewed by \`reviewer\`_`) — **must NOT** embed the swe-workbench remark (` ([swe-workbench](https://github.com/lugassawan/swe-workbench))`) or `posted`/`deduped` counts; this skill appends the remark conditionally (public repos only) and its own stats clause in Step 4, since repo visibility and those counts aren't known until Step 2/4 run |
 | `BLOCKING_SCOPE` | one of `NONE`, `OUT-OF-DIFF-ONLY`, `IN-DIFF`; default `IN-DIFF` if the caller omits it (fail-safe). `workflow-pr-review`/`workflow-pr-review-followup` set this from the reviewer agent's own in-diff/out-of-diff classification; the specialist PR-mode sub-flow intentionally omits it (specialist auditors don't classify diff-scope), which falls back to `IN-DIFF` — the diff-scoping flip (Step 3) accordingly never fires for specialist-mode reviews. This is a deliberate divergence, not an oversight. |
-| `FINDINGS[]` | each row has `severity`, `body`, and `anchor ∈ {inline, pr-level}`; `anchor=inline` rows must also have `path` and `line` |
+| `FINDINGS[]` | each row has `severity`, `body`, and `anchor ∈ {inline, pr-level}`; `anchor=inline` rows must also have `path` and `line`. **Inline comment bodies must NOT contain the byline/remark** in any form — a `comments[]` body is `finding.body` verbatim; the byline/remark is a review-level concern built once in Step 4, never folded into a per-finding body (issue #531) |
 | `CALLER_TAG` | non-empty, one of `general`, `followup`, or the specialist mode name (e.g. `security`, `dependency`) — scopes this skill's own state file so two callers reviewing the same PR concurrently never share (and can't clobber) each other's threads cache |
 
 Abort message: `"workflow-pr-review-post: invalid payload — <field> <problem>. Refusing to post."`
@@ -69,7 +69,7 @@ Pagination via `pageInfo { endCursor hasNextPage }` if a real PR exceeds 100 thr
 
 Uses its own `${PR}-post-threads-${CALLER_TAG}.json` state file — scoped by `CALLER_TAG` so it's distinct both from any `${PR}.json`/`${PR}-threads.json`/`${PR}-followup*.json` files the caller may hold, AND from another caller's own `${PR}-post-threads-*.json` reviewing the same PR concurrently (e.g. a general review and a specialist `--mode security` review both in flight — without the tag, both would share one cache file and one run's Step 6 reap could delete the other's cache mid-flight).
 
-## Step 2 — Dedup + post
+## Step 2 — Dedup + pre-validate + assemble
 
 Partition `FINDINGS[]` by `anchor`.
 
@@ -81,7 +81,7 @@ For each: **fuzzy-match** against fetched threads, against ANY author:
 - Body Jaccard token overlap ≥ 0.4.
 - `isResolved == false`.
 
-**On match**: skip posting. If `$CURRENT_USER` has not already 👍'd (check `reactions.nodes[].user.login`; use `reactions(first: 20, ...)` — 5 truncates busy threads), add a 👍 to the thread head (first comment's `id`):
+**On match**: skip posting, increment `$deduped`. If `$CURRENT_USER` has not already 👍'd (check `reactions.nodes[].user.login`; use `reactions(first: 20, ...)` — 5 truncates busy threads), add a 👍 to the thread head (first comment's `id`):
 
 ```bash
 gh api graphql -F subjectId="$THREAD_HEAD_ID" -f query='
@@ -90,26 +90,26 @@ gh api graphql -F subjectId="$THREAD_HEAD_ID" -f query='
   }'
 ```
 
-**On no match**: post a new inline comment via REST (supports `line=` directly):
+**On no match**: the finding survives dedup and becomes a candidate for the pending review's `comments[]` batch, posted atomically in Step 4 (`POST .../pulls/{n}/reviews`) instead of individually here. A candidate's body is `finding.body` **verbatim** — never `$BYLINE`/`$BYLINE_FULL`/`$REMARK` concatenated in; the byline is a review-level concern built once in Step 4 (issue #531 — inline comments must never repeat it).
+
+**Pre-validate before assembly**: the atomic Reviews API POST in Step 4 submits the whole batch in one call — one bad `(path, line)` 422s the *entire* review, and the error body carries no per-comment index to identify which row failed (an assumption to confirm on a scratch PR), so a stale or invalid line must be caught here, before it can poison the batch. Confirm each survivor's `line` lands on a `+` (added/modified) line for `path` in the diff at `$HEAD_SHA` — reuse the diff already fetched for this run, or re-fetch with `gh pr diff "$PR"`. **In-diff** → assemble into `comments[]` below. **Out-of-diff** → re-anchor the finding `pr-level` and fold it into the PR-level batch below — this is the contract's existing home for out-of-diff rows.
+
+Assemble each in-diff survivor into the pending review's `comments[]` **JSON array** via `jq` — **not** `gh api` bracket-indexed field flags. `gh api -f "comments[0][path]=..." -f "comments[1][path]=..."` builds a JSON *object* keyed by stringified indices (`{"comments":{"0":{...},"1":{...}}}`), not an array — GitHub's Reviews API requires `comments` to be an array and rejects the object shape outright, so that syntax can never work here (verified against a live `gh` install; do not reintroduce it). `jq --arg`/`--argjson` give the same raw-string safety `-f body=` gives a scalar field: a finding body starting with `@author…` is embedded as a literal JSON string value, never file-expanded — there is no `-f`/`-F` hazard once the payload is built as real JSON rather than passed through `gh api`'s own field-flag parser (see [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md)). Never string-concatenate `$BODY` directly into a JSON literal — a body containing `"` or `\` would break the JSON or inject fields; always go through `jq --arg`.
 
 ```bash
-gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
-  -f body="$BODY" \
-  -F path="$REPO_PATH" \
-  -F line="$LINE" \
-  -F side=RIGHT \
-  -F commit_id="$HEAD_SHA"
+COMMENTS_JSON="[]"
+for row in "${INLINE_SURVIVORS[@]}"; do   # each row resolves REPO_PATH, LINE, BODY — dedup- and diff-validated
+  COMMENTS_JSON=$(jq --arg path "$REPO_PATH" --argjson line "$LINE" --arg body "$BODY" \
+    '. + [{path: $path, line: $line, side: "RIGHT", body: $body}]' <<<"$COMMENTS_JSON")
+done
+N=$(jq 'length' <<<"$COMMENTS_JSON")
 ```
 
-**Why `-f body=`, not `-F body=`:** a finding body may start with `@author…`; `-F` would silently
-`@`-expand it into a file read. See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md).
-**Spot-check** any body sourced from a file: `gh api <endpoint>/{id} -q '.body'`.
-
-Track counts: `posted_inline=N`, `deduped=M`. On HTTP 422: skip, log "skipped (line out of range)", count toward stale-SHA (see Failure modes) — `anchor=inline` is only ever assigned to findings already classified in-diff (both callers' anchor rules guarantee this before Step 2 runs), so no row reaching this loop is legitimately out-of-diff; a 422 here always means either a genuinely invalid line or a stale `commit_id`, never an expected context-line reference.
+Freeze `N` here — the **candidate** inline count. `N` becomes `posted_inline` only once Step 4's atomic submit actually lands; a whole-review 422 can still change that outcome (see Step 4 and Failure modes).
 
 ### PR-level findings (`anchor=pr-level`)
 
-No thread to dedup against — `dependency-auditor` rows (no `File:Line`) and any inline row whose line fell out-of-diff both land here. Batch ALL pr-level findings into **one** general PR comment (not deduped across runs — see Common mistakes):
+No thread to dedup against — `dependency-auditor` rows (no `File:Line`), any inline row demoted above, and any inline row whose line fell out-of-diff both land here. Batch ALL pr-level findings (original + demoted) into **one** general PR comment (not deduped across runs — see Common mistakes), posted here in Step 2 — **before** Step 4's review submit — so `posted_pr_level` is already a landed count by the time the byline is built:
 
 ```bash
 if gh pr comment "$PR" --body "$PR_LEVEL_BODY"; then
@@ -120,9 +120,9 @@ else
 fi
 ```
 
-Only issue this call when at least one pr-level finding exists. `posted_pr_level` must be set **after** the call, gated on its exit status — never increment it unconditionally before knowing whether the post actually landed, or a failed batch gets reported as posted in Step 4's byline and wrongly fires Step 5's CTA on a `posted > 0` that corresponds to nothing on the PR. Maintain `posted=$((posted_inline + posted_pr_level))` as the combined total used by the CTA/suppression outcome-axis checks below (Steps 4–5); the byline in Step 4 reports the split counts separately so a dependency-mode run (pr-level only) doesn't misreport itself as having posted inline comments.
+Only issue this call when at least one pr-level finding exists (including demoted rows). `posted_pr_level` must be set **after** the call, gated on its exit status — never increment it unconditionally before knowing whether the post actually landed, or a failed batch gets reported as posted in Step 4's byline and wrongly fires Step 5's CTA on a `posted > 0` that corresponds to nothing on the PR. Maintain `posted=$((posted_inline + posted_pr_level))` as the combined total used by the CTA/suppression outcome-axis checks below (Steps 4–5); the byline in Step 4 reports the split counts separately so a dependency-mode run (pr-level only) doesn't misreport itself as having posted inline comments.
 
-## Step 3 — Self-review gate + diff-scoping flip
+## Step 3 — Self-review gate + diff-scoping flip + submit event
 
 ```bash
 if [ -z "$CURRENT_USER" ] || [ -z "$AUTHOR_LOGIN" ]; then
@@ -136,30 +136,104 @@ if [ "$DECISION" = "COMMENT" ] && [ "$BLOCKING_SCOPE" = "OUT-OF-DIFF-ONLY" ] \
    && [ "$IS_SELF_REVIEW" = false ] && [ "$IDENTITY_KNOWN" = true ]; then
   DECISION=APPROVE
 fi
+
+if [ "$IS_SELF_REVIEW" = true ]; then EVENT=COMMENT; else EVENT="$DECISION"; fi
 ```
 
 Identity unknown (`CURRENT_USER` or `AUTHOR_LOGIN` empty) → `IS_SELF_REVIEW=false` but `IDENTITY_KNOWN=false` suppresses the flip (fail-safe: never auto-approve when authorship can't be verified).
 
+`$EVENT` — not `$DECISION` — is what Step 4 actually submits to the Reviews API. GitHub blocks a self-authored `APPROVE` outright but allows a self-authored `COMMENT`, so on self-review `EVENT` is forced to `COMMENT` regardless of `$DECISION` (e.g. a clean scan with no findings still yields `DECISION=APPROVE`) — this replaces the pre-#531 behavior of skipping submit entirely on self-review, which under the atomic posting model would have silently dropped every inline comment along with it. The core never submits `APPROVE` on self-review.
+
 ## Step 4 — Submit
 
-The review body is lean by design: decision line + byline (+ optional informational notes) only — findings already posted in Step 2 must NOT be restated here. `$BYLINE` is the caller's identity clause only (e.g. `_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench))._`) — it cannot include `posted`/`deduped` counts, since those are only known after Step 2 runs here in the core. This skill appends the stats clause itself:
+The review body is lean by design: decision line + byline (+ optional informational notes) only — findings already posted in Step 2 must NOT be restated here. On self-review the decision line is omitted (the run always submits `EVENT=COMMENT`, never the pre-flip `$DECISION`, which could misleadingly read `APPROVE`) but the byline/stats clause still appears — self-review no longer skips submit outright (see Step 3). `$BYLINE` is the caller's identity clause only (e.g. `` _Reviewed by `reviewer`_ ``) — it must NOT embed the swe-workbench remark, and it cannot include `posted`/`deduped` counts, since those are only known after Step 2 runs here in the core. This skill appends both:
 
 ```bash
-BYLINE_FULL="${BYLINE} Posted ${posted_inline} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
-if [ "$IS_SELF_REVIEW" = false ]; then
-  SUMMARY=$(printf '**Review Decision: %s**\n\n%s\n' "$DECISION" "$BYLINE_FULL")
-else
-  SUMMARY=""
-fi
+IS_PRIVATE=$(gh repo view "${OWNER}/${REPO}" --json isPrivate -q '.isPrivate' 2>/dev/null)
+REMARK=""
+[ "$IS_PRIVATE" = "false" ] && REMARK=" ([swe-workbench](https://github.com/lugassawan/swe-workbench))"
 ```
+
+`IS_PRIVATE` is gated on a **confirmed** `"false"` (public) result — an empty/errored lookup (permission issue, transient failure) or an explicit `"true"` both leave `REMARK` empty. This is deliberately fail-safe: never advertise the tool on a repo whose visibility couldn't be confirmed public.
 
 The lean body above has no out-of-diff carve-out section — that mechanism belonged to the pre-#499 single-loop design, where in-diff and out-of-diff findings shared one posting path. This refactor's `anchor` partition (Step 2) already gives out-of-diff findings their own dedicated path (the pr-level batch comment), so there is nothing left to defer into the review body.
 
-Submit when `IS_SELF_REVIEW = false` (GitHub blocks self-approval):
-- `APPROVE` → `gh pr review "$PR" --approve --body "$SUMMARY"`
-- `COMMENT` → `gh pr review "$PR" --comment --body "$SUMMARY"`
+**Build the pre-submit body from `$N`, not `$posted_inline`.** The atomic POST's own `body=$SUMMARY` field has to describe what it is *about to* post, and `$posted_inline` is not assigned until after that same POST completes — referencing it here would embed an unset/empty count into the review body itself. Atomicity makes the `$N` assumption safe: either all `$N` comments land together with this exact body, or the POST fails outright and the fallback below rebuilds `$SUMMARY` from the real landed count before its own separate submit:
 
-Skip when `IS_SELF_REVIEW = true`. **Never** use `--request-changes`. Findings already posted inline/PR-level in Step 2 must NOT be restated in `$SUMMARY`.
+```bash
+BYLINE_FULL="${BYLINE}${REMARK}. Posted ${N} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
+if [ "$IS_SELF_REVIEW" = true ]; then SUMMARY=$(printf '%s\n' "$BYLINE_FULL")
+else SUMMARY=$(printf '**Review Decision: %s**\n\n%s\n' "$DECISION" "$BYLINE_FULL"); fi
+```
+
+**Submit — atomic path first, when `N > 0`:**
+
+```bash
+if [ "$N" -gt 0 ]; then
+  PAYLOAD=$(jq -n --arg commit_id "$HEAD_SHA" --arg event "$EVENT" --arg body "$SUMMARY" --argjson comments "$COMMENTS_JSON" \
+    '{commit_id: $commit_id, event: $event, body: $body, comments: $comments}')
+  RESP=$(gh api --method POST "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" --input - <<<"$PAYLOAD" 2>&1)
+  if [ $? -eq 0 ]; then
+    posted_inline=$N; SUBMITTED=true
+  elif echo "$RESP" | grep -q '422'; then
+    # Stale commit_id, or a line pre-validate missed — re-fetch HEAD and
+    # GENUINELY re-validate/reassemble (do NOT resubmit $COMMENTS_JSON
+    # unchanged); demote anything newly out-of-diff to a pr-level comment.
+    HEAD_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+    COMMENTS_JSON="[]"; STILL_IN_DIFF=()
+    for row in "${INLINE_SURVIVORS[@]}"; do   # each row resolves REPO_PATH, LINE, BODY
+      if line_is_in_diff "$REPO_PATH" "$LINE" "$HEAD_SHA"; then   # same predicate as Step 2's pre-validate pass
+        COMMENTS_JSON=$(jq --arg path "$REPO_PATH" --argjson line "$LINE" --arg body "$BODY" \
+          '. + [{path: $path, line: $line, side: "RIGHT", body: $body}]' <<<"$COMMENTS_JSON")
+        STILL_IN_DIFF+=("$row")
+      else
+        gh pr comment "$PR" --body "$BODY" && posted_pr_level=$((posted_pr_level + 1))
+      fi
+    done
+    INLINE_SURVIVORS=("${STILL_IN_DIFF[@]}"); N=$(jq 'length' <<<"$COMMENTS_JSON")
+    BYLINE_FULL="${BYLINE}${REMARK}. Posted ${N} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
+    if [ "$IS_SELF_REVIEW" = true ]; then SUMMARY=$(printf '%s\n' "$BYLINE_FULL")
+    else SUMMARY=$(printf '**Review Decision: %s**\n\n%s\n' "$DECISION" "$BYLINE_FULL"); fi
+
+    PAYLOAD=$(jq -n --arg commit_id "$HEAD_SHA" --arg event "$EVENT" --arg body "$SUMMARY" --argjson comments "$COMMENTS_JSON" \
+      '{commit_id: $commit_id, event: $event, body: $body, comments: $comments}')
+    RESP2=$(gh api --method POST "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" --input - <<<"$PAYLOAD" 2>&1)
+    [ $? -eq 0 ] && { posted_inline=$N; SUBMITTED=true; }
+  fi
+  # Any other failure (network, 5xx) is NOT retried — never blind-retry a POST
+  # with no idempotency key; SUBMITTED stays unset, falls through below.
+fi
+
+if [ "${SUBMITTED:-false}" != true ]; then
+  # Reached when N=0 (nothing to batch — today's plain submit) OR the atomic
+  # POST 422'd twice OR failed on network/5xx — model-A per-comment fallback.
+  posted_inline=0
+  for row in "${INLINE_SURVIVORS[@]}"; do   # empty loop when N=0; each row resolves REPO_PATH, LINE, BODY
+    if gh api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
+         -f body="$BODY" \
+         -F path="$REPO_PATH" \
+         -F line="$LINE" \
+         -F side=RIGHT \
+         -F commit_id="$HEAD_SHA"; then
+      posted_inline=$((posted_inline + 1))
+    else
+      # Never drop a finding silently on a fallback POST failure — demote to
+      # a follow-up pr-level note (same treatment an out-of-diff finding gets).
+      echo "[warn] individual comment POST failed for $REPO_PATH:$LINE — demoting to pr-level." >&2
+      gh pr comment "$PR" --body "$BODY" && posted_pr_level=$((posted_pr_level + 1))
+    fi
+  done
+  BYLINE_FULL="${BYLINE}${REMARK}. Posted ${posted_inline} inline comment(s) and ${posted_pr_level} PR-level note(s), deduped ${deduped}."
+  if [ "$IS_SELF_REVIEW" = true ]; then SUMMARY=$(printf '%s\n' "$BYLINE_FULL")
+  else SUMMARY=$(printf '**Review Decision: %s**\n\n%s\n' "$DECISION" "$BYLINE_FULL"); fi
+  if [ "$IS_SELF_REVIEW" = false ] && [ "$EVENT" = "APPROVE" ]; then gh pr review "$PR" --approve --body "$SUMMARY"
+  else gh pr review "$PR" --comment --body "$SUMMARY"; fi
+fi
+```
+
+In the fallback block, `$posted_inline` is read *after* the loop assigns it — no ordering hazard, since `$SUMMARY` here feeds the fallback's own `gh pr review` submit, never the already-sent atomic POST. When `N=0` the loop body never executes and `posted_inline` stays `0`, degenerating exactly to the pre-#531 plain submit — the empty-`comments[]` case is a fall-through, not a special case.
+
+**Never** use `--request-changes`. **Never** blind-retry the atomic POST on a network/5xx failure — there is no idempotency key for this endpoint, so a retried call that actually landed the first time double-posts every comment; the single retry above is scoped to a confirmed 422 only. Findings already posted inline/PR-level in Step 2 must NOT be restated in `$SUMMARY`.
 
 ## Step 5 — Address-feedback CTA (conditional)
 
@@ -193,18 +267,17 @@ bash "$_RT/runtime/clean-state-files.sh" "/tmp/swe-workbench-pr-review/${PR}-pos
   || echo "✓ state file reaped: /tmp/swe-workbench-pr-review/${PR}-post-threads-${CALLER_TAG}.json"
 ```
 
-This skill never touches the caller's own worktree or preflight state files (e.g. `${PR}.json`, `${PR}-followup.json`) — those stay the caller's responsibility, cleaned up alongside its own worktree teardown after this skill returns.
-
-## Dedup contract (inline only)
-
-A new finding `(path, line, body)` matches an existing thread `T` IFF: `T.path == finding.path` (exact) AND `|T.line - finding.line| ≤ 5` (or `T.startLine`) AND Jaccard overlap ≥ 0.4 AND `T.isResolved == false`. Match against ANY author. On match, skip posting AND add 👍 if not already reacted.
+This skill never touches the caller's own worktree or preflight state files (e.g. `${PR}.json`, `${PR}-followup.json`) — those stay the caller's responsibility, cleaned up alongside its own worktree teardown after this skill returns. (Dedup contract: see the fuzzy-match rule in Step 2 — same `path`, `|line delta| ≤ 5`, Jaccard ≥ 0.4, unresolved, any author.)
 
 ## Failure modes
 
 | Failure | Signal | Action |
 |---|---|---|
-| Comment-post returns 422 (line out of range) | HTTP 422 | Skip, log "skipped (line out of range)", count toward stale-SHA — `anchor=inline` guarantees the line was in-diff when classified, so a 422 here is never an expected out-of-diff reference. |
-| All in-diff POSTs returned 422 (stale `commit_id`) | `posted == 0` AND every in-diff finding 422'd | Re-fetch `HEAD_SHA` via `gh pr view "$PR" --json headRefOid -q .headRefOid` and retry once. If still failing, abort with "HEAD_SHA mismatch — PR updated mid-review". |
+| A pre-validated finding is out-of-diff at post time (`HEAD_SHA` advanced since the diff-scoping scan) | Line-in-diff check fails during Step 2 assembly | Demote to the pr-level batch — never drop a finding silently. |
+| Atomic review POST returns 422 — stale `commit_id`, since every row in `comments[]` was pre-validated in-diff before assembly | `gh api` non-zero exit, response contains `422` | Re-fetch `HEAD_SHA` (`gh pr view "$PR" --json headRefOid -q .headRefOid`), re-run pre-validate/assemble, retry the atomic POST **once**. Still failing → fall back to model-A per-comment posting (rebuild `$SUMMARY` from the actual landed count, submit the event via `gh pr review`). |
+| Atomic review POST fails on network/5xx | Non-422 failure | **Never** blind-retry — no idempotency key for this endpoint, so a retried call that already landed double-posts every comment. Fall straight to the model-A fallback. |
+| `comments[]` is empty (`N == 0`) | No inline survivors after dedup + pre-validate | Fall through to `gh pr review --approve\|--comment` directly — no atomic POST attempted (the existing pre-#531 path, unchanged). |
+| Self-review (`IS_SELF_REVIEW=true`) | `CURRENT_USER == AUTHOR_LOGIN` | Submit with `EVENT=COMMENT` regardless of `$DECISION` — GitHub blocks self-`APPROVE` but allows self-`COMMENT`, so this run's inline/pr-level comments still land instead of the whole submit being skipped. |
 | All findings dedup-matched | `posted == 0` | Submit with body noting "no new findings — all previously raised". Decision unaffected. |
 | GraphQL pagination needed (PR > 100 threads) | `hasNextPage == true` | Loop with `after: endCursor`. Known v1 limit if not hit/implemented. |
 | `gh pr comment` fails for a pr-level batch | Non-zero exit | Log and continue — inline findings from the same run must still post/submit; do not abort the whole flow over the pr-level fallback. |
@@ -214,7 +287,10 @@ A new finding `(path, line, body)` matches an existing thread `T` IFF: `T.path =
 | Mistake | Fix |
 |---|---|
 | Dedup pr-level findings against `reviewThreads` | `reviewThreads` only covers inline comment threads; a pr-level finding has no `path`/`line` to match against. Batch and post once; re-running the same specialist mode on an unchanged PR will re-post the batch (known v1 limitation — no pr-level dedup yet). |
-| `-F body="$BODY"` on a finding that starts with `@` → silent `@`-file-expansion | Use `-f body=` (raw). See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). |
+| Assemble `comments[]` via `gh api` bracket-indexed field flags, or string-concatenate `$BODY` into a JSON literal | Bracket indices (`comments[0][path]=...`) build a stringified-key *object*, not an array — GitHub's Reviews API rejects it. String concatenation breaks on `"`/`\`. Build `comments[]` as real JSON via `jq --arg`/`--argjson` and post with `gh api --input -`. |
+| `-F body=` on the fallback POST for a finding that starts with `@` → silent `@`-file-expansion | Use `-f body="$BODY"` (raw). See [`docs/gh-api-field-flags.md`](../../docs/gh-api-field-flags.md). |
+| Concatenate `$BYLINE`/`$BYLINE_FULL`/`$REMARK` into a `comments[]` body | Inline comment bodies are `finding.body` verbatim — the byline/remark is a Step 4, review-level concern only (issue #531). |
+| Post inline comments individually while assembling `comments[]` | Assemble the whole batch and submit it atomically via `POST .../pulls/{n}/reviews`; per-comment posting is the model-A fallback, reachable only after a confirmed double-422 (or when `N=0`). |
 | Apply the diff-scoping flip on self-review or unknown identity | Gated on `IS_SELF_REVIEW=false` AND `IDENTITY_KNOWN=true`. Either false → no flip. |
 | Reuse the caller's own state-file names for the threads cache | This skill owns `${PR}-post-threads-${CALLER_TAG}.json` specifically so it never collides with a caller's `${PR}.json`/`${PR}-threads.json`/`${PR}-followup*.json`, nor with another caller's own tagged threads cache for the same PR. |
 | Set `posted_pr_level` before checking whether `gh pr comment` succeeded | Gate the assignment on the call's exit status — a failed batch must leave `posted_pr_level=0`, not the finding count, or the byline/CTA misreport what was actually posted. |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -107,7 +107,7 @@ Parse Step 4's `reviewer` output into `FINDINGS[]` rows (`severity`, `path`, `li
 
 - `PR`, `OWNER`, `REPO`, `HEAD_SHA`, `BASE`, `CURRENT_USER`, `AUTHOR_LOGIN` — from Step 1.
 - `DECISION`, `BLOCKING_SCOPE` — parsed in Step 5.
-- `BYLINE` — `_Reviewed by \`reviewer\` ([swe-workbench](https://github.com/lugassawan/swe-workbench))._`
+- `BYLINE` — `_Reviewed by \`reviewer\`_` (identity-only — the core appends the swe-workbench remark itself, conditionally on public repos; see `skills/workflow-pr-review-post/SKILL.md` Step 4).
 - `CALLER_TAG` — `general` (scopes the core's own threads-cache filename so it never collides with a concurrent followup or specialist run on the same PR).
 - `FINDINGS[]` — as parsed above.
 

--- a/tests/test_pr_review_skill_body_flag.py
+++ b/tests/test_pr_review_skill_body_flag.py
@@ -1,25 +1,30 @@
-"""Guards the Step 2 inline-comment POST in the shared PR-review posting core
-against the `gh api -F body=` @-expansion hazard (issue #494).
+"""Guards the raw-body discipline of the shared PR-review posting core's two
+comment-posting call sites against injection/@-expansion hazards (issue #494).
 
 A reviewer finding body is free-form text that can legitimately start with
-`@author...`. `gh api -F body=` treats an @-prefixed value as a file path to
-read, so posting such a finding with `-F` would silently read (or fail to
-read) a bogus file instead of posting the literal text. `-f body=` forces a
-raw string and is the fix mirrored from `reply-and-resolve.sh` (see
-test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f).
+`@author...` or contain `"`/`\\` characters. Two distinct hazards apply
+depending on the call site:
 
-The inline-comment POST used to be duplicated in workflow-pr-review/SKILL.md
-and workflow-pr-review-followup/SKILL.md; both now delegate posting to
-workflow-pr-review-post/SKILL.md, which owns the single POST call site this
-test guards (issue #499).
+1. `gh api -F body=` treats an @-prefixed value as a file path to read, so
+   posting such a finding with `-F` would silently read (or fail to read) a
+   bogus file instead of posting the literal text. `-f body=` forces a raw
+   string and is the fix mirrored from `reply-and-resolve.sh` (see
+   test_reply_and_resolve_script.py::test_body_flag_is_lowercase_f_not_uppercase_f).
+2. Building a JSON array (GitHub's `comments[]` field) by string-concatenating
+   a free-form body directly into a JSON literal would let a body containing
+   `"` or `\\` break the JSON or inject fields. `jq --arg` escapes safely.
 
-Unlike the runtime script, `gh api` and the `-F body=` flag sit on separate
-continuation lines inside the skill's fenced code block, so a single-line
-`"body=" in ln and "gh api" in ln` filter would match nothing and pass
-vacuously. This test extracts the fenced bash block containing the POST and
-asserts on the literal flag string within it — scoped to the code block, not
-the whole file, since the "Common mistakes" table also mentions `-F body=`
-in prose as the anti-pattern being warned against.
+Since issue #531, the primary inline-posting path is the atomic
+`POST /pulls/{n}/reviews` call with a `comments[]` array (pending-review
+model). `gh api` bracket-indexed field flags (`-f "comments[0][path]=..."`)
+cannot build this array — they build a JSON *object* keyed by stringified
+indices, which GitHub's API rejects — so `comments[]` is built as real JSON
+via `jq` and the whole payload is posted with `gh api --input -` (see
+docs/gh-api-field-flags.md). The old single-comment `POST /pulls/{n}/comments`
+call is now reachable only as the model-A fallback after a confirmed
+double-422 on the atomic path, and still uses `-f`/`-F` field flags directly
+(a scalar-field endpoint, not an array), carrying the original raw-body
+requirement — so this test guards both call sites.
 """
 
 import re
@@ -34,21 +39,68 @@ SKILL_PATHS = [
 CODE_BLOCK_RE = re.compile(r"```bash\n(.*?)\n\s*```", re.DOTALL)
 
 
-def _post_code_block(text: str) -> str:
-    for block in CODE_BLOCK_RE.findall(text):
-        if "pulls/${PR}/comments" in block:
-            return block
-    raise AssertionError("no fenced bash block found for the pulls/{PR}/comments POST")
+def _blocks_containing(text: str, marker: str) -> list[str]:
+    return [block for block in CODE_BLOCK_RE.findall(text) if marker in block]
 
 
-def test_step6_post_uses_lowercase_f_not_uppercase_f_for_body():
+def test_comments_array_never_built_via_bracket_indexed_field_flags():
+    # Scoped to fenced bash blocks only — prose elsewhere in the file (Common
+    # mistakes table, Step 2 explanation) legitimately names this anti-pattern
+    # to warn against it; only *executable* bash reintroducing it is a bug.
     for path in SKILL_PATHS:
-        block = _post_code_block(path.read_text())
-        assert '-f body="$BODY"' in block, (
-            f"{path}: expected -f body=\"$BODY\" (raw string) in the Step 6 "
-            "inline-comment POST"
+        for block in CODE_BLOCK_RE.findall(path.read_text()):
+            assert "comments[$i][" not in block and "comments[0][" not in block, (
+                f"{path}: a bash block builds comments[] via gh api "
+                "bracket-indexed field flags — this produces a JSON object "
+                "with stringified keys, not an array, which GitHub's Reviews "
+                "API rejects. Build comments[] as real JSON via jq instead."
+            )
+
+
+def test_comments_json_assembled_via_jq_arg_for_body():
+    for path in SKILL_PATHS:
+        blocks = _blocks_containing(path.read_text(), "COMMENTS_JSON")
+        assert blocks, (
+            f"{path}: no fenced bash block found assembling COMMENTS_JSON"
         )
-        assert '-F body="$BODY"' not in block, (
+        assert any('--arg body "$BODY"' in b for b in blocks), (
+            f"{path}: expected jq --arg body \"$BODY\" (safe raw-string "
+            "escaping) when assembling a comments[] row — string-concatenating "
+            "$BODY into a JSON literal would let a body containing \" or \\ "
+            "break the JSON or inject fields"
+        )
+        assert any('--argjson line "$LINE"' in b for b in blocks), (
+            f"{path}: expected jq --argjson line \"$LINE\" (typed scalar) "
+            "when assembling a comments[] row"
+        )
+
+
+def test_atomic_reviews_post_uses_input_flag_not_f_F_for_body():
+    for path in SKILL_PATHS:
+        blocks = _blocks_containing(path.read_text(), "pulls/${PR}/reviews")
+        assert blocks, (
+            f"{path}: no fenced bash block found for the atomic "
+            "pulls/{PR}/reviews POST"
+        )
+        assert any("--input -" in b for b in blocks), (
+            f"{path}: the atomic pulls/{{PR}}/reviews POST must use "
+            "'gh api --input -' with a jq-built JSON payload — -f/-F field "
+            "flags cannot represent the comments[] array field"
+        )
+
+
+def test_fallback_per_comment_post_uses_lowercase_f_not_uppercase_f_for_body():
+    for path in SKILL_PATHS:
+        blocks = _blocks_containing(path.read_text(), "pulls/${PR}/comments")
+        assert blocks, (
+            f"{path}: no fenced bash block found for the model-A fallback "
+            "pulls/{PR}/comments POST"
+        )
+        assert any('-f body="$BODY"' in b for b in blocks), (
+            f"{path}: expected -f body=\"$BODY\" (raw string) in the fallback "
+            "per-comment POST"
+        )
+        assert not any('-F body="$BODY"' in b for b in blocks), (
             f"{path}: -F body=\"$BODY\" would @-file-expand a finding body "
             "that starts with @author"
         )

--- a/tests/test_skill_repo_ambiguity.py
+++ b/tests/test_skill_repo_ambiguity.py
@@ -225,30 +225,36 @@ def test_cleanup_merged_resolves_default_branch_dynamically():
 
 
 def test_pr_review_byline_and_summary_link_to_tool_repo():
-    """BYLINE (both pr-review consumers) and SUMMARY (the shared posting core)
+    """BYLINE (all pr-review-post callers) and SUMMARY (the shared posting core)
     must link to the tool repo, not the PR's own repo.
 
     The bug: BYLINE used https://github.com/${OWNER}/${REPO} — the PR's repo —
     instead of the constant https://github.com/lugassawan/swe-workbench. The
     fallback SUMMARY had no URL at all (bare parenthetical "(swe-workbench)").
 
-    Since #499, BYLINE is authored by each consumer (workflow-pr-review,
-    workflow-pr-review-followup) and handed to workflow-pr-review-post, which
-    builds $SUMMARY from it. So the templated-URL / bare-paren / canonical-link
-    checks apply to the consumers (they own BYLINE's content); the SUMMARY-
-    references-BYLINE check applies to the core (it owns SUMMARY construction).
+    Since #531, BYLINE is authored by each caller as an **identity-only**
+    clause (e.g. `_Reviewed by \\`reviewer\\`_`) — no remark, no link. The core
+    (workflow-pr-review-post) owns the ` ([swe-workbench](url))` remark as a
+    single constant and appends it to `$BYLINE_FULL` only when the target repo
+    is confirmed public (`IS_PRIVATE = "false"`). So the templated-URL /
+    bare-paren checks still apply to all three files; the canonical-link
+    checks flip polarity from #499 — the link now belongs to the core only,
+    and its *absence* from each caller's BYLINE is itself part of the
+    contract (a caller re-adding the remark would duplicate it on private
+    repos, since the core has no way to strip a caller-embedded remark).
 
     Assertions:
     1. Templated URL ${OWNER}/${REPO} is gone — not present anywhere in any file.
     2. No BYLINE= or SUMMARY= assignment contains a bare "(swe-workbench)" without
        a markdown link.
-    3. The canonical markdown link appears in each consumer's documented BYLINE.
+    3. The canonical markdown link appears in the core (it owns the remark) and
+       does NOT appear in either consumer's documented BYLINE (identity-only).
     4. The core's SUMMARY construction reuses $BYLINE (via $BYLINE_FULL) by
        variable reference, not by repeating the URL string.
     """
     canonical = "[swe-workbench](https://github.com/lugassawan/swe-workbench)"
     buggy_url = "https://github.com/${OWNER}/${REPO}"
-    bare_paren = re.compile(r'^(BYLINE|SUMMARY)=.*\(swe-workbench\)', re.MULTILINE)
+    bare_paren = re.compile(r'^(BYLINE|SUMMARY|REMARK)=.*\(swe-workbench\)', re.MULTILINE)
 
     for skill_path in (PR_REVIEW_SKILL, PR_REVIEW_FOLLOWUP_SKILL, POST_CORE_SKILL):
         body = skill_path.read_text()
@@ -261,28 +267,35 @@ def test_pr_review_byline_and_summary_link_to_tool_repo():
             f"Replace with the hardcoded tool URL: https://github.com/lugassawan/swe-workbench"
         )
 
-        # 2. No BYLINE= or SUMMARY= assignment with bare (swe-workbench) — no link
+        # 2. No BYLINE=/SUMMARY=/REMARK= assignment with bare (swe-workbench) — no link
         bare_hits = bare_paren.findall(body)
         assert not bare_hits, (
-            f"{skill_name}/SKILL.md has a BYLINE= or SUMMARY= assignment with bare "
+            f"{skill_name}/SKILL.md has a BYLINE=/SUMMARY=/REMARK= assignment with bare "
             f"'(swe-workbench)' (no markdown link).\n"
             f"Replace with '[swe-workbench](https://github.com/lugassawan/swe-workbench)'."
         )
 
-    # 3. Canonical link must appear in each consumer's documented BYLINE
+    # 3. Canonical link belongs to the core only (it owns the conditional remark) —
+    #    since #531 each caller's BYLINE is identity-only and must NOT embed it.
+    core_body = POST_CORE_SKILL.read_text()
+    assert canonical in core_body, (
+        f"{POST_CORE_SKILL.parent.name}/SKILL.md does not contain the canonical link '{canonical}'.\n"
+        f"The core owns the swe-workbench remark and must hardcode the tool URL there."
+    )
     for skill_path in (PR_REVIEW_SKILL, PR_REVIEW_FOLLOWUP_SKILL):
         body = skill_path.read_text()
-        assert canonical in body, (
-            f"{skill_path.parent.name}/SKILL.md does not contain the canonical link '{canonical}'.\n"
-            f"BYLINE must hardcode the tool URL, not interpolate the review-target repo."
+        assert canonical not in body, (
+            f"{skill_path.parent.name}/SKILL.md must NOT contain the canonical link '{canonical}' "
+            f"in its documented BYLINE — since #531 BYLINE is identity-only; the core appends "
+            f"the remark itself, conditionally on public repos."
         )
 
     # 4. The core's SUMMARY construction must reference $BYLINE via $BYLINE_FULL
     # (not duplicate the URL string)
-    core_body = POST_CORE_SKILL.read_text()
     assert re.search(r'BYLINE_FULL="\$\{BYLINE\}', core_body), (
         f"{POST_CORE_SKILL.parent.name}/SKILL.md must derive BYLINE_FULL from \"${{BYLINE}}\" "
-        f"so the caller-supplied byline (and its hardcoded URL) flows through unchanged."
+        f"so the caller-supplied byline flows through unchanged, with the remark appended "
+        f"(not embedded) conditionally."
     )
     assert re.search(r'SUMMARY=\$\(printf .+"\$BYLINE_FULL"', core_body, re.DOTALL), (
         f"{POST_CORE_SKILL.parent.name}/SKILL.md SUMMARY construction does not reference "

--- a/tests/test_workflow_pr_review_post_pending_review.py
+++ b/tests/test_workflow_pr_review_post_pending_review.py
@@ -1,0 +1,225 @@
+"""Regression tests for issue #531 — inline-byline removal, pending-review
+(atomic) posting, and the public-only swe-workbench remark.
+
+Target end state (see the #531 plan):
+  - Inline comment bodies (public or private repo) carry finding text only —
+    no byline, no remark, ever.
+  - The summary byline includes the ` ([swe-workbench](url))` remark only
+    when the target repo is confirmed public; private/unknown omits it
+    (fail-safe).
+  - Inline findings post via one atomic `POST /pulls/{n}/reviews` call
+    (comments[] + event) instead of a per-finding loop; self-review submits
+    `event=COMMENT` (GitHub blocks self-APPROVE) so inline comments still
+    land instead of being skipped outright.
+
+Scope: skills/workflow-pr-review-post/SKILL.md (the shared posting core) —
+the only file that owns posting mechanics per the #499 dependency rule.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POST_CORE_SKILL = ROOT / "skills" / "workflow-pr-review-post" / "SKILL.md"
+
+
+def _text() -> str:
+    return POST_CORE_SKILL.read_text()
+
+
+# ---------------------------------------------------------------------------
+# (a) inline comment bodies must never contain the byline/remark
+# ---------------------------------------------------------------------------
+
+
+def test_input_contract_forbids_byline_in_inline_bodies():
+    text = _text()
+    assert re.search(
+        r"(?i)inline comment bod(?:y|ies).{0,120}must not contain the byline",
+        text,
+    ), (
+        "workflow-pr-review-post: the input contract must explicitly forbid the "
+        "byline/remark from appearing in any inline (comments[]) finding body "
+        "(#531 regression guard)"
+    )
+
+
+def test_comments_assembly_body_is_finding_body_verbatim():
+    text = _text()
+    assert '--arg body "$BODY"' in text, (
+        "workflow-pr-review-post: comments[] body assembly must set "
+        "body=$BODY verbatim (the finding's own body), via jq --arg"
+    )
+    for bad in (
+        '--arg body "$BYLINE"',
+        '--arg body "$BYLINE_FULL"',
+        '--arg body "$REMARK"',
+        'body: $body} + $BYLINE',
+    ):
+        assert bad not in text, (
+            f"workflow-pr-review-post: comments[] body must never concatenate "
+            f"{bad!r} — the byline/remark is a Step 4 review-level concern only"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) isPrivate detection + public-only remark + unknown -> omit fail-safe
+# ---------------------------------------------------------------------------
+
+
+def test_visibility_detected_via_gh_repo_view_isprivate():
+    text = _text()
+    assert re.search(r'IS_PRIVATE=\$\(gh repo view .*isPrivate', text), (
+        "workflow-pr-review-post: IS_PRIVATE must be assigned from a "
+        "'gh repo view ... --json isPrivate -q .isPrivate' call"
+    )
+
+
+def test_remark_gated_on_confirmed_public_not_absence_of_true():
+    text = _text()
+    assert re.search(r'"\$IS_PRIVATE"\s*=\s*"false"', text), (
+        "workflow-pr-review-post: the remark must be gated on IS_PRIVATE = \"false\" "
+        "(confirmed public) — gating on '!= true' would wrongly include the "
+        "empty/error case"
+    )
+
+
+def test_remark_omitted_on_unknown_visibility_failsafe():
+    text = _text()
+    assert re.search(r"(?i)fail-safe.{0,60}never advertise", text), (
+        "workflow-pr-review-post: must document that an empty/errored IS_PRIVATE "
+        "result omits the remark (fail-safe — never advertise on an unconfirmed repo)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) self-review submits EVENT=COMMENT, never APPROVE
+# ---------------------------------------------------------------------------
+
+
+def test_self_review_forces_event_comment():
+    text = _text()
+    assert re.search(
+        r'if \[ "\$IS_SELF_REVIEW" = true \]; then EVENT=COMMENT', text
+    ), (
+        "workflow-pr-review-post: self-review must force EVENT=COMMENT "
+        "regardless of $DECISION (GitHub blocks self-APPROVE but allows "
+        "self-COMMENT, so inline comments still land)"
+    )
+    assert 'SUMMARY=""' not in text, (
+        "workflow-pr-review-post: the old skip-submit SUMMARY=\"\" self-review "
+        "branch must be removed — self-review now submits event=COMMENT with a "
+        "real body instead of skipping submit entirely"
+    )
+
+
+def test_never_approve_on_self_review_documented():
+    text = _text()
+    assert re.search(r"(?i)never.{0,20}APPROVE.{0,20}self-review", text), (
+        "workflow-pr-review-post: must explicitly document that self-review "
+        "never submits APPROVE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) empty comments[] falls through to gh pr review --approve|--comment
+# ---------------------------------------------------------------------------
+
+
+def test_empty_comments_falls_through_to_gh_pr_review():
+    text = _text()
+    assert re.search(r'\[\s*"\$N"\s*-gt\s*0\s*\]', text), (
+        "workflow-pr-review-post: submit must branch on whether N (candidate "
+        "inline count) is greater than zero"
+    )
+    assert re.search(r"gh pr review .*--approve", text), (
+        "workflow-pr-review-post: the empty/fallback path must still support "
+        "gh pr review --approve"
+    )
+    assert re.search(r"gh pr review .*--comment", text), (
+        "workflow-pr-review-post: the empty/fallback path must still support "
+        "gh pr review --comment"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) atomic-422 retries once against a re-fetched HEAD, then falls back
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_422_retries_once_then_falls_back_to_model_a():
+    text = _text()
+    assert re.search(r"(?i)retry.{0,30}once", text), (
+        "workflow-pr-review-post: must document a single retry on a "
+        "whole-review 422"
+    )
+    assert re.search(r"headRefOid", text), (
+        "workflow-pr-review-post: the 422 retry must re-fetch HEAD_SHA via "
+        "'gh pr view ... --json headRefOid'"
+    )
+    assert re.search(r"(?i)model-A", text), (
+        "workflow-pr-review-post: must document the model-A per-comment "
+        "fallback path reachable after a confirmed double-422"
+    )
+
+
+def test_never_blind_retries_on_network_or_5xx():
+    text = _text()
+    assert re.search(r"(?i)never.{0,20}blind-retry", text), (
+        "workflow-pr-review-post: must document that network/5xx failures are "
+        "never blind-retried (no idempotency key — a retried success after an "
+        "already-landed post would double-post every comment)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reviewer-caught regression: the pre-submit SUMMARY is embedded in the
+# atomic POST's own body= field, so it must be built from the frozen
+# candidate count $N — $posted_inline is not assigned until *after* that
+# same POST is attempted, so referencing it in the pre-submit body silently
+# expands to an empty string in the review actually posted to GitHub.
+# ---------------------------------------------------------------------------
+
+
+def test_pre_submit_summary_built_from_candidate_count_n():
+    text = _text()
+    assert "Posted ${N} inline comment(s)" in text, (
+        "workflow-pr-review-post: the pre-submit BYLINE_FULL (embedded into the "
+        "atomic POST's own body=$SUMMARY) must read 'Posted ${N} inline "
+        "comment(s)' — $posted_inline is unset until Step 4's atomic POST "
+        "attempt completes, so using it in the pre-submit body posts an empty "
+        "count on every successful atomic-path run"
+    )
+
+
+def test_deduped_count_tracked_in_dedup_match_branch():
+    text = _text()
+    assert re.search(r"(?i)increment.{0,20}`?\$?deduped", text), (
+        "workflow-pr-review-post: the dedup 'On match' branch must explicitly "
+        "instruct incrementing $deduped — the old single-paragraph "
+        "'posted_inline=N, deduped=M' tracking note was removed when Step 2 "
+        "was rewritten and never replaced"
+    )
+
+
+def test_422_retry_rebuilds_comments_against_refreshed_head():
+    text = _text()
+    assert re.search(r"STILL_IN_DIFF|re-check.{0,40}in.diff", text, re.IGNORECASE), (
+        "workflow-pr-review-post: the 422 retry must actually re-validate/rebuild "
+        "COMMENTS_ARGS against the refreshed HEAD_SHA (not just claim to in prose "
+        "while reusing the original unchanged array) — a genuinely stale line "
+        "would otherwise 422 again on retry"
+    )
+
+
+def test_fallback_loop_never_silently_drops_a_finding():
+    text = _text()
+    assert re.search(
+        r"(?i)fallback.{0,200}never.{0,20}drop|never.{0,40}drop.{0,200}fallback",
+        text,
+        re.DOTALL,
+    ), (
+        "workflow-pr-review-post: the model-A fallback loop must document that "
+        "a comment failing even the individual per-comment POST is demoted to a "
+        "follow-up pr-level comment and logged — never silently skipped"
+    )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Inline PR-review comments no longer carry the reviewer byline/remark on any repo, public or private (issue #531) — enforced structurally (`comments[]` bodies come from `finding.body` verbatim) and by an explicit input-contract clause + regression test.
- Migrated inline posting from a per-finding `POST /pulls/{n}/comments` loop to an atomic pending-review model: findings are pre-validated against the diff, assembled into a `comments[]` JSON array via `jq`, and posted in one `POST /pulls/{n}/reviews` call (`gh api --input -`, not bracket-indexed field flags — those build a stringified-key object, not an array, and GitHub rejects it).
- The ` ([swe-workbench](https://github.com/lugassawan/swe-workbench))` remark in the review summary byline now appends only when the target repo is confirmed public (`gh repo view --json isPrivate` returns `"false"`); private/unknown-visibility repos omit it (fail-safe). Callers now author an identity-only `BYLINE`; the core owns the remark as a single constant.
- Self-review now submits `event=COMMENT` (GitHub blocks self-`APPROVE` but allows self-`COMMENT`) instead of skipping submit entirely, so a self-authored review's inline/pr-level comments still land under the new atomic model.
- On a 422 from the atomic POST, the core re-fetches `HEAD_SHA`, re-validates/reassembles against it, and retries once; a second failure (or a non-422 failure, never blind-retried) falls back to posting each comment individually.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 1829/1829 pass, including new regression coverage for the #531 byline-removal, public-only-remark gating, self-review `event=COMMENT`, empty-`comments[]` fall-through, and atomic-422-fallback contracts

### Type-tailored checks (feat)
- [x] New behaviour verified end-to-end via TDD (failing assertions written first, then the `SKILL.md` prose edited to match) and two independent code-review passes (plan-alignment + diff correctness/security/design), including a live verification that `gh api --input -` with a `jq`-built JSON payload correctly produces the `comments[]` array (the original bracket-indexed `-f` approach was caught and fixed in review — it silently builds a JSON object, not an array).

Closes #531
