### PR TITLE
[chore] Regenerate pip lockfile for pygments 2.20.0->2.21.0

### DIFF
--- a/tests/requirements.lock
+++ b/tests/requirements.lock
@@ -16,9 +16,9 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
-pygments==2.20.0 \
-    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
-    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pygments==2.21.0 \
+    --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9 \
+    --hash=sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c
     # via pytest
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Regenerate `tests/requirements.lock` — upstream `pygments` released `2.21.0`, invalidating the pinned `2.20.0` hash and failing the `lockfile-check` CI job on every PR based on current `main` (discovered via PR #614's unrelated CI failure).
- `release-requirements.lock` and `build-requirements.lock` were already up to date; only `requirements.lock` needed regeneration (`bash scripts/lock-pip-requirements.sh`).
- No functional change — pinned dependency version bump only, matching repo precedent (#483, #506, #516, #601).

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/lock-pip-requirements.sh --check` — all three lockfiles now report up to date
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `pytest tests/ -q` — 2541 passed, 2 skipped (pre-existing, unrelated)

Issue: N/A — pre-existing lockfile drift on `main`, discovered while shipping #612; not itself tracked by a numbered issue.
