### PR TITLE
[chore] Reframe the orchestrator: true exemption and enforce that the flag is earned

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ It checks:
 - `.claude-plugin/plugin.json` — JSON well-formedness, required fields (`name`, `version`, `description`).
 - `.claude-plugin/marketplace.json` — JSON well-formedness, `plugins[0].name` and `plugins[0].version` match `plugin.json`.
 - `hooks/hooks.json` — JSON well-formedness and structural shape.
-- `skills/*/SKILL.md` — flat layout (no nesting), required frontmatter (`name`, `description`), `name` matches directory name, ≤150-line cap (≤300 for skills with `orchestrator: true`).
+- `skills/*/SKILL.md` — flat layout (no nesting), required frontmatter (`name`, `description`), `name` matches directory name, ≤150-line cap (≤300 for skills with `orchestrator: true`). A skill at or under 150 lines that declares `orchestrator: true` must reference at least one other skill or agent — the flag must be earned by composition or by size, not added opportunistically. See `docs/extending.md` (`## Philosophy`).
 - `agents/*.md` — required frontmatter (`name`, `description`).
 - `commands/*.md` — required frontmatter (`description`).
 - `skills/*/templates/*.md` — every `[[detect:KEY]]` marker is documented in the adjacent `SKILL.md`'s `## Project Detection` section.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -69,7 +69,9 @@ family routes there regardless of the specific skill name).
 
 Skills are intentionally small — each under 150 lines. A sharp, well-triggered skill teaches Claude the right thing at the right moment. A giant skill burns context on material the current task does not need. If a skill grows past 150 lines, split it.
 
-Orchestrator skills that compose many sub-skills (see the `development` workflow) may exceed 150 lines. When they do, extract conditional content (mode templates, rarely-loaded sub-flows) into companion files inside the skill's directory rather than padding the always-loaded `SKILL.md`.
+A skill's frontmatter can opt into a higher cap with `orchestrator: true`, which raises the limit to 300 lines (`scripts/validate.py`'s `BASE_SKILL_CAP` / `ORCHESTRATOR_SKILL_CAP`). This is common, not a rare exception — most `workflow-*` skills carry it. Two distinct shapes earn it: skills that compose many sub-skills or subagents (e.g. `workflow-development`), and skills that drive a careful multi-step external-tool procedure without composing anything at all (e.g. `workflow-cleanup-merged`, a 298-line git/gh sequence with zero sub-skill references).
+
+The flag has to be doing work, and that's enforced: `scripts/validate.py`'s `check_orchestrator_flag_earned()` fails any skill that declares `orchestrator: true`, sits at or under the 150-line base cap, *and* references no other skill or agent — that combination means the flag isn't earning anything. Reaching for the flag is still not a substitute for splitting: extract conditional content (mode templates, rarely-loaded sub-flows) into companion files inside the skill's directory rather than padding the always-loaded `SKILL.md`.
 
 ## Dependency flow
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -11,6 +11,12 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent
 FAILURES = []
 
+# SKILL.md line caps (#568). A skill declaring 'orchestrator: true' in its
+# frontmatter gets the higher cap — see check_orchestrator_flag_earned() for
+# the rule that the flag itself must be earned (size or composition).
+BASE_SKILL_CAP = 150
+ORCHESTRATOR_SKILL_CAP = 300
+
 # Hook events that fire unconditionally and have no tool name to match against.
 # Do NOT add PreToolUse / PostToolUse here — those are tool-matcher events and
 # must carry a "matcher" field. Only true lifecycle events belong in this set.
@@ -258,12 +264,61 @@ def check_skills(cache=None):
                 f"frontmatter name {fm.get('name')!r} does not match directory name {skill_dir_name!r}",
             )
         is_orchestrator = fm.get("orchestrator", "").lower() == "true"
-        cap = 300 if is_orchestrator else 150
+        cap = ORCHESTRATOR_SKILL_CAP if is_orchestrator else BASE_SKILL_CAP
         if line_count > cap:
             fail(
                 skill_md.relative_to(ROOT),
                 f"exceeds {cap}-line cap ({line_count} lines)"
                 + ("" if is_orchestrator else "; add 'orchestrator: true' to frontmatter if intentional"),
+            )
+
+
+_ORCHESTRATOR_NAMESPACED_REF_RE = re.compile(r'`swe-workbench:([\w-]+)`')
+_ORCHESTRATOR_BARE_REF_RE = re.compile(r'`([\w-]+)`')
+
+
+def check_orchestrator_flag_earned(cache=None):
+    """A skill declaring 'orchestrator: true' must earn the higher cap (#568):
+    either by needing the extra headroom (line count > BASE_SKILL_CAP) or by
+    coordinating other skills/agents. A skill at or under BASE_SKILL_CAP that
+    references nothing has an inert flag and should have it removed.
+
+    Reference detection is a coarse heuristic: any backtick-quoted token that
+    resolves to a real skill/agent id counts, even a purely contrastive or
+    negative mention (e.g. "unlike `other-skill`, this one does X"). It does
+    not verify the mention is actually a delegation."""
+    skills_dir = ROOT / "skills"
+    agents_dir = ROOT / "agents"
+    skills_cache = cache[1] if cache is not None else None
+
+    valid_ids = {p.name for p in skills_dir.iterdir() if p.is_dir() and (p / "SKILL.md").is_file()}
+    valid_ids |= {p.stem for p in agents_dir.glob("*.md")}
+
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        skill_dir_name = skill_md.parent.name
+        if skills_cache is not None and skill_md in skills_cache:
+            text = skills_cache[skill_md]
+            if text is None:
+                continue  # already reported by check_skills
+        else:
+            text = skill_md.read_text(encoding="utf-8")
+        fm = parse_frontmatter(skill_md, text=text)
+        if fm is None or fm.get("orchestrator", "").lower() != "true":
+            continue
+        line_count = len(text.splitlines())
+        if line_count > BASE_SKILL_CAP:
+            continue  # headroom earns the flag outright
+        own_valid_ids = valid_ids - {skill_dir_name}
+        referenced = (
+            set(_ORCHESTRATOR_NAMESPACED_REF_RE.findall(text))
+            | set(_ORCHESTRATOR_BARE_REF_RE.findall(text))
+        ) & own_valid_ids
+        if not referenced:
+            fail(
+                skill_md.relative_to(ROOT),
+                f"declares 'orchestrator: true' but is {line_count} lines (at or under the "
+                f"{BASE_SKILL_CAP}-line base cap) and references no other skill or agent; "
+                "remove the flag, or reference the skills/agents it coordinates",
             )
 
 
@@ -1692,6 +1747,7 @@ def main():
     check_marketplace_json(plugin_data)
     check_hooks_json()
     check_skills(cache=cache)
+    check_orchestrator_flag_earned(cache=cache)
     check_skill_trigger_fixtures()
     check_agents(cache=cache)
     check_commands()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -521,6 +521,137 @@ class TestCheckSkills:
 
 
 # ──────────────────────────────────────────────
+# check_orchestrator_flag_earned (#568)
+# ──────────────────────────────────────────────
+
+class TestCheckOrchestratorFlagEarned:
+    def _skill_body(self, extra_lines=95, orchestrator=True, extra_text=""):
+        fm = "---\nname: my-skill\ndescription: A skill\n"
+        if orchestrator:
+            fm += "orchestrator: true\n"
+        fm += "---\n"
+        body = fm + extra_text + "\n" + ("x\n" * extra_lines)
+        return body
+
+    def test_flag_short_no_refs_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, skills={"my-skill": self._skill_body()})
+        validate.check_orchestrator_flag_earned()
+        assert any("orchestrator" in f for f in validate.FAILURES)
+
+    def test_flag_short_bare_agent_ref_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"my-skill": self._skill_body(extra_text="Delegates to `some-agent`.\n")},
+            agents=[{"name": "some-agent", "description": "d"}],
+        )
+        validate.check_orchestrator_flag_earned()
+        assert len(validate.FAILURES) == 0
+
+    def test_flag_short_namespaced_skill_ref_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={
+                "my-skill": self._skill_body(
+                    extra_text="Composes `swe-workbench:other-skill`.\n"
+                ),
+                "other-skill": "---\nname: other-skill\ndescription: d\n---\n",
+            },
+        )
+        validate.check_orchestrator_flag_earned()
+        assert len(validate.FAILURES) == 0
+
+    def test_flag_over_base_cap_no_refs_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, skills={"my-skill": self._skill_body(extra_lines=196)})
+        validate.check_orchestrator_flag_earned()
+        assert len(validate.FAILURES) == 0
+
+    def test_no_flag_short_no_refs_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root, skills={"my-skill": self._skill_body(orchestrator=False)})
+        validate.check_orchestrator_flag_earned()
+        assert len(validate.FAILURES) == 0
+
+    def test_flag_short_self_reference_only_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"my-skill": self._skill_body(extra_text="See `my-skill` for details.\n")},
+        )
+        validate.check_orchestrator_flag_earned()
+        assert any("orchestrator" in f for f in validate.FAILURES)
+
+    def test_flag_short_nonexistent_ref_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"my-skill": self._skill_body(extra_text="See `nonexistent-thing` for details.\n")},
+        )
+        validate.check_orchestrator_flag_earned()
+        assert any("orchestrator" in f for f in validate.FAILURES)
+
+    def test_flag_exactly_at_base_cap_no_refs_fails(self, reset_validate):
+        """line_count == BASE_SKILL_CAP (150) is still 'at or under' and must fail —
+        pins the boundary so a future '>' vs '>=' swap would be caught."""
+        root = reset_validate
+        fm = "---\nname: my-skill\ndescription: A skill\norchestrator: true\n---\n"
+        body = fm + "x\n" * (validate.BASE_SKILL_CAP - fm.count("\n"))
+        assert len(body.splitlines()) == validate.BASE_SKILL_CAP
+        make_plugin_tree(root, skills={"my-skill": body})
+        validate.check_orchestrator_flag_earned()
+        assert any("orchestrator" in f for f in validate.FAILURES)
+
+    def test_flag_one_over_base_cap_no_refs_passes(self, reset_validate):
+        """line_count == BASE_SKILL_CAP + 1 already has the headroom and must pass."""
+        root = reset_validate
+        fm = "---\nname: my-skill\ndescription: A skill\norchestrator: true\n---\n"
+        body = fm + "x\n" * (validate.BASE_SKILL_CAP + 1 - fm.count("\n"))
+        assert len(body.splitlines()) == validate.BASE_SKILL_CAP + 1
+        make_plugin_tree(root, skills={"my-skill": body})
+        validate.check_orchestrator_flag_earned()
+        assert len(validate.FAILURES) == 0
+
+    def test_cache_none_sentinel_is_skipped_without_double_reporting(self, reset_validate):
+        """A None cache entry (unreadable file) is check_skills's failure to report,
+        not this check's — it must not raise and must not add its own failure."""
+        root = reset_validate
+        make_plugin_tree(root, skills={"my-skill": self._skill_body()})
+        skill_md = root / "skills" / "my-skill" / "SKILL.md"
+        cache = ({}, {skill_md: None})
+        validate.check_orchestrator_flag_earned(cache=cache)
+        assert len(validate.FAILURES) == 0
+
+    def test_green_baseline_live_repo(self, reset_validate, monkeypatch):
+        """Live repo must have zero unearned orchestrator: true flags (#568) —
+        every current flag is earned by size or by composition."""
+        real_root = Path(__file__).parent.parent
+        monkeypatch.setattr(validate, "ROOT", real_root)
+        cache = validate._build_cache()
+        validate.check_orchestrator_flag_earned(cache=cache)
+        assert validate.FAILURES == []
+
+
+class TestOrchestratorFlagDocs:
+    """Docs must name the literal frontmatter key and cap number where authors
+    read them, not bury the rule in the validator's failure-path hint (#568)."""
+
+    REAL_ROOT = Path(__file__).parent.parent
+
+    def test_extending_md_names_flag_and_cap(self):
+        text = (self.REAL_ROOT / "docs" / "extending.md").read_text(encoding="utf-8")
+        assert "orchestrator: true" in text
+        assert "300" in text
+
+    def test_contributing_md_names_flag_and_cap(self):
+        text = (self.REAL_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        assert "orchestrator: true" in text
+        assert "300" in text
+
+
+# ──────────────────────────────────────────────
 # check_agents
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `docs/extending.md`'s Philosophy section never named the `orchestrator: true` frontmatter key or the 300-line cap — the only place an author learned the flag existed was the validator's failure-path hint on `check_skills()`. Name both explicitly, describe the two shapes that actually earn it (composing sub-skills/subagents, or driving a multi-step external-tool procedure with zero composition), and extend the matching `CONTRIBUTING.md` bullet.
- Extract `BASE_SKILL_CAP`/`ORCHESTRATOR_SKILL_CAP` constants in `scripts/validate.py` so `check_skills()` and the new check share the same 150-line boundary by construction.
- Add `check_orchestrator_flag_earned()`: fails a skill that declares `orchestrator: true`, sits at or under the 150-line base cap, AND references no other skill or agent (via either the namespaced `` `swe-workbench:<id>` `` form or the bare `` `<id>` `` form used by ~30 SKILL.md files). Registered in `main()`.
- Measurement during grill disproved the "hand-audit for opportunistic flags" hypothesis from #568 — every flag currently in the repo is earned (10 of 16 exceed 150 lines outright; the remaining 6 all reference collaborators). No `skills/**/SKILL.md` is touched. This ships as a forward ratchet, not a cleanup.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually — verified the ratchet actually fires by temporarily adding `orchestrator: true` to `skills/language-dart/SKILL.md` (92 lines, no refs), confirming `bash scripts/validate.sh` failed with the new message, then reverting and confirming 0 failures again.
- [x] `bash scripts/validate.sh` — 0 failures against the live repo
- [x] `pytest tests/ -v` — 2460/2460 pass (1 unrelated skip)
- [x] `python3 -m compileall -q scripts tests` — clean

### Type-tailored checks (chore)
- [x] No behavior change to existing passing skills/agents/commands — `check_orchestrator_flag_earned` is additive and green on arrival (zero existing failures)

Closes #568
