### PR TITLE
[chore] Route skill-local scripts through a bin/ dispatcher

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -28,6 +28,7 @@ full implementation, invocable directly by its bare `swe-workbench-<name>` comma
 | `swe-workbench-pr-review-submit` | Posting mechanism for workflow-pr-review-post's Steps 1-4: fetch review threads (paginated), Jaccard dedup + 👍 reactions, diff-line pre-validate, pr-level batching, self-review/diff-scoping decision flip, atomic Reviews-API submit with a bounded 422 retry and a per-comment fallback. `--findings-json <path\|->` in; `printf %q`-quoted `KEY=VALUE` lines out |
 | `swe-workbench-reap-run-dir` | Safe `rm -rf` for a single run-scoped scratch dir allocated by `swe-workbench-new-run-dir` (depth-exactly-one, name-shape, ownership, and `.git`-absence checks) |
 | `swe-workbench-reply-and-resolve` | Post a PR review thread reply (REST) and optionally resolve it (GraphQL) |
+| `swe-workbench-skill-script` | Invoke a skill-local `scripts/<name>.sh` helper (`swe-workbench-skill-script <skill> <script> [args...]`) — rejects traversal, resolves the plugin root itself so no skill has to |
 | `swe-workbench-sync-pr-metadata` | Apply a revised title and/or body to an existing PR (address-feedback Phase 6 drift sync) |
 
 `swe-workbench-comment-scan` and `swe-workbench-pr-review-submit` are the two scripts in this
@@ -61,3 +62,11 @@ script that calls a sibling script (e.g. `swe-workbench-preflight-pr` calling
 `swe-workbench-fetch-pr`) resolves it via `dirname "$0"`/`dirname "${BASH_SOURCE[0]}"`, never a bare
 PATH lookup and never `CLAUDE_PLUGIN_ROOT` — see any script with a sibling call in `bin/` for the
 exact form.
+
+A skill with its own `scripts/` helpers (e.g. `workflow-cleanup-merged`, `workflow-branch-sync`)
+never constructs a path to them either. It invokes `swe-workbench-skill-script <skill> <script>
+[args...]`, which resolves the plugin root itself and execs the target — see
+`docs/plugin-platform-decisions.md` for why this replaced the doctor-anchor `_RT=` derivation that
+briefly stood in for it. The dispatcher always execs the target via `bash` (mirroring
+`swe-workbench-fetch-pr`'s sibling-call form) rather than relying on the target's own shebang, so
+every skill-local `scripts/*.sh` helper is assumed to be bash.

--- a/bin/swe-workbench-skill-script
+++ b/bin/swe-workbench-skill-script
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Invoke a skill-local scripts/ helper without any skill-prose path construction.
+# Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]
+set -euo pipefail
+SKILL="${1:?Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]}"
+SCRIPT="${2:?Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]}"
+shift 2
+
+case "$SKILL" in
+  */*|*..*) echo "swe-workbench-skill-script: invalid skill name: $SKILL" >&2; exit 1 ;;
+esac
+case "$SCRIPT" in
+  */*|*..*) echo "swe-workbench-skill-script: invalid script name: $SCRIPT" >&2; exit 1 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="$ROOT/skills/$SKILL/scripts/$SCRIPT"
+
+[ -f "$TARGET" ] || {
+  echo "swe-workbench-skill-script: not found: skills/$SKILL/scripts/$SCRIPT" >&2
+  exit 1
+}
+
+exec bash "$TARGET" "$@"

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -80,3 +80,25 @@ controls (`bash_guard.sh`, `secret_guard.py`) that originally motivated the ques
 in the table above hits the same failure mode: `if` is one more predicate that can silently
 disable a hook (a miss reads as "hook chose not to fire," not as an error) for zero filtering
 benefit over what `matcher` already provides or what the script can check for itself at runtime.
+
+## 5. `swe-workbench-skill-script` dispatcher replaces the doctor-anchor `_RT=` derivation
+
+**(a) Why the doctor-anchor derivation was replaced.** #571 collapsed `runtime/` into `bin/` and
+retired the `CLAUDE_PLUGIN_ROOT` injector hook. Skills with their own `scripts/` helpers
+(`workflow-cleanup-merged`, `workflow-branch-sync`) still needed to resolve a skill-local path, so
+#578 introduced `_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"` at every
+call site as a stand-in root derivation. That traded one copy-pasted preamble for another: 10
+occurrences across 2 files, and still path construction living in skill prose rather than in a
+script — the same shape of duplication `bin/README.md`'s "Reference pattern" exists to prevent for
+every other `bin/` script. `bin/swe-workbench-skill-script <skill> <script> [args...]` (#569)
+owns that resolution once, as a dispatcher: skill prose invokes it as a bare command, with no
+`_RT`/`_SCRIPTS` variables anywhere.
+
+**(b) Why the `command -v swe-workbench-<name>` guard itself is not extractable.** A PATH-
+availability guard cannot live inside a PATH-resolved helper. If `bin/` is off `PATH`, the helper
+(dispatcher or otherwise) is unreachable too — the caller gets the shell's bare
+`command not found` (exit 127) instead of the guard's actionable message ("reinstall or update the
+swe-workbench plugin"). The guard has to run *before* anything that depends on `bin/` being on
+`PATH`, which rules out delegating it to a script that is itself only reachable via `PATH`. It
+stays exactly where it is today: one `command -v` line at the top of each skill's first executable
+block, per `bin/README.md`'s "Reference pattern".

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -83,16 +83,16 @@ benefit over what `matcher` already provides or what the script can check for it
 
 ## 5. `swe-workbench-skill-script` dispatcher replaces the doctor-anchor `_RT=` derivation
 
-**(a) Why the doctor-anchor derivation was replaced.** #571 collapsed `runtime/` into `bin/` and
-retired the `CLAUDE_PLUGIN_ROOT` injector hook. Skills with their own `scripts/` helpers
+**(a) Why the doctor-anchor derivation was replaced.** Once `runtime/` collapsed into `bin/` and
+the `CLAUDE_PLUGIN_ROOT` injector hook was retired, skills with their own `scripts/` helpers
 (`workflow-cleanup-merged`, `workflow-branch-sync`) still needed to resolve a skill-local path, so
-#578 introduced `_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"` at every
-call site as a stand-in root derivation. That traded one copy-pasted preamble for another: 10
-occurrences across 2 files, and still path construction living in skill prose rather than in a
-script — the same shape of duplication `bin/README.md`'s "Reference pattern" exists to prevent for
-every other `bin/` script. `bin/swe-workbench-skill-script <skill> <script> [args...]` (#569)
-owns that resolution once, as a dispatcher: skill prose invokes it as a bare command, with no
-`_RT`/`_SCRIPTS` variables anywhere.
+a stand-in root derivation —
+`_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"` — was introduced at every
+call site. That traded one copy-pasted preamble for another: 10 occurrences across 2 files, and
+still path construction living in skill prose rather than in a script — the same shape of
+duplication `bin/README.md`'s "Reference pattern" exists to prevent for every other `bin/` script.
+`bin/swe-workbench-skill-script <skill> <script> [args...]` owns that resolution once, as a
+dispatcher: skill prose invokes it as a bare command, with no `_RT`/`_SCRIPTS` variables anywhere.
 
 **(b) Why the `command -v swe-workbench-<name>` guard itself is not extractable.** A PATH-
 availability guard cannot live inside a PATH-resolved helper. If `bin/` is off `PATH`, the helper

--- a/skills/workflow-branch-sync/SKILL.md
+++ b/skills/workflow-branch-sync/SKILL.md
@@ -26,13 +26,11 @@ orchestrator: true
 ### Step 1 — Preflight Guard
 
 ```bash
-command -v swe-workbench-doctor >/dev/null 2>&1 || {
+command -v swe-workbench-skill-script >/dev/null 2>&1 || {
   echo "swe-workbench runtime commands not on PATH — reinstall or update the swe-workbench plugin." >&2
   exit 1
 }
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-branch-sync/scripts"
-eval "$("$_SCRIPTS/preflight-guard.sh")"
+eval "$(swe-workbench-skill-script workflow-branch-sync preflight-guard.sh)"
 ```
 
 Emits `CURRENT_BRANCH`, `DEFAULT_BRANCH` (detected — never hardcode `main`), `IS_DEFAULT`, `DETACHED`, `DIRTY`.
@@ -97,9 +95,7 @@ RIMBA=$(command -v rimba 2>/dev/null \
 ### Step 4 — Detect Result
 
 ```bash
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-branch-sync/scripts"
-_DETECT_OUT="$("$_SCRIPTS/detect-conflicts.sh")"
+_DETECT_OUT="$(swe-workbench-skill-script workflow-branch-sync detect-conflicts.sh)"
 eval "$(head -1 <<<"$_DETECT_OUT")"
 UNMERGED=$(tail -n +2 <<<"$_DETECT_OUT")
 ```
@@ -120,9 +116,7 @@ For **each** file in `UNMERGED`:
 3. Prompt for one of: **keep-mine**, **keep-main**, **manual**.
    - **keep-mine / keep-main**: apply via
      ```bash
-     _RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-     _SCRIPTS="$_RT/skills/workflow-branch-sync/scripts"
-     "$_SCRIPTS/apply-resolution.sh" "<file>" "<mine|main>" "<merge|rebase>"
+     swe-workbench-skill-script workflow-branch-sync apply-resolution.sh "<file>" "<mine|main>" "<merge|rebase>"
      ```
      This script does the ours/theirs translation (see Common Mistakes) and stages the file — do not call `git checkout --ours/--theirs` directly from this skill.
    - **manual**: open the file in place for the user to edit, wait for confirmation. Before staging, verify no conflict markers remain: `grep -qE '^(<{7}|={7}|>{7})' "<file>"` must find **nothing**. If a marker is still present, do not stage — warn the user and re-prompt for confirmation instead of silently committing broken content. Once clean, `git add "<file>"`.
@@ -141,9 +135,7 @@ Surfaces *functional* duplication a textual diff structurally cannot see — the
    - `CHECK_REDUNDANCY=on` but `MERGE_BASE` came back empty from Step 3 (unrelated histories) → report "redundancy check skipped: unrelated histories" and proceed to Step 7.
 2. **Gather** (deterministic):
    ```bash
-   _RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-   _SCRIPTS="$_RT/skills/workflow-branch-sync/scripts"
-   _REDUND_OUT="$("$_SCRIPTS/redundancy-scope.sh" "$MERGE_BASE" "$PRE_SYNC_HEAD" "origin/$DEFAULT_BRANCH")"
+   _REDUND_OUT="$(swe-workbench-skill-script workflow-branch-sync redundancy-scope.sh "$MERGE_BASE" "$PRE_SYNC_HEAD" "origin/$DEFAULT_BRANCH")"
    eval "$(grep -E '^(MERGE_BASE|CANDIDATES)=' <<<"$_REDUND_OUT")"
    ```
    Only the plain `MERGE_BASE=`/`CANDIDATES=` scalar lines are eval-safe and get eval'd here — the `CANDIDATE`/`MAIN_ADD` records are structured, not simple `KEY=VALUE`, and are parsed as data below, never eval'd. If `CANDIDATES=0`, report "no redundancy candidates found" and proceed to Step 7 — never dispatch the subagent for zero candidates.

--- a/skills/workflow-cleanup-merged/SKILL.md
+++ b/skills/workflow-cleanup-merged/SKILL.md
@@ -77,13 +77,11 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 
 Then invoke the companion script, passing the resolved default branch as `$2`:
 
 ```bash
-command -v swe-workbench-clean-state-files >/dev/null 2>&1 || {
+command -v swe-workbench-skill-script >/dev/null 2>&1 || {
   echo "swe-workbench runtime commands not on PATH — reinstall or update the swe-workbench plugin." >&2
   exit 1
 }
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"
-eval "$("$_SCRIPTS/sync-and-verify.sh" "<headRefName>" "$DEFAULT_BRANCH")"
+eval "$(swe-workbench-skill-script workflow-cleanup-merged sync-and-verify.sh "<headRefName>" "$DEFAULT_BRANCH")"
 ```
 
 **⚠️ Bash-tool timeout coupling (must hold, not optional):** invoke this Bash tool call with an explicit `timeout: 600000` (~600s). The script's own internal watchdog computes an adaptive budget capped at ~570s (see `TOTAL_CAP` in `sync-and-verify.sh`) precisely so it fires *before* the harness's external tool-call timeout. Bash's own default tool-call timeout is 120s — well under the script's worst-case adaptive budget on a large monorepo worktree. If the external timeout fires first, the harness kills the whole process tree uncontrolled: the internal watchdog never gets to run its own controlled TERM→KILL sequence, and Block D's detection code never executes — the interrupted-hook state goes undetected and unreported. The script cannot self-enforce this invariant; it depends entirely on the caller passing this explicit timeout.
@@ -113,15 +111,13 @@ When the rimba post-merge hook is active (see `### rimba + post-merge hook (fast
 
 ### Step 5 — Residual Sweep (PR-scoped)
 ```bash
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"; eval "$("$_SCRIPTS/sweep-residuals.sh" "<number>")"
+eval "$(swe-workbench-skill-script workflow-cleanup-merged sweep-residuals.sh "<number>")"
 ```
 This is a **backstop**, not a replacement for each flow's own Phase 7 cleanup: it force-removes any leftover `#<number>`-keyed ephemeral artifacts from `workflow-pr-review`, `workflow-pr-review-followup`, and `workflow-address-feedback` when their own cleanup failed or was interrupted — the reviewer worktrees `pr-review-<number>` and `pr-followup-<number>` (plus their bare-`<number>` `/tmp` fallback paths) and both reviewer branches, the `address-feedback-<number>` worktree, and `#<number>`'s orphaned `/tmp` state JSON (Step 2 already proved `#<number>` is `MERGED`, so this force-removal is safe). It never deletes the `address-feedback-<number>` branch — that may be the PR's real head branch — and never touches the shared containing dirs `/tmp/swe-workbench-pr-review/` or `/tmp/swe-workbench-address-feedback/`, since a concurrent unrelated PR may hold live state there. Worktrees with uncommitted changes are skipped rather than force-removed, with a stderr warning, so an interrupted session's local-only work is never silently discarded. **This runs before Step 6's branch deletion on purpose:** a stale `address-feedback-<number>` worktree checks out the PR's real head branch directly, so if it still exists, Step 6's `git branch -D` would be refused by git and silently swallowed by `eval` unless this sweep clears it first. The script emits `SWEPT_WORKTREES=<n>`, `SWEPT_STATE_FILES=<n>`, `RESIDUAL_NONE=0|1` via `eval` and always exits 0. After it runs, also delete any scratchpad files **you** (the agent executing this skill) created for this PR's review/feedback/cleanup work — scoped to `#<number>` only, never a blanket wipe of the scratchpad directory; the harness scratchpad path layout is undocumented and version-fragile, so this step stays prose guidance rather than shipped shell code.
 
 ### Step 6 — Delete Branches
 ```bash
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"; eval "$("$_SCRIPTS/delete-branches.sh" "<headRefName>")"
+eval "$(swe-workbench-skill-script workflow-cleanup-merged delete-branches.sh "<headRefName>")"
 ```
 The script self-detects `MAIN_REPO` and anchors `cd` internally. It emits exactly two `KEY=VALUE` lines:
 - `LOCAL_DELETED=0|1` — `1` if the script deleted the local branch; `0` if it was already gone.
@@ -171,8 +167,7 @@ Execute the first strategy whose preconditions hold. Fall through to the next if
 
 1. `core.hooksPath` resolves to a directory containing an executable `post-merge` file that invokes `rimba clean --merged --force`. Detection:
    ```bash
-   _RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-   _SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"; eval "$("$_SCRIPTS/check-rimba-hook.sh")"
+   eval "$(swe-workbench-skill-script workflow-cleanup-merged check-rimba-hook.sh)"
    ```
    `RIMBA_HOOK_ACTIVE=1` is required. (The grep inside the script excludes comment-only lines so a documented-but-disabled invocation does not yield a false positive.)
 2. After Step 3 sync, HEAD on `$MAIN_REPO` is on `$DEFAULT_BRANCH` (the hook's own branch guard requires it).
@@ -192,8 +187,7 @@ The hook silently swallows errors (`|| true`). If the verification gate yields `
 **Preconditions:**
 - rimba MCP server is active in the session, OR the rimba binary resolves on PATH or a known install location:
   ```bash
-  _RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-  _SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"; RIMBA=$("$_SCRIPTS/resolve-rimba.sh")
+  RIMBA=$(swe-workbench-skill-script workflow-cleanup-merged resolve-rimba.sh)
   ```
   `RIMBA` must be non-empty (or MCP server active).
 
@@ -228,8 +222,7 @@ If the rimba `remove` or `clean` (MCP tool or `$RIMBA` binary) reports failure, 
 Run the companion script and eval its `KEY=VALUE` output:
 
 ```bash
-_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"
-_SCRIPTS="$_RT/skills/workflow-cleanup-merged/scripts"; eval "$("$_SCRIPTS/probe-worktree.sh" "<headRefName>")"
+eval "$(swe-workbench-skill-script workflow-cleanup-merged probe-worktree.sh "<headRefName>")"
 ```
 
 - `WORKTREE`: matching worktree path, or empty if none (skip Batch B when empty).

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -1,6 +1,6 @@
 """Existence, executability, shebang, and syntax checks for bin/ scripts (issue #571, #550).
 
-bin/ is the sole home for these thirteen scripts — runtime/ is retired, and there is no
+bin/ is the sole home for these fourteen scripts — runtime/ is retired, and there is no
 wrapper/target split left to check. Each must carry the swe-workbench- prefix, be executable,
 start with a matching #!/usr/bin/env <interp> shebang, never reference $CLAUDE_PLUGIN_ROOT,
 and resolve any sibling script via dirname "$0"/"${BASH_SOURCE[0]}" (bash) or
@@ -10,6 +10,7 @@ Path(__file__).parent (python3) — never a bare PATH lookup.
 import os
 import py_compile
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -32,6 +33,7 @@ SCRIPTS = {
     "swe-workbench-pr-review-submit": "python3",
     "swe-workbench-reap-run-dir": "bash",
     "swe-workbench-reply-and-resolve": "bash",
+    "swe-workbench-skill-script": "bash",
     "swe-workbench-sync-pr-metadata": "bash",
 }
 
@@ -146,3 +148,104 @@ def test_e2e_comment_scan_reads_stdin():
         env=dict(_CLEAN_ENV),
     )
     assert result.returncode == 0, f"bin/swe-workbench-comment-scan failed:\n{result.stderr}"
+
+
+# ──────────────────────────────────────────────
+# swe-workbench-skill-script dispatcher (issue #569): runtime behavior
+# ──────────────────────────────────────────────
+#
+# These tests build an isolated <tmp>/bin + <tmp>/skills tree (copying only the dispatcher
+# itself) rather than exercising it against the real skills/ directory, so the dispatcher's
+# own traversal-rejection and passthrough behavior is verified independently of any real
+# skill script's content or future changes.
+
+
+def _isolated_dispatcher(tmp_path):
+    """Copy the dispatcher into <tmp_path>/bin/ so its self-located ROOT is <tmp_path>."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    dispatcher = bin_dir / "swe-workbench-skill-script"
+    shutil.copy2(BIN / "swe-workbench-skill-script", dispatcher)
+    dispatcher.chmod(0o755)
+    return dispatcher
+
+
+def _write_scratch_script(tmp_path, skill, script, body):
+    scripts_dir = tmp_path / "skills" / skill / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    path = scripts_dir / script
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_e2e_skill_script_dispatches_and_passes_stdout_through(tmp_path):
+    dispatcher = _isolated_dispatcher(tmp_path)
+    _write_scratch_script(tmp_path, "fake-skill", "greet.sh", 'echo "hello $1"')
+    result = subprocess.run(
+        [str(dispatcher), "fake-skill", "greet.sh", "world"],
+        capture_output=True, text=True, env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 0
+    assert result.stdout == "hello world\n"
+
+
+def test_e2e_skill_script_passes_exit_code_through(tmp_path):
+    dispatcher = _isolated_dispatcher(tmp_path)
+    _write_scratch_script(tmp_path, "fake-skill", "fail.sh", "exit 3")
+    result = subprocess.run(
+        [str(dispatcher), "fake-skill", "fail.sh"],
+        capture_output=True, text=True, env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 3
+
+
+def test_e2e_skill_script_passes_args_with_spaces_through(tmp_path):
+    dispatcher = _isolated_dispatcher(tmp_path)
+    _write_scratch_script(tmp_path, "fake-skill", "echo-arg.sh", 'printf "%s" "$1"')
+    result = subprocess.run(
+        [str(dispatcher), "fake-skill", "echo-arg.sh", "a file with spaces.txt"],
+        capture_output=True, text=True, env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 0
+    assert result.stdout == "a file with spaces.txt"
+
+
+def test_e2e_skill_script_rejects_missing_target():
+    result = subprocess.run(
+        [str(BIN / "swe-workbench-skill-script"), "bogus-skill", "nope.sh"],
+        capture_output=True, text=True, env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "not found" in result.stderr
+
+
+def test_e2e_skill_script_rejects_traversal():
+    dispatcher = BIN / "swe-workbench-skill-script"
+    cases = [
+        ("../etc", "passwd"),
+        ("workflow-cleanup-merged", "../../../etc/passwd"),
+        ("a/b", "script.sh"),
+        ("skill", "a/b.sh"),
+        ("..", "script.sh"),
+        ("foo..bar", "script.sh"),
+    ]
+    for skill, script in cases:
+        result = subprocess.run(
+            [str(dispatcher), skill, script],
+            capture_output=True, text=True, env=dict(_CLEAN_ENV),
+        )
+        assert result.returncode == 1, f"expected rejection for skill={skill!r} script={script!r}"
+        assert result.stdout == ""
+        assert result.stderr.strip(), f"expected a stderr message for skill={skill!r} script={script!r}"
+
+
+def test_e2e_skill_script_requires_both_args():
+    dispatcher = BIN / "swe-workbench-skill-script"
+    for args in ([], ["only-skill"]):
+        result = subprocess.run(
+            [str(dispatcher), *args],
+            capture_output=True, text=True, env=dict(_CLEAN_ENV),
+        )
+        assert result.returncode != 0, f"expected non-zero exit for args={args!r}"

--- a/tests/test_branch_sync_skill.py
+++ b/tests/test_branch_sync_skill.py
@@ -218,9 +218,9 @@ def test_step4_captures_detect_conflicts_output_once():
     called twice (which could observe different repo state between calls)."""
     body = _body()
     step4 = body.split("### Step 4")[1].split("### Step 5")[0]
-    # Count actual invocations (the $_SCRIPTS/... call form), not prose mentions
+    # Count actual invocations (the dispatcher call form), not prose mentions
     # of the filename in the explanatory sentence.
-    assert step4.count("$_SCRIPTS/detect-conflicts.sh") == 1
+    assert step4.count("swe-workbench-skill-script workflow-branch-sync detect-conflicts.sh") == 1
     assert "_DETECT_OUT" in step4
 
 

--- a/tests/test_runtime_root_binding.py
+++ b/tests/test_runtime_root_binding.py
@@ -9,6 +9,15 @@ inline gh/jq silently.
 #560 replaced $CLAUDE_PLUGIN_ROOT-based path construction with bare `swe-workbench-<name>`
 commands (bin/ is on PATH while the plugin is enabled). The guard now checks the command is
 reachable via `command -v`, once, before worktree entry, rather than checking a resolved path.
+
+Root cause #3 (#569, fixed by #578 + this change): skills with their own `scripts/` helpers
+(workflow-cleanup-merged, workflow-branch-sync) still needed *some* way to resolve a skill-local
+path. #578 replaced the retired `$CLAUDE_PLUGIN_ROOT` preamble with a doctor-anchor derivation
+(`_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"`) repeated at every call
+site — itself a 10-occurrence duplication, and still path construction in skill prose. This was
+replaced with `bin/swe-workbench-skill-script <skill> <script> [args...]`, a single dispatcher
+that owns root resolution; skill prose now invokes it as a bare command with no `_RT`/`_SCRIPTS`
+variables anywhere.
 """
 
 import re
@@ -30,7 +39,6 @@ SKILLS_WITH_PREFLIGHT = [
 
 _PREFLIGHT_RE = re.compile(r'command -v swe-workbench-[\w-]+ >/dev/null 2>&1')
 _GUARD_STR = "not on PATH — reinstall or update the swe-workbench plugin"
-_RT_DERIVATION = '_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"'
 
 
 def _skill_text(skill_name: str) -> str:
@@ -65,9 +73,10 @@ def test_no_inline_root_resolution_at_script_call_sites():
 
     All runtime-script invocations must use bare `swe-workbench-<name>` commands so PATH
     resolution happens once, at plugin-load time, with no per-call path construction. Skills
-    that need their own skill-local root (to resolve their skills/<name>/scripts/ helpers)
-    now derive it from the resolved `swe-workbench-doctor` command instead — see
-    test_rt_derived_from_doctor_command. There is no remaining exemption for this pattern.
+    that need to invoke their own skill-local scripts/ helpers do so via
+    `swe-workbench-skill-script <skill> <script>` — see test_no_path_resolution_in_skill_prose
+    and test_skill_local_scripts_invoked_via_dispatcher. There is no remaining exemption for
+    this pattern.
     """
     for skill in SKILLS_WITH_PREFLIGHT:
         text = _skill_text(skill)
@@ -78,58 +87,59 @@ def test_no_inline_root_resolution_at_script_call_sites():
         ]
         assert not raw_occurrences, (
             f"skills/{skill}/SKILL.md has inline ${{CLAUDE_PLUGIN_ROOT:-$(git rev-parse ...)}} "
-            f"— this pattern is retired; derive _RT from `command -v swe-workbench-doctor` instead:\n"
+            f"— this pattern is retired; use `swe-workbench-skill-script` instead:\n"
             + "\n".join(f"  line {no}: {ln}" for no, ln in raw_occurrences)
         )
 
 
-def test_rt_derived_from_doctor_command():
-    """Every _RT= assignment must derive the skill root from the resolved doctor command.
+_PATH_RESOLUTION_RE = re.compile(r'_RT\s*=|\$\(dirname "\$\(command -v')
 
-    Not every skill in SKILLS_WITH_PREFLIGHT binds _RT — only those with skill-local
-    scripts/ helpers (e.g. workflow-branch-sync, workflow-cleanup-merged) do. For those that
-    do, the RHS must be exactly the pinned form so every skill resolves its root identically.
+_SKILL_DIRS = sorted(p.name for p in (ROOT / "skills").iterdir() if p.is_dir())
+
+_SKILLS_WITH_LOCAL_SCRIPTS = sorted(
+    p.name for p in (ROOT / "skills").iterdir() if (p / "scripts").is_dir()
+)
+
+
+def test_no_path_resolution_in_skill_prose():
+    """No SKILL.md may construct a path to a skill-local script itself.
+
+    #578 replaced the retired $CLAUDE_PLUGIN_ROOT preamble with a doctor-anchor _RT=
+    derivation repeated at every call site — still path construction in skill prose, just a
+    different RHS. `bin/swe-workbench-skill-script` now owns all of that resolution; no
+    SKILL.md should ever assign `_RT=` or derive a root via `dirname "$(command -v ...)"`.
     """
-    for skill in SKILLS_WITH_PREFLIGHT:
+    assert _SKILL_DIRS, "no skills found under skills/ — fixture list must not be empty"
+    for skill in _SKILL_DIRS:
         text = _skill_text(skill)
-        assign_lines = [ln.strip() for ln in text.splitlines() if re.match(r'\s*_RT\s*=', ln)]
-        for ln in assign_lines:
-            assert ln == _RT_DERIVATION, (
-                f"skills/{skill}/SKILL.md defines _RT via an unexpected form: {ln!r} — "
-                f"expected {_RT_DERIVATION!r}"
-            )
+        offenders = [
+            (i, ln.strip())
+            for i, ln in enumerate(text.splitlines(), 1)
+            if _PATH_RESOLUTION_RE.search(ln)
+        ]
+        assert not offenders, (
+            f"skills/{skill}/SKILL.md constructs a path instead of using "
+            "swe-workbench-skill-script:\n" + "\n".join(f"  line {no}: {ln}" for no, ln in offenders)
+        )
 
 
-def _bash_blocks(text: str) -> list[list[str]]:
-    """Extract fenced ```bash ... ``` blocks, allowing leading indentation on the fence."""
-    lines = text.splitlines()
-    blocks = []
-    i = 0
-    while i < len(lines):
-        if re.match(r'^\s*```bash\s*$', lines[i]):
-            start = i + 1
-            j = start
-            while j < len(lines) and lines[j].strip() != "```":
-                j += 1
-            blocks.append(lines[start:j])
-            i = j + 1
-        else:
-            i += 1
-    return blocks
+def test_skill_local_scripts_invoked_via_dispatcher():
+    """Every skill-local scripts/*.sh helper must be invoked via the dispatcher, by name.
 
-
-def test_rt_defined_in_every_block_that_uses_it():
-    """Each Bash tool call is a fresh shell — a block referencing $_RT/$_SCRIPTS must define
-    _RT itself, not rely on a prior block's assignment having "stuck"."""
-    for skill in SKILLS_WITH_PREFLIGHT:
+    Skills with their own scripts/ dir (workflow-cleanup-merged, workflow-branch-sync) must
+    reference each helper as `swe-workbench-skill-script <skill> <script>`, never a
+    constructed path — this is the replacement for the retired _RT/_SCRIPTS pattern.
+    """
+    assert _SKILLS_WITH_LOCAL_SCRIPTS, "no skills with a scripts/ dir found — fixture list must not be empty"
+    for skill in _SKILLS_WITH_LOCAL_SCRIPTS:
         text = _skill_text(skill)
-        for block in _bash_blocks(text):
-            block_text = "\n".join(block)
-            if not re.search(r'\$_RT\b|\$_SCRIPTS\b', block_text):
-                continue
-            assert re.search(r'^\s*_RT\s*=', block_text, re.MULTILINE), (
-                f"skills/{skill}/SKILL.md has a bash block referencing $_RT/$_SCRIPTS "
-                f"without defining _RT in the same block:\n{block_text}"
+        script_names = sorted(p.name for p in (ROOT / "skills" / skill / "scripts").glob("*.sh"))
+        assert script_names, f"skills/{skill}/scripts/ has no .sh files"
+        for name in script_names:
+            pattern = re.compile(rf'swe-workbench-skill-script {re.escape(skill)} {re.escape(name)}\b')
+            assert pattern.search(text), (
+                f"skills/{skill}/SKILL.md must invoke skills/{skill}/scripts/{name} via "
+                f"'swe-workbench-skill-script {skill} {name}'"
             )
 
 


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Add `bin/swe-workbench-skill-script <skill-name> <script-name> [args...]` — a dispatcher that self-locates the plugin root, rejects `/` and `..` in either argument, validates the target `skills/<skill>/scripts/<script>` exists, and `exec bash`s it through with stdout/exit-code passthrough.
- Rewrite the 10 call sites across `skills/workflow-cleanup-merged/SKILL.md` (6) and `skills/workflow-branch-sync/SKILL.md` (4) that previously derived a skill-local root via `_RT="$(cd "$(dirname "$(command -v swe-workbench-doctor)")/.." && pwd)"` — they now invoke the dispatcher directly. Re-point both skills' preflight guards to `command -v swe-workbench-skill-script` (the command actually invoked downstream).
- Retarget `tests/test_runtime_root_binding.py`: delete the two tests that pinned the old `_RT=` derivation in place (they would have passed vacuously forever once the pattern was gone — the exact failure mode a prior fix in this repo called out), add `test_no_path_resolution_in_skill_prose` and `test_skill_local_scripts_invoked_via_dispatcher`, both asserting a non-empty fixture list before looping.
- Add 6 runtime/e2e tests for the dispatcher itself in `tests/test_bin_scripts.py` (traversal rejection, exit-code passthrough, stdout passthrough, args-with-spaces, missing target, missing args) — the existing static checks (shebang/syntax/executability) didn't exercise any of this.
- Fix a prose-pinning test in `tests/test_branch_sync_skill.py` that asserted the literal old `$_SCRIPTS/detect-conflicts.sh` string.
- Docs: `bin/README.md` gets the new dispatcher row + an extended Reference pattern note; `docs/plugin-platform-decisions.md` gets a new ruling recording why the doctor-anchor derivation was replaced and why the `command -v` PATH guard itself can't be moved into a PATH-resolved helper.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — clean
- [x] `bash -n bin/swe-workbench-skill-script` — clean
- [x] `shellcheck --severity=warning bin/swe-workbench-skill-script` — 0 issues
- [x] `pytest tests/ -q` — 2420 passed, 1 skipped (pre-existing, unrelated)
- [x] Manually invoked the dispatcher against real skill scripts (`resolve-rimba.sh`, `preflight-guard.sh`, `probe-worktree.sh`) and against traversal/missing-target/missing-args inputs
- [x] Post-change `grep -rn '_RT=' skills/` and `grep -rn 'dirname "$(command -v' skills/` both return empty

### Type-tailored checks (chore)
- [x] `pytest tests/ -q` passes in full (not just changed files) — a prior migration in this repo found prose-pinning tests outside the obviously-changed file, which is exactly what happened here (`test_branch_sync_skill.py`)

Closes #569
