### PR TITLE
[feat] LSP code-intelligence literacy for orchestrator skills and depth-first agents

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -2,7 +2,7 @@
 name: auditor
 description: Cold-start codebase audit specialist — readonly multi-domain sweep across security, performance, reliability, tooling, and testing. Surfaces ranked findings with root-cause reasoning chains and counter-evidence calibration. Invoke when you want a time-boxed audit of an unfamiliar codebase, not a single-domain depth-first pass.
 model: sonnet
-tools: Read, Grep, Glob, Bash, Skill
+tools: Read, Grep, Glob, Bash, Skill, LSP
 skills:
   - swe-workbench:principle-code-review
   - swe-workbench:principle-security
@@ -35,7 +35,7 @@ You perform cold-start, time-boxed, multi-domain audits of unfamiliar codebases.
 git log --oneline -20          # recent activity, team velocity
 ```
 
-Use `Glob` for top-level layout. Read manifests: `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`. Note the tech stack and entry points.
+Use `Glob` for top-level layout. Read manifests: `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pom.xml`. Note the tech stack and entry points. See @./shared/lsp.md for handing a finding's anchor off from `Grep` to `LSP` once you need to confirm callers or an implementation, rather than trusting a text match.
 
 ### 2. Domain sweeps (gated by --scope)
 

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -2,7 +2,7 @@
 name: debugger
 description: Bug-fix specialist — root-cause via systematic-debugging, then a minimal behavior-changing fix with a regression test. Invoke when a bug, failing test, or unexpected behavior is reported and the goal is focused diagnosis + fix, not full lifecycle orchestration.
 model: sonnet
-tools: Read, Edit, Grep, Glob, Bash, Skill
+tools: Read, Edit, Grep, Glob, Bash, Skill, LSP
 skills:
   - swe-workbench:principle-solid
   - swe-workbench:principle-clean-architecture
@@ -19,7 +19,7 @@ You are a debugger. You find the root cause, then make the smallest change that 
 
 Root-cause investigation is delegated — do NOT re-derive the discipline.
 
-1. Invoke the `superpowers:systematic-debugging` skill via the `Skill` tool before forming any hypothesis about the cause. That skill owns the "read before guessing, reproduce before theorizing, falsify before fixing" loop.
+1. Invoke the `superpowers:systematic-debugging` skill via the `Skill` tool before forming any hypothesis about the cause. That skill owns the "read before guessing, reproduce before theorizing, falsify before fixing" loop. When that loop calls for tracing the failing symbol's callers, use `Grep`/`Glob` to locate the anchor and `LSP` (`findReferences`/`prepareCallHierarchy` → `incomingCalls`) to walk outward from it with certainty instead of guessing from text matches — see @./shared/lsp.md.
 2. Return here with a confirmed root cause backed by concrete evidence.
 3. Apply the output contract and principle lens below.
 

--- a/agents/refactorer.md
+++ b/agents/refactorer.md
@@ -2,7 +2,7 @@
 name: refactorer
 description: Refactoring specialist — applies Fowler's catalog in small, behavior-preserving steps. Invoke when cleaning up a messy function, module, or class before adding a feature.
 model: sonnet
-tools: Read, Edit, Grep, Glob, Bash, Skill
+tools: Read, Edit, Grep, Glob, Bash, Skill, LSP
 skills:
   - swe-workbench:principle-refactoring
   - swe-workbench:principle-clean-code
@@ -26,7 +26,7 @@ You are a refactoring specialist. You improve structure without changing observa
 
 1. **Diagnose.** Name the smell using `swe-workbench:principle-refactoring`'s smell→move mapping (preloaded via frontmatter — invoke explicitly only if not already present in context).
 2. **Coverage audit.** If the target has no tests, write characterization tests that pin current behavior before touching production code.
-3. **Plan.** Emit an ordered list of moves from `swe-workbench:principle-refactoring`'s Fowler catalog.
+3. **Plan.** Emit an ordered list of moves from `swe-workbench:principle-refactoring`'s Fowler catalog. Before a Move Function or rename, use `Grep`/`Glob` to find the anchor and `LSP` (`findReferences`/`incomingCalls`) to confirm every call site — a missed caller turns a behavior-preserving step into a breaking one; see @./shared/lsp.md.
 4. **Execute.** One step at a time. Run tests after each. Commit per step when practical.
 5. **Verify.** Run the full suite at the end. Diff the public API to confirm nothing external changed. Run the comment scan per @./shared/comment-scan.md and account for every must-triage finding (`KEEP <id> <reason>` or `FIXED <id>`) — the `-M` rename detection it relies on matters here specifically, since this agent moves functions and their doc comments without rewriting them.
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Senior code reviewer — audits diffs for correctness, security, design, missing tests, and comment quality. Invoke when reviewing a PR, a diff, or a completed feature.
 model: sonnet
-tools: Read, Grep, Glob, Bash, Skill
+tools: Read, Grep, Glob, Bash, Skill, LSP
 skills:
   - swe-workbench:principle-code-review
   - swe-workbench:principle-clean-code
@@ -28,7 +28,7 @@ You are a senior code reviewer. Your job is to catch the issues a careful collea
 
 0. **Heuristics loaded.** `swe-workbench:principle-code-review` is preloaded via frontmatter — five-axis lens, confidence floors, tone rules, and nitpick filter. Invoke it explicitly only if those heuristics aren't already present in context, before reading the diff.
 1. Read the diff end-to-end before commenting.
-2. Use `Grep`/`Glob` to understand callers and blast radius.
+2. Use `Grep`/`Glob` to understand callers and blast radius; see @./shared/lsp.md for when to hand off to `LSP` instead of trusting a text match.
 3. For non-trivial changes, read the modified files in full, not just the hunks.
 4. Group findings by severity: Critical, High, Medium, Low. See @./shared/severity-output-contract.md for the base format, sort order, and silence rule. Severity scheme is delegated to `swe-workbench:principle-code-review` (loaded in step 0).
 5. Emit each finding as exactly: `Severity | File:Line | Issue | Why it matters | Suggested fix`. Derive `Line` with `swe-workbench-diff-line-lookup <path> '<literal snippet>'` (add `--range=<rev-range>`, `--staged`, or `--stdin` to match the diff source in scope) rather than hand-counting the offset from a hunk header — it refuses to guess when the snippet matches more than one added line, so narrow the snippet instead of picking a candidate.

--- a/agents/shared/lsp.md
+++ b/agents/shared/lsp.md
@@ -1,0 +1,27 @@
+# LSP navigation
+
+`LSP` gives you a running language server's semantic index of the codebase — the same engine
+behind an IDE's "Go to Definition" or "Find All References," resolving symbols by type and scope
+rather than by spelling. It exposes nine operations: `goToDefinition`, `findReferences`, `hover`,
+`documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`,
+`incomingCalls`, and `outgoingCalls`.
+
+## LSP follows; it does not find
+
+`LSP` has no free-text search of its own — every call needs an anchor position first. The handoff
+is a fixed two-step pair:
+
+1. Use `Grep`/`Glob` to locate the anchor — the symbol's declaration or a call site — giving you
+   its `filePath`, `line`, and `character`.
+2. Feed that anchor to `LSP`: `goToDefinition` or `findReferences` to expand outward from it, or
+   `prepareCallHierarchy` followed by `incomingCalls`/`outgoingCalls` to walk the call graph.
+
+Grep is weakest exactly where this matters: shadowed names, same-named methods on unrelated
+types, re-exports, and callers reached only through an interface all read as text noise to Grep
+but resolve correctly through the language server's semantic index.
+
+## Availability gate — mandatory
+
+> Attempt one LSP call for symbol navigation. If it returns no servers or an error, state
+> `LSP unavailable — falling back to Grep` once and use Grep for the remainder of this run.
+> Do not retry LSP.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -22,6 +22,14 @@ The following MCP servers enable browser-driven E2E testing and console/network 
 
 **Gate behaviour:** when a browser feature is invoked and the required server is absent, the command returns `BLOCKED: … run \`claude mcp add …\` …` and stops. It does not fall back silently or produce partial results. Non-browser `/swe-workbench:test` (unit) and non-web-UI `/swe-workbench:debug` are completely unaffected by these servers.
 
+## Language servers (optional, graceful-fallback)
+
+| Server | Used by | Install | Required? |
+|---|---|---|---|
+| Any LSP server configured in Claude Code (`gopls`, `tsserver`, `pyright`, `rust-analyzer`, …) | `reviewer`, `auditor`, `debugger`, `refactorer` — symbol expansion via the `LSP` tool | Configured in Claude Code itself; this plugin declares and installs none | Optional |
+
+**Fallback behaviour:** unlike the browser servers above, LSP absence never blocks. Agents attempt one call, state `LSP unavailable — falling back to Grep` once, and use `Grep` for the remainder of the run. No `BLOCKED:` sentinel, no partial results, no repeated retries.
+
 ## Claude Code native tools
 
 The following tools are built into Claude Code itself — no plugin install required:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -39,6 +39,14 @@ _BROWSER_INSTALL_HINTS = re.compile(
     r'claude mcp add \S+|npx @playwright/mcp@latest|npx chrome-devtools-mcp@latest'
 )
 
+# LSP tool gate (#559). Any agent granting LSP in its tools: frontmatter must
+# preload the shared LSP doc, which in turn must carry the fallback sentence.
+# Deliberately NOT a body-text regex: agents/shared/principles.md:27 uses "LSP"
+# for the Liskov Substitution Principle, so a substring/body match would
+# false-positive on every agent preloading principle-solid.
+_LSP_FALLBACK = "LSP unavailable — falling back to Grep"   # em dash, U+2014
+_LSP_SHARED_INCLUDE = "@./shared/lsp.md"
+
 
 def fail(path, reason):
     FAILURES.append(f"  {path}: {reason}")
@@ -1280,6 +1288,79 @@ def check_browser_tool_gate(cache=None):
                 )
 
 
+def check_lsp_tool_gate(cache=None):
+    """Any agent granting LSP in its tools: frontmatter must preload
+    agents/shared/lsp.md, and that shared file must carry the LSP-unavailable
+    fallback sentence (#559).
+
+    Only ever inspects the tools: frontmatter scalar (parsed via
+    parse_frontmatter, split on ',' with exact-token membership) — never a
+    body-text regex. agents/shared/principles.md uses "LSP" for the Liskov
+    Substitution Principle, so a body-text match would false-positive on every
+    agent preloading principle-solid.
+
+    If no agent grants LSP, this returns without requiring the shared file to
+    exist — that keeps the check from ossifying a future removal of LSP.
+    """
+    agents_cache = cache[0] if cache is not None else None
+    agents_dir = ROOT / "agents"
+    if not agents_dir.is_dir():
+        return
+
+    granting = []
+    for md in sorted(agents_dir.glob("*.md")):
+        if agents_cache is not None and md in agents_cache:
+            text = agents_cache[md]
+            if text is None:
+                fail(md.relative_to(ROOT), "could not read file")
+                continue
+        else:
+            try:
+                text = md.read_text(encoding="utf-8")
+            except OSError:
+                fail(md.relative_to(ROOT), "could not read file")
+                continue
+        fm = parse_frontmatter(md, text=text)
+        if not fm:
+            continue
+        tools = fm.get("tools")
+        if not isinstance(tools, str):
+            continue
+        tokens = {t.strip() for t in tools.split(",")}
+        if "LSP" not in tokens:
+            continue
+        granting.append((md, text))
+
+    if not granting:
+        return
+
+    shared_path = agents_dir / "shared" / "lsp.md"
+    try:
+        shared_text = shared_path.read_text(encoding="utf-8")
+    except OSError:
+        shared_text = None
+
+    if shared_text is None:
+        fail(
+            shared_path.relative_to(ROOT),
+            "one or more agents grant LSP in tools: but agents/shared/lsp.md "
+            "is missing — add the shared LSP doc with the fallback sentence (#559)",
+        )
+    elif _LSP_FALLBACK not in shared_text:
+        fail(
+            shared_path.relative_to(ROOT),
+            f"missing the fallback sentence {_LSP_FALLBACK!r} (#559)",
+        )
+
+    for md, text in granting:
+        if _LSP_SHARED_INCLUDE not in text:
+            fail(
+                md.relative_to(ROOT),
+                f"grants LSP in tools: but body is missing the "
+                f"{_LSP_SHARED_INCLUDE!r} include (#559)",
+            )
+
+
 # ──────────────────────────────────────────────
 # echo/printf shell footgun (#549)
 # ──────────────────────────────────────────────
@@ -1629,6 +1710,7 @@ def main():
     check_test_subprocess_env()
     check_no_cycles(cache=cache)
     check_browser_tool_gate(cache=cache)
+    check_lsp_tool_gate(cache=cache)
     check_no_echo_var_hazard(cache=cache)
     check_no_printf_var_format(cache=cache)
     check_no_unenumerated_tmp_write(cache=cache)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1293,11 +1293,12 @@ def check_lsp_tool_gate(cache=None):
     agents/shared/lsp.md, and that shared file must carry the LSP-unavailable
     fallback sentence (#559).
 
-    Only ever inspects the tools: frontmatter scalar (parsed via
-    parse_frontmatter, split on ',' with exact-token membership) — never a
-    body-text regex. agents/shared/principles.md uses "LSP" for the Liskov
-    Substitution Principle, so a body-text match would false-positive on every
-    agent preloading principle-solid.
+    Only ever inspects the tools: frontmatter value (parsed via
+    parse_frontmatter, either the scalar split on ',' or the YAML sequence
+    form, with exact-token membership) — never a body-text regex.
+    agents/shared/principles.md uses "LSP" for the Liskov Substitution
+    Principle, so a body-text match would false-positive on every agent
+    preloading principle-solid.
 
     If no agent grants LSP, this returns without requiring the shared file to
     exist — that keeps the check from ossifying a future removal of LSP.
@@ -1324,9 +1325,12 @@ def check_lsp_tool_gate(cache=None):
         if not fm:
             continue
         tools = fm.get("tools")
-        if not isinstance(tools, str):
+        if isinstance(tools, str):
+            tokens = {t.strip() for t in tools.split(",")}
+        elif isinstance(tools, list):
+            tokens = {str(t).strip() for t in tools}
+        else:
             continue
-        tokens = {t.strip() for t in tools.split(",")}
         if "LSP" not in tokens:
             continue
         granting.append((md, text))

--- a/skills/workflow-codebase-audit/SKILL.md
+++ b/skills/workflow-codebase-audit/SKILL.md
@@ -48,6 +48,8 @@ Build a plain-prose prompt from the parsed flags:
 
 Pass this to the `auditor` subagent. The agent is read-only and self-paces to the time-box.
 
+Symbol-navigation hint: `Grep`/`Glob` locates an anchor, then `LSP` expands from it — one attempt only; on no servers or error, state `LSP unavailable — falling back to Grep` once and use Grep for the rest of the run.
+
 ### Phase 3 — Schema validation
 
 Every finding returned by the auditor must include all three reasoning fields:

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -162,7 +162,8 @@ Verify baseline tests pass before writing any code.
 
 **Goal:** Write code following the plan, committing incrementally.
 
-New comments stay within `swe-workbench:principle-clean-code`'s per-language comment caps (Comment discipline) — assess at write-time so comments are lean on the first pass, rather than relying on the Phase 4 review backstop.
+- New comments stay within `swe-workbench:principle-clean-code`'s per-language comment caps (Comment discipline) — assess at write-time so comments are lean on the first pass, rather than relying on the Phase 4 review backstop.
+- **Symbol navigation.** Use `Grep`/`Glob` to locate an anchor (`filePath`/`line`/`character`), then `LSP` to expand from it (`goToDefinition`, `findReferences`, `prepareCallHierarchy`/`incomingCalls`/`outgoingCalls`); attempt one LSP call — on no servers or error, state `LSP unavailable — falling back to Grep` once, use Grep for the rest of the run, and do not retry.
 
 Choose execution strategy:
 - **Sequential or separate session** → invoke `superpowers:executing-plans`

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -83,6 +83,7 @@ Pass the agent:
 - Footer instruction (opt-in per `## Decision footer`): end with EXACTLY ONE of `**Review Decision: APPROVE**` or `**Review Decision: COMMENT**`. Never `REQUEST_CHANGES`.
 - Blocking-scope instruction (opt-in per `## Blocking-scope verdict`): classify each Critical/High as in-diff (`+` lines) or out-of-diff; mark out-of-diff with `**Informational (out-of-diff):** `; emit `**Blocking Scope: NONE|OUT-OF-DIFF-ONLY|IN-DIFF**` before the footer. APPROVE/COMMENT rule unchanged.
 - Ticket-context prelude (if Step 3 produced one).
+- Symbol-navigation hint: `Grep`/`Glob` locates an anchor, then `LSP` expands from it — one attempt only; on no servers or error, state `LSP unavailable — falling back to Grep` once and use Grep for the rest of the run. A language server may not be rooted at the ephemeral worktree `$WT`, which is exactly what the one-attempt fallback already handles.
 
 ### Step 5 — Parse decision footer + blocking-scope verdict
 

--- a/tests/test_lsp_literacy.py
+++ b/tests/test_lsp_literacy.py
@@ -1,0 +1,162 @@
+"""Acceptance-pinning tests — LSP code-intelligence literacy (#559).
+
+Pins the real, already-shipped content added across Tasks 1-4 of this
+feature: the four agents that grant LSP in their tools: frontmatter and
+reference the shared LSP doc, agents/shared/lsp.md's nine named operations,
+the three orchestrator skills' LSP-unavailable fallback sentence, and
+docs/dependencies.md's Language servers section.
+
+This is a regression suite against the real repo tree, not a red-green
+TDD exercise — every test here should pass immediately and simply guard
+against future drift. Matches the style of test_agent_language_catalog.py:
+module-level ROOT constant, direct .read_text() on real files, no tmp_path
+or reset_validate fixture.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+AGENTS_DIR = ROOT / "agents"
+SKILLS_DIR = ROOT / "skills"
+
+# The four agents this feature grants LSP to.
+LSP_AGENTS = ["reviewer", "auditor", "debugger", "refactorer"]
+
+# The nine LSP operations named in agents/shared/lsp.md.
+LSP_OPERATIONS = [
+    "goToDefinition",
+    "findReferences",
+    "hover",
+    "documentSymbol",
+    "workspaceSymbol",
+    "goToImplementation",
+    "prepareCallHierarchy",
+    "incomingCalls",
+    "outgoingCalls",
+]
+
+# The three orchestrator skills that carry the LSP-unavailable fallback hint.
+ORCHESTRATOR_SKILLS = [
+    "workflow-development",
+    "workflow-pr-review",
+    "workflow-codebase-audit",
+]
+
+FALLBACK_SENTENCE = "LSP unavailable — falling back to Grep"
+
+
+def _agent_text(name: str) -> str:
+    path = AGENTS_DIR / f"{name}.md"
+    assert path.exists(), f"agents/{name}.md does not exist"
+    return path.read_text(encoding="utf-8")
+
+
+def _agent_frontmatter(name: str) -> str:
+    """Return the raw text between the first two '---' lines."""
+    text = _agent_text(name)
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, f"agents/{name}.md has no closed frontmatter block"
+    return parts[1]
+
+
+# ──────────────────────────────────────────────────────────────
+# Agent tools: grants LSP + references @./shared/lsp.md
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("agent_name", LSP_AGENTS)
+def test_agent_grants_lsp_tool(agent_name):
+    """Each LSP agent's tools: frontmatter scalar lists LSP."""
+    frontmatter = _agent_frontmatter(agent_name)
+    tools_line = next(
+        (line for line in frontmatter.splitlines() if line.strip().startswith("tools:")),
+        None,
+    )
+    assert tools_line is not None, f"agents/{agent_name}.md has no tools: line in frontmatter"
+    tools = [t.strip() for t in tools_line.split(":", 1)[1].split(",")]
+    assert "LSP" in tools, (
+        f"agents/{agent_name}.md tools: frontmatter is missing 'LSP': {tools_line!r}"
+    )
+
+
+@pytest.mark.parametrize("agent_name", LSP_AGENTS)
+def test_agent_references_shared_lsp_doc(agent_name):
+    """Each LSP agent's body references @./shared/lsp.md."""
+    text = _agent_text(agent_name)
+    assert "@./shared/lsp.md" in text, (
+        f"agents/{agent_name}.md is missing a reference to '@./shared/lsp.md'."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# No background: key (pins Spike 3's resolution)
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("agent_name", LSP_AGENTS)
+def test_agent_has_no_background_key(agent_name):
+    """No LSP agent carries a background: key in frontmatter.
+
+    An agent with no `background` key keeps `LSP` intact (Spike 3's
+    resolution). This guards against a future regression that adds one.
+    """
+    frontmatter = _agent_frontmatter(agent_name)
+    has_background_key = any(
+        line.strip().startswith("background:") for line in frontmatter.splitlines()
+    )
+    assert not has_background_key, (
+        f"agents/{agent_name}.md unexpectedly has a 'background:' key in "
+        "frontmatter — this key is known to strip LSP from an agent's "
+        "effective toolset."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# agents/shared/lsp.md names all nine operations
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("operation", LSP_OPERATIONS)
+def test_shared_lsp_doc_names_operation(operation):
+    """agents/shared/lsp.md names every one of the nine LSP operations."""
+    path = AGENTS_DIR / "shared" / "lsp.md"
+    assert path.exists(), "agents/shared/lsp.md does not exist"
+    text = path.read_text(encoding="utf-8")
+    assert operation in text, (
+        f"agents/shared/lsp.md is missing the operation name '{operation}'."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# Orchestrator skills carry the LSP-unavailable fallback sentence
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("skill_name", ORCHESTRATOR_SKILLS)
+def test_orchestrator_skill_has_fallback_sentence(skill_name):
+    """Each orchestrator skill's SKILL.md contains the literal fallback sentence."""
+    path = SKILLS_DIR / skill_name / "SKILL.md"
+    assert path.exists(), f"skills/{skill_name}/SKILL.md does not exist"
+    text = path.read_text(encoding="utf-8")
+    assert FALLBACK_SENTENCE in text, (
+        f"skills/{skill_name}/SKILL.md is missing the literal fallback "
+        f"sentence '{FALLBACK_SENTENCE}' (real em dash, U+2014)."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# docs/dependencies.md has the Language servers section
+# ──────────────────────────────────────────────────────────────
+
+
+def test_dependencies_doc_has_language_servers_section():
+    """docs/dependencies.md contains the Language servers section header."""
+    path = ROOT / "docs" / "dependencies.md"
+    assert path.exists(), "docs/dependencies.md does not exist"
+    text = path.read_text(encoding="utf-8")
+    assert "## Language servers (optional, graceful-fallback)" in text, (
+        "docs/dependencies.md is missing the "
+        "'## Language servers (optional, graceful-fallback)' section."
+    )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2886,6 +2886,26 @@ class TestCheckLspToolGate:
         validate.check_lsp_tool_gate()
         assert any("shared/lsp.md" in f for f in validate.FAILURES)
 
+    def test_grants_lsp_list_form_missing_include_fails(self, reset_validate):
+        """List-form tools: (e.g. `tools:\\n  - Read\\n  - LSP`) must be treated
+        as granting LSP just like the scalar comma-separated form — otherwise a
+        contributor could silently bypass the gate by switching YAML encodings (#559)."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        shared_dir = agents_dir / "shared"
+        shared_dir.mkdir(exist_ok=True)
+        (shared_dir / "lsp.md").write_text(
+            "LSP unavailable — falling back to Grep\n", encoding="utf-8"
+        )
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools:\n  - Read\n  - LSP\n---\n\n"
+            "No shared include here.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert any("shared/lsp.md" in f for f in validate.FAILURES)
+
     def test_grants_lsp_shared_file_reworded_sentence_fails(self, reset_validate):
         root = reset_validate
         agents_dir = root / "agents"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2842,6 +2842,120 @@ class TestCheckBrowserToolGate:
 
 
 # ──────────────────────────────────────────────
+# LSP tool gate (#559)
+# ──────────────────────────────────────────────
+
+class TestCheckLspToolGate:
+    """check_lsp_tool_gate: any agent granting LSP in its tools: frontmatter must
+    carry @./shared/lsp.md, and the shared file must carry the LSP-unavailable
+    fallback sentence. The gate must key on the tools: frontmatter scalar only —
+    never on body-text "LSP", since agents/shared/principles.md uses "LSP" for the
+    Liskov Substitution Principle and most agents preload principle-solid (#559)."""
+
+    def test_grants_lsp_with_include_and_shared_file_passes(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        shared_dir = agents_dir / "shared"
+        shared_dir.mkdir(exist_ok=True)
+        (shared_dir / "lsp.md").write_text(
+            "LSP unavailable — falling back to Grep\n", encoding="utf-8"
+        )
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep, LSP\n---\n\n"
+            "See @./shared/lsp.md for LSP usage guidance.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert validate.FAILURES == []
+
+    def test_grants_lsp_missing_include_fails(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        shared_dir = agents_dir / "shared"
+        shared_dir.mkdir(exist_ok=True)
+        (shared_dir / "lsp.md").write_text(
+            "LSP unavailable — falling back to Grep\n", encoding="utf-8"
+        )
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep, LSP\n---\n\n"
+            "No shared include here.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert any("shared/lsp.md" in f for f in validate.FAILURES)
+
+    def test_grants_lsp_shared_file_reworded_sentence_fails(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        shared_dir = agents_dir / "shared"
+        shared_dir.mkdir(exist_ok=True)
+        (shared_dir / "lsp.md").write_text(
+            "LSP is unavailable, fall back to Grep instead.\n", encoding="utf-8"
+        )
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep, LSP\n---\n\n"
+            "See @./shared/lsp.md for LSP usage guidance.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert any("fallback sentence" in f for f in validate.FAILURES)
+
+    def test_grants_lsp_shared_file_absent_fails(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep, LSP\n---\n\n"
+            "See @./shared/lsp.md for LSP usage guidance.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert any("shared/lsp.md" in f for f in validate.FAILURES)
+
+    def test_liskov_substitution_body_text_does_not_trigger_gate(self, reset_validate):
+        """The Liskov regression guard: body prose mentioning LSP must never be
+        mistaken for a tools: grant — this is the test that matters most."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep\n---\n\n"
+            "LSP is about honoring contracts between base and derived types.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert validate.FAILURES == []
+
+    def test_lspx_token_not_treated_as_granting(self, reset_validate):
+        """Token-boundary guard: a substring test would match a hypothetical LSPX tool."""
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, LSPX\n---\n\n"
+            "Body text without any LSP shared include.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert validate.FAILURES == []
+
+    def test_no_agent_grants_lsp_no_shared_file_passes(self, reset_validate):
+        root = reset_validate
+        agents_dir = root / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        (agents_dir / "my-agent.md").write_text(
+            "---\nname: my-agent\ndescription: d\ntools: Read, Grep\n---\n\n"
+            "Nothing special here.\n",
+            encoding="utf-8",
+        )
+        validate.check_lsp_tool_gate()
+        assert validate.FAILURES == []
+
+
+# ──────────────────────────────────────────────
 # e2e-test-writer agent structural assertions
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds LSP code-intelligence literacy to four depth-first agents (`reviewer`, `auditor`, `debugger`, `refactorer`) via a new shared doc `agents/shared/lsp.md` teaching the "Grep/Glob locates the anchor, `LSP` expands from it" two-step handoff (LSP cannot search by name — every op needs `filePath`/`line`/`character`), plus a mandatory one-attempt-then-fallback gate.
- Adds `check_lsp_tool_gate` to `scripts/validate.py`: any agent granting `LSP` in frontmatter `tools:` must reference `@./shared/lsp.md`, keyed strictly on the frontmatter token — never a body-text regex, since `agents/shared/principles.md` and `skills/principle-solid/SKILL.md` legitimately use "LSP" to mean Liskov Substitution Principle.
- Adds the same symbol-navigation guidance (inline, since skills have no `@./shared/` include mechanism) to the three orchestrator skills: `workflow-development` (net +1 line, staying at its 300-line `orchestrator: true` cap), `workflow-pr-review`, `workflow-codebase-audit`.
- Documents the optional, graceful-fallback nature of LSP servers in `docs/dependencies.md` (new section, contrasted explicitly with the existing hard-gated browser-automation servers).
- New `tests/test_lsp_literacy.py` pins all of the above against the real repo tree.

## Resolved open questions (for reviewers)
- **`background:` key on the four agents:** resolved as **none of the above** — no `background` key is added anywhere. A spike confirmed an agent with no `background` key keeps the `LSP` tool usable, so `debugger` stays parallel-eligible in `workflow-codebase-audit --depth=deep`'s fan-out with no special-casing needed.
- **Manual transcript-grep acceptance item:** superseded by real CI — `check_lsp_tool_gate` (structural, frontmatter-keyed) plus `tests/test_lsp_literacy.py` (real-tree pinning) together discharge this; no manual canary is needed.
- `code-impl` deliberately stays out of scope (background-eligible, no LSP) — `workflow-delegated-implementation`'s parallel worktree-isolated dispatch is worth more than LSP access for it.

## Test Plan
- [x] Changed skills/commands/agents load without errors — `python scripts/validate.py` passes clean, including the new `check_lsp_tool_gate`.
- [x] Examples in the diff were exercised manually — ran the plan's targeted negative check confirming zero false positives against `agents/shared/principles.md` / `skills/principle-solid/SKILL.md`'s pre-existing "LSP" (Liskov) usage.
- [x] `wc -l skills/workflow-development/SKILL.md` reads exactly 300 (at its `orchestrator: true` cap).

### Type-tailored checks (feat)
- [x] New behaviour verified: each of the four agents' `tools:` frontmatter now grants `LSP` and references `@./shared/lsp.md`; `agents/shared/lsp.md` names all nine LSP operations and carries the fallback gate sentence verbatim (real em dash, U+2014); the three orchestrator skills and `docs/dependencies.md` carry the same sentence inline.
- [x] Full suite: `pytest tests/ -v` — 2369 passed, 1 skipped (pre-existing, unrelated).

Closes #559
