### PR TITLE
[chore] Pi: manifest-only skill reach + bin/ PATH exposure

### DIFF
--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -1,5 +1,5 @@
 /**
- * swe-workbench adapter for Pi Coding Agent (ADR-0001 phase 1, issue #604).
+ * swe-workbench adapter for Pi Coding Agent.
  *
  * Mirrors two harness affordances Claude Code already provides for this plugin, pointing at
  * the SAME skills/ and bin/ trees Claude Code uses — nothing under skills/ is duplicated:

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -1,0 +1,102 @@
+/**
+ * swe-workbench adapter for Pi Coding Agent (ADR-0001 phase 1, issue #604).
+ *
+ * Mirrors two harness affordances Claude Code already provides for this plugin, pointing at
+ * the SAME skills/ and bin/ trees Claude Code uses — nothing under skills/ is duplicated:
+ *   1. `<plugin>/bin` on PATH, so every skill's bare `swe-workbench-<name>` command resolves
+ *      unchanged (see bin/README.md).
+ *   2. All skills/<name>/SKILL.md directories reachable, via `resources_discover`.
+ *
+ * Two Pi API facts recorded here so a later phase (#607) does not rediscover them the hard way:
+ *   - `ExtensionContext` (dist/core/extensions/types.d.ts) exposes no settings accessor. An
+ *     extension that wants the user's `shellPath`/`shellCommandPrefix` would have to re-register
+ *     the `bash` tool, which silently discards both — and a `commandPrefix` approach would
+ *     overwrite the user's own `shellCommandPrefix`. This adapter only ever appends to
+ *     `process.env.PATH`; it never touches the bash tool or `pi.on("tool_call")`.
+ *   - The shipped `examples/extensions/bash-spawn-hook.ts` wraps the bash tool by dropping its
+ *     `_ctx` argument, which kills the `PI_SESSION_ID`/`PI_MODEL`/`PI_PROVIDER` env vars the bash
+ *     tool's own guidelines tell the model to read. Do not copy that pattern verbatim.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+class PluginRootNotFoundError extends Error {
+  constructor(startDir: string) {
+    super(`swe-workbench: could not find .claude-plugin/plugin.json above ${startDir}`);
+    this.name = "PluginRootNotFoundError";
+  }
+}
+
+/** Walks up from `startDir` until a directory contains .claude-plugin/plugin.json. */
+function findPluginRoot(startDir: string): string {
+  let dir = startDir;
+  while (true) {
+    if (existsSync(join(dir, ".claude-plugin", "plugin.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) throw new PluginRootNotFoundError(startDir);
+    dir = parent;
+  }
+}
+
+const PREAMBLE_MARKER = "<!-- swe-workbench:pi-bin-preamble -->";
+
+function composePreamble(sections: { title: string; body: string }[]): string {
+  return (
+    `\n\n${PREAMBLE_MARKER}\n` +
+    sections.map((s) => `## ${s.title}\n\n${s.body}`).join("\n\n")
+  );
+}
+
+/** Extracts the body of bin/README.md's "## Current scripts" section, up to the next "## " heading. */
+function extractCurrentScripts(readmeText: string): string | null {
+  const heading = "## Current scripts";
+  const start = readmeText.indexOf(heading);
+  if (start === -1) return null;
+  const rest = readmeText.slice(start + heading.length);
+  const nextHeadingOffset = rest.indexOf("\n## ");
+  const body = nextHeadingOffset === -1 ? rest : rest.slice(0, nextHeadingOffset);
+  return body.trim();
+}
+
+export default function (pi: ExtensionAPI): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const root = findPluginRoot(here);
+
+  const binDir = join(root, "bin");
+  const pathEntries = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  if (!pathEntries.includes(binDir)) {
+    process.env.PATH = [...pathEntries, binDir].join(delimiter);
+  }
+
+  const readmeText = readFileSync(join(binDir, "README.md"), "utf8");
+  const currentScripts = extractCurrentScripts(readmeText);
+  const preamble =
+    currentScripts === null
+      ? null
+      : composePreamble([
+          { title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts },
+        ]);
+
+  let warnedMissingAnchor = false;
+
+  pi.on("resources_discover", () => ({ skillPaths: [join(root, "skills")] }));
+
+  pi.on("session_start", (_event, ctx: ExtensionContext) => {
+    if (preamble === null && !warnedMissingAnchor && ctx.hasUI) {
+      warnedMissingAnchor = true;
+      ctx.ui.notify(
+        "swe-workbench: bin/README.md's '## Current scripts' section was not found — the " +
+          "bin/ script inventory will not be injected into the system prompt this session.",
+        "warning",
+      );
+    }
+  });
+
+  pi.on("before_agent_start", (event) => {
+    if (preamble === null) return;
+    if (event.systemPrompt.includes(PREAMBLE_MARKER)) return;
+    return { systemPrompt: event.systemPrompt + preamble };
+  });
+}

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -60,6 +60,22 @@ function extractCurrentScripts(readmeText: string): string | null {
   return body.trim();
 }
 
+/**
+ * Reads bin/README.md and extracts the "## Current scripts" section. Returns null on any
+ * failure (file missing/unreadable, or heading missing) — this is a doc file, not load-bearing
+ * for PATH exposure or skill discovery, so its absence must degrade the preamble feature alone,
+ * never take down the whole extension.
+ */
+function readCurrentScripts(binDir: string): string | null {
+  let readmeText: string;
+  try {
+    readmeText = readFileSync(join(binDir, "README.md"), "utf8");
+  } catch {
+    return null;
+  }
+  return extractCurrentScripts(readmeText);
+}
+
 export default function (pi: ExtensionAPI): void {
   const here = dirname(fileURLToPath(import.meta.url));
   const root = findPluginRoot(here);
@@ -70,8 +86,7 @@ export default function (pi: ExtensionAPI): void {
     process.env.PATH = [...pathEntries, binDir].join(delimiter);
   }
 
-  const readmeText = readFileSync(join(binDir, "README.md"), "utf8");
-  const currentScripts = extractCurrentScripts(readmeText);
+  const currentScripts = readCurrentScripts(binDir);
   const preamble =
     currentScripts === null
       ? null
@@ -87,7 +102,7 @@ export default function (pi: ExtensionAPI): void {
     if (preamble === null && !warnedMissingAnchor && ctx.hasUI) {
       warnedMissingAnchor = true;
       ctx.ui.notify(
-        "swe-workbench: bin/README.md's '## Current scripts' section was not found — the " +
+        "swe-workbench: bin/README.md's '## Current scripts' section could not be read — the " +
           "bin/ script inventory will not be injected into the system prompt this session.",
         "warning",
       );

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "swe-workbench-pi",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Pi Coding Agent adapter for the swe-workbench plugin",
+  "pi": {
+    "extensions": ["./extensions"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  }
+}

--- a/skills/comms-context/SKILL.md
+++ b/skills/comms-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comms-context
-description: Fetch on-call and discussion context from Slack threads and PagerDuty incidents — participants, timeline, and status. Auto-loads on Slack permalinks or PagerDuty incident references. Keywords: Slack, thread, permalink, PagerDuty, incident, on-call, participants.
+description: Fetch on-call and discussion context from Slack threads and PagerDuty incidents — participants, timeline, and status. Auto-loads on Slack permalinks or PagerDuty incident references. Keywords — Slack, thread, permalink, PagerDuty, incident, on-call, participants.
 ---
 
 ## When to invoke

--- a/skills/principle-data-modeling/SKILL.md
+++ b/skills/principle-data-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-data-modeling
-description: Data modeling: relational vs document vs KV vs graph selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution via expand–contract, query-first design, retention and archival. Auto-load when designing schemas, choosing a storage paradigm, discussing normalization or denormalization, schema evolution, indexing strategy, hot-key avoidance, query-first design, or data retention.
+description: Data modeling — relational vs document vs KV vs graph selection, normalization depth, indexing strategy, hot-key avoidance, schema evolution via expand–contract, query-first design, retention and archival. Auto-load when designing schemas, choosing a storage paradigm, discussing normalization or denormalization, schema evolution, indexing strategy, hot-key avoidance, query-first design, or data retention.
 ---
 <!-- preload-canary: SWB-PRELOAD-PRINCIPLE-DATA-MODELING -->
 

--- a/skills/principle-release-engineering/SKILL.md
+++ b/skills/principle-release-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-release-engineering
-description: Release engineering: semver discipline, tag identity, rollout strategy, rollback planning, expand-contract for breaking changes, kill-switch, feature flag, release notes audience, idempotent release automation, post-release verification. Auto-load when cutting a release, planning a breaking API change, writing release notes, choosing a version bump, designing a rollback plan, using a feature flag as a kill-switch, or building release automation scripts.
+description: Release engineering — semver discipline, tag identity, rollout strategy, rollback planning, expand-contract for breaking changes, kill-switch, feature flag, release notes audience, idempotent release automation, post-release verification. Auto-load when cutting a release, planning a breaking API change, writing release notes, choosing a version bump, designing a rollback plan, using a feature flag as a kill-switch, or building release automation scripts.
 ---
 <!-- preload-canary: SWB-PRELOAD-PRINCIPLE-RELEASE-ENGINEERING -->
 

--- a/skills/workflow-audit-emit-issues/SKILL.md
+++ b/skills/workflow-audit-emit-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-audit-emit-issues
-description: After a codebase audit, groups audit findings by subsystem (path prefix) and emits them as context-rich GitHub issues with template discovery, label selection, and a batch preview-confirm gate before filing. Keywords: audit findings grouped github issues subsystem emit.
+description: After a codebase audit, groups audit findings by subsystem (path prefix) and emits them as context-rich GitHub issues with template discovery, label selection, and a batch preview-confirm gate before filing. Keywords — audit findings grouped github issues subsystem emit.
 orchestrator: true
 ---
 

--- a/skills/workflow-codebase-knowledge/SKILL.md
+++ b/skills/workflow-codebase-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-codebase-knowledge
-description: Use to understand an unfamiliar codebase — presents architecture overview, module map, public API surfaces, and conventions as a layered mental model. Knowledge-presentation only: read-only sweep, no defect ranking, no reasoning chains. Distinct from workflow-codebase-audit (finding-oriented defect detection) and tech-writer / /swe-workbench:document (generates new prose artifacts). Ideal for onboarding, knowledge-handoff, and reviewer context-gathering.
+description: Use to understand an unfamiliar codebase — presents architecture overview, module map, public API surfaces, and conventions as a layered mental model. Knowledge-presentation only — read-only sweep, no defect ranking, no reasoning chains. Distinct from workflow-codebase-audit (finding-oriented defect detection) and tech-writer / /swe-workbench:document (generates new prose artifacts). Ideal for onboarding, knowledge-handoff, and reviewer context-gathering.
 ---
 
 # Workflow: Codebase Knowledge

--- a/skills/workflow-dependency-upgrade/SKILL.md
+++ b/skills/workflow-dependency-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-dependency-upgrade
-description: Use when walking the dependency-upgrade lifecycle — routine sweep, Dependabot/Renovate PR triage, CVE patch, or major-version migration. Structured runbook: triage+batch → bump regen lockfile → build/test → breakage-triage → PR hygiene. Per-ecosystem command matrix; composes principle-security. Keywords: dependency upgrade bump lockfile Dependabot Renovate semver CVE supply-chain breakage
+description: Use when walking the dependency-upgrade lifecycle — routine sweep, Dependabot/Renovate PR triage, CVE patch, or major-version migration. Structured runbook — triage+batch → bump regen lockfile → build/test → breakage-triage → PR hygiene. Per-ecosystem command matrix; composes principle-security. Keywords — dependency upgrade bump lockfile Dependabot Renovate semver CVE supply-chain breakage
 ---
 
 # workflow-dependency-upgrade

--- a/skills/workflow-performance-investigation/SKILL.md
+++ b/skills/workflow-performance-investigation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-performance-investigation
-description: Profile-first performance investigation runbook — reproduce and baseline a metric, pick a profiler from the ecosystem tooling matrix (Go/Python/JVM/Node/Rust/Ruby/.NET/native), capture CPU + alloc profiles under load, hand the profile to the performance-tuner agent for ranked hotspot read, classify by bottleneck taxonomy (CPU/memory-GC/I-O/lock-contention), form one hypothesis, make one isolated change, before/after measurement, regression guard. Keywords: profile flame graph hotspot bottleneck slow endpoint investigation benchmark.
+description: Profile-first performance investigation runbook — reproduce and baseline a metric, pick a profiler from the ecosystem tooling matrix (Go/Python/JVM/Node/Rust/Ruby/.NET/native), capture CPU + alloc profiles under load, hand the profile to the performance-tuner agent for ranked hotspot read, classify by bottleneck taxonomy (CPU/memory-GC/I-O/lock-contention), form one hypothesis, make one isolated change, before/after measurement, regression guard. Keywords — profile flame graph hotspot bottleneck slow endpoint investigation benchmark.
 ---
 
 # workflow-performance-investigation

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1,4 +1,4 @@
-"""Contract and behavioural tests for the Pi Coding Agent adapter (issue #604, ADR-0001 phase 1).
+"""Contract and behavioural tests for the Pi Coding Agent adapter.
 
 Two layers:
   - Always-on (static/contract): pi/package.json shape, bin/README.md anchor shape, no

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1,0 +1,196 @@
+"""Contract and behavioural tests for the Pi Coding Agent adapter (issue #604, ADR-0001 phase 1).
+
+Two layers:
+  - Always-on (static/contract): pi/package.json shape, bin/README.md anchor shape, no
+    hardcoded root hop in the extension source. No Node required.
+  - Behavioural (skipif no Node >= 22): drives the real pi/extensions/index.ts through
+    `node --experimental-strip-types` with a stub ExtensionAPI, since every
+    `@earendil-works/*` import in the extension is type-only and therefore elided by the
+    stripper — no module resolution, no node_modules, needed.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+PACKAGE_JSON = ROOT / "pi" / "package.json"
+INDEX_TS = ROOT / "pi" / "extensions" / "index.ts"
+BIN_README = ROOT / "bin" / "README.md"
+
+_DRIVER = """
+import { pathToFileURL } from "node:url";
+import { delimiter } from "node:path";
+
+const mod = await import(pathToFileURL(process.argv[2]).href);
+const factory = mod.default;
+
+const handlers = {};
+const stubPi = {
+  on(event, handler) {
+    handlers[event] = handler;
+  },
+};
+const stubCtx = { hasUI: true, ui: { notify() {} } };
+
+await factory(stubPi);
+await factory(stubPi); // second invocation simulates a session reload
+
+const discoverResult = await handlers["resources_discover"](
+  { type: "resources_discover", cwd: process.cwd(), reason: "startup" },
+  stubCtx,
+);
+
+const firstInjection = await handlers["before_agent_start"](
+  { type: "before_agent_start", prompt: "hi", systemPrompt: "BASE-PROMPT", systemPromptOptions: {} },
+  stubCtx,
+);
+const promptAfterFirst = firstInjection && firstInjection.systemPrompt
+  ? firstInjection.systemPrompt
+  : "BASE-PROMPT";
+
+const secondInjection = await handlers["before_agent_start"](
+  { type: "before_agent_start", prompt: "hi again", systemPrompt: promptAfterFirst, systemPromptOptions: {} },
+  stubCtx,
+);
+
+console.log(JSON.stringify({
+  discoverResult,
+  pathEntries: (process.env.PATH ?? "").split(delimiter).filter(Boolean),
+  firstInjection,
+  secondInjection,
+}));
+"""
+
+
+def _node_major_version():
+    node = shutil.which("node")
+    if node is None:
+        return None
+    result = subprocess.run(
+        [node, "--version"], capture_output=True, text=True, env=_CLEAN_ENV, timeout=10
+    )
+    # "v22.6.0\n" -> 22
+    return int(result.stdout.strip().lstrip("v").split(".")[0])
+
+
+_NODE_MAJOR = _node_major_version()
+requires_node = pytest.mark.skipif(
+    _NODE_MAJOR is None or _NODE_MAJOR < 22,
+    reason="behavioural pi extension tests require Node >= 22 (--experimental-strip-types)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Always-on: static/contract checks
+# ---------------------------------------------------------------------------
+
+
+def test_package_json_is_valid_json_with_exact_keys():
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    assert set(data.keys()) == {
+        "name",
+        "version",
+        "private",
+        "type",
+        "description",
+        "pi",
+        "peerDependencies",
+    }
+
+
+def test_package_json_values():
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    assert data["name"] == "swe-workbench-pi"
+    assert data["version"] == "0.0.0"
+    assert data["private"] is True
+    assert data["type"] == "module"
+    assert data["pi"] == {"extensions": ["./extensions"]}
+    assert data["peerDependencies"] == {"@earendil-works/pi-coding-agent": "*"}
+
+
+def test_package_json_has_no_pi_skills_key():
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    assert "skills" not in data["pi"], (
+        "pi.skills must be absent — the extension's resources_discover handler is the sole "
+        "source of skill paths so all 60 skills register exactly once"
+    )
+
+
+def test_package_json_has_no_dependencies_key():
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    assert "dependencies" not in data
+
+
+def test_bin_readme_current_scripts_section_has_a_terminating_heading():
+    text = BIN_README.read_text(encoding="utf-8")
+    start = text.find("## Current scripts")
+    assert start != -1, "bin/README.md must contain the literal '## Current scripts' heading"
+    next_heading = text.find("\n## ", start + len("## Current scripts"))
+    assert next_heading != -1, (
+        "a later '## ' heading must terminate the Current scripts section so extraction "
+        "in pi/extensions/index.ts has a well-defined end"
+    )
+
+
+def test_index_ts_has_no_hardcoded_root_hop():
+    text = INDEX_TS.read_text(encoding="utf-8")
+    assert '"../.."' not in text and "'../..'" not in text, (
+        "the plugin root must be resolved by walking up for .claude-plugin/plugin.json, "
+        "not a hardcoded hop — a #611 relocation would silently break a hardcoded hop"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: drive the real extension under node --experimental-strip-types
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def extension_result(tmp_path_factory):
+    if _NODE_MAJOR is None or _NODE_MAJOR < 22:
+        pytest.skip("requires Node >= 22")
+    driver = tmp_path_factory.mktemp("pi-extension-driver") / "driver.mjs"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    node = shutil.which("node")
+    assert node is not None
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), str(INDEX_TS)],
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@requires_node
+def test_resources_discover_returns_exactly_the_skills_dir(extension_result):
+    assert extension_result["discoverResult"] == {"skillPaths": [str(ROOT / "skills")]}
+
+
+@requires_node
+def test_path_gains_bin_dir_exactly_once_after_two_factory_invocations(extension_result):
+    bin_dir = str(ROOT / "bin")
+    assert extension_result["pathEntries"].count(bin_dir) == 1
+
+
+@requires_node
+def test_before_agent_start_injects_marker_and_first_script_row(extension_result):
+    injected = extension_result["firstInjection"]["systemPrompt"]
+    assert "<!-- swe-workbench:pi-bin-preamble -->" in injected
+    assert "swe-workbench-clean-ephemeral" in injected
+
+
+@requires_node
+def test_before_agent_start_does_not_duplicate_on_already_injected_prompt(extension_result):
+    # Second call received a prompt that already contains the marker; it must be a no-op.
+    # A void handler return serializes as an absent key, not JSON null.
+    second = extension_result.get("secondInjection")
+    assert second is None or "systemPrompt" not in second

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -39,7 +39,7 @@ const stubPi = {
 const stubCtx = { hasUI: true, ui: { notify() {} } };
 
 await factory(stubPi);
-await factory(stubPi); // second invocation simulates a session reload
+await factory(stubPi); // second invocation: defends against this file loading as two Extension instances
 
 const discoverResult = await handlers["resources_discover"](
   { type: "resources_discover", cwd: process.cwd(), reason: "startup" },
@@ -117,8 +117,9 @@ def test_package_json_values():
 def test_package_json_has_no_pi_skills_key():
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
     assert "skills" not in data["pi"], (
-        "pi.skills must be absent — the extension's resources_discover handler is the sole "
-        "source of skill paths so all 60 skills register exactly once"
+        "pi.skills must be absent — the extension's resources_discover handler must stay the "
+        "sole, single source of truth for skill paths, not one of two independently maintained "
+        "declarations that could drift apart"
     )
 
 
@@ -194,3 +195,38 @@ def test_before_agent_start_does_not_duplicate_on_already_injected_prompt(extens
     # A void handler return serializes as an absent key, not JSON null.
     second = extension_result.get("secondInjection")
     assert second is None or "systemPrompt" not in second
+
+
+@requires_node
+def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
+    """A missing bin/README.md must not take down PATH exposure or skill discovery.
+
+    Regression test: the extension used to read bin/README.md unguarded, so a missing file
+    threw synchronously inside the factory — which fails the whole extension, not just the
+    system-prompt preamble feature (the one failure mode the code already degrades for).
+    """
+    synthetic_root = tmp_path_factory.mktemp("pi-synthetic-root")
+    (synthetic_root / ".claude-plugin").mkdir()
+    (synthetic_root / ".claude-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
+    (synthetic_root / "bin").mkdir()  # deliberately no README.md
+    (synthetic_root / "skills").mkdir()
+    synthetic_index = synthetic_root / "pi" / "extensions" / "index.ts"
+    synthetic_index.parent.mkdir(parents=True)
+    synthetic_index.write_text(INDEX_TS.read_text(encoding="utf-8"), encoding="utf-8")
+
+    driver = tmp_path_factory.mktemp("pi-extension-driver-missing-readme") / "driver.mjs"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    node = shutil.which("node")
+    assert node is not None
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), str(synthetic_index)],
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    assert parsed["discoverResult"] == {"skillPaths": [str(synthetic_root / "skills")]}
+    assert str(synthetic_root / "bin") in parsed["pathEntries"]
+    assert "systemPrompt" not in (parsed.get("firstInjection") or {})


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Adds `pi/package.json` + `pi/extensions/index.ts` — a ~95-line runtime adapter extension for [Pi Coding Agent](https://pi.dev), Phase 1 of 9 under ADR-0001 (#613). Points Pi at the *same* `skills/` and `bin/` trees Claude Code already uses — zero files duplicated, unlike the earlier #398 attempt (94 duplicated files, no generator, no drift check).
- The adapter: resolves the plugin root by walking up from `import.meta.url` for `.claude-plugin/plugin.json` (no hardcoded `../..` hop); appends `<root>/bin` to `PATH` (append, not prepend — preserves user shadowing precedence, correcting this issue's original "prepends" wording); registers `resources_discover` so all 60 `skills/*/SKILL.md` load; injects `bin/README.md`'s `## Current scripts` table into the system prompt via `before_agent_start`, idempotently.
- Adds `tests/test_pi_extension.py` — static/contract checks (no Node required) plus behavioural tests that drive the real `index.ts` under `node --experimental-strip-types` with a stub `ExtensionAPI` (works because every `@earendil-works/*` import is `import type`, elided by the stripper — no `node_modules` needed).
- **Also fixes 7 pre-existing `skills/*/SKILL.md` files** (`comms-context`, `principle-data-modeling`, `principle-release-engineering`, `workflow-audit-emit-issues`, `workflow-codebase-knowledge`, `workflow-dependency-upgrade`, `workflow-performance-investigation`): each `description:` frontmatter value contained an unquoted `: ` (colon+space) that Pi's real YAML parser rejects as an ambiguous nested mapping, silently dropping the skill — invisible to Claude Code's lenient, line-anchored frontmatter reader. Verified directly against Pi's own skill loader: 53/60 skills loaded before the fix, 60/60 after. Fix is a pure colon→em-dash punctuation swap per file, no wording change. This is a deviation from this phase's own stated acceptance criterion 2 ("nothing under `skills/` changes") — see scope-correction comment on #604 for the full reasoning on why it ships here rather than as a separate follow-up.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors — `bash scripts/validate.sh` clean (only pre-existing, unrelated line-cap warnings); confirmed 60/60 skills parse under Pi's real YAML loader (was 53/60 before the fix).
- [x] Examples in the diff were exercised manually — see below.
- [x] `pytest tests/ -v` — full suite, 2587 passed, 2 skipped.

### Type-tailored checks (chore)
- [x] Zero-LLM probe (`pi -e pi/extensions/index.ts -e <scratch-probe>.ts -p "/swb-probe"`, extension-command dispatch bypasses the agent loop — no provider tokens spent): all 60 skills reachable (`loadedFromOurDirCount: 60`, `missingDirNames: []`); `principle-clean-architecture`'s loaded `filePath` is the literal source path (no duplication); `<root>/bin` on `PATH` exactly once; `spawnSync("swe-workbench-gh-timeout", ["--help"])` resolved as a bare command, exit 0.
- [x] One real `pi -p` smoke run (user's configured provider) with prompt exercising `/skill:principle-clean-architecture` and the bare `swe-workbench-gh-timeout --help` command — confirmed via the session transcript that the model read the real skill file at its real repo path and executed the bare command through the bash tool with real `gh --help` output returned. The probe's `before_agent_start` hook also confirmed both `event.systemPrompt` and `ctx.getSystemPrompt()` contained the injected preamble marker.
- [x] `git diff --stat -- skills/ commands/ agents/` — **not empty** (7 `skills/*/SKILL.md` files), a deliberate, documented deviation from the original plan (see Summary above and the scope-correction comment on #604).
- [x] Two independent code reviews (a general-purpose reviewer that cross-checked every API claim against the installed Pi package's own `.d.ts`/`.js` source, and the repo's `swe-workbench:reviewer` subagent) converged on the same Important/Medium finding — an unguarded `readFileSync(bin/README.md)` that would have taken down the *entire* extension (PATH + skill discovery, not just the preamble feature) if that file were ever missing or unreadable. Fixed with a `try/catch`-guarded `readCurrentScripts()` that degrades to "no preamble" instead, with a new regression test (`test_missing_bin_readme_degrades_gracefully`) that reproduces the pre-fix crash before asserting the fix. A second, Low-severity finding (a test's rationale message inaccurately claimed `pi.skills` + `resources_discover` together would double-register skills — Pi's loader already dedupes by path) was also corrected.

### Notes for reviewers
- **Criterion 4 (the `pi -p` smoke exercising the injected system-prompt marker) is a capability Claude Code doesn't have.** Claude Code puts `bin/` on `PATH` and lets skill bodies name the commands directly; Pi gets the same PATH exposure *plus* an explicit bin/ script inventory injected into its system prompt. This is justified on its own merits — the injected table is what makes bare-command invocation legible to the model before any skill is loaded — not smuggled in as "parity" with Claude Code.
- **`pi/package.json` has no lockfile and isn't on any dependabot ecosystem**, a policy asymmetry in an otherwise pip-locked repo. Mitigated to near-zero: `peerDependencies` only (no `dependencies`), because every import in the extension is `import type` and therefore erased before runtime — this repo never runs `npm install` for it.
- **Supported Phase 1 install forms**: `pi install /abs/path/to/swe-workbench/pi` or `pi -e <path>/pi/extensions/index.ts`. A `pi install git:github.com/...` / `npm:` install is a known future gap (clones the repo root, finds no manifest there, loads `skills/` but not the adapter) — noted on #611, to be closed before any such install command is documented.
- Three further deferred items (not fixed in this PR, each noted on its owning issue): `validate.py`'s filesystem walk not skipping a hypothetical `pi/node_modules` (#605), the `swe-workbench:<id>` vs. Pi's unprefixed `/skill:<name>` dangling-reference gap (#608), and `swe-workbench-reap-session-scratch`'s unrecoverable capability gap on Pi (#613, non-goal).

Closes #604
