### PR TITLE
[feat] Document the Jackson null-element collection foot-gun (#599)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -103,7 +103,7 @@ this mirrors the footer's opt-in contract.
 
 See @./shared/principles.md and @./shared/languages.md for the skill catalog.
 
-**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope.
+**Language skill (required):** Identify the language(s) in scope and invoke the matching `language-*` skill (e.g., `swe-workbench:language-python` for `.py` files). State which language skill(s) you loaded, or note "N/A" if no language-specific code is in scope. Derive the language set from the extensions of the diff's changed paths, not from which files you happened to open — a grep-only pass over a small diff still requires loading the matching skill.
 
 Everything else in this catalog is preloaded via frontmatter; the one skill below stays conditional — invoke it via the `Skill` tool only when the review surfaces a concern in its domain:
 

--- a/skills/language-java/SKILL.md
+++ b/skills/language-java/SKILL.md
@@ -31,10 +31,18 @@ double area = switch (shape) {
 - Return `Optional<T>` from methods that may have no result; never use it as a field or parameter type.
 - `Optional` is not a null check replacement — it signals "absence is a valid outcome."
 - Annotate parameters and fields with `@NonNull` / `@Nullable` for static analysis.
+- Jackson populates `List<T>` with literal nulls from valid JSON (`{"content":[null]}`) regardless
+  of declared nullability — filter before mapping over an externally-deserialized collection, or
+  drop them at the boundary with `@JsonSetter(contentNulls = Nulls.SKIP)`.
 
 ```java
 Optional<User> find(String id) { ... }
 find(id).map(User::email).orElseThrow(() -> new NotFoundException(id));
+
+List<String> ids = payload.content().stream()
+    .filter(Objects::nonNull)
+    .map(Content::id)
+    .toList();
 ```
 
 ## Concurrency — virtual threads (JDK 21+)
@@ -71,6 +79,7 @@ try (var conn = dataSource.getConnection()) {
 - `Stream` for transformations; avoid imperative loops when a pipeline is clearer.
 - `.toList()` (JDK 16+) over `Collectors.toList()` — returns an unmodifiable list.
 - Use `List.of`, `Map.of`, `Set.of` for small immutable collections; `Map.copyOf` to defensively copy.
+- Externally-deserialized sources may hold null elements — see Optional and null discipline.
 
 ```java
 List<String> emails = users.stream()

--- a/skills/language-java/SKILL.md
+++ b/skills/language-java/SKILL.md
@@ -126,3 +126,4 @@ void computesTax(double income, double expectedTax) {
 - Mutable `static` state outside of intentional singletons.
 - `equals` without a matching `hashCode` override.
 - Blocking inside a reactive pipeline or `CompletableFuture` chain.
+- Trusting a declared non-null element type on a Jackson-deserialized collection.

--- a/skills/language-kotlin/SKILL.md
+++ b/skills/language-kotlin/SKILL.md
@@ -9,10 +9,15 @@ description: Kotlin idioms — null safety, coroutines, sealed interfaces, scope
 - `?` makes nullability explicit in the type — `String?` vs `String`.
 - Safe-call `?.` returns null instead of throwing. Elvis `?:` provides a default.
 - **Never use `!!` in production code** — it is a promise you will never break that can't be verified.
+- Jackson does not null-check collection *elements* even with `jackson-module-kotlin` — a declared
+  `List<Content>` can hold nulls from `{"content":[null]}`. Use `filterNotNull()` (not
+  `filter { it != null }`, which leaves the type as `List<Content?>`), or
+  `@JsonSetter(contentNulls = Nulls.SKIP)` at the boundary.
 
 ```kotlin
 val length = name?.trim()?.length ?: 0
 user?.email?.let { send(it) }   // null-guard + scoping
+val ids = payload.content.filterNotNull().map { it.id }
 ```
 
 ## Data classes and sealed interfaces
@@ -120,3 +125,4 @@ fun `fetch returns cached value`() = runTest {
 - Nesting scope functions more than one level deep.
 - `lateinit var` outside dependency injection — prefer `by lazy` or constructor injection.
 - `GlobalScope` — ties coroutines to the process lifetime instead of a logical scope.
+- Trusting a declared non-null element type on a Jackson-deserialized collection.

--- a/skills/principle-code-review/SKILL.md
+++ b/skills/principle-code-review/SKILL.md
@@ -12,7 +12,7 @@ Principles for high-signal code review. For tool-specific mechanics (diff-size r
 
 Every review covers five axes:
 
-- **Correctness** — off-by-ones, null paths, concurrency races, lost errors, unhandled edge cases, paired-guard predicate gaps (a check enforced by one sibling but missing in its pair).
+- **Correctness** — off-by-ones, null paths, concurrency races, lost errors, unhandled edge cases, null elements inside externally-deserialized collections (a valid payload can populate them), paired-guard predicate gaps (a check enforced by one sibling but missing in its pair).
 - **Security** — injection, auth/authz gaps, secrets in code, unsafe deserialization, SSRF, missing input validation at trust boundaries.
 - **Design integrity** — SOLID violations, leaky abstractions, tight coupling, circular deps, domain logic bleeding into infrastructure.
   *For complexity / duplication / length, prefer Quality-stage output over subjective comments — see `swe-workbench:workflow-development`.*

--- a/tests/test_deserialization_null_guidance.py
+++ b/tests/test_deserialization_null_guidance.py
@@ -1,0 +1,143 @@
+"""Structural tests for the Jackson null-element collection foot-gun guidance (closes #599).
+
+Acceptance criteria:
+- AC1: skills/language-java/SKILL.md's '## Optional and null discipline' section names Jackson,
+  shows a literal-null-element JSON payload (e.g. {"content":[null]}), and names a null filter.
+- AC2: skills/language-java/SKILL.md's '## Streams and collections' section cross-references
+  Optional and null discipline for externally-deserialized sources.
+- AC3: skills/language-kotlin/SKILL.md's '## Null safety' section names Jackson and filterNotNull.
+- AC4: skills/language-kotlin/SKILL.md's '## Avoid' section carries the anti-pattern line about
+  trusting a declared non-null element type on a Jackson-deserialized collection.
+- AC5: both skills name the `contentNulls` JsonSetter attribute (the correct fix for null
+  *elements*, as opposed to `nulls`, which only handles an explicit null on the property itself)
+  and neither contains the bare string "nulls = Nulls.SKIP" (a ratchet against the wrong attribute).
+- AC6: both skill files stay within the 150-line cap enforced by scripts/validate.py.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+JAVA_SKILL = ROOT / "skills" / "language-java" / "SKILL.md"
+KOTLIN_SKILL = ROOT / "skills" / "language-kotlin" / "SKILL.md"
+
+
+def _section(body: str, heading: str) -> str:
+    """Extract body of a ## heading, stopping at the next ## heading (skips fenced blocks).
+
+    Returns "" when the heading is absent so callers can assert with their own message.
+    """
+    marker = f"## {heading}"
+    if marker not in body:
+        return ""
+    start = body.index(marker) + len(marker)
+    rest = body[start:]
+    fence_open = False
+    lines = []
+    for line in rest.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~~"):
+            fence_open = not fence_open
+        if not fence_open and line.startswith("## "):
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def test_java_skill_file_exists():
+    assert JAVA_SKILL.exists(), "skills/language-java/SKILL.md must exist"
+
+
+def test_kotlin_skill_file_exists():
+    assert KOTLIN_SKILL.exists(), "skills/language-kotlin/SKILL.md must exist"
+
+
+def test_java_optional_and_null_discipline_names_jackson_foot_gun():
+    body = JAVA_SKILL.read_text()
+    section = _section(body, "Optional and null discipline")
+    assert section.strip(), (
+        "skills/language-java/SKILL.md must contain a non-empty "
+        "'## Optional and null discipline' section"
+    )
+    assert "Jackson" in section, (
+        "'## Optional and null discipline' must name Jackson as the source of the foot-gun"
+    )
+    assert '"content":[null]' in section or '"content": [null]' in section, (
+        "'## Optional and null discipline' must show a literal-null-element JSON payload "
+        'such as {"content":[null]}'
+    )
+    assert "filter" in section.lower(), (
+        "'## Optional and null discipline' must name a null filter as the consumer-side remedy"
+    )
+
+
+def test_java_streams_and_collections_cross_references_null_discipline():
+    body = JAVA_SKILL.read_text()
+    section = _section(body, "Streams and collections")
+    assert section.strip(), (
+        "skills/language-java/SKILL.md must contain a non-empty '## Streams and collections' section"
+    )
+    assert "Optional and null discipline" in section, (
+        "'## Streams and collections' must cross-reference 'Optional and null discipline' "
+        "so a reviewer reading a .map() pipeline lands on the Jackson null-element guidance"
+    )
+
+
+def test_kotlin_null_safety_names_jackson_and_filter_not_null():
+    body = KOTLIN_SKILL.read_text()
+    section = _section(body, "Null safety")
+    assert section.strip(), (
+        "skills/language-kotlin/SKILL.md must contain a non-empty '## Null safety' section"
+    )
+    assert "Jackson" in section, (
+        "'## Null safety' must name Jackson as the source of the foot-gun"
+    )
+    assert "filterNotNull" in section, (
+        "'## Null safety' must name filterNotNull() as the remedy — filter { it != null } "
+        "leaves the type as List<Content?> and buys nothing"
+    )
+
+
+def test_kotlin_avoid_carries_jackson_anti_pattern():
+    body = KOTLIN_SKILL.read_text()
+    section = _section(body, "Avoid")
+    assert section.strip(), "skills/language-kotlin/SKILL.md must contain a non-empty '## Avoid' section"
+    assert "Jackson" in section, (
+        "'## Avoid' must carry an anti-pattern line naming Jackson-deserialized collections"
+    )
+    assert "non-null" in section.lower() or "non null" in section.lower(), (
+        "'## Avoid' must call out trusting a declared non-null element type"
+    )
+
+
+def test_java_and_kotlin_name_content_nulls_not_bare_nulls_skip():
+    for skill in (JAVA_SKILL, KOTLIN_SKILL):
+        body = skill.read_text()
+        assert "contentNulls" in body, (
+            f"{skill} must name the contentNulls JsonSetter attribute — nulls handles an "
+            "explicit null on the property itself, contentNulls handles nulls inside the "
+            "collection/map/array, which is the bug being documented"
+        )
+        assert "nulls = Nulls.SKIP" not in body, (
+            f"{skill} must not contain the bare 'nulls = Nulls.SKIP' — that attribute handles "
+            "an explicit null property value, not null collection elements, and would not fix "
+            "the reported bug"
+        )
+
+
+def test_java_skill_stays_within_line_cap():
+    body = JAVA_SKILL.read_text()
+    line_count = len(body.splitlines())
+    assert line_count <= 150, (
+        f"skills/language-java/SKILL.md must stay within the 150-line cap "
+        f"(scripts/validate.py); currently {line_count} lines"
+    )
+
+
+def test_kotlin_skill_stays_within_line_cap():
+    body = KOTLIN_SKILL.read_text()
+    line_count = len(body.splitlines())
+    assert line_count <= 150, (
+        f"skills/language-kotlin/SKILL.md must stay within the 150-line cap "
+        f"(scripts/validate.py); currently {line_count} lines"
+    )

--- a/tests/test_deserialization_null_guidance.py
+++ b/tests/test_deserialization_null_guidance.py
@@ -12,6 +12,9 @@ Acceptance criteria:
   *elements*, as opposed to `nulls`, which only handles an explicit null on the property itself)
   and neither contains the bare string "nulls = Nulls.SKIP" (a ratchet against the wrong attribute).
 - AC6: both skill files stay within the 150-line cap enforced by scripts/validate.py.
+- AC7: skills/language-java/SKILL.md's '## Avoid' section also carries the anti-pattern line,
+  matching Kotlin's symmetry — a reviewer fast-scanning only the Avoid checklist must see it
+  flagged for Java too, not just Kotlin (PR #600 owner feedback).
 """
 
 from pathlib import Path
@@ -68,6 +71,20 @@ def test_java_optional_and_null_discipline_names_jackson_foot_gun():
     )
     assert "filter" in section.lower(), (
         "'## Optional and null discipline' must name a null filter as the consumer-side remedy"
+    )
+
+
+def test_java_avoid_carries_jackson_anti_pattern():
+    body = JAVA_SKILL.read_text()
+    section = _section(body, "Avoid")
+    assert section.strip(), "skills/language-java/SKILL.md must contain a non-empty '## Avoid' section"
+    assert "Jackson" in section, (
+        "'## Avoid' must carry an anti-pattern line naming Jackson-deserialized collections — "
+        "a reviewer fast-scanning only the Avoid checklist should still see this flagged, "
+        "matching the symmetry Kotlin's '## Avoid' already has"
+    )
+    assert "non-null" in section.lower() or "non null" in section.lower(), (
+        "'## Avoid' must call out trusting a declared non-null element type"
     )
 
 

--- a/tests/test_principle_code_review_skill.py
+++ b/tests/test_principle_code_review_skill.py
@@ -64,6 +64,23 @@ def test_correctness_bullet_mentions_paired_guard_predicate_gaps():
     )
 
 
+def test_correctness_bullet_mentions_deserialized_collection_null_elements():
+    """The Correctness axis bullet must name null elements inside deserialized collections (#599)."""
+    body = _read()
+    section = _section(body, "Five-Axis Review Lens")
+    bullets = _axis_bullet_lines(section)
+    correctness_line = next(
+        (line for line in bullets if line.strip().startswith("- **Correctness**")),
+        "",
+    )
+    assert correctness_line, "Five-Axis Review Lens must have a '- **Correctness**' bullet"
+    lowered = correctness_line.lower()
+    assert "deserialized collection" in lowered, (
+        "the Correctness bullet must mention null elements inside externally-deserialized "
+        "collections — a valid payload can populate a typed collection with null elements"
+    )
+
+
 def test_five_axis_framing_has_exactly_five_axes():
     """The 'five axes' framing must remain accurate after the Comment quality addition."""
     body = _read()


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Add Jackson null-element-inside-collection foot-gun guidance to `skills/language-java/SKILL.md` (Optional and null discipline + Streams and collections cross-reference) and `skills/language-kotlin/SKILL.md` (Null safety + Avoid) — valid JSON like `{"content":[null]}` deserializes into a typed `List<T>` holding a literal null element regardless of declared nullability; consumer-side remedy is a filter (`Objects::nonNull` / `filterNotNull()`), durable boundary fix is `@JsonSetter(contentNulls = Nulls.SKIP)` (not the property-level `nulls` attribute, which does not fix this bug).
- Extend the language-neutral Correctness axis bullet in `skills/principle-code-review/SKILL.md` to name null elements inside externally-deserialized collections.
- Add one routing-only sentence to `agents/reviewer.md`'s "Language skill (required)" gate: derive the language set from the diff's changed-path extensions, not just from files opened — closes the gap where a small diff (e.g. one new `List<Content>` field) triggers a grep-only pass that skips loading the language skill.
- Add `tests/test_deserialization_null_guidance.py` (new) and extend `tests/test_principle_code_review_skill.py`, including a ratchet that the guidance names `contentNulls` and never the bare `nulls = Nulls.SKIP` string — the wrong attribute would not fix the reported bug.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues, both edited SKILL.md files well under the 150-line cap (128/150 each)
- [x] `pytest tests/ -v` — 2540 passed, 2 skipped (pre-existing, unrelated)
- [x] `grep -rn 'BAD\|GOOD' skills/` stays empty (repo convention: no anti-pattern comment markers)
- [x] Both required Phase 4 reviews (requesting-code-review skill + swe-workbench:reviewer subagent) returned clean, no Critical/Important findings, "Ready to merge: Yes"

### Type-tailored checks (feat)
- [x] New guidance is additive only — no existing skill behavior removed or altered beyond the inserted clause
- [x] `agents/reviewer.md`'s `@./shared/languages.md` reference and the literal `"Language skill (required)"` gate marker are preserved verbatim (confirmed via `tests/test_agent_language_catalog.py`)

Closes #599
