### PR TITLE
[chore] Namespace machine-actionable skill/agent refs (#586)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ It checks:
 - `skills/*/triggers.txt` — every skill must have a sibling `triggers.txt` with ≥2 non-empty non-comment lines (each ≤200 chars).
 - `skills/*/examples/**/*.md` — companion example files must be ≤120 lines each. See `docs/extending.md` for the full `examples/` convention (multi-fence `// file:` header rule, visibility ordering).
 - Dependency-flow graph (`check_no_cycles`) — action-cued `` `swe-workbench:<id>` `` activations must not form cycles across commands, skills, and agents. See `docs/extending.md` (`## Dependency flow`) for the allowed layering rules that this check enforces.
+- Bare actionable references (`check_bare_actionable_refs`) — machine-actionable dispatch references must use the namespaced `` `swe-workbench:<id>` `` form: every skill/agent id in `commands/*.md` (outside fenced code), and every skill/agent id on a dispatch-cued line in `skills/*/SKILL.md` (same action-cue classifier as `check_no_cycles`). Bare is fine for prose, catalog tables, README enumerations, and a skill naming itself. A genuinely non-dispatch line can opt out with `<!-- validate: prose-ref -->`.
 
 The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`).
 

--- a/commands/architect.md
+++ b/commands/architect.md
@@ -16,7 +16,7 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
 
-Delegate to the `architect` subagent. Its output must include:
+Delegate to the `swe-workbench:architect` subagent. Its output must include:
 
 1. **Decision** — one paragraph stating what was chosen and why.
 2. **Context & forcing function** — why this decision is needed now.

--- a/commands/audit-codebase.md
+++ b/commands/audit-codebase.md
@@ -34,14 +34,14 @@ The skill handles phase orchestration, schema enforcement, fan-out (deep mode), 
 
 ## Output
 
-The `workflow-codebase-audit` skill (via the `auditor` subagent) produces a ranked findings document. Expect:
+The `swe-workbench:workflow-codebase-audit` skill (via the `swe-workbench:auditor` subagent) produces a ranked findings document. Expect:
 
 - **Summary header** — scope, depth, and time-box used; total finding count by domain.
 - **Ranked findings** — ordered by severity (Critical → High → Medium → Low), each with: domain tag, `File:Line` anchor, concise issue title, root-cause reasoning chain, and counter-evidence note (what was checked that did NOT confirm the finding).
 - **Domain sections** — `security`, `perf`, `reliability`, `tooling`, `testing` (only domains in `--scope` are rendered; `all` renders all five).
 - **Next-action recommendations** — top-N actionable fixes the team should address first, keyed to finding IDs.
 
-In `--depth deep`, the `security-auditor` additionally deep-dives the top-N security findings and the `debugger` attempts to reproduce the top-N reliability findings; their outputs are appended as sub-sections.
+In `--depth deep`, the `swe-workbench:security-auditor` additionally deep-dives the top-N security findings and the `swe-workbench:debugger` attempts to reproduce the top-N reliability findings; their outputs are appended as sub-sections.
 
 ## Step 4 — Offer to emit findings as GitHub issues
 

--- a/commands/capture.md
+++ b/commands/capture.md
@@ -14,7 +14,7 @@ The user wants to capture: $ARGUMENTS
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
 
-Delegate to the `product-manager` subagent. Its response must deliver all of the following before any issue is filed:
+Delegate to the `swe-workbench:product-manager` subagent. Its response must deliver all of the following before any issue is filed:
 
 1. **Auth + repo detection.** Run `gh auth status`, then `gh repo view --json nameWithOwner -q '.nameWithOwner'`. Surface the detected repo in the preview as `Filing into: <owner>/<repo>`. If either command fails, bail with a clear single-line message ("Repo detection failed: <reason>. Run `gh repo view` to diagnose.") and stop.
 

--- a/commands/cleanup-merged.md
+++ b/commands/cleanup-merged.md
@@ -13,7 +13,7 @@ When the skill completes, print a summary listing each artifact (worktree, local
 
 ## Output
 
-The `workflow-cleanup-merged` skill produces a structured artifact summary. Expect one status line per artifact:
+The `swe-workbench:workflow-cleanup-merged` skill produces a structured artifact summary. Expect one status line per artifact:
 
 - **Worktree** — path and whether it was removed or was already absent.
 - **Local branch** — branch name and whether it was deleted or was already gone.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -89,7 +89,7 @@ Non-web symptoms (backend panics, CLI failures, test assertion errors): skip thi
 
 Non-production, non-on-call symptoms: skip this step entirely — no gate, no prompt.
 
-Delegate to the `debugger` subagent. Its output must include:
+Delegate to the `swe-workbench:debugger` subagent. Its output must include:
 
 1. **Repro** — exact steps, inputs, and the observed failure (command, stack trace, or assertion delta).
 2. **Hypotheses** — 2–3 candidate causes, each falsifiable with the observation that would confirm or rule it out.
@@ -101,6 +101,6 @@ Delegate to the `debugger` subagent. Its output must include:
 
 Absolute rule: no fix without a failing test first. This command changes behavior to match spec — it is not a refactor.
 
-**Design-fork escalation.** The debugger has no `Agent` tool and cannot consult subagents itself — if its diagnosis surfaces a design fork, it surfaces the fork in its output instead. When that happens, you (the orchestrator) consult the `senior-engineer` subagent before finalizing the plan, per the worker→orchestrator consult contract in `swe-workbench:workflow-development`'s SKILL.md (Phase 2). Fold its read into the plan; do not invent the architectural answer yourself.
+**Design-fork escalation.** The debugger has no `Agent` tool and cannot consult subagents itself — if its diagnosis surfaces a design fork, it surfaces the fork in its output instead. When that happens, you (the orchestrator) consult the `swe-workbench:senior-engineer` subagent before finalizing the plan, per the worker→orchestrator consult contract in `swe-workbench:workflow-development`'s SKILL.md (Phase 2). Fold its read into the plan; do not invent the architectural answer yourself.
 
 **Plan output:** If you (the orchestrator) author a plan based on the subagent's response **and that plan modifies the codebase** (fix / make / implement) — whether saved to a plan file or passed to `ExitPlanMode` — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section in the plan per `skills/workflow-development/templates/plan-workflow-section.md`. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so the placeholders are substituted from this repo, not left as `[[detect:…]]`. Since `/swe-workbench:debug` always produces a fix (file edits), Mode A always applies here.

--- a/commands/design.md
+++ b/commands/design.md
@@ -16,7 +16,7 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 
 **Grill-me mode:** activate `swe-workbench:workflow-grill` and run its interrogation loop to completion (exit on shared understanding or when the user says "proceed"). Then thread the emitted `## Resolved decisions` block into the command's normal artifact/delegation step below — the same way a ticket-context summary is prepended — and continue as in standard mode.
 
-Delegate to the `senior-engineer` subagent. Its response must contain:
+Delegate to the `swe-workbench:senior-engineer` subagent. Its response must contain:
 
 1. **Problem restatement** — confirm the real question and surface implicit constraints (scale, team size, change frequency, latency budget, compliance).
 2. **Options** — 2–3 candidate approaches, each with sketch, strengths, weaknesses, and reversibility.

--- a/commands/document.md
+++ b/commands/document.md
@@ -7,7 +7,7 @@ Target: $ARGUMENTS
 
 If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
 
-Delegate to the `tech-writer` subagent. Its output must include:
+Delegate to the `swe-workbench:tech-writer` subagent. Its output must include:
 
 1. **Artifact type** — which category (README section, ADR, ARCHITECTURE/OVERVIEW, inline comment).
 2. **Target path** — the exact file path the artifact will live at.

--- a/commands/extend.md
+++ b/commands/extend.md
@@ -20,7 +20,7 @@ IS_DRAFT=$(printf '%s' "$PR_JSON" | python3 -c "import sys,json; d=json.load(sys
 
 Note: `gh pr view` resolves against `origin`; on fork-based workflows where `origin` is the fork, it may return no PR. If that happens, use `gh pr view --repo <upstream-owner>/<repo>` explicitly.
 
-If `PR_STATE` is `"OPEN"`: capture PR_NUM, HEAD_REF, PR_URL, and IS_DRAFT into context. If `IS_DRAFT` is `"true"`, note "Draft PR detected — it will not be auto-marked ready-for-review." Before activating `workflow-extend`, complete the following interrogation step (OPEN branch only):
+If `PR_STATE` is `"OPEN"`: capture PR_NUM, HEAD_REF, PR_URL, and IS_DRAFT into context. If `IS_DRAFT` is `"true"`, note "Draft PR detected — it will not be auto-marked ready-for-review." Before activating `swe-workbench:workflow-extend`, complete the following interrogation step (OPEN branch only):
 
 **Interrogation mode.** Before producing anything, resolve the mode:
 
@@ -33,7 +33,7 @@ If `PR_STATE` is `"OPEN"`: capture PR_NUM, HEAD_REF, PR_URL, and IS_DRAFT into c
 
 Then activate `swe-workbench:workflow-extend` with all four values.
 
-The list below is a visible contract of the phases `workflow-extend` runs — it does **not** replace the skill activation above. Execute phases 2–5 in order. **Phase 1 (Branch) is intentionally skipped** — the open PR branch is reused, so no new branch or worktree is created.
+The list below is a visible contract of the phases `swe-workbench:workflow-extend` runs — it does **not** replace the skill activation above. Execute phases 2–5 in order. **Phase 1 (Branch) is intentionally skipped** — the open PR branch is reused, so no new branch or worktree is created.
 
 **Phase 2 — Implement**
 Execute the plan via `superpowers:executing-plans` or `superpowers:subagent-driven-development`. Apply `swe-workbench:principle-tdd` per unit: red → green → refactor.
@@ -51,7 +51,7 @@ Running the Skill inline and skipping the `swe-workbench:reviewer` subagent (or 
 **Phase 5 — Deliver**
 Invoke `swe-workbench:workflow-commit-and-pr` to update the **existing** PR — never `gh pr create`, never a second PR.
 
-If `PR_STATE` is not `"OPEN"` (empty, `"CLOSED"`, `"MERGED"`, or `gh` error): surface the following `AskUserQuestion` and **return** — do **not** activate `workflow-extend`:
+If `PR_STATE` is not `"OPEN"` (empty, `"CLOSED"`, `"MERGED"`, or `gh` error): surface the following `AskUserQuestion` and **return** — do **not** activate `swe-workbench:workflow-extend`:
 
 ```json
 {
@@ -81,5 +81,5 @@ Absolute rules:
 - Never create a new branch or worktree.
 - Never call `gh pr create` when an open PR exists for this branch.
 - Never create a second PR — the only delivery path is updating the existing PR.
-- Escalate to `senior-engineer` only on explicit user opt-in ("consult senior-engineer" / "this is architectural").
+- Escalate to `swe-workbench:senior-engineer` only on explicit user opt-in ("consult senior-engineer" / "this is architectural").
 - Do not skip Phase 3 (Verify) or Phase 4 (Review) under any circumstances.

--- a/commands/hotfix.md
+++ b/commands/hotfix.md
@@ -24,4 +24,4 @@ Absolute rules:
 - Verification and review always run *after* the PR is opened, never before — this command's entire identity is deferred verification. Do not reorder to verify-then-PR; that is `/swe-workbench:implement`.
 - Write the deferred-verification marker (`<!-- swe-workbench:deferred-verification -->`) into the PR body at open time. Strip it only if the regression test is backfilled AND verification is green, before requesting merge — never strip it preemptively.
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope, even under time pressure.
-- Do not invent architectural answers — escalate any genuine design fork to `senior-engineer`.
+- Do not invent architectural answers — escalate any genuine design fork to `swe-workbench:senior-engineer`.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -19,15 +19,15 @@ If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context`
 Activate the `swe-workbench:workflow-development` skill in **Mode B (Implementation-Time Behavior)**. Execute all five phases in order:
 
 **Phase 1 — Branch**
-Isolate this work in a worktree when the scope warrants it (non-trivial changes, risk of destabilizing main). For tiny single-file changes, skip with a written rationale. `workflow-development` Phase 1 will detect the worktree provider automatically: `rimba add <task>` when rimba is available (PATH or common install locations), otherwise `superpowers:using-git-worktrees`.
+Isolate this work in a worktree when the scope warrants it (non-trivial changes, risk of destabilizing main). For tiny single-file changes, skip with a written rationale. `swe-workbench:workflow-development` Phase 1 will detect the worktree provider automatically: `rimba add <task>` when rimba is available (PATH or common install locations), otherwise `superpowers:using-git-worktrees`.
 
 **Phase 2 — Implement**
-- **Architectural consult (conditional):** If the ticket implies a new service, a boundary or contract change, a technology choice, or any non-trivial design fork — invoke the `senior-engineer` subagent *before* plan-writing for a boundary/trade-off read. Fold its output into the plan.
+- **Architectural consult (conditional):** If the ticket implies a new service, a boundary or contract change, a technology choice, or any non-trivial design fork — invoke the `swe-workbench:senior-engineer` subagent *before* plan-writing for a boundary/trade-off read. Fold its output into the plan.
 - If no written plan exists, draft one via `superpowers:writing-plans`. **Whenever you author or finalize a plan that modifies the codebase — whether saved to a plan file or passed to `ExitPlanMode`** — first activate `swe-workbench:workflow-development` in **Mode A** and embed the rendered `## Workflow` section per `skills/workflow-development/templates/plan-workflow-section.md` **before the plan is finalized (i.e. before `ExitPlanMode`)**. Run the skill's project-detection (`git branch -a`, `git log --oneline -20`, Makefile grep, PR-template lookup) so placeholders are substituted from this repo, not left as `[[detect:…]]`. Since `/swe-workbench:implement` always modifies the codebase, Mode A always applies here.
   - **Defect guard:** if the plan being finalized lacks a `## Workflow` section, add it before emitting the plan rather than passing an incomplete plan to `ExitPlanMode`.
-- Execute via `superpowers:executing-plans` for sequential work, `superpowers:subagent-driven-development` for parallelizable units, or `swe-workbench:workflow-delegated-implementation` when scope/complexity warrants grouping changes into focused `code-impl` sub-agent dispatches to keep the orchestrator context lean.
+- Execute via `superpowers:executing-plans` for sequential work, `superpowers:subagent-driven-development` for parallelizable units, or `swe-workbench:workflow-delegated-implementation` when scope/complexity warrants grouping changes into focused `swe-workbench:code-impl` sub-agent dispatches to keep the orchestrator context lean.
 - Apply `swe-workbench:principle-tdd` per implementation unit: red → green → refactor.
-- **Mid-implementation forks:** If an architectural decision emerges that was not anticipated in the plan, pause and consult `senior-engineer` rather than guessing. Update the plan before continuing.
+- **Mid-implementation forks:** If an architectural decision emerges that was not anticipated in the plan, pause and consult `swe-workbench:senior-engineer` rather than guessing. Update the plan before continuing.
 
 **Phase 3 — Verify**
 Run `superpowers:verification-before-completion` before claiming any phase done. Do not advance to Phase 4 until this passes clean.
@@ -46,5 +46,5 @@ Absolute rules:
 - If the ticket lacks acceptance criteria, stop and ask the user — do not invent scope.
 - Do not skip Phase 3 (verify) or Phase 4 (review) under any circumstances.
 - Phase 2 is TDD per unit: write the failing test first, then the implementation, then refactor.
-- Do not invent architectural answers — escalate any design fork to `senior-engineer`.
+- Do not invent architectural answers — escalate any design fork to `swe-workbench:senior-engineer`.
 - Do not open the PR (Phase 5) until Phases 3 and 4 both pass clean.

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -7,11 +7,11 @@ Migration: $ARGUMENTS
 
 If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
 
-Delegate to the `migrator` subagent. Its output must include:
+Delegate to the `swe-workbench:migrator` subagent. Its output must include:
 
 1. **Class** — DB schema, framework upgrade, runtime, API/contract, or event-schema. Determines the dominant hazard.
 2. **Shapes** — current (A) and target (B) stated precisely, plus the call-site map (readers and writers enumerated).
-3. **Strategy** — chosen approach (online vs. offline, phased vs. big-bang) with rationale; deferred to `senior-engineer` if ambiguous.
+3. **Strategy** — chosen approach (online vs. offline, phased vs. big-bang) with rationale; deferred to `swe-workbench:senior-engineer` if ambiguous.
 4. **Phase plan** — five phases (Expand → Backfill → Dual-write → Switch → Contract), each with what-happens / reversible-by / gate-to-advance slots filled in.
 5. **Risks** — lock duration, backfill cost on a representative replica, sunset window vs. client release cycle.
 

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -7,7 +7,7 @@ Target: $ARGUMENTS
 
 If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its structured summary to the delegation context below. Skip if $ARGUMENTS is free-text with no recognizable ref. (Trigger patterns are defined in that skill's "When to invoke" section.)
 
-Delegate to the `refactorer` subagent. Its output must include:
+Delegate to the `swe-workbench:refactorer` subagent. Its output must include:
 
 1. **Diagnosis** — which smell is present (Long Method, Feature Envy, Primitive Obsession, Shotgun Surgery, Divergent Change, etc.) and why it hurts.
 2. **Target state** — the shape of the code after refactoring, referenced to Fowler's catalog.

--- a/commands/report-issue.md
+++ b/commands/report-issue.md
@@ -3,7 +3,7 @@ description: File a plugin bug or feature request directly into lugassawan/swe-w
 argument-hint: "[<one-line thought> — omit to draft from conversation/memory]"
 ---
 
-> **Override (this command only):** The `product-manager` agent's default rules "Does not pass `--repo` explicitly to `gh issue create`" (Decision boundaries) and "Never pass `--repo`" (Mutation rules) are **suspended** for `/swe-workbench:report-issue`. You MUST pass `--repo lugassawan/swe-workbench` on every `gh` invocation in this flow. No other rule is changed.
+> **Override (this command only):** The `swe-workbench:product-manager` agent's default rules "Does not pass `--repo` explicitly to `gh issue create`" (Decision boundaries) and "Never pass `--repo`" (Mutation rules) are **suspended** for `/swe-workbench:report-issue`. You MUST pass `--repo lugassawan/swe-workbench` on every `gh` invocation in this flow. No other rule is changed.
 
 The user wants to file a plugin issue: $ARGUMENTS
 
@@ -93,7 +93,7 @@ Reply `1` → **Branch A — Quick pick**. Reply `2` → **Branch B — Synthesi
 
 ---
 
-Delegate to the `product-manager` subagent. Its response must deliver all of the following before any issue is filed:
+Delegate to the `swe-workbench:product-manager` subagent. Its response must deliver all of the following before any issue is filed:
 
 1. **Auth + repo check.** Set `repo="lugassawan/swe-workbench"`. Run `gh auth status` to check permissions — if the output indicates the token lacks repo/issue write scope, print a one-line warning:
    > Warning: your gh token may lack issue-write scope on `lugassawan/swe-workbench`; filing may fail at confirm time.
@@ -133,7 +133,7 @@ Delegate to the `product-manager` subagent. Its response must deliver all of the
 
    **Redaction pass (privacy guard).** Before writing the body in step 8, scan the drafted body for confidential identifiers pulled from conversation context and replace each with a generic placeholder. Prefer over-redaction — the user restores false positives at the preview gate.
 
-   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and the following public tech names and their canonical domains: GitHub (`github.com`, `api.github.com`), Claude Code, the `gh` CLI, Python, pytest, Node, npm, pip. When uncertain whether a name is public, prefer to redact it.
+   - **Allowlist — NEVER redact** (these are the legitimate subject of the issue): the target repo `lugassawan/swe-workbench` and the bare string `swe-workbench`; this plugin's command/skill/agent names (e.g. `report-issue`, `capture`, `product-manager`, `workflow-*`, `principle-*`, `language-*`); plugin-internal file paths (e.g. `commands/report-issue.md`); the repo owner handle `lugassawan`; and the following public tech names and their canonical domains: GitHub (`github.com`, `api.github.com`), Claude Code, the `gh` CLI, Python, pytest, Node, npm, pip. When uncertain whether a name is public, prefer to redact it. <!-- validate: prose-ref -->
    - **Redact when NOT allowlisted** (handle camelCase / snake_case / kebab-case variants):
      - Email addresses → `[internal-email]`
      - URLs, hostnames, internal domains (e.g. `*.corp`, `*.internal`, company domains) → `[internal-host]`

--- a/commands/review.md
+++ b/commands/review.md
@@ -18,14 +18,14 @@ Parse `$ARGUMENTS` left-to-right:
 
    | `--mode` value (and aliases) | Normalized mode | Delegates to |
    |---|---|---|
-   | `general` | `general` | `reviewer` |
-   | `security`, `sec` | `security` | `security-auditor` |
-   | `accessibility`, `a11y` | `accessibility` | `accessibility-auditor` |
-   | `dependency`, `deps` | `dependency` | `dependency-auditor` |
-   | `performance`, `perf` | `performance` | `performance-tuner` |
-   | `tests` *(no short alias — keyword is already short)* | `tests` | `test-reviewer` |
-   | `contributor-trust`, `trust` | `contributor-trust` | `contributor-auditor` |
-   | `ux` *(no short alias)* | `ux` | `product-designer` |
+   | `general` | `general` | `swe-workbench:reviewer` |
+   | `security`, `sec` | `security` | `swe-workbench:security-auditor` |
+   | `accessibility`, `a11y` | `accessibility` | `swe-workbench:accessibility-auditor` |
+   | `dependency`, `deps` | `dependency` | `swe-workbench:dependency-auditor` |
+   | `performance`, `perf` | `performance` | `swe-workbench:performance-tuner` |
+   | `tests` *(no short alias — keyword is already short)* | `tests` | `swe-workbench:test-reviewer` |
+   | `contributor-trust`, `trust` | `contributor-trust` | `swe-workbench:contributor-auditor` |
+   | `ux` *(no short alias)* | `ux` | `swe-workbench:product-designer` |
 
    Strip `--mode <value>` from `$ARGUMENTS`. Store the normalized mode. If the value is unrecognized, print an error listing valid values and stop.
 
@@ -54,7 +54,7 @@ Apply these inference rules **in precedence order** (first match wins; ties reso
 4. **performance** — diff touches perf-sensitive hot-path globs (`**/cache/**`, `**/queries/**`, `**/db/**`, `**/index*`, `**/search*`) AND the diff is small (< 200 lines changed).
 5. **general** — fallthrough when none of the above match.
 
-> **Note:** `tests`, `contributor-trust`, and `ux` are intentionally absent from auto-inference — all must be requested explicitly. `tests` rationale: test files are also valid targets for general review, so auto-routing would suppress the full-spectrum `reviewer` on test-only diffs. `contributor-trust` rationale: author signal and pattern-risk checks only make sense on PRs from external contributors; auto-firing on local diffs would add noise with no signal. `ux` rationale: UX-only diffs are rare and subjective; the caller must opt in deliberately to avoid noisy UX reports on backend-only changes.
+> **Note:** `tests`, `contributor-trust`, and `ux` are intentionally absent from auto-inference — all must be requested explicitly. `tests` rationale: test files are also valid targets for general review, so auto-routing would suppress the full-spectrum `swe-workbench:reviewer` on test-only diffs. `contributor-trust` rationale: author signal and pattern-risk checks only make sense on PRs from external contributors; auto-firing on local diffs would add noise with no signal. `ux` rationale: UX-only diffs are rare and subjective; the caller must opt in deliberately to avoid noisy UX reports on backend-only changes.
 
 Print exactly:
 > `Inferred mode: <mode> — reason: <one-sentence justification>`
@@ -87,20 +87,20 @@ Ground judgements in SOLID and Clean Architecture principles. Do not nitpick for
 
 The skill owns: pre-flight (`gh auth`, `gh pr view`), ephemeral worktree under `/tmp/swe-workbench-pr-review/<N>`, ticket-context chain, reviewer invocation with footer instruction, decision-footer parsing, GraphQL thread fetch + dedup + REST inline-comment post, `gh pr review --approve|--comment` submission, non-blocking cleanup. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and failure-mode handling.
 
-**When `--mode` is set to a postable specialist value (security, accessibility, dependency, performance, tests, ux) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style — severity-organized findings, same format as local-diff mode above. This mode is **postable**: after printing findings, offer to post them through the same dedup/post/submit machinery `workflow-pr-review` uses, rather than hand-constructing `gh api` calls that would bypass its dedup and thread-safety logic. See `## Specialist post sub-flow` below.
+**When `--mode` is set to a postable specialist value (security, accessibility, dependency, performance, tests, ux) with a PR number:** fetch the PR diff via `gh pr diff <N>` and run the specialist auditor against it in local-diff style — severity-organized findings, same format as local-diff mode above. This mode is **postable**: after printing findings, offer to post them through the same dedup/post/submit machinery `swe-workbench:workflow-pr-review` uses, rather than hand-constructing `gh api` calls that would bypass its dedup and thread-safety logic. See `## Specialist post sub-flow` below.
 
-**When `--mode contributor-trust`:** run `contributor-auditor` against the PR diff and print its findings (including the closing **Merge confidence** footer), then append: "Trust triage is advisory — not posted to the PR." **Stop** — `contributor-auditor`'s contract is advisory-only and never posts; this mode is signal-only and skips the sub-flow below entirely.
+**When `--mode contributor-trust`:** run `swe-workbench:contributor-auditor` against the PR diff and print its findings (including the closing **Merge confidence** footer), then append: "Trust triage is advisory — not posted to the PR." **Stop** — `swe-workbench:contributor-auditor`'s contract is advisory-only and never posts; this mode is signal-only and skips the sub-flow below entirely.
 
 If the PR number was obtained via auto-detect (user replied `yes` to the prompt in Step 1) rather than an explicit argument, the same branching applies: `--mode general` (or no `--mode`) delegates to `swe-workbench:workflow-pr-review`; `contributor-trust` is signal-only; every other mode is postable per the sub-flow below.
 
 ## Specialist post sub-flow
 
-**The post/skip `AskUserQuestion` prompt below fires in exactly one case: a postable specialist mode (security, accessibility, dependency, performance, tests, ux) resolved in PR mode.** It never fires for `contributor-trust` (advisory-only, see above — stops before reaching this section) and never fires for local-diff mode (there is no PR to post to — see the explicit "no posting prompt" note in `## Local-diff mode` above). General mode has its own posting flow inside `workflow-pr-review` and does not go through this sub-flow either.
+**The post/skip `AskUserQuestion` prompt below fires in exactly one case: a postable specialist mode (security, accessibility, dependency, performance, tests, ux) resolved in PR mode.** It never fires for `contributor-trust` (advisory-only, see above — stops before reaching this section) and never fires for local-diff mode (there is no PR to post to — see the explicit "no posting prompt" note in `## Local-diff mode` above). General mode has its own posting flow inside `swe-workbench:workflow-pr-review` and does not go through this sub-flow either.
 
-1. **Preflight:** reuse `swe-workbench-preflight-pr` for `owner`/`repo`/`head_sha`/`base`/`author_login` — pass `JSON="/tmp/swe-workbench-pr-review/${PR}-review-${MODE}.json"` (mode-scoped, distinct from `workflow-pr-review`'s own `${PR}.json` (first-pass mode) and `${PR}-followup.json` (followup mode), so a specialist run never collides with a concurrent general or followup review of the same PR) — plus `gh api /user -q .login` for `current_user`. Also allocate this sub-flow's own run-scoped scratch dir: `eval "$(swe-workbench-new-run-dir "review-${MODE}" "$PR")"` — `$RUN_DIR` is a mode-0700 directory under `/tmp/swe-workbench-run/` for ad-hoc bash artifacts, distinct from the mode-scoped state file above.
-2. **Ephemeral worktree:** `rimba add pr:<N> --task "review-<mode>-<N>" --skip-deps --skip-hooks` when rimba is available. When rimba is absent, use the direct-git fallback from `workflow-pr-review` Step 2 but with the same mode-scoped naming as the rimba path — `WT="/tmp/swe-workbench-pr-review/<mode>-${PR}"`, branch `review-<mode>-${PR}` — so a specialist run's worktree/branch never collides with a general review's `pr-review-${PR}` or another specialist mode's own run.
+1. **Preflight:** reuse `swe-workbench-preflight-pr` for `owner`/`repo`/`head_sha`/`base`/`author_login` — pass `JSON="/tmp/swe-workbench-pr-review/${PR}-review-${MODE}.json"` (mode-scoped, distinct from `swe-workbench:workflow-pr-review`'s own `${PR}.json` (first-pass mode) and `${PR}-followup.json` (followup mode), so a specialist run never collides with a concurrent general or followup review of the same PR) — plus `gh api /user -q .login` for `current_user`. Also allocate this sub-flow's own run-scoped scratch dir: `eval "$(swe-workbench-new-run-dir "review-${MODE}" "$PR")"` — `$RUN_DIR` is a mode-0700 directory under `/tmp/swe-workbench-run/` for ad-hoc bash artifacts, distinct from the mode-scoped state file above.
+2. **Ephemeral worktree:** `rimba add pr:<N> --task "review-<mode>-<N>" --skip-deps --skip-hooks` when rimba is available. When rimba is absent, use the direct-git fallback from `swe-workbench:workflow-pr-review` Step 2 but with the same mode-scoped naming as the rimba path — `WT="/tmp/swe-workbench-pr-review/<mode>-${PR}"`, branch `review-<mode>-${PR}` — so a specialist run's worktree/branch never collides with a general review's `pr-review-${PR}` or another specialist mode's own run.
 3. Run the specialist auditor against `git -C "$WT" diff "origin/$BASE"...HEAD`; print severity-organized findings (unchanged from the existing specialist output above).
-4. **Prompt:** call the `AskUserQuestion` tool — not a free-text "reply post/skip" prompt (matching the `AskUserQuestion` pattern `workflow-pr-review-post`'s own Step 5 CTA already uses, for the same reason: a clickable button beats "type a keyword"):
+4. **Prompt:** call the `AskUserQuestion` tool — not a free-text "reply post/skip" prompt (matching the `AskUserQuestion` pattern `swe-workbench:workflow-pr-review-post`'s own Step 5 CTA already uses, for the same reason: a clickable button beats "type a keyword"):
 
    ```json
    {
@@ -116,12 +116,12 @@ If the PR number was obtained via auto-detect (user replied `yes` to the prompt 
    }
    ```
 
-   Substitute the real PR number for `<N>`. On **Skip** (or any other answer), stop — no posting; reap this sub-flow's own `${PR}-review-${MODE}.json` via `swe-workbench-clean-state-files` and `$RUN_DIR` via `swe-workbench-reap-run-dir`, then tear down the worktree in the background using the **same task name Step 2 created** (`rimba remove "review-<mode>-<N>" --force`, or the matching git-fallback branch/worktree cleanup) — this is a clean exit, not an aborted-mid-scan state, so unlike `workflow-pr-review` Step 5's abort case the worktree is NOT preserved for inspection.
-5. **On `Post`:** normalize the auditor's documented finding rows into `FINDINGS[]` — `severity` and `body` (fold any extra columns, e.g. `test-reviewer`'s `Category`, into `body`) from every row; `path`/`line` from `File:Line` when present. Set `anchor=inline` when a `File:Line` exists AND the line falls on a `+` line (not a context line) in `git -C "$WT" diff "origin/$BASE"...HEAD`; `anchor=pr-level` otherwise — `dependency-auditor` rows have no `File:Line` and always anchor `pr-level`. Derive `DECISION`: at least one row with `severity ∈ {Critical, High}` → `COMMENT`; otherwise `APPROVE` (no footer to parse — these auditors don't emit one; this mirrors the general reviewer's own APPROVE-unless-Critical/High convention rather than flipping to `COMMENT` on any finding regardless of severity). Invoke `swe-workbench:workflow-pr-review-post` with:
+   Substitute the real PR number for `<N>`. On **Skip** (or any other answer), stop — no posting; reap this sub-flow's own `${PR}-review-${MODE}.json` via `swe-workbench-clean-state-files` and `$RUN_DIR` via `swe-workbench-reap-run-dir`, then tear down the worktree in the background using the **same task name Step 2 created** (`rimba remove "review-<mode>-<N>" --force`, or the matching git-fallback branch/worktree cleanup) — this is a clean exit, not an aborted-mid-scan state, so unlike `swe-workbench:workflow-pr-review` Step 5's abort case the worktree is NOT preserved for inspection.
+5. **On `Post`:** normalize the auditor's documented finding rows into `FINDINGS[]` — `severity` and `body` (fold any extra columns, e.g. `swe-workbench:test-reviewer`'s `Category`, into `body`) from every row; `path`/`line` from `File:Line` when present. Set `anchor=inline` when a `File:Line` exists AND the line falls on a `+` line (not a context line) in `git -C "$WT" diff "origin/$BASE"...HEAD`; `anchor=pr-level` otherwise — `swe-workbench:dependency-auditor` rows have no `File:Line` and always anchor `pr-level`. Derive `DECISION`: at least one row with `severity ∈ {Critical, High}` → `COMMENT`; otherwise `APPROVE` (no footer to parse — these auditors don't emit one; this mirrors the general reviewer's own APPROVE-unless-Critical/High convention rather than flipping to `COMMENT` on any finding regardless of severity). Invoke `swe-workbench:workflow-pr-review-post` with:
    - `PR`, `OWNER`, `REPO`, `HEAD_SHA`, `BASE`, `CURRENT_USER`, `AUTHOR_LOGIN` — from Step 1.
    - `DECISION` — as derived above.
-   - `BLOCKING_SCOPE` — intentionally omitted; specialist auditors don't classify in-diff vs out-of-diff, so it falls back to the core's `IN-DIFF` fail-safe default and the diff-scoping flip never fires for specialist-mode reviews (unlike `workflow-pr-review` in either mode, which does set it from the reviewer agent's own classification).
-   - `BYLINE` — `` _Reviewed by `<auditor>`_ `` (identity-only — substitute the specific agent from the mode table, e.g. `security-auditor`; the core appends the swe-workbench remark itself, conditionally on public repos).
+   - `BLOCKING_SCOPE` — intentionally omitted; specialist auditors don't classify in-diff vs out-of-diff, so it falls back to the core's `IN-DIFF` fail-safe default and the diff-scoping flip never fires for specialist-mode reviews (unlike `swe-workbench:workflow-pr-review` in either mode, which does set it from the reviewer agent's own classification).
+   - `BYLINE` — `` _Reviewed by `<auditor>`_ `` (identity-only — substitute the specific agent from the mode table, e.g. `swe-workbench:security-auditor`; the core appends the swe-workbench remark itself, conditionally on public repos).
    - `CALLER_TAG` — the mode name (e.g. `security`).
    - `RUN_DIR` — this sub-flow's own Step 1 allocation, for the core's optional mid-workflow debug persist.
    - `FINDINGS[]` — as normalized above.
@@ -136,4 +136,4 @@ If the PR number was obtained via auto-detect (user replied `yes` to the prompt 
 
 Invoke `swe-workbench:workflow-pr-review` via the `Skill` tool with `MODE=followup`, passing the resolved PR number.
 
-The skill owns: pre-flight (`gh auth`, `gh pr view`, plus a followup-only open-PR gate), ephemeral worktree (`--task "pr-followup-$PR"` to avoid colliding with prior primary-review worktrees), ticket-context chain, `reviewer` agent invocation, dedup against existing threads (Jaccard ≥ 0.4, ±5-line), posts only truly-new inline comments, and submits an APPROVE or COMMENT review event. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and its mode-resolution table.
+The skill owns: pre-flight (`gh auth`, `gh pr view`, plus a followup-only open-PR gate), ephemeral worktree (`--task "pr-followup-$PR"` to avoid colliding with prior primary-review worktrees), ticket-context chain, `swe-workbench:reviewer` agent invocation, dedup against existing threads (Jaccard ≥ 0.4, ±5-line), posts only truly-new inline comments, and submits an APPROVE or COMMENT review event. See `skills/workflow-pr-review/SKILL.md` for the full 7-step contract and its mode-resolution table.

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -7,11 +7,11 @@ Target: $ARGUMENTS
 
 If $ARGUMENTS contains a ticket reference, invoke `swe-workbench:ticket-context` first and prepend its summary to the delegation context. (Trigger patterns are defined in that skill's "When to invoke" section.)
 
-Delegate to the `security-auditor` subagent with the resolved diff (PR diff via `gh pr diff <N>` if $ARGUMENTS is a PR number — stripping a leading `#` if present; otherwise the local-diff cascade: `git diff` → `git diff --staged` → `git diff origin/main...HEAD`). Ask for a prioritized findings report.
+Delegate to the `swe-workbench:security-auditor` subagent with the resolved diff (PR diff via `gh pr diff <N>` if $ARGUMENTS is a PR number — stripping a leading `#` if present; otherwise the local-diff cascade: `git diff` → `git diff --staged` → `git diff origin/main...HEAD`). Ask for a prioritized findings report.
 
 ## Output
 
-The `security-auditor` subagent produces a severity-organized findings report. Expect:
+The `swe-workbench:security-auditor` subagent produces a severity-organized findings report. Expect:
 
 - **Critical** — data exfiltration, authentication bypass, direct secret exposure, remote code execution risk.
 - **High** — exploitable injection (SQLi, XSS, SSRF, XXE), broken access control, insecure deserialization.

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -18,10 +18,10 @@ Invoke `swe-workbench:workflow-branch-sync`, passing the resolved strategy (`mer
 
 ## Output
 
-The `workflow-branch-sync` skill produces a per-file resolution summary followed by a push prompt:
+The `swe-workbench:workflow-branch-sync` skill produces a per-file resolution summary followed by a push prompt:
 
 1. **Sync result** — clean (fast-forward/no-conflict) or resolved-with-conflicts, and the strategy used (merge/rebase).
-2. **Per-file resolution** — one line per conflicting file: which side was kept (mine/main/manual) and the one-line rationale surfaced by the `conflict-resolver` subagent.
+2. **Per-file resolution** — one line per conflicting file: which side was kept (mine/main/manual) and the one-line rationale surfaced by the `swe-workbench:conflict-resolver` subagent.
 3. **Redundancy assessment** (only when `--check-redundancy` was passed — opt-in) — any whole-file candidates the branch added that the default branch already grew independently elsewhere, auto-applied (whole-file, zero references) or escalated to you per candidate.
 4. **Push prompt** — the result is left local; the skill asks before pushing. Merge pushes with `git push`; rebase pushes with `git push --force-with-lease` — never a plain force push.
 

--- a/commands/test.md
+++ b/commands/test.md
@@ -35,12 +35,12 @@ Do not delegate to any agent until the gate passes.
 
 Dispatch the following two-agent pipeline in sequence:
 
-1. **`e2e-test-writer`** — explores the live app via Playwright MCP, authors durable spec files, and produces a behaviour inventory + spec paths.
-2. **`e2e-test-verifier`** — receives the spec paths from step 1, runs them via the project's detected E2E command, and distrusts false-greens.
+1. **`swe-workbench:e2e-test-writer`** — explores the live app via Playwright MCP, authors durable spec files, and produces a behaviour inventory + spec paths.
+2. **`swe-workbench:e2e-test-verifier`** — receives the spec paths from step 1, runs them via the project's detected E2E command, and distrusts false-greens.
 
-If `e2e-test-writer` returns a `BLOCKED:` sentinel, surface it to the user and stop — do not invoke `e2e-test-verifier`.
+If `swe-workbench:e2e-test-writer` returns a `BLOCKED:` sentinel, surface it to the user and stop — do not invoke `swe-workbench:e2e-test-verifier`.
 
-If `e2e-test-verifier` returns a `BLOCKED:` sentinel, surface it to the user.
+If `swe-workbench:e2e-test-verifier` returns a `BLOCKED:` sentinel, surface it to the user.
 
 ### E2E output contract
 
@@ -136,7 +136,7 @@ No verifier is invoked for this path.
 
 ## Unit path (default)
 
-Delegate to the `test-writer` subagent. Its output must include:
+Delegate to the `swe-workbench:test-writer` subagent. Its output must include:
 
 1. **Behaviour inventory** — numbered list of all behaviours identified.
 2. **Test file location and naming** — where the new tests live.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -565,6 +565,107 @@ def check_skill_skill_refs(cache=None):
                 )
 
 
+_BARE_ID_RE = re.compile(r'`([\w-]+)`')
+_PROSE_REF_EXEMPTION_MARKER = '<!-- validate: prose-ref -->'
+
+
+def _bare_actionable_id_set():
+    """Return the set of every resolvable skill and agent id, mirroring the
+    resolution index _build_dep_graph builds for the cycle checker."""
+    ids = set()
+    for p in (ROOT / "skills").glob("*/SKILL.md"):
+        ids.add(p.parent.name)
+    for p in (ROOT / "agents").glob("*.md"):
+        if p.parent.name == "shared":
+            continue
+        ids.add(p.stem)
+    return ids
+
+
+def check_bare_actionable_refs(cache=None):
+    """Machine-actionable dispatch references must use the namespaced
+    `swe-workbench:<id>` form (#586).
+
+    check_command_skill_refs / check_skill_skill_refs only resolution-check
+    the already-namespaced `` `swe-workbench:<id>` `` pattern, so a bare
+    dispatch id (e.g. "Delegate to the `senior-engineer` subagent") is never
+    validated and can silently drift from the namespaced form used for the
+    identical construct elsewhere. Two rules, both scoped to
+    machine-actionable dispatch — prose, catalog tables, and README
+    enumerations are untouched:
+
+    Rule 1 (commands/*.md): every bare skill/agent id outside a fenced code
+    block must be namespaced — command bodies are dispatch scripts, so no
+    action-cue heuristic is applied. A line may opt out with the
+    '<!-- validate: prose-ref -->' marker (a genuinely non-dispatch mention,
+    e.g. an example list of literal identifier strings).
+
+    Rule 2 (skills/*/SKILL.md): only lines the action-cued activation
+    classifier (_ACTION_RE / _POINTER_RE / _SLASH_CMD_RE, shared with
+    check_no_cycles's _build_dep_graph) would treat as a dispatch edge. A
+    skill naming its own id is exempt (self-reference), and the same
+    exemption marker opts out a line the classifier over-flags as a
+    dispatch cue when it is really prose.
+    """
+    if cache is None:
+        cache = _build_cache()
+    skills_cache = cache[1]
+
+    ids = _bare_actionable_id_set()
+    commands_dir = ROOT / "commands"
+    skills_dir = ROOT / "skills"
+
+    # Rule 1 — commands/*.md
+    for cmd_md in sorted(commands_dir.glob("*.md")):
+        try:
+            text = cmd_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        stripped = _strip_fenced_code_blocks(text)
+        for i, line in enumerate(stripped.split('\n'), start=1):
+            if line.lstrip().startswith('@'):
+                continue
+            if _PROSE_REF_EXEMPTION_MARKER in line:
+                continue
+            for bare_id in _BARE_ID_RE.findall(line):
+                if bare_id in ids:
+                    fail(
+                        cmd_md.relative_to(ROOT),
+                        f"line {i}: bare reference `{bare_id}` must be namespaced as "
+                        f"`swe-workbench:{bare_id}` — machine-actionable references in "
+                        f"commands/ are dispatch instructions, not prose (mark a genuinely "
+                        f"non-dispatch line with '{_PROSE_REF_EXEMPTION_MARKER}' to exempt it)",
+                    )
+
+    # Rule 2 — skills/*/SKILL.md dispatch-cued lines
+    for skill_md, text in skills_cache.items():
+        if skill_md.parent.parent != skills_dir:
+            continue
+        if text is None:
+            continue
+        own_id = skill_md.parent.name
+        stripped = _strip_fenced_code_blocks(text)
+        for i, line in enumerate(stripped.split('\n'), start=1):
+            if line.lstrip().startswith('@'):
+                continue
+            if _PROSE_REF_EXEMPTION_MARKER in line:
+                continue
+            clean = _SLASH_CMD_RE.sub('', line)
+            if not _ACTION_RE.search(clean):
+                continue
+            if _POINTER_RE.search(clean):
+                continue
+            for bare_id in _BARE_ID_RE.findall(line):
+                if bare_id not in ids or bare_id == own_id:
+                    continue
+                fail(
+                    skill_md.relative_to(ROOT),
+                    f"line {i}: bare reference `{bare_id}` on a dispatch-cued line must be "
+                    f"namespaced as `swe-workbench:{bare_id}` (mark the line "
+                    f"'{_PROSE_REF_EXEMPTION_MARKER}' if it is genuinely not a dispatch)",
+                )
+
+
 def check_workflow_development_activation_contract():
     """The '/swe-workbench:<cmd>' tokens in workflow-development's description frontmatter
     must match exactly the set of commands whose .md files reference
@@ -1819,6 +1920,7 @@ def main():
     check_preloaded_skills(cache=cache)
     check_command_skill_refs()
     check_skill_skill_refs(cache=cache)
+    check_bare_actionable_refs(cache=cache)
     check_workflow_development_activation_contract()
     check_plan_mode_workflow_embedding()
     check_workflow_full_fidelity_mandate()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -601,11 +601,14 @@ def check_bare_actionable_refs(cache=None):
     e.g. an example list of literal identifier strings).
 
     Rule 2 (skills/*/SKILL.md): only lines the action-cued activation
-    classifier (_ACTION_RE / _POINTER_RE / _SLASH_CMD_RE, shared with
-    check_no_cycles's _build_dep_graph) would treat as a dispatch edge. A
-    skill naming its own id is exempt (self-reference), and the same
-    exemption marker opts out a line the classifier over-flags as a
-    dispatch cue when it is really prose.
+    classifier (_ACTION_RE / _POINTER_RE / _SLASH_CMD_RE — the same regexes
+    check_no_cycles's _build_dep_graph uses) would treat as a dispatch edge.
+    Note this scans a narrower line set than _build_dep_graph: Rule 2 also
+    strips fenced code blocks first (_strip_fenced_code_blocks), so a
+    dispatch-cued line inside a fenced example is a cycle-graph edge but not
+    a Rule 2 candidate. A skill naming its own id is exempt (self-reference),
+    and the same exemption marker opts out a line the classifier over-flags
+    as a dispatch cue when it is really prose.
     """
     if cache is None:
         cache = _build_cache()

--- a/skills/workflow-branch-sync/SKILL.md
+++ b/skills/workflow-branch-sync/SKILL.md
@@ -111,7 +111,7 @@ Capture the script's output **once** into `_DETECT_OUT`, then split it — do no
 
 For **each** file in `UNMERGED`:
 
-1. Dispatch the `conflict-resolver` subagent with the file path, `OPERATION`, and the conflicted content (both sides, retrievable via `git show :2:<file>` / `git show :3:<file>` for a merge, or the equivalent staged blobs during a rebase — the subagent may also use `git log`/`git blame` on both sides for judgement).
+1. Dispatch the `swe-workbench:conflict-resolver` subagent with the file path, `OPERATION`, and the conflicted content (both sides, retrievable via `git show :2:<file>` / `git show :3:<file>` for a merge, or the equivalent staged blobs during a rebase — the subagent may also use `git log`/`git blame` on both sides for judgement).
 2. Present the subagent's per-hunk rationale and its file-level recommendation to the user, alongside both sides' content.
 3. Prompt for one of: **keep-mine**, **keep-main**, **manual**.
    - **keep-mine / keep-main**: apply via
@@ -180,7 +180,7 @@ Prompt: "Sync complete locally on `$CURRENT_BRANCH`. Push now?"
 | Pre-sync stash pop conflicts | `git stash pop` reports a conflict in Step 7 | Surface exactly like a Step 5 file conflict — show both sides, let the user resolve, `git add`, then `git stash drop` (a conflicting pop leaves the stash entry in place rather than consuming it). |
 | `--check-redundancy` requested on an unrelated-history repo | `MERGE_BASE` comes back empty from Step 3's capture | Skip Step 6 with a one-line reason ("unrelated histories") — never crash, never treat this as a sync failure. |
 | `redundancy-assessor` emits an id `redundancy-scope.sh` never enumerated | Sentinel `id=<n>` with no matching `CANDIDATE id=<n>` line in `_REDUND_OUT` | Reject the finding outright — never act on an unvalidated id, regardless of how plausible its accompanying prose looks. |
-| `redundancy-assessor` labels a `refs>0` or symbol-level candidate `AUTO-APPLY` | That id's own `CANDIDATE ... refs=<count>` line in `_REDUND_OUT` shows `refs` nonzero despite an `AUTO-APPLY` sentinel | Downgrade to `ESCALATE` before the tiered gate runs — the tier label is agent free text too, not just the path/id; never bypass the human because of a mislabeled tier. |
+| `redundancy-assessor` labels a `refs>0` or symbol-level candidate `AUTO-APPLY` | That id's own `CANDIDATE ... refs=<count>` line in `_REDUND_OUT` shows `refs` nonzero despite an `AUTO-APPLY` sentinel | Downgrade to `ESCALATE` before the tiered gate runs — the tier label is agent free text too, not just the path/id; never bypass the human because of a mislabeled tier. <!-- validate: prose-ref --> |
 | `redundancy-scope.sh` enumerated a candidate but `redundancy-assessor` never emitted a sentinel for its id | A `CANDIDATE id=<n>` line in `_REDUND_OUT` with no matching `**Redundancy: …** id=<n>` in the subagent's output | Treat that candidate as unresolved — do not assume `NONE`, do not act on it. Report it to the user alongside the resolved findings. |
 | A branch and main both add the identical path (add/add conflict) | The path already appeared in Step 5's resolved `UNMERGED` list, yet also surfaces as a Step 6 `CANDIDATE` | Narrow overlap: the two steps can disagree since Step 6 reasons independently. Prefer the Step 5 resolution — Step 5's keep-mine/keep-main choice for a path already-resolved there takes precedence over a same-path Step 6 finding. |
 

--- a/skills/workflow-codebase-audit/SKILL.md
+++ b/skills/workflow-codebase-audit/SKILL.md
@@ -46,7 +46,7 @@ Build a plain-prose prompt from the parsed flags:
 > "Time-box: `<time-box>`. Scope: `<scope>`. Depth: `<depth>`. Top-N: `<top-n>`.
 > Run a cold-start multi-domain audit of this codebase. Return findings in the full 11-field schema."
 
-Pass this to the `auditor` subagent. The agent is read-only and self-paces to the time-box.
+Pass this to the `swe-workbench:auditor` subagent. The agent is read-only and self-paces to the time-box.
 
 Symbol-navigation hint: `Grep`/`Glob` locates an anchor, then `LSP` expands from it — one attempt only; on no servers or error, state `LSP unavailable — falling back to Grep` once and use Grep for the rest of the run.
 
@@ -66,8 +66,8 @@ Skip this phase entirely for `--depth=quick` and `--depth=standard`.
 
 For `--depth=deep`:
 
-1. Take the top-N security findings → invoke `security-auditor` subagent for depth-first CVE + threat analysis.
-2. Take the top-N reliability findings by rank → invoke `debugger` subagent for root-cause + fix recommendation.
+1. Take the top-N security findings → invoke `swe-workbench:security-auditor` subagent for depth-first CVE + threat analysis.
+2. Take the top-N reliability findings by rank → invoke `swe-workbench:debugger` subagent for root-cause + fix recommendation.
 
 Wait for both agents to complete before proceeding to Phase 5.
 
@@ -123,4 +123,4 @@ Wait for both agents to complete before proceeding to Phase 5.
 - **Soft time-box.** The auditor self-paces. There is no hard kill; findings reported at natural completion.
 - **Schema enforcement is non-negotiable.** Drop findings that lack `root_cause`, `reasoning_chain`, or `counter_evidence_considered`. Never invent or infer these fields from partial evidence.
 - **Never invent findings.** If evidence is absent, omit the finding. Silence is correct; false positives erode trust faster than missed findings.
-- **Fan-out only on deep.** Quick and standard modes stay single-pass. Do not invoke `security-auditor` or `debugger` unless `--depth=deep`.
+- **Fan-out only on deep.** Quick and standard modes stay single-pass. Do not invoke `swe-workbench:security-auditor` or `swe-workbench:debugger` unless `--depth=deep`.

--- a/skills/workflow-dependency-upgrade/SKILL.md
+++ b/skills/workflow-dependency-upgrade/SKILL.md
@@ -25,8 +25,8 @@ Structured runbook for the full upgrade lifecycle: triage → bump → test → 
 ## Composition
 
 - **`swe-workbench:principle-security`** — supply-chain integrity, CVE triage, SBOM, lockfile pinning, frozen installs.
-- **`security-auditor` agent** — CVE confirmation and dependency-graph risk read.
-- **`reviewer` agent** — breakage diff read for ambiguous API/type changes.
+- **`swe-workbench:security-auditor` agent** — CVE confirmation and dependency-graph risk read.
+- **`swe-workbench:reviewer` agent** — breakage diff read for ambiguous API/type changes.
 
 > **Sub-skill:** `swe-workbench:workflow-commit-and-pr` — used at Phase 5 for commit format enforcement and PR filing.
 
@@ -55,7 +55,7 @@ Structured runbook for the full upgrade lifecycle: triage → bump → test → 
 
 | Class | Typical cause | Action |
 |-------|--------------|--------|
-| Type / compile errors | API renamed or signature changed | Update call sites; consult `reviewer` for large diffs |
+| Type / compile errors | API renamed or signature changed | Update call sites; consult `swe-workbench:reviewer` for large diffs |
 | Behavioral test failures | Semantic change in dep behavior | Read changelog/release notes; update assertions |
 | Transitive / peer conflicts | Two deps require incompatible sub-dep | Force-resolve or isolate in its own PR |
 | CVE still flagged post-bump | Transitive pin to old version | Override transitive dep version explicitly |

--- a/skills/workflow-development/SKILL.md
+++ b/skills/workflow-development/SKILL.md
@@ -17,7 +17,7 @@ Single source of truth for how development work flows. Three modes:
 ## When This Skill Activates
 
 - **Mode A:** Writing or finalizing an implementation plan (before `ExitPlanMode`)
-- **Mode B:** User says "implement this", "build this", "execute this plan", "run the implementation plan end to end" — any branch → code → deliver flow. For focused bug diagnosis prefer `/swe-workbench:debug` (invokes the `debugger` subagent, which composes `superpowers:systematic-debugging`); escalate here when the fix needs the full 5-phase lifecycle.
+- **Mode B:** User says "implement this", "build this", "execute this plan", "run the implementation plan end to end" — any branch → code → deliver flow. For focused bug diagnosis prefer `/swe-workbench:debug` (invokes the `debugger` subagent, which composes `superpowers:systematic-debugging`); escalate here when the fix needs the full 5-phase lifecycle. <!-- validate: prose-ref -->
   - **Prefer entering here rather than calling `superpowers:executing-plans` directly** — Phase 2 already delegates to it while adding the surrounding Branch → Verify → Review → Deliver lifecycle.
 - **Mode C:** User says "orchestrate these issues", "run in parallel", multi-issue campaigns with >3 issues
 
@@ -112,7 +112,7 @@ Choose execution strategy:
 - **Sequential or separate session** → invoke `superpowers:executing-plans`
 - **Independent tasks, same session** → invoke `superpowers:subagent-driven-development`
 - **No plan / ad-hoc** → implement directly with `swe-workbench:principle-tdd` per unit
-- **Scope/complexity warrants isolation** → invoke `swe-workbench:workflow-delegated-implementation` to group changes and dispatch each cohesive group to a focused `code-impl` sub-agent; consume the summary (not the diff) to stay lean
+- **Scope/complexity warrants isolation** → invoke `swe-workbench:workflow-delegated-implementation` to group changes and dispatch each cohesive group to a focused `swe-workbench:code-impl` sub-agent; consume the summary (not the diff) to stay lean
 
 If a delegated `code-impl` run returns with verification evidence, mark Phase 3 "completed by sub-skill" per the deduplication rule above.
 
@@ -125,7 +125,7 @@ Commit logically grouped changes as you go. Never bundle unrelated changes.
 | Tests | Test files and test utilities |
 | Wiring | Integration, routing, CLI registration |
 
-**Design-fork consult contract.** Worker subagents hold no `Agent` tool (verified: 0 of 21) — none can consult a peer subagent itself, regardless of what an individual agent's prompt text says. `debugger` follows this contract: it surfaces a design fork in its output rather than attempting the consult. (Other worker prompts may still self-instruct to consult a subagent directly — that is a pre-existing instance of the same bug class, not a license to violate the tool grant; fix on sight.) The orchestrator (the top-level context activating this skill, which holds `Agent`) owns the `senior-engineer` consult: it reads the surfaced fork, invokes `senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
+**Design-fork consult contract.** Worker subagents hold no `Agent` tool (verified: 0 of 21) — none can consult a peer subagent itself, regardless of what an individual agent's prompt text says. `swe-workbench:debugger` follows this contract: it surfaces a design fork in its output rather than attempting the consult. (Other worker prompts may still self-instruct to consult a subagent directly — that is a pre-existing instance of the same bug class, not a license to violate the tool grant; fix on sight.) The orchestrator (the top-level context activating this skill, which holds `Agent`) owns the `swe-workbench:senior-engineer` consult: it reads the surfaced fork, invokes `swe-workbench:senior-engineer` for the boundary/trade-off read, validates the resulting direction, and folds it back into the plan before continuing.
 
 ---
 

--- a/skills/workflow-extend/SKILL.md
+++ b/skills/workflow-extend/SKILL.md
@@ -45,7 +45,7 @@ Obtain a Unix timestamp: `TS=$(date +%s)`. Write spec to `/tmp/extend-${TS}.md` 
 
 | User phrase | Action |
 |---|---|
-| "consult senior-engineer" / "this is architectural" | Invoke `senior-engineer` subagent for a boundary read; fold its AC output into the spec before confirming. |
+| "consult senior-engineer" / "this is architectural" | Invoke `swe-workbench:senior-engineer` subagent for a boundary read; fold its AC output into the spec before confirming. |
 | "frame as a bug" / "this is a regression" | Route entirely to `swe-workbench:debugger` subagent; skip Phases B–D (debugger has its own verify+review loop). Commit per debugger output on the existing branch. |
 | "also file an issue" / "track this in github" | After Phase D delivery, chain `product-manager` agent (its confirm gate handles filing). |
 
@@ -58,7 +58,7 @@ Render `skills/workflow-extend/templates/plan-extend-section.md` into the spec. 
 - `[[detect:commit-style]]` → from `git log --oneline -5` (detect `[type]` vs `type:` pattern)
 - `[[detect:test-command]]`, `[[detect:format-command]]`, `[[detect:lint-command]]` → from Makefile grep or `package.json` scripts
 
-Do NOT invoke `workflow-development` Mode A here — this skill renders its own template. Phase 1 (Branch) is intentionally absent.
+Do NOT invoke `swe-workbench:workflow-development` Mode A here — this skill renders its own template. Phase 1 (Branch) is intentionally absent.
 
 ## Phase C — Implement, Verify, Review
 

--- a/skills/workflow-hotfix/SKILL.md
+++ b/skills/workflow-hotfix/SKILL.md
@@ -93,7 +93,7 @@ swe-workbench-clean-state-files /tmp/hotfix-pr-body-<N>.txt
 
 ## Phase 4 — Verify + Review (after the PR is open)
 
-Run exactly the same two gates `workflow-development` runs, just against the now-open PR:
+Run exactly the same two gates `workflow-development` runs, just against the now-open PR: <!-- validate: prose-ref -->
 
 - **Verify:** `superpowers:verification-before-completion` (imports/format/quality/lint/test).
 - **Review — BOTH in parallel, neither optional:**

--- a/skills/workflow-performance-investigation/SKILL.md
+++ b/skills/workflow-performance-investigation/SKILL.md
@@ -18,13 +18,13 @@ Profile-first runbook: baseline → profile → ranked hotspots → hypothesize 
 ## When NOT to invoke
 
 - Design-time hot-path review (Big-O, allocation choices, N+1 avoidance) → use `swe-workbench:principle-performance` directly.
-- You already have a profile and only need the ranked hotspot read → invoke the `performance-tuner` agent directly via `/swe-workbench:review --mode perf`.
+- You already have a profile and only need the ranked hotspot read → invoke the `swe-workbench:performance-tuner` agent directly via `/swe-workbench:review --mode perf`.
 - Reviewing a PR diff for perf regressions → `/swe-workbench:review --mode perf`.
 
 ## Composition
 
 - **`swe-workbench:principle-performance`** — design-time discipline (Big-O, allocation, N+1, data locality). Run inline or hand off; never skip the discipline layer.
-- **`performance-tuner` agent** — ranked hotspot analysis given a captured profile. Hand the profile artifact at Phase 3; do not invoke before a profile exists.
+- **`swe-workbench:performance-tuner` agent** — ranked hotspot analysis given a captured profile. Hand the profile artifact at Phase 3; do not invoke before a profile exists.
 - **`swe-workbench:observability-context`** — production signal framing at Phase 1 only (a Sentry error rate, regression, or alert that motivated this investigation). Never invoke it at Phase 3 or later, and never let its output substitute for the profile artifact `performance-tuner` requires — see the Evidence-class caveat in Phase 1 below.
 
 ## Phases
@@ -44,7 +44,7 @@ Profile-first runbook: baseline → profile → ranked hotspots → hypothesize 
 
 ### Phase 3 — Rank hotspots
 
-1. Hand the profile artifact to the **`performance-tuner` agent** (`/swe-workbench:review --mode perf`) for ranked hotspot read.
+1. Hand the profile artifact to the **`swe-workbench:performance-tuner` agent** (`/swe-workbench:review --mode perf`) for ranked hotspot read.
 2. Classify each hotspot by bottleneck taxonomy: CPU-bound · memory/GC · I/O · lock-contention.
 3. Surface the top 3 ranked hotspots with their taxonomy label before hypothesizing.
 

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -100,7 +100,7 @@ git worktree add --detach "$WT" "${MODE_TAG}-${PR}"
 
 Read `title` and `body` from the saved JSON. Match `[A-Z]+-\d+`, atlassian/Confluence URLs, or `#\d+`/PR refs in either field plus the last 5 commit messages (`git -C "$WT" log --oneline -5`). If matched, invoke `swe-workbench:ticket-context` and capture its summary as a prelude to the reviewer prompt.
 
-### Step 4 — Invoke `reviewer`
+### Step 4 — Invoke `swe-workbench:reviewer`
 
 Pass the agent:
 - Working-directory hint: absolute path of the worktree (`$WT`).

--- a/skills/workflow-worktree-session/SKILL.md
+++ b/skills/workflow-worktree-session/SKILL.md
@@ -18,7 +18,7 @@ Triggers: user named or pointed at a worktree that already exists, or is resumin
 
 Examples: "open the `feat-login` worktree", "switch to `test-enter`", "move into `.worktrees/auth`", "cd into the worktree I made", "continue work in the worktree I made", "resume in the worktree", "I've been cd-ing into the worktree", "I've been cd-prefixing commands".
 
-1. Discover the path. Resolve rimba using the detection helper in `workflow-development` Phase 1 (`$RIMBA`). If non-empty, run `$RIMBA list --json` to list worktrees. Otherwise use `git worktree list --porcelain`:
+1. Discover the path. Resolve rimba using the detection helper in `workflow-development` Phase 1 (`$RIMBA`). If non-empty, run `$RIMBA list --json` to list worktrees. Otherwise use `git worktree list --porcelain`: <!-- validate: prose-ref -->
 
    ```bash
    git worktree list --porcelain \

--- a/tests/test_architect_command.py
+++ b/tests/test_architect_command.py
@@ -20,7 +20,7 @@ def test_architect_command_file_exists():
     assert fm is not None, "architect.md must have valid frontmatter"
     assert "description" in fm, "architect.md frontmatter must have a description field"
     # `name` is intentionally absent: commands are auto-discovered by filename; validate.py only requires `description`.
-    assert "`architect`" in text, "architect.md must reference the `architect` subagent"
+    assert "`swe-workbench:architect`" in text, "architect.md must reference the `swe-workbench:architect` subagent"
 
 
 def test_architect_command_invokes_ticket_context():

--- a/tests/test_document_command.py
+++ b/tests/test_document_command.py
@@ -19,7 +19,7 @@ def test_document_command_file_exists():
     fm = validate.parse_frontmatter(DOCUMENT_CMD, text=text)
     assert fm is not None, "document.md must have valid frontmatter"
     assert "description" in fm, "document.md frontmatter must have a description field"
-    assert "`tech-writer`" in text, "document.md must reference the `tech-writer` subagent"
+    assert "`swe-workbench:tech-writer`" in text, "document.md must reference the `swe-workbench:tech-writer` subagent"
 
 
 def test_document_command_invokes_ticket_context():

--- a/tests/test_migrate_command.py
+++ b/tests/test_migrate_command.py
@@ -19,7 +19,7 @@ def test_migrate_command_file_exists():
     fm = validate.parse_frontmatter(MIGRATE_CMD, text=text)
     assert fm is not None, "migrate.md must have valid frontmatter"
     assert "description" in fm, "migrate.md frontmatter must have a description field"
-    assert "`migrator`" in text, "migrate.md must reference the `migrator` subagent"
+    assert "`swe-workbench:migrator`" in text, "migrate.md must reference the `swe-workbench:migrator` subagent"
 
 
 def test_migrate_command_invokes_ticket_context():

--- a/tests/test_report_issue_command.py
+++ b/tests/test_report_issue_command.py
@@ -182,7 +182,7 @@ def test_report_issue_step9_cleanup_on_success_only():
 def _branch_b_slice(text):
     pos = text.find("### Branch B")
     assert pos != -1, "commands/report-issue.md must contain a '### Branch B' heading"
-    end = text.find("Delegate to the `product-manager` subagent", pos)
+    end = text.find("Delegate to the `swe-workbench:product-manager` subagent", pos)
     assert end != -1, (
         "commands/report-issue.md must contain the delegation block after Branch B"
     )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1520,6 +1520,153 @@ class TestCheckSkillSkillRefs:
 
 
 # ──────────────────────────────────────────────
+# check_bare_actionable_refs (#586)
+# ──────────────────────────────────────────────
+
+class TestCheckBareActionableRefs:
+    def test_bare_agent_id_in_command_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "agents" / "reviewer.md").write_text(
+            "---\nname: reviewer\ndescription: d\ntools: Read\n---\n",
+            encoding="utf-8",
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nDelegate to the `reviewer` subagent.\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert any("reviewer" in f and "swe-workbench:reviewer" in f for f in validate.FAILURES)
+
+    def test_bare_skill_id_in_command_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nInvoke `foo` skill.\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert any("foo" in f for f in validate.FAILURES)
+
+    def test_namespaced_ref_in_command_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nInvoke `swe-workbench:foo` skill.\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_bare_id_inside_fenced_block_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\n```\nDelegate to the `foo` skill.\n```\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_exemption_marker_suppresses_in_command(self, reset_validate):
+        """Rule 1's marker escape hatch (used for real at report-issue.md's
+        redaction allowlist), isolated from the live-tree test."""
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={"foo": "---\nname: foo\ndescription: d\n---\n"},
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nNever redact `foo`. <!-- validate: prose-ref -->\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_command_id_in_command_passes(self, reset_validate):
+        """report-issue.md:136 regression — a bare id that resolves only to a
+        command (not a skill or agent) is never in the checked id set."""
+        root = reset_validate
+        make_plugin_tree(root)
+        (root / "commands" / "capture.md").write_text(
+            "---\ndescription: d\n---\n\nCommand body.\n", encoding="utf-8",
+        )
+        (root / "commands" / "my-cmd.md").write_text(
+            "---\ndescription: d\n---\n\nNever redact `capture`.\n",
+            encoding="utf-8",
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_bare_id_in_skill_prose_without_action_cue_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={
+                "my-skill": "---\nname: my-skill\ndescription: d\n---\n\nRelated: `target-skill` handles that.\n",
+                "target-skill": "---\nname: target-skill\ndescription: d\n---\n",
+            },
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_bare_id_on_skill_dispatch_line_fails(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={
+                "my-skill": "---\nname: my-skill\ndescription: d\n---\n\nInvoke `target-skill` now.\n",
+                "target-skill": "---\nname: target-skill\ndescription: d\n---\n",
+            },
+        )
+        validate.check_bare_actionable_refs()
+        assert any("target-skill" in f for f in validate.FAILURES)
+
+    def test_self_reference_passes(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={
+                "my-skill": "---\nname: my-skill\ndescription: d\n---\n\nActivating `my-skill` now.\n",
+            },
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_exemption_marker_suppresses(self, reset_validate):
+        root = reset_validate
+        make_plugin_tree(
+            root,
+            skills={
+                "my-skill": (
+                    "---\nname: my-skill\ndescription: d\n---\n\n"
+                    "Invoke `target-skill` now. <!-- validate: prose-ref -->\n"
+                ),
+                "target-skill": "---\nname: target-skill\ndescription: d\n---\n",
+            },
+        )
+        validate.check_bare_actionable_refs()
+        assert validate.FAILURES == []
+
+    def test_bare_actionable_refs_live_tree_passes(self, reset_validate, monkeypatch):
+        """The real repo must already be fully normalized (#586)."""
+        monkeypatch.setattr(validate, "ROOT", Path(__file__).parent.parent)
+        validate.FAILURES.clear()
+        cache = validate._build_cache()
+        validate.check_bare_actionable_refs(cache=cache)
+        assert validate.FAILURES == [], f"validate.py failures: {validate.FAILURES}"
+
+
+# ──────────────────────────────────────────────
 # check_workflow_development_activation_contract
 # ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Issue #586's premise didn't hold — bare refs in agent preload declarations are already a hard validator failure, and the true count (529 bare refs / 81 files) was mostly legitimate prose/catalog/README content that stays bare by design. The real, narrower defect: some `commands/*.md` and `skills/*/SKILL.md` files write machine-actionable dispatch instructions in bare form (e.g. "Delegate to the `senior-engineer` subagent") while the identical construct elsewhere uses the namespaced `swe-workbench:<id>` form, and no validator caught the drift.
- Adds `check_bare_actionable_refs()` to `scripts/validate.py` as a regression ratchet: Rule 1 requires every bare skill/agent id in `commands/*.md` (outside fenced code) to be namespaced; Rule 2 flags bare ids only on skill dispatch-cued lines in `skills/*/SKILL.md`, reusing the existing `_ACTION_RE`/`_POINTER_RE`/`_SLASH_CMD_RE` classifier `check_no_cycles` already uses. A `<!-- validate: prose-ref -->` marker exempts genuine non-dispatch mentions.
- Namespaces ~76 bare dispatch refs across 17 `commands/*.md` files and 11 `skills/*/SKILL.md` files (the code-review pass caught 4 more sites the mechanical sweep's classifier missed, since they used verbs like "Hand"/"Pass" outside the reused action-cue word list).
- Retargets 4 test files whose assertions pinned the bare form on now-rewritten lines, and adds a `TestCheckBareActionableRefs` suite (10 cases + a live-tree assertion) plus a CONTRIBUTING.md bullet documenting the new check.
- Out of scope by design: `agents/*.md` prose, `docs/catalog.md`, `README.md`, and command ids (`report-issue`, `capture`, `sync`) — a follow-up issue covers the optional prose-only pass.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 scripts/validate.py` — 0 issues; deliberately regressed one normalized line and stripped one exemption marker to confirm the new check fires and names the escape hatch, then restored both
- [x] `pytest tests/ -v` — 2472 passed, 1 skipped
- [x] Dependency-flow cycle simulation (`_build_dep_graph`) re-run before/after: 63 nodes/80 edges → 68 nodes/109 edges, 0 cycles both times
- [x] Both required reviewers (swe-workbench:reviewer subagent + plan-alignment reviewer) ran in parallel; all Important findings fixed, Minor findings addressed

### Type-tailored checks (chore)
- [x] Repo builds/validates cleanly after the change (`scripts/validate.py`, full `pytest`)

Closes #586
