### PR TITLE
[fix] Quote CLAUDE_PLUGIN_ROOT in all hook command strings

### DIFF
--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -53,3 +53,33 @@ two consequences:
   prefix requirement stands regardless of this ordering — PATH placement is not something this
   repo controls or should rely on — but it's worth recording that the shadowing direction is the
   opposite of what might be assumed.
+
+## 4. Hook `if` conditions — considered, not adopted
+
+`.claude-plugin/schemas/plugin.schema.json` defines the command-hook object as `{type, command,
+if, shell, timeout, statusMessage, once, async, asyncRewake}`. `if` is documented as *"Permission
+rule syntax to filter when this hook runs (e.g. `Bash(git *)`). Only runs if the tool call matches
+the pattern."* — it filters a tool-call payload against a pattern; it is not a general-purpose
+guard.
+
+Applied to every entry in `hooks/hooks.json` (issue #557), no `if` buys anything:
+
+| Hook | Event | Why `if` buys nothing |
+|---|---|---|
+| `bash_guard.sh` | `PreToolUse` / `Bash` | `Bash(*)` is exactly redundant with `matcher` |
+| `inject_plugin_root.sh` | `PreToolUse` / `Bash` | Same |
+| `skill_usage_record.sh` | `PreToolUse` / `Skill` | `Skill(*)` is exactly redundant with `matcher` |
+| `worktree_permission_grant.sh` | `PreToolUse` / `Read\|Edit\|Write` | Worktree root is runtime-resolved, not a static path rule |
+| `secret_guard.py` | `PreToolUse` / `Write\|Edit` | Same as `worktree_permission_grant.sh` — no static pattern captures "contains a credential" |
+| `skill_autoload_hint.sh` | `PostToolUse` / `Read\|Edit\|Write` | Would need every extension enumerated; a miss silently loses the hint |
+| `skill_usage_flush.sh` | `SubagentStop` | No tool call to match against — inert at best, disabling at worst |
+| `workflow_resume_hint.sh` ×3 | `SessionStart` | Same — lifecycle events carry no tool call |
+
+**Ruling: no `hooks.json` entry may carry an `if` key**, enforced by
+`scripts/validate.py:check_hooks_json()`. This is strictly stronger than the two security
+controls (`bash_guard.sh`, `secret_guard.py`) that originally motivated the question — every entry
+in the table above hits the same failure mode: `if` is one more predicate that can silently
+disable a hook (a miss reads as "hook chose not to fire," not as an error) for zero filtering
+benefit over what `matcher` already provides or what the script can check for itself at runtime.
+
+Cross-reference: #547, #557.

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -62,7 +62,7 @@ rule syntax to filter when this hook runs (e.g. `Bash(git *)`). Only runs if the
 the pattern."* — it filters a tool-call payload against a pattern; it is not a general-purpose
 guard.
 
-Applied to every entry in `hooks/hooks.json` (issue #557), no `if` buys anything:
+Applied to every entry in `hooks/hooks.json`, no `if` buys anything:
 
 | Hook | Event | Why `if` buys nothing |
 |---|---|---|
@@ -81,5 +81,3 @@ controls (`bash_guard.sh`, `secret_guard.py`) that originally motivated the ques
 in the table above hits the same failure mode: `if` is one more predicate that can silently
 disable a hook (a miss reads as "hook chose not to fire," not as an error) for zero filtering
 benefit over what `matcher` already provides or what the script can check for itself at runtime.
-
-Cross-reference: #547, #557.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/bash_guard.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/bash_guard.sh"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/inject_plugin_root.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/inject_plugin_root.sh"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_usage_record.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/skill_usage_record.sh"
           }
         ]
       },
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/worktree_permission_grant.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/worktree_permission_grant.sh"
           }
         ]
       },
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/secret_guard.py"
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/secret_guard.py"
           }
         ]
       }
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_autoload_hint.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/skill_autoload_hint.sh"
           }
         ]
       }
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/skill_usage_flush.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/skill_usage_flush.sh"
           }
         ]
       }
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/workflow_resume_hint.sh"
           }
         ]
       },
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/workflow_resume_hint.sh"
           }
         ]
       },
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PLUGIN_ROOT/hooks/workflow_resume_hint.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/hooks/workflow_resume_hint.sh"
           }
         ]
       }

--- a/hooks/inject_plugin_root.sh
+++ b/hooks/inject_plugin_root.sh
@@ -6,8 +6,8 @@
 # tool calls, so a command like `bash "$CLAUDE_PLUGIN_ROOT/runtime/foo.sh"`
 # resolves to an empty prefix and fails. This hook's OWN environment does
 # have the authoritative value (proven by the fact that hooks.json invokes
-# every hook via $CLAUDE_PLUGIN_ROOT/hooks/<script>), so it reads it and
-# re-injects it into the command about to run.
+# every hook via bash "${CLAUDE_PLUGIN_ROOT}"/hooks/<script>), so it reads
+# it and re-injects it into the command about to run.
 #
 # Surgical scope: only rewrites commands that reference CLAUDE_PLUGIN_ROOT
 # and don't already assign it. Never blocks — exit 0 in every branch.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -164,6 +164,16 @@ def check_marketplace_json(plugin_data):
             )
 
 
+# Closed-form shape for every hooks.json command string (issue #557): an
+# explicit interpreter plus a quoted, braced CLAUDE_PLUGIN_ROOT expansion.
+# This is a positive invariant this repo owns, not validation against the
+# platform schema — a future hook needing arguments must widen this regex
+# explicitly, which is the fail-loud behaviour intended.
+_HOOK_COMMAND_SHAPE_RE = re.compile(
+    r'^(?:bash|python3) "\$\{CLAUDE_PLUGIN_ROOT\}"/hooks/[A-Za-z0-9_.-]+$'
+)
+
+
 def check_hooks_json():
     path = ROOT / "hooks" / "hooks.json"
     try:
@@ -195,8 +205,21 @@ def check_hooks_json():
                     continue
                 if not isinstance(hook.get("type"), str):
                     fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].type must be a string")
-                if not isinstance(hook.get("command"), str):
+                command = hook.get("command")
+                if not isinstance(command, str):
                     fail(path.relative_to(ROOT), f"hooks.{event}[{i}].hooks[{j}].command must be a string")
+                elif not _HOOK_COMMAND_SHAPE_RE.match(command):
+                    fail(
+                        path.relative_to(ROOT),
+                        f"hooks.{event}[{i}].hooks[{j}].command {command!r} does not match the "
+                        f"required shape '(bash|python3) \"${{CLAUDE_PLUGIN_ROOT}}\"/hooks/<script>' (#557)",
+                    )
+                if "if" in hook:
+                    fail(
+                        path.relative_to(ROOT),
+                        f"hooks.{event}[{i}].hooks[{j}] carries an 'if' condition — no hooks.json "
+                        f"entry may use 'if' (see docs/plugin-platform-decisions.md §4)",
+                    )
 
 
 def check_skills(cache=None):
@@ -909,6 +932,28 @@ def check_hook_scripts():
             fail(py_file.relative_to(ROOT), str(exc))
 
 
+def check_hook_script_permissions():
+    """Every hooks/*.sh and hooks/*.py must be executable.
+
+    hooks.json now always spells out an explicit interpreter (bash/python3),
+    so the exec bit is no longer load-bearing for hook invocation itself —
+    but it must stay set so a script also works when run directly (e.g. by a
+    developer debugging it, or a future caller that invokes it bare). This
+    closes a real gap: skill_usage_record.sh, skill_usage_flush.sh, and
+    workflow_resume_hint.sh previously had zero exec-bit coverage anywhere
+    in this repo's checks or tests (#557).
+
+    Checks the exec bit only (os.access, matching check_bin_wrappers() below)
+    rather than an exact 0755 mode: a checkout under umask 002 legitimately
+    produces 0775 for a file git tracks as executable, and that must not be
+    a spurious failure unrelated to any file actually edited.
+    """
+    hooks_dir = ROOT / "hooks"
+    for script in sorted(list(hooks_dir.glob("*.sh")) + list(hooks_dir.glob("*.py"))):
+        if not os.access(script, os.X_OK):
+            fail(script.relative_to(ROOT), "must be executable (chmod +x)")
+
+
 # Every bin/ wrapper must be invokable as a bare command once <plugin>/bin is
 # on PATH: exec-bit set, a #!/usr/bin/env <interp> shebang (any interpreter,
 # not just bash — see docs/plugin-platform-decisions.md), and the
@@ -1573,6 +1618,7 @@ def main():
     check_unwired_principle_skills(cache=cache)
     check_examples()
     check_hook_scripts()
+    check_hook_script_permissions()
     check_bin_wrappers()
     check_test_subprocess_env()
     check_no_cycles(cache=cache)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,7 +42,10 @@ def make_plugin_tree(
             "PreToolUse": [
                 {
                     "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": "exit 0"}],
+                    "hooks": [{
+                        "type": "command",
+                        "command": 'bash "${CLAUDE_PLUGIN_ROOT}"/hooks/example.sh',
+                    }],
                 }
             ]
         }

--- a/tests/test_hooks_json_wiring.py
+++ b/tests/test_hooks_json_wiring.py
@@ -1,0 +1,177 @@
+"""Runtime regression guard for hooks/hooks.json command strings (issue #557).
+
+Every hooks.json command must resolve correctly when CLAUDE_PLUGIN_ROOT
+contains a space, under a bash login shell. Unquoted `$CLAUDE_PLUGIN_ROOT/...`
+word-splits under bash/sh (but not zsh) once the value contains a space,
+silently killing the hook — for bash_guard.sh and secret_guard.py that means
+a security control stops vetting tool calls with no error surfaced. Pinning
+`bash -c` here (never `$SHELL`/`sh`) is load-bearing: a harness that shelled
+out via zsh would report green against the pre-fix strings and guard nothing.
+See docs/plugin-platform-decisions.md for background.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+HOOKS_JSON = ROOT / "hooks" / "hooks.json"
+
+
+def _hook_commands():
+    """Return the deduplicated set of command strings from hooks.json, in
+    first-seen order (workflow_resume_hint.sh appears identically 3x)."""
+    data = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    seen = []
+    for matchers in data["hooks"].values():
+        for entry in matchers:
+            for hook in entry.get("hooks", []):
+                cmd = hook["command"]
+                if cmd not in seen:
+                    seen.append(cmd)
+    return seen
+
+
+def _script_name(cmd):
+    """Basename after the final '/', independent of the shape regex — both
+    the pre-fix (unquoted) and fixed (quoted, interpreter-prefixed) forms
+    end in '/hooks/<script>', so this works for either without assuming the
+    fix is already in place (a pre-fix hooks.json must still build a usable
+    fixture so the resolution failure surfaces as a real subprocess exit
+    code, not a Python-side AttributeError from a regex that only matches
+    the fixed shape)."""
+    return cmd.rstrip().rsplit("/", 1)[-1]
+
+
+def _script_interp(cmd):
+    return "python3" if cmd.split(None, 1)[0] == "python3" else "bash"
+
+
+def _stub_source(interp, name):
+    if interp == "python3":
+        return f'print("EXECUTED:{name}")\n'
+    return f'echo "EXECUTED:{name}"\n'
+
+
+@pytest.fixture
+def fake_plugin_root(tmp_path):
+    """A plugin root at a spaced path, with a stub for every hook script.
+
+    Stubs (not the real scripts) are deliberate: the defect under test is
+    command-string *resolution*, not hook behavior — that's covered by
+    test_hooks.py, test_secret_guard.py, and test_workflow_resume_hook.py.
+    """
+    root = tmp_path / "with space" / "root"
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    for cmd in _hook_commands():
+        name = _script_name(cmd)
+        interp = _script_interp(cmd)
+        stub = hooks_dir / name
+        stub.write_text(_stub_source(interp, name), encoding="utf-8")
+        stub.chmod(0o755)
+    return root
+
+
+def _run_command(cmd, plugin_root):
+    return subprocess.run(
+        ["bash", "-c", cmd],
+        env={**dict(_CLEAN_ENV), "CLAUDE_PLUGIN_ROOT": str(plugin_root)},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@pytest.mark.parametrize("cmd", _hook_commands())
+class TestSpacedRootResolution:
+    def test_resolves_with_spaced_root(self, cmd, fake_plugin_root):
+        name = _script_name(cmd)
+        result = _run_command(cmd, fake_plugin_root)
+        assert result.returncode == 0, (
+            f"command {cmd!r} failed against a spaced CLAUDE_PLUGIN_ROOT "
+            f"(exit {result.returncode}): {result.stderr!r}"
+        )
+        assert result.stdout.strip() == f"EXECUTED:{name}"
+
+    def test_execute_bit_independent(self, cmd, fake_plugin_root):
+        """The interpreter prefix means a stub with its exec bit stripped
+        must still run — resolution never depends on the shebang or +x."""
+        name = _script_name(cmd)
+        stub = fake_plugin_root / "hooks" / name
+        stub.chmod(0o644)
+        result = _run_command(cmd, fake_plugin_root)
+        assert result.returncode == 0, (
+            f"command {cmd!r} failed against a non-executable stub "
+            f"(exit {result.returncode}): {result.stderr!r}"
+        )
+        assert result.stdout.strip() == f"EXECUTED:{name}"
+
+
+def test_unquoted_form_word_splits_and_fails_with_127():
+    """Literal, hardcoded proof of the underlying bug (issue #557) —
+    independent of hooks.json's live content, so this regression proof
+    holds even once every real command already passes the fixed shape.
+
+    An unquoted `$CLAUDE_PLUGIN_ROOT` expansion word-splits under bash once
+    the value contains a space: the first word ('/no') is treated as the
+    command to execute, is not found, and bash exits 127 before ever
+    reaching the intended script. This mirrors the empirical verification
+    from the issue:
+
+        bash, unquoted  $R/hooks/x.sh   -> ARG=[/no]  ARG=[such/dir/hooks/x.sh]
+    """
+    result = subprocess.run(
+        ["bash", "-c", "$CLAUDE_PLUGIN_ROOT/hooks/bash_guard.sh"],
+        env={**dict(_CLEAN_ENV), "CLAUDE_PLUGIN_ROOT": "/no such/dir"},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 127, (
+        f"expected the unquoted form to word-split and exit 127, got "
+        f"{result.returncode}: {result.stderr!r}"
+    )
+    # The distinguishing signal isn't the exit code alone (a quoted-but-
+    # missing script also exits 127) — it's *what* bash reports as missing:
+    # the split-off first word, never the intended script path.
+    assert "/no: No such file or directory" in result.stderr, (
+        f"expected bash to report the split fragment '/no' as missing, got: {result.stderr!r}"
+    )
+    assert "bash_guard.sh" not in result.stderr
+
+
+def test_quoted_form_survives_spaced_root():
+    """Counterpart to the above: the fixed, quoted form must NOT word-split
+    the same spaced value. Exit code is still 127 (the script doesn't exist
+    on this scratch path) — the proof is that bash reports the FULL spaced
+    path as missing, showing the value survived as one word, not a split
+    fragment."""
+    result = subprocess.run(
+        ["bash", "-c", 'bash "${CLAUDE_PLUGIN_ROOT}"/hooks/bash_guard.sh'],
+        env={**dict(_CLEAN_ENV), "CLAUDE_PLUGIN_ROOT": "/no such/dir"},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert "/no such/dir/hooks/bash_guard.sh" in result.stderr, (
+        f"expected the full spaced path in bash's error, got: {result.stderr!r}"
+    )
+
+
+def test_secret_guard_uses_python3():
+    cmds = [c for c in _hook_commands() if "secret_guard.py" in c]
+    assert cmds, "secret_guard.py not found in hooks.json"
+    for cmd in cmds:
+        assert cmd.startswith("python3 "), f"expected python3 interpreter, got: {cmd!r}"
+
+
+def test_sh_scripts_use_bash():
+    cmds = [c for c in _hook_commands() if c.rstrip().endswith(".sh")]
+    assert cmds, "no .sh hook commands found in hooks.json"
+    for cmd in cmds:
+        assert cmd.startswith("bash "), f"expected bash interpreter, got: {cmd!r}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -259,6 +259,115 @@ class TestCheckHooksJson:
         validate.check_hooks_json()
         assert any("PreToolUse[0].hooks[0] must be an object" in f for f in validate.FAILURES)
 
+    def test_conforming_command_shape_passes(self, reset_validate):
+        root = reset_validate
+        good = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": 'bash "${CLAUDE_PLUGIN_ROOT}"/hooks/x.sh'}],
+                }]
+            }
+        }
+        make_plugin_tree(root, hooks_json=good)
+        validate.check_hooks_json()
+        assert len(validate.FAILURES) == 0
+
+    def test_unquoted_command_fails_shape(self, reset_validate):
+        root = reset_validate
+        bad = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "$CLAUDE_PLUGIN_ROOT/hooks/x.sh"}],
+                }]
+            }
+        }
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("does not match the required shape" in f for f in validate.FAILURES)
+
+    def test_bare_path_command_fails_shape(self, reset_validate):
+        root = reset_validate
+        bad = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": '"${CLAUDE_PLUGIN_ROOT}"/hooks/x.sh'}],
+                }]
+            }
+        }
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("does not match the required shape" in f for f in validate.FAILURES)
+
+    def test_if_key_fails(self, reset_validate):
+        root = reset_validate
+        bad = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": 'bash "${CLAUDE_PLUGIN_ROOT}"/hooks/x.sh',
+                        "if": "Bash(git *)",
+                    }],
+                }]
+            }
+        }
+        make_plugin_tree(root, hooks_json=bad)
+        validate.check_hooks_json()
+        assert any("carries an 'if' condition" in f for f in validate.FAILURES)
+
+
+# ──────────────────────────────────────────────
+# check_hook_script_permissions
+# ──────────────────────────────────────────────
+
+class TestCheckHookScriptPermissions:
+    def test_conforming_permissions_pass(self, reset_validate):
+        root = reset_validate
+        hooks_dir = root / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / "example.sh"
+        script.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+        script.chmod(0o755)
+        validate.check_hook_script_permissions()
+        assert len(validate.FAILURES) == 0
+
+    def test_umask_002_mode_0775_still_passes(self, reset_validate):
+        """A checkout under umask 002 legitimately produces 0775 for a file
+        git tracks as executable — must not be a spurious failure (only the
+        exec bit matters, not the exact mode)."""
+        root = reset_validate
+        hooks_dir = root / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / "example.sh"
+        script.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+        script.chmod(0o775)
+        validate.check_hook_script_permissions()
+        assert len(validate.FAILURES) == 0
+
+    def test_not_executable_fails(self, reset_validate):
+        root = reset_validate
+        hooks_dir = root / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / "example.sh"
+        script.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+        script.chmod(0o644)
+        validate.check_hook_script_permissions()
+        assert any("must be executable" in f for f in validate.FAILURES)
+
+    def test_python_hook_checked_too(self, reset_validate):
+        root = reset_validate
+        hooks_dir = root / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        script = hooks_dir / "example.py"
+        script.write_text("#!/usr/bin/env python3\nprint('hi')\n", encoding="utf-8")
+        script.chmod(0o644)
+        validate.check_hook_script_permissions()
+        assert any("example.py" in f and "must be executable" in f for f in validate.FAILURES)
+
 
 # ──────────────────────────────────────────────
 # check_skills


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Every `hooks/hooks.json` command string was a bare, unquoted `$CLAUDE_PLUGIN_ROOT/hooks/<script>`. When the plugin root path contains a space and the login shell is bash/sh (not zsh), the unquoted expansion word-splits before the shell resolves a command, and the hook silently never executes — for `bash_guard.sh` and `secret_guard.py` this is a silent loss of a security control with no error surfaced.
- Rewrites all 10 command strings to an explicit-interpreter, quoted form: `bash "${CLAUDE_PLUGIN_ROOT}"/hooks/<script>.sh` / `python3 "${CLAUDE_PLUGIN_ROOT}"/hooks/secret_guard.py`. Entry order, matchers, and events are unchanged.
- Adds `tests/test_hooks_json_wiring.py`: a runtime regression guard that runs every hooks.json command string via `bash -c` (pinned — never `$SHELL`/`sh`, since zsh doesn't word-split and would hide the bug) against a spaced `CLAUDE_PLUGIN_ROOT`, plus two hardcoded literal RED/GREEN tests reproducing the exact `exit 127` word-split failure from the issue and its quoted-form fix.
- Extends `scripts/validate.py::check_hooks_json()` with a closed-form command-shape regex and a check that no hook entry carries an `if` key, and adds a new `check_hook_script_permissions()` asserting every `hooks/*.sh`/`*.py` is executable (checks the exec bit, not an exact mode, so a `umask 002` checkout doesn't false-positive).
- Adds `## 4. Hook `if` conditions — considered, not adopted` to `docs/plugin-platform-decisions.md`, documenting a scope correction from the issue: analysis against the platform schema shows `if` buys nothing for *any* of the 10 hooks (not just the 5 "advisory" ones the issue's acceptance criteria called out) — see the PR comment on #557 for the full per-hook table.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh && pytest tests/ -v` — 2292 passed, 1 skipped (pre-existing)
- [x] `shellcheck -S warning` over all `.sh` files and `bin/swe-workbench-*` — 0 issues

### Type-tailored checks (fix)
- [x] Reproduced the original bug directly: `bash -c '$CLAUDE_PLUGIN_ROOT/hooks/bash_guard.sh'` against a spaced root exits 127 (word-split); confirmed the fixed form resolves correctly
- [x] Proved RED before GREEN: reverted `hooks/hooks.json` to its pre-fix content and confirmed `tests/test_hooks_json_wiring.py` fails with a genuine subprocess `exit 127` (not a Python-side error) across all 8 hook scripts; restored the fix and confirmed GREEN
- [x] Two independent review passes (plan-alignment + diff-level correctness/security/design) completed; both findings (RED-proof mechanism, exec-bit exact-mode fragility under `umask 002`) fixed and re-verified

Closes #557
