### PR TITLE
[chore] Regenerate pip lockfile for wheel 0.47.0->0.48.0

### DIFF
--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -28,9 +28,9 @@ pyproject-hooks==1.2.0 \
     # via
     #   build
     #   pip-tools
-wheel==0.47.0 \
-    --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced \
-    --hash=sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3
+wheel==0.48.0 \
+    --hash=sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab \
+    --hash=sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Regenerate `tests/build-requirements.lock` — upstream `wheel` released `0.48.0`, invalidating the pinned `0.47.0` hash and failing the `lockfile-check` CI job on every PR based on current `main` (discovered via PR #600's unrelated CI failure).
- `requirements.lock` and `release-requirements.lock` were already up to date; only `build-requirements.lock` needed regeneration (`bash scripts/lock-pip-requirements.sh`).
- No functional change — pinned dependency version bump only, matching repo precedent (#483, #506, #516).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/lock-pip-requirements.sh --check` — all three lockfiles now report up to date
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest tests/ -q` — 2530 passed, 2 skipped (pre-existing, unrelated)

Issue: N/A — pre-existing lockfile drift on `main`, discovered while shipping #599; not itself tracked by a numbered issue.
