### PR TITLE
[chore] Tighten workflow-hotfix and workflow-extend trigger descriptions

### DIFF
--- a/skills/workflow-delegated-implementation/SKILL.md
+++ b/skills/workflow-delegated-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-delegated-implementation
-description: Phase-2 delegation protocol for workflow-development — conditional scope/complexity gate, file-change grouping by commit-taxonomy axis (Infrastructure/Core logic/Tests/Wiring), dispatch to code-impl with a structured brief (goal, file_set, verify_cmd), summary-only result consumption (re-read prevention), sequential-default with opt-in worktree-isolated parallelism. Distinct from superpowers:subagent-driven-development, which orchestrates tasks in parallel by default; the delegation protocol gates on scope, groups by commit-axis cohesion, and enforces a diff-free return contract.
+description: Phase-2 delegation protocol for workflow-development — conditional scope/complexity gate, file-change grouping by commit-taxonomy axis (Infrastructure/Core logic/Tests/Wiring), dispatch to code-impl with a structured brief (goal, file_set, verify_cmd), summary-only verification result consumption (re-read prevention), sequential-default with opt-in worktree-isolated parallelism. Distinct from superpowers:subagent-driven-development, which orchestrates tasks in parallel by default; the delegation protocol gates on scope, groups by commit-axis cohesion, and enforces a diff-free return contract.
 orchestrator: true
 ---
 

--- a/skills/workflow-extend/SKILL.md
+++ b/skills/workflow-extend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-extend
-description: Captures a mid-PR sub-idea and implements it on the same branch as the existing PR — skips Phase 1 (Branch), preserves Verify → Review → Deliver, and uses workflow-commit-and-pr to update existing PR. Never creates a new branch or new PR.
+description: Captures a mid-PR sub-idea — a small related improvement surfaced mid-flight — and implements onto the same branch as the existing PR without opening anything new, delivering through the update existing PR path. Never a new branch, never a new PR. Activated by /swe-workbench:extend.
 orchestrator: true
 ---
 

--- a/skills/workflow-hotfix/SKILL.md
+++ b/skills/workflow-hotfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-hotfix
-description: Branch-based P0 hotfix lifecycle — skips the worktree provider, ships a PR immediately after a minimal fix (ahead of verification and review, deferred by design), stamps a deferred-verification marker on the PR body, then reconciles it once a regression test lands and the suite is green again. Activated by /swe-workbench:hotfix.
+description: Branch-based P0 incident hotfix lifecycle — skips the worktree provider, opens a ready-for-review PR immediately after a minimal hotfix, ahead of verification and review (deferred by design), stamps a deferred-verification marker in the PR body, then reconciles once a regression test lands and the suite goes green. Activated by /swe-workbench:hotfix.
 orchestrator: true
 ---
 

--- a/tests/test_skill_triggers.py
+++ b/tests/test_skill_triggers.py
@@ -198,6 +198,68 @@ def test_prompt_ranks_target_skill_top1(
     )
 
 
+# ── Family margin guard (issue #566) ──────────────────────────────────────
+
+# Minimum BM25 margin a workflow-* fixture must hold over its nearest non-sibling
+# workflow-* competitor. 9x _SCORE_MARGIN: tight enough to catch the class of
+# generic-description regression #566 found (hotfix margins of 0.243 / 0.829 / 0.920
+# against other workflow-* skills), loose enough to leave the tightest *unrelated*
+# family pair — workflow-codebase-audit vs workflow-codebase-knowledge at 1.077,
+# a pair this change never touches — comfortably green. A 1.0 floor would leave
+# that untouched pair only 4.5% from red.
+_FAMILY_MARGIN = 0.9
+
+_WORKFLOW_FIXTURES = [
+    (skill_name, prompt)
+    for skill_name, prompt in _FIXTURES
+    if skill_name.startswith("workflow-")
+]
+assert _WORKFLOW_FIXTURES, (
+    f"No workflow-* trigger fixtures found under {_SKILLS_DIR} — "
+    "check triggers.txt naming/glob before trusting this guard"
+)
+
+
+@pytest.mark.parametrize(
+    "skill_name,prompt",
+    _WORKFLOW_FIXTURES,
+    ids=[f"{s}::{p[:50]}" for s, p in _WORKFLOW_FIXTURES],
+)
+def test_workflow_family_margin(skill_name, prompt, real_corpus, real_index, sibling_sets):
+    """Every workflow-* fixture must clear its nearest non-sibling workflow-*
+    competitor by >= _FAMILY_MARGIN, regardless of overall rank.
+
+    Scoped to workflow-* vs workflow-* on purpose: this is the family #566 flagged
+    as prone to generic, lifecycle-plumbing descriptions that bleed BM25 signal
+    onto siblings. Other sub-1.0 margins in the corpus (e.g. language-swift,
+    principle-resiliency) have non-workflow targets and are out of scope here.
+    """
+    ranked = _rank_skills(prompt, real_corpus, real_index)
+    scores = dict(ranked)
+    target_score = scores[skill_name]
+
+    _all_groups = [s for s in sibling_sets if skill_name in s]
+    my_siblings = set().union(*_all_groups) if _all_groups else {skill_name}
+
+    rivals = [
+        (n, sc)
+        for n, sc in ranked
+        if n != skill_name and n.startswith("workflow-") and n not in my_siblings
+    ]
+    if not rivals:
+        return
+
+    nearest_name, nearest_score = max(rivals, key=lambda kv: kv[1])
+    margin = target_score - nearest_score
+    assert margin >= _FAMILY_MARGIN, (
+        f"prompt for `{skill_name}` scores {target_score:.3f} but nearest non-sibling "
+        f"workflow-* rival `{nearest_name}` scores {nearest_score:.3f} "
+        f"(margin {margin:.3f} < {_FAMILY_MARGIN}). "
+        f"Tighten skills/{skill_name}/SKILL.md description to reduce overlap with "
+        f"`{nearest_name}`."
+    )
+
+
 # ── Deliberate-vague acceptance test (acceptance criterion #5) ───────────
 
 def test_deliberately_vague_description_is_flagged():

--- a/tests/test_skill_triggers.py
+++ b/tests/test_skill_triggers.py
@@ -206,7 +206,7 @@ def test_prompt_ranks_target_skill_top1(
 # against other workflow-* skills), loose enough to leave the tightest *unrelated*
 # family pair — workflow-codebase-audit vs workflow-codebase-knowledge at 1.077,
 # a pair this change never touches — comfortably green. A 1.0 floor would leave
-# that untouched pair only 4.5% from red.
+# that untouched pair only 0.077 above the line (1.077 vs. 1.0).
 _FAMILY_MARGIN = 0.9
 
 _WORKFLOW_FIXTURES = [


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Tighten `workflow-hotfix` and `workflow-extend`'s `description:` frontmatter — both were generic enough that BM25 (`tests/test_skill_triggers.py`, 61-skill corpus, no stopword list/stemming) routed other skills' own trigger prompts to them as the nearest runner-up instead of the correct target.
- `workflow-hotfix`: swap bare `fix` → `hotfix`, drop `it`/`is` filler clauses (stopword-IDF accidents driving overlap with `workflow-bug-triage`), add `incident`.
- `workflow-extend`: drop generic lifecycle-plumbing phrases that bled onto sibling orchestrator skills (`skips Phase 1`, `preserves Verify → Review → Deliver`, `uses workflow-commit-and-pr`), add the distinguishing tokens `small`/`related`/`improvement`/`opening`. All 5 tokens pinned by `tests/test_extend_command.py:60` are preserved verbatim.
- `workflow-delegated-implementation`: one-word fix — "summary-only result consumption" → "summary-only **verification** result consumption" — closing a description/triggers.txt vocabulary gap of the same class.
- Add a regression guard: `_FAMILY_MARGIN = 0.9` and a new parametrized test `test_workflow_family_margin` in `tests/test_skill_triggers.py`, asserting every `workflow-*` trigger fixture clears its nearest non-sibling `workflow-*` rival by ≥ 0.9 BM25 points, so this class of drift can't recur silently.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -v` — 2414 passed, 1 skipped
- [x] `bash scripts/validate.sh` — all checks passed
- [x] New guard test confirmed RED-before / GREEN-after (see tables below)
- [x] Reproduced issue #566's own metric script — neither `workflow-extend` nor `workflow-hotfix` appears in the top-4 runner-up leaderboard post-fix

### Type-tailored checks (chore)
- [x] Plugin builds/loads: `bash scripts/validate.sh` clean

### Before / after: runner-up leaderboard (issue #566's own reproduction script)

| Skill | Runner-up count (before) | Runner-up count (after) |
|---|---|---|
| `workflow-extend` | 8 | 3 |
| `workflow-hotfix` | 6 | 0 |
| `workflow-cleanup-merged` | 6 | 7 (unaffected, top of leaderboard) |
| `workflow-codebase-knowledge` | 6 | 5 |

Neither `workflow-extend` nor `workflow-hotfix` appears in the post-fix top-4 (`workflow-cleanup-merged` 7, `workflow-pr-review` 6, then a 5-way tie).

### Before / after: BM25 margins

| Pair | Before | After |
|---|---|---|
| `workflow-address-feedback` vs `workflow-hotfix` | 0.243 | 5.05 |
| `workflow-bug-triage` vs `workflow-hotfix` | 0.829 | 11.02 |
| `workflow-delegated-implementation` vs `workflow-hotfix` | 0.920 | 3.93 |
| `workflow-extend` own fixture #3 vs nearest non-sibling | 1.986 | 19.51 |
| `workflow-hotfix` own fixtures (min margin) | ~4.69 | 5.37 |
| Tightest family margin overall (any workflow-* pair) | 0.243 | **1.077** (`workflow-codebase-audit` vs `workflow-codebase-knowledge` — untouched pair) |

`_FAMILY_MARGIN = 0.9` is calibrated below that untouched 1.077 floor with headroom, so this fix doesn't newly redline an unrelated pair.

Closes #566
