### PR TITLE
[feat] Document MySQL 8.0 DDL migration footguns in language-sql (#575)

### DIFF
--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -31,6 +31,25 @@ description: SQL idioms — query tuning, EXPLAIN plans, table definitions, cons
 - Know the anomalies you are allowing: dirty reads, non-repeatable reads, phantoms, and write skew.
 - Use optimistic concurrency with version columns when conflicts are rare and retriable.
 
+## DDL migration footguns (MySQL 8.0)
+- `BEGIN`/`COMMIT` around DDL grants no atomicity in MySQL: each DDL statement auto-commits independently, wrapper or not. Treat it as a readability convention, not a safety net.
+- A run killed mid-way (CI timeout, dropped connection) leaves earlier statements committed while the tracker records nothing — drifted schema, no audit trail. Plan recovery forward-only; make each statement independently re-runnable.
+- `ADD COLUMN` already gets `ALGORITHM=INSTANT` (metadata-only) by default on 8.0.12+. An explicit `INPLACE` or `COPY` overrides that default and forces a full table+index rebuild — treat as a defect unless the column is genuinely `INSTANT`-ineligible (pre-8.0.29: end-of-table adds only; `ROW_FORMAT=COMPRESSED` always). `DROP COLUMN` only becomes `INSTANT`-eligible on 8.0.29+.
+- `ADD INDEX`/`DROP INDEX` are the exception: `ALGORITHM=INPLACE, LOCK=NONE` is correct and expected here — `INSTANT` cannot build an index, so do not flag `INPLACE` on index DDL.
+- Check `information_schema.tables.table_rows` before choosing an approach; migration cost is invisible in the DDL text and scales with table size, not statement count.
+- On tables over 50M rows, split `INSTANT`-eligible column adds into their own migration file, separate from index builds — a mid-run failure then leaves a smaller, more legible partial state.
+
+```sql
+-- Suspect: forces a full rebuild MySQL would otherwise skip (8.0.12+ defaults to INSTANT)
+ALTER TABLE orders ADD COLUMN notes TEXT, ALGORITHM=INPLACE, LOCK=NONE;
+
+-- Preferred: let MySQL pick INSTANT; add columns without the override
+ALTER TABLE orders ADD COLUMN notes TEXT;
+
+-- Correct: INSTANT cannot build an index; INPLACE is required here
+ALTER TABLE orders ADD INDEX idx_orders_customer_id (customer_id), ALGORITHM=INPLACE, LOCK=NONE;
+```
+
 ## Deadlock avoidance
 - Touch shared tables and rows in a consistent order across code paths.
 - Lock only what you need, as late as possible, and commit as soon as the invariant is protected.
@@ -99,4 +118,5 @@ ROLLBACK;
 - Schema changes without rollback or compatibility planning.
 - Unbounded queries in production paths.
 - Relying on implicit ordering without `ORDER BY`.
+- Wrapping MySQL DDL in `BEGIN`/`COMMIT` for atomicity, or an unqualified `ALGORITHM=INPLACE` on a column add — see DDL migration footguns above.
 - Never build SQL by concatenating untrusted input — use parameterized queries or prepared statements. ORM raw-query escape hatches (e.g. Django's `extra()`, SQLAlchemy's `text()`) are equally dangerous. See `swe-workbench:principle-security`.

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -119,5 +119,5 @@ ROLLBACK;
 - Schema changes without rollback or compatibility planning.
 - Unbounded queries in production paths.
 - Relying on implicit ordering without `ORDER BY`.
-- Wrapping MySQL DDL in `BEGIN`/`COMMIT` for atomicity, or an unnecessary `ALGORITHM=INPLACE`/`COPY` on a column add — see DDL migration footguns above.
+- Wrapping MySQL DDL in `BEGIN`/`COMMIT` for atomicity, or an unnecessary `ALGORITHM=INPLACE`/`COPY` on a column add/drop — see DDL migration footguns above.
 - Never build SQL by concatenating untrusted input — use parameterized queries or prepared statements. ORM raw-query escape hatches (e.g. Django's `extra()`, SQLAlchemy's `text()`) are equally dangerous. See `swe-workbench:principle-security`.

--- a/skills/language-sql/SKILL.md
+++ b/skills/language-sql/SKILL.md
@@ -43,8 +43,9 @@ description: SQL idioms — query tuning, EXPLAIN plans, table definitions, cons
 -- Suspect: forces a full rebuild MySQL would otherwise skip (8.0.12+ defaults to INSTANT)
 ALTER TABLE orders ADD COLUMN notes TEXT, ALGORITHM=INPLACE, LOCK=NONE;
 
--- Preferred: let MySQL pick INSTANT; add columns without the override
-ALTER TABLE orders ADD COLUMN notes TEXT;
+-- Preferred: pin INSTANT explicitly — errors loudly if ineligible instead of
+-- silently degrading to INPLACE/COPY the way an omitted ALGORITHM clause would
+ALTER TABLE orders ADD COLUMN notes TEXT, ALGORITHM=INSTANT;
 
 -- Correct: INSTANT cannot build an index; INPLACE is required here
 ALTER TABLE orders ADD INDEX idx_orders_customer_id (customer_id), ALGORITHM=INPLACE, LOCK=NONE;
@@ -118,5 +119,5 @@ ROLLBACK;
 - Schema changes without rollback or compatibility planning.
 - Unbounded queries in production paths.
 - Relying on implicit ordering without `ORDER BY`.
-- Wrapping MySQL DDL in `BEGIN`/`COMMIT` for atomicity, or an unqualified `ALGORITHM=INPLACE` on a column add — see DDL migration footguns above.
+- Wrapping MySQL DDL in `BEGIN`/`COMMIT` for atomicity, or an unnecessary `ALGORITHM=INPLACE`/`COPY` on a column add — see DDL migration footguns above.
 - Never build SQL by concatenating untrusted input — use parameterized queries or prepared statements. ORM raw-query escape hatches (e.g. Django's `extra()`, SQLAlchemy's `text()`) are equally dangerous. See `swe-workbench:principle-security`.

--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -37,7 +37,9 @@ wheel==0.47.0 \
 pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
-    # via pip-tools
+    # via
+    #   -r tests/build-requirements.txt
+    #   pip-tools
 setuptools==83.0.0 \
     --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
     --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3

--- a/tests/build-requirements.txt
+++ b/tests/build-requirements.txt
@@ -1,1 +1,5 @@
 pip-tools==7.5.3
+# pip 26.2 removed pip._internal.utils.compat.stdlib_pkgs, which pip-tools'
+# own sync module still imports — breaks even the latest pip-tools (7.6.0)
+# as of 2026-08-02. Pin below it until upstream ships a fix.
+pip<26.2

--- a/tests/test_language_sql_mysql_ddl.py
+++ b/tests/test_language_sql_mysql_ddl.py
@@ -1,0 +1,129 @@
+"""Structural tests for the MySQL 8.0 DDL migration footguns convention (closes #575).
+
+Acceptance criteria:
+- AC1: skills/language-sql/SKILL.md flags ALGORITHM=INPLACE/COPY on ADD COLUMN/DROP COLUMN as a
+  suspect override of MySQL 8.0's default ALGORITHM=INSTANT, while confirming the same hint is
+  correct and necessary on ADD INDEX/DROP INDEX (INSTANT cannot build an index).
+- AC2: the section states BEGIN/COMMIT grants no atomicity over DDL in MySQL — each statement
+  auto-commits independently.
+- AC3: the section references checking table size (information_schema.tables.table_rows) before
+  choosing a migration approach.
+- AC4: the section recommends splitting migrations on very large tables (>50M rows) so a partial
+  failure leaves a smaller, more legible state.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+SQL_SKILL = ROOT / "skills" / "language-sql" / "SKILL.md"
+
+HEADING = "DDL migration footguns (MySQL 8.0)"
+
+
+def _section(body: str, heading: str) -> str:
+    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks).
+
+    Returns "" when the heading is absent so callers can assert with their own message.
+    """
+    marker = f"## {heading}"
+    if marker not in body:
+        return ""
+    start = body.index(marker) + len(marker)
+    rest = body[start:]
+    fence_open = False
+    lines = []
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~~"):
+            fence_open = not fence_open
+        if not fence_open and line.startswith("## "):
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def test_sql_skill_file_exists():
+    assert SQL_SKILL.exists(), "skills/language-sql/SKILL.md must exist"
+
+
+def test_has_ddl_migration_footguns_section():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), (
+        f"skills/language-sql/SKILL.md must contain a non-empty '## {HEADING}' section"
+    )
+
+
+def test_ddl_atomicity_language_and_begin():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), f"'## {HEADING}' section is empty or missing"
+    assert "BEGIN" in section, (
+        f"'## {HEADING}' must reference BEGIN when explaining DDL auto-commit behavior"
+    )
+    import re
+
+    assert re.search(r"atomic|auto-?commit", section, re.IGNORECASE), (
+        f"'## {HEADING}' must state that DDL statements auto-commit independently "
+        "(no atomicity from BEGIN/COMMIT)"
+    )
+
+
+def test_add_drop_column_flags_inplace_copy_as_suspect():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), f"'## {HEADING}' section is empty or missing"
+    assert "ADD COLUMN" in section, f"'## {HEADING}' must mention ADD COLUMN"
+    assert "INSTANT" in section, f"'## {HEADING}' must mention ALGORITHM=INSTANT as the 8.0 default"
+    import re
+
+    assert re.search(r"INPLACE|COPY", section), (
+        f"'## {HEADING}' must call out INPLACE/COPY as overriding the INSTANT default"
+    )
+    assert re.search(r"overrides?|defect|suspect", section, re.IGNORECASE), (
+        f"'## {HEADING}' must characterize an explicit INPLACE/COPY on a column add/drop as "
+        "an override/defect, not a neutral fact"
+    )
+
+
+def test_add_drop_index_marks_inplace_as_correct():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), f"'## {HEADING}' section is empty or missing"
+    assert "INDEX" in section, f"'## {HEADING}' must mention ADD INDEX/DROP INDEX"
+    assert "LOCK=NONE" in section, f"'## {HEADING}' must reference LOCK=NONE for index builds"
+    import re
+
+    assert re.search(r"correct|expected|necessary", section, re.IGNORECASE), (
+        f"'## {HEADING}' must state that INPLACE/LOCK=NONE is correct and expected for index "
+        "operations, not a blanket ban on INPLACE"
+    )
+
+
+def test_references_table_row_count_check():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), f"'## {HEADING}' section is empty or missing"
+    assert "table_rows" in section, (
+        f"'## {HEADING}' must reference information_schema.tables.table_rows as a pre-migration check"
+    )
+
+
+def test_references_large_table_migration_split():
+    body = SQL_SKILL.read_text()
+    section = _section(body, HEADING)
+    assert section.strip(), f"'## {HEADING}' section is empty or missing"
+    assert "50M" in section, f"'## {HEADING}' must reference the 50M-row threshold"
+    assert "split" in section.lower(), (
+        f"'## {HEADING}' must recommend splitting migrations on very large tables"
+    )
+
+
+def test_skill_file_stays_within_line_cap():
+    body = SQL_SKILL.read_text()
+    line_count = len(body.splitlines())
+    assert line_count <= 150, (
+        f"skills/language-sql/SKILL.md must stay within the 150-line cap "
+        f"(scripts/validate.py); currently {line_count} lines"
+    )

--- a/tests/test_language_sql_mysql_ddl.py
+++ b/tests/test_language_sql_mysql_ddl.py
@@ -12,6 +12,7 @@ Acceptance criteria:
   failure leaves a smaller, more legible state.
 """
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -62,8 +63,6 @@ def test_ddl_atomicity_language_and_begin():
     assert "BEGIN" in section, (
         f"'## {HEADING}' must reference BEGIN when explaining DDL auto-commit behavior"
     )
-    import re
-
     assert re.search(r"atomic|auto-?commit", section, re.IGNORECASE), (
         f"'## {HEADING}' must state that DDL statements auto-commit independently "
         "(no atomicity from BEGIN/COMMIT)"
@@ -76,14 +75,17 @@ def test_add_drop_column_flags_inplace_copy_as_suspect():
     assert section.strip(), f"'## {HEADING}' section is empty or missing"
     assert "ADD COLUMN" in section, f"'## {HEADING}' must mention ADD COLUMN"
     assert "INSTANT" in section, f"'## {HEADING}' must mention ALGORITHM=INSTANT as the 8.0 default"
-    import re
-
     assert re.search(r"INPLACE|COPY", section), (
         f"'## {HEADING}' must call out INPLACE/COPY as overriding the INSTANT default"
     )
     assert re.search(r"overrides?|defect|suspect", section, re.IGNORECASE), (
         f"'## {HEADING}' must characterize an explicit INPLACE/COPY on a column add/drop as "
         "an override/defect, not a neutral fact"
+    )
+    assert re.search(r"DROP COLUMN.{0,120}8\.0\.29|8\.0\.29.{0,120}DROP COLUMN", section, re.DOTALL), (
+        f"'## {HEADING}' must tie DROP COLUMN's INSTANT eligibility specifically to 8.0.29, "
+        "distinct from ADD COLUMN's pre-8.0.29 end-of-table-only rule — the ticket's own premise "
+        "conflated the two"
     )
 
 
@@ -93,8 +95,6 @@ def test_add_drop_index_marks_inplace_as_correct():
     assert section.strip(), f"'## {HEADING}' section is empty or missing"
     assert "INDEX" in section, f"'## {HEADING}' must mention ADD INDEX/DROP INDEX"
     assert "LOCK=NONE" in section, f"'## {HEADING}' must reference LOCK=NONE for index builds"
-    import re
-
     assert re.search(r"correct|expected|necessary", section, re.IGNORECASE), (
         f"'## {HEADING}' must state that INPLACE/LOCK=NONE is correct and expected for index "
         "operations, not a blanket ban on INPLACE"


### PR DESCRIPTION
## Summary
- Add `## DDL migration footguns (MySQL 8.0)` section to `skills/language-sql/SKILL.md` documenting two MySQL 8.0 DDL footguns from a production incident: `ALGORITHM=INPLACE`/`COPY` silently overriding the 8.0.12+ `INSTANT` default on `ADD COLUMN`/`DROP COLUMN` (while being correct/required on `ADD INDEX`/`DROP INDEX`), and `BEGIN`/`COMMIT` granting no atomicity over DDL since each statement auto-commits independently.
- Correct the ticket's `ADD COLUMN`/`DROP COLUMN` INSTANT-eligibility conflation: `DROP COLUMN` INSTANT support landed in 8.0.29, distinct from `ADD COLUMN`'s pre-8.0.29 end-of-table-only rule.
- Add a dedicated structural test file `tests/test_language_sql_mysql_ddl.py` pinning the section's required content per acceptance criterion.
- Scope correction: the ticket named a "sqitch-migration" skill that doesn't exist in this repo; the guidance was added to `skills/language-sql/SKILL.md`, which already auto-loads on `.sql` files — posted as a comment on #575 before opening this PR.
- Unrelated CI fix bundled in: pin `pip<26.2` in `tests/build-requirements.txt`/`.lock`. Upstream `pip` 26.2 (released today) dropped `pip._internal.utils.compat.stdlib_pkgs`, which `pip-tools`' own sync module still imports on both the pinned 7.5.3 and the latest 7.6.0 — broke `scripts/lock-pip-requirements.sh`'s venv bootstrap and failed the `lockfile-check` required CI job on this PR. Pinning below the broken release was the only fix that didn't just trade one CI failure for a worse one.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 -m pytest tests/test_language_sql_mysql_ddl.py -v` — 8/8 pass
- [x] `bash scripts/validate.sh` — all checks pass (150-line cap, frontmatter, ordering)
- [x] `python3 -m pytest tests/ -q` — full suite, 2273 passed, 1 skipped, no regressions
- [x] `bash scripts/lock-pip-requirements.sh --check` — all three lockfiles up to date after the `pip<26.2` pin

### Type-tailored checks (feat)
- [x] New `## DDL migration footguns (MySQL 8.0)` section reads correctly in context (after Transactions and isolation, before Deadlock avoidance) and the `sql` fence is well-formed
- [x] `## Testing` still precedes `## Avoid` (tests/test_behaviour_and_ordering_conventions.py)
- [x] `triggers.txt` and skill frontmatter `description` untouched (no BM25 trigger-margin regression)

Closes #575
