### PR TITLE
[chore] Review agents/*.md model tier assignment — candidates for opus

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Architecture artifact author — produces ADRs, RFCs, and cross-service contracts for decisions that have no existing codebase to read. Invoke when the output must be a written decision record, not a recommendation about existing code: authoring an ADR, drafting a cross-team RFC, decomposing a service, or making a multi-system technology selection.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, WebFetch, Skill
 skills:
   - swe-workbench:principle-clean-architecture

--- a/agents/migrator.md
+++ b/agents/migrator.md
@@ -1,7 +1,7 @@
 ---
 name: migrator
 description: Migration specialist — executes schema, framework, runtime, API, and event-schema migrations through expand → backfill → switch → contract phases, each independently deployable and reversible. Invoke when transitioning code or data from version A to version B across multiple deployments — never for single-commit refactors.
-model: sonnet
+model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 skills:
   - swe-workbench:principle-api-design

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: security-auditor
 description: Security audit specialist — depth-first review of a diff or file for OWASP Top 10, secret leakage, insecure-by-default APIs, and language-specific foot-guns. Invoke when you want a focused security report, not a holistic code review.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, Skill
 skills:
   - swe-workbench:principle-security

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: senior-engineer
 description: Architectural advisor — thinks in boundaries, contracts, and change vectors. Invoke when choosing between approaches, scoping a new service, or evaluating an architecture.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, WebFetch, Skill
 skills:
   - swe-workbench:principle-clean-architecture

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 - [catalog.md](catalog.md) — commands, subagents, and skills (full tables).
 - [extending.md](extending.md) — how to add new skills; philosophy behind the design.
 - [dependencies.md](dependencies.md) — runtime plugin dependencies.
-- [cost-audit.md](cost-audit.md) — point-in-time model-tier audit (snapshot at #160).
+- [cost-audit.md](cost-audit.md) — point-in-time model-tier audits: initial snapshot at #160, re-tier pass at #612.
 - [cost-tiers.md](cost-tiers.md) — forward-looking convention for assigning model tiers to new agents.
 - [secret-detection.md](secret-detection.md) — PreToolUse hook that blocks hardcoded secrets before Write/Edit writes the file.
 - [workflow-state.md](workflow-state.md) — SessionStart hook that persists workflow phase state across auto-compaction and injects a resume preamble.

--- a/docs/cost-audit.md
+++ b/docs/cost-audit.md
@@ -89,3 +89,48 @@ Skills have no `model:` field — they are prose instructions injected into the 
 | 3 | All other swe-workbench surfaces | ~22% | No change; monitor. If any single surface exceeds 15% for 3 consecutive days, open a cost-audit follow-up. |
 
 **Post-merge:** compare against this baseline after one representative day of use. Log delta as a comment on issue #160.
+
+---
+
+## Re-tier pass — 2026-08-21 (#612)
+
+Deliberate per-agent pass over all 22 shipped agents (17 `sonnet`, 5 `haiku`, 0 `opus` at
+start), applying the reasoned-promotion path added to `cost-tiers.md` in this same PR.
+Explicitly not a blanket bump — most agents keep their existing tier. See `cost-tiers.md`
+for the decision rubric (silent failure / one-way door / adversarial reasoning /
+frequency×delta veto) applied below. This section is additive; the 2026-05-10 snapshot
+above is left untouched as a historical record.
+
+**Bumped to opus (4):**
+
+| Agent | Rationale |
+|---|---|
+| architect | Output is a durable published artifact (ADR/RFC) with no automatic downstream gate; must surface unstated constraints/risks; invoked only for major design decisions, not per-PR |
+| migrator | Phase 5 (Contract) is explicitly not reversible; the agent authors its own advance-gate metrics, so a blind spot in its call-site mapping propagates into the very check meant to catch it; migrations are occasional, not per-PR |
+| security-auditor | A missed exploitability judgment ships a real vulnerability unnoticed; its output is a de facto security clearance once merged; targeted at security-sensitive diffs only, not every PR |
+| senior-engineer | Explicit escalation target for an unresolved architectural fork another worker couldn't judge itself; consult-only, not per-PR |
+
+**Kept on sonnet (13):**
+
+| Agent | Rationale |
+|---|---|
+| accessibility-auditor | Applies a fixed WCAG catalog to what's present in a diff, not absence-hunting; advisory, human-reviewed; dispatched on most frontend PRs |
+| auditor | Breadth sweep against a known checklist, not novel adversarial reasoning; advisory report only, never merged/published |
+| code-impl | Every change passes through Phase 3 Verify + Phase 4 Review before landing; highest-frequency agent in the delegated-implementation path |
+| conflict-resolver | Bounded to one file's hunks; recommendation still goes through the normal Verify/Review pipeline before merge |
+| contributor-auditor | Checklist-driven evidence gathering against a fixed rubric; explicitly advisory only — never posts to the PR |
+| debugger | Self-verifying by construction — regression test must fail before the fix and pass after; high frequency |
+| e2e-test-writer | Output is spec files only (no production-code edit rights); e2e-test-verifier runs and validates every spec immediately after |
+| performance-tuner | Matches a profiled root cause to a fixed optimization-pattern library; no Edit tool, advisory only |
+| product-designer | Nielsen's 10 heuristics plus explicit checklist axes — catalog application; advisory, diff-scoped |
+| redundancy-assessor | Built-in tier guardrail already contains the risk: AUTO-APPLY restricted to whole-file + zero-refs matches, anything ambiguous forced to ESCALATE |
+| refactorer | Hard test-gate discipline (green between steps, revert on red) makes silent failure structurally unlikely; high frequency |
+| reviewer | Dispatched on effectively every PR; five-axis review is explicitly moderate-depth breadth, not adversarial depth, by its own boundary docs |
+| test-reviewer | Advisory-only, never edits test files itself; categories are enumerable and pattern-matchable |
+
+**Unchanged (haiku, out of scope for this pass):** dependency-auditor, e2e-test-verifier,
+product-manager, tech-writer, test-writer.
+
+**Enforcement:** `tests/test_agent_model_tiers.py` pins every agent's `model:` to the table
+above and asserts every `opus` agent is named in this section — the tier cannot drift
+silently.

--- a/docs/cost-audit.md
+++ b/docs/cost-audit.md
@@ -108,7 +108,7 @@ above is left untouched as a historical record.
 | architect | Output is a durable published artifact (ADR/RFC) with no automatic downstream gate; must surface unstated constraints/risks; invoked only for major design decisions, not per-PR |
 | migrator | Phase 5 (Contract) is explicitly not reversible; the agent authors its own advance-gate metrics, so a blind spot in its call-site mapping propagates into the very check meant to catch it; migrations are occasional, not per-PR |
 | security-auditor | A missed exploitability judgment ships a real vulnerability unnoticed; its output is a de facto security clearance once merged; targeted at security-sensitive diffs only, not every PR |
-| senior-engineer | Explicit escalation target for an unresolved architectural fork another worker couldn't judge itself; consult-only, not per-PR |
+| senior-engineer | Criterion 3 (absence-detection): explicit escalation target for an unresolved architectural fork another worker couldn't judge itself, precisely because nothing downstream can independently validate the trade-off analysis; consult-only, not per-PR |
 
 **Kept on sonnet (13):**
 

--- a/docs/cost-tiers.md
+++ b/docs/cost-tiers.md
@@ -60,7 +60,7 @@ or security/correctness judgment?
 - Output is a durable published artifact (ADR/RFC) with no automatic downstream gate — a wrong constraint or unnamed risk becomes precedent (architect)
 - A phase is explicitly not reversible, and the agent authors its own advance-gate metrics — a blind spot in its call-site mapping propagates into the very check meant to catch it (migrator)
 - A wrong judgment is a security clearance that ships a real, unnoticed vulnerability (security-auditor)
-- The agent is the explicit escalation target for an unresolved architectural fork another worker couldn't judge itself (senior-engineer)
+- The agent is the explicit escalation target for an unresolved architectural fork another worker couldn't judge itself, and the escalation exists precisely because no other worker or reviewer in the pipeline can independently validate the trade-off analysis — criterion 3 (absence-detection), not 1+2 (senior-engineer)
 
 None of these apply on every PR — each is invoked occasionally by design, which is what keeps the frequency×delta veto from blocking the promotion.
 

--- a/docs/cost-tiers.md
+++ b/docs/cost-tiers.md
@@ -8,9 +8,12 @@ Forward-looking convention for model assignment in swe-workbench agents. For the
 |---|---|---|---|
 | S (small) | `haiku` | Single-purpose fetch, format, or extract. Deterministic output from well-specified input. No cross-file reasoning or correctness judgment. | product-manager, tech-writer, test-writer, dependency-auditor |
 | M (medium) | `sonnet` | Mechanical but judgment-bearing. Must weigh trade-offs, apply a pattern catalog, or preserve an invariant across steps. | debugger, refactorer, performance-tuner, accessibility-auditor, product-designer |
-| L (large) | `sonnet` (default) or `opus` (with evidence) | High-stakes reasoning. Security exploitability, multi-system architecture, or correctness in concurrent / distributed settings. Opus only when measurable improvement is demonstrated. | reviewer, security-auditor, architect, senior-engineer |
+| L (large) | `sonnet` (default) or `opus` (promoted) | High-stakes reasoning. Security exploitability, multi-system architecture, or correctness in concurrent / distributed settings. | reviewer, security-auditor, architect, senior-engineer, migrator |
 
-**Default:** when in doubt, start at Tier M (`sonnet`). Downgrade to haiku only after confirming the task is mechanical. Promote to opus only with a measured A/B result.
+**Default:** when in doubt, start at Tier M (`sonnet`). Downgrade to haiku only after confirming the task is mechanical. Promote to opus via either gate below — this repo has no A/B harness or telemetry, so **reasoned promotion is the primary path**, not a fallback:
+
+- **Measured** — an A/B result showing opus measurably outperforms sonnet on the agent's actual task.
+- **Reasoned** — the agent matches a forcing function below, argued explicitly against the frequency×delta veto (a high-frequency agent needs a materially stronger case than an occasional one) and recorded as a one-line keep/bump rationale alongside the change.
 
 ## Where the field lives
 
@@ -33,8 +36,8 @@ Does the agent require multi-step reasoning, cross-file synthesis,
 or security/correctness judgment?
    │
    ├── Yes ──► Tier M or L (sonnet). For high-stakes correctness
-   │           (security, architecture): Tier L, consider opus only
-   │           with measured evidence.
+   │           (security, architecture): Tier L, promote to opus
+   │           when a forcing function applies (measured or reasoned).
    │
    └── No ──► Is the output deterministic given well-specified input?
                  │
@@ -48,10 +51,18 @@ or security/correctness judgment?
 - Output is idiomatic code generated from a behavioral spec (test-writer)
 - Output is a tabular report extracted from manifest files (dependency-auditor)
 
-**Keep on sonnet even if it looks simple:**
-- Involves security exploitability assessment (security-auditor)
-- Must preserve behavioral invariants across steps (refactorer, migrator)
-- Output influences architecture or published contracts (architect, senior-engineer)
+**Keep on sonnet even if it looks high-stakes:**
+- Behavior-preservation is enforced by a hard test gate, not judgment alone (refactorer — green between every step or revert)
+- Root cause is confirmed by a failing-then-passing regression test, not self-authored reasoning alone (debugger)
+- Output flows through Phase 3 Verify + Phase 4 Review before it can land (code-impl)
+
+**Forcing functions for opus:**
+- Output is a durable published artifact (ADR/RFC) with no automatic downstream gate — a wrong constraint or unnamed risk becomes precedent (architect)
+- A phase is explicitly not reversible, and the agent authors its own advance-gate metrics — a blind spot in its call-site mapping propagates into the very check meant to catch it (migrator)
+- A wrong judgment is a security clearance that ships a real, unnoticed vulnerability (security-auditor)
+- The agent is the explicit escalation target for an unresolved architectural fork another worker couldn't judge itself (senior-engineer)
+
+None of these apply on every PR — each is invoked occasionally by design, which is what keeps the frequency×delta veto from blocking the promotion.
 
 ## When to revisit
 
@@ -62,6 +73,11 @@ Downgrade a Tier M agent to haiku when:
 Revert a haiku agent to sonnet when:
 - A user-visible regression is traced to reasoning depth (not tool availability) within 14 days.
 - PR description must note the reversion and the failing case.
+
+Revert an opus agent to sonnet when:
+- 14 days pass with no case where the extra reasoning depth visibly changed the outcome versus a comparable sonnet run.
+- The forcing function that justified the promotion no longer applies (e.g. a downstream gate was added that now catches what previously shipped silently).
+- PR description must note the reversion and cite which of the two conditions triggered it.
 
 Flag concentration in telemetry: if any single agent exceeds 15% of session token spend for more than 3 days, open a cost-audit follow-up issue.
 

--- a/tests/test_agent_model_tiers.py
+++ b/tests/test_agent_model_tiers.py
@@ -12,9 +12,8 @@ COST_AUDIT = ROOT / "docs" / "cost-audit.md"
 
 VALID_TIERS = {"haiku", "sonnet", "opus"}
 
-# One line per shipped agent — encodes the #612 per-agent keep/bump pass.
-# Bumped to opus: architect, migrator, security-auditor, senior-engineer.
-# Rationale for every agent lives in docs/cost-audit.md's re-tier section.
+# Encodes the #612 keep/bump pass; rationale lives in docs/cost-audit.md's
+# re-tier section. Bumped to opus: architect, migrator, security-auditor, senior-engineer.
 EXPECTED_TIERS = {
     "accessibility-auditor": "sonnet",
     "architect": "opus",

--- a/tests/test_agent_model_tiers.py
+++ b/tests/test_agent_model_tiers.py
@@ -1,0 +1,97 @@
+"""Ratchet test for agents/*.md model tier assignments (issue #612)."""
+
+from pathlib import Path
+
+import pytest
+
+import validate
+
+ROOT = Path(__file__).parent.parent
+AGENTS_DIR = ROOT / "agents"
+COST_AUDIT = ROOT / "docs" / "cost-audit.md"
+
+VALID_TIERS = {"haiku", "sonnet", "opus"}
+
+# One line per shipped agent — encodes the #612 per-agent keep/bump pass.
+# Bumped to opus: architect, migrator, security-auditor, senior-engineer.
+# Rationale for every agent lives in docs/cost-audit.md's re-tier section.
+EXPECTED_TIERS = {
+    "accessibility-auditor": "sonnet",
+    "architect": "opus",
+    "auditor": "sonnet",
+    "code-impl": "sonnet",
+    "conflict-resolver": "sonnet",
+    "contributor-auditor": "sonnet",
+    "debugger": "sonnet",
+    "dependency-auditor": "haiku",
+    "e2e-test-verifier": "haiku",
+    "e2e-test-writer": "sonnet",
+    "migrator": "opus",
+    "performance-tuner": "sonnet",
+    "product-designer": "sonnet",
+    "product-manager": "haiku",
+    "redundancy-assessor": "sonnet",
+    "refactorer": "sonnet",
+    "reviewer": "sonnet",
+    "security-auditor": "opus",
+    "senior-engineer": "opus",
+    "tech-writer": "haiku",
+    "test-reviewer": "sonnet",
+    "test-writer": "haiku",
+}
+
+
+def _agent_files():
+    return sorted(AGENTS_DIR.glob("*.md"))
+
+
+def test_every_agent_model_is_a_known_tier():
+    for path in _agent_files():
+        fm = validate.parse_frontmatter(path)
+        assert fm is not None, f"{path} has no parseable frontmatter"
+        model = fm.get("model")
+        assert model in VALID_TIERS, (
+            f"{path.name}: model '{model}' is not one of {sorted(VALID_TIERS)}"
+        )
+
+
+@pytest.mark.parametrize("agent_name", sorted(EXPECTED_TIERS))
+def test_agent_model_matches_expected_tier(agent_name):
+    path = AGENTS_DIR / f"{agent_name}.md"
+    assert path.exists(), f"agents/{agent_name}.md must exist"
+    fm = validate.parse_frontmatter(path)
+    assert fm is not None, f"{path.name} has no parseable frontmatter"
+    assert fm.get("model") == EXPECTED_TIERS[agent_name], (
+        f"{agent_name}: expected model '{EXPECTED_TIERS[agent_name]}', "
+        f"got '{fm.get('model')}'"
+    )
+
+
+def test_expected_tiers_matches_agents_directory():
+    on_disk = {path.stem for path in _agent_files()}
+    expected = set(EXPECTED_TIERS)
+    assert on_disk == expected, (
+        "agents/ directory and EXPECTED_TIERS have diverged — "
+        f"only on disk: {sorted(on_disk - expected)}, "
+        f"only in EXPECTED_TIERS: {sorted(expected - on_disk)}"
+    )
+
+
+RETIER_SECTION_HEADING = "## Re-tier pass — 2026-08-21 (#612)"
+
+
+def test_every_opus_agent_is_recorded_in_cost_audit():
+    opus_agents = sorted(name for name, tier in EXPECTED_TIERS.items() if tier == "opus")
+    assert COST_AUDIT.exists(), "docs/cost-audit.md must exist"
+    text = COST_AUDIT.read_text(encoding="utf-8")
+    assert RETIER_SECTION_HEADING in text, (
+        f"docs/cost-audit.md must have a {RETIER_SECTION_HEADING!r} section "
+        "recording the #612 decisions — the pre-existing 2026-05-10 snapshot "
+        "does not count, since agent names it lists don't reflect this pass"
+    )
+    section = text.split(RETIER_SECTION_HEADING, 1)[1]
+    for name in opus_agents:
+        assert name in section, (
+            f"{name} is tiered opus but is not recorded in docs/cost-audit.md's "
+            f"{RETIER_SECTION_HEADING!r} section"
+        )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Bump 4 of 22 shipped subagents (`architect`, `migrator`, `security-auditor`, `senior-engineer`) from `model: sonnet` to `model: opus`, via a written per-agent rubric (silent failure × one-way door, OR adversarial/absence-detection reasoning, gated by a frequency×delta veto) — explicitly not a blanket bump; 13 of the 17 `sonnet` agents keep their tier.
- Add `tests/test_agent_model_tiers.py`, a ratchet test pinning every agent's exact `model:` value, enforcing `agents/` directory ↔ expected-tiers symmetry, and requiring every `opus` agent to be documented in `docs/cost-audit.md`.
- Amend `docs/cost-tiers.md`: replace the "opus only with measured A/B evidence" convention (this repo has no A/B harness) with a two-path gate (measured OR reasoned-with-rubric), add a "Forcing functions for opus" list, and add a symmetrical opus→sonnet revert trigger.
- Append (not rewrite) a new dated section to `docs/cost-audit.md` recording all 22 agents' keep/bump decision and rationale; the pre-existing 2026-05-10 snapshot is left untouched as a historical record.
- Update `docs/README.md`'s `cost-audit.md` description, which no longer describes a single point-in-time snapshot.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Full `pytest tests/` suite green (2566 passed, 2 skipped, 0 failed)
- [x] `bash scripts/validate.sh` — 0 issues
- [x] Comment-scan against the branch diff — 0 must-triage findings
- [x] Two independent review passes (plan-alignment + diff correctness/security/design) run in parallel; no Critical/High findings; the one Important finding (senior-engineer bump rationale not naming its rubric leg) fixed and re-verified

### Type-tailored checks (docs)
- [x] Links and cross-references in the touched docs (`cost-tiers.md`, `cost-audit.md`, `README.md`) resolve to real sections/files

Closes #612
