### PR TITLE
[chore] Pi: prompt templates via commands/ passthrough (#606)

### DIFF
--- a/commands/converge.md
+++ b/commands/converge.md
@@ -213,13 +213,16 @@ jq -c '.[] | select(.anchor == "inline")' "$RUN_DIR/round-${N}-findings.json" | 
     # `diff-line-lookup` does internally — rather than merely falling inside a hunk's numeric
     # range, which would also match unchanged context lines and defeat the "exact line, not just
     # some added line in the hunk" guarantee stated above.
+    # $(0) means the same thing as awk's whole-record variable in every awk — written this way
+    # because Pi's prompt-template argument substitution rewrites a bare dollar-zero token to
+    # the empty string. Do not "simplify" this back to a bare dollar-zero.
     IN_HUNK=$(git diff "origin/$BASE"...HEAD -- "$ROW_PATH" | awk -v line="$ROW_LINE" '
       /^@@/ {
-        if (match($0, /\+[0-9]+/)) new_line = substr($0, RSTART + 1, RLENGTH - 1) + 0
+        if (match($(0), /\+[0-9]+/)) new_line = substr($(0), RSTART + 1, RLENGTH - 1) + 0
         next
       }
       {
-        first = substr($0, 1, 1)
+        first = substr($(0), 1, 1)
         if (first == "+") {
           if (new_line == line) { print "yes"; exit }
           new_line++

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -1,11 +1,21 @@
 /**
  * swe-workbench adapter for Pi Coding Agent.
  *
- * Mirrors two harness affordances Claude Code already provides for this plugin, pointing at
- * the SAME skills/ and bin/ trees Claude Code uses — nothing under skills/ is duplicated:
+ * Mirrors three harness affordances Claude Code already provides for this plugin, pointing at
+ * the SAME skills/, bin/, and commands/ trees Claude Code uses — nothing under those is
+ * duplicated:
  *   1. `<plugin>/bin` on PATH, so every skill's bare `swe-workbench-<name>` command resolves
  *      unchanged (see bin/README.md).
  *   2. All skills/<name>/SKILL.md directories reachable, via `resources_discover`.
+ *   3. All commands/*.md reachable as Pi prompt templates, also via `resources_discover`'s
+ *      `promptPaths` — deliberately NOT the `pi.prompts` manifest key (#606). The manifest
+ *      route's loader (`collectFiles()`) recurses into subdirectories; `promptPaths`'s loader
+ *      (`loadTemplatesFromDir()`, dist/core/prompt-templates.js) does not. Since template names
+ *      are derived with a flat `basename()` at every depth, the manifest route would silently
+ *      publish any future `commands/<subdir>/*.md` as a top-level `/command` — this repo held
+ *      exactly such a subdirectory (`commands/shared/`) until Phase 0 removed it. The
+ *      `resources_discover` route makes that class of bug structurally unrepresentable instead
+ *      of requiring a regression test to catch it.
  *
  * Two Pi API facts recorded here so a later phase (#607) does not rediscover them the hard way:
  *   - `ExtensionContext` (dist/core/extensions/types.d.ts) exposes no settings accessor. An
@@ -96,7 +106,10 @@ export default function (pi: ExtensionAPI): void {
 
   let warnedMissingAnchor = false;
 
-  pi.on("resources_discover", () => ({ skillPaths: [join(root, "skills")] }));
+  pi.on("resources_discover", () => ({
+    skillPaths: [join(root, "skills")],
+    promptPaths: [join(root, "commands")],
+  }));
 
   pi.on("session_start", (_event, ctx: ExtensionContext) => {
     if (preamble === null && !warnedMissingAnchor && ctx.hasUI) {

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -8,7 +8,7 @@
  *      unchanged (see bin/README.md).
  *   2. All skills/<name>/SKILL.md directories reachable, via `resources_discover`.
  *   3. All commands/*.md reachable as Pi prompt templates, also via `resources_discover`'s
- *      `promptPaths` — deliberately NOT the `pi.prompts` manifest key (#606). The manifest
+ *      `promptPaths` — deliberately NOT the `pi.prompts` manifest key. The manifest
  *      route's loader (`collectFiles()`) recurses into subdirectories; `promptPaths`'s loader
  *      (`loadTemplatesFromDir()`, dist/core/prompt-templates.js) does not. Since template names
  *      are derived with a flat `basename()` at every depth, the manifest route would silently
@@ -17,7 +17,7 @@
  *      `resources_discover` route makes that class of bug structurally unrepresentable instead
  *      of requiring a regression test to catch it.
  *
- * Two Pi API facts recorded here so a later phase (#607) does not rediscover them the hard way:
+ * Two Pi API facts recorded here so a later phase does not rediscover them the hard way:
  *   - `ExtensionContext` (dist/core/extensions/types.d.ts) exposes no settings accessor. An
  *     extension that wants the user's `shellPath`/`shellCommandPrefix` would have to re-register
  *     the `bash` tool, which silently discards both — and a `commandPrefix` approach would

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -34,8 +34,8 @@ PI_EXTENSIONS_INDEX = ROOT / "pi" / "extensions" / "index.ts"
 # unchanged, on that package's `src/core/prompt-templates.ts` at the same pin). Re-diff this
 # against the installed package (`grep -n substituteArgs pi/node_modules/@earendil-works/
 # pi-coding-agent/dist/core/prompt-templates.js`) whenever `pi/package.json`'s
-# peerDependencies bump changes the pin — the alternation is what silently eats `$0` (issue
-# #606): the final `\$(...|\d+)` branch matches any `$<digits>`, including `$0`, and the
+# peerDependencies bump changes the pin — the alternation is what silently eats `$0`:
+# the final `\$(...|\d+)` branch matches any `$<digits>`, including `$0`, and the
 # matched substring is replaced with `args[-1] ?? ""` — i.e. the empty string, since no
 # template is ever invoked with a 0th positional arg. `$(0)` is the portable escape: it is
 # valid awk (an expression field reference `$(0)` means the same thing as `$0`) but does not
@@ -121,25 +121,31 @@ def _frontmatter_block(path):
 
 
 def _body_after_frontmatter(path):
-    """Return the body Pi's own parseFrontmatter would hand to substituteArgs.
+    """Return (body, body_start_line): the body Pi's own parseFrontmatter would hand to
+    substituteArgs, and the 1-indexed line in the original file where that body's first
+    character lives (post-normalization, pre-strip) — so callers can report accurate line
+    numbers for matches found inside `body`, which has leading/trailing whitespace stripped
+    and so cannot be offset from directly by counting its own newlines alone.
 
     Mirrors dist/utils/frontmatter.js's extractFrontmatter exactly (source at
-    @earendil-works/pi-coding-agent@0.84.2): find the closing '---' via indexOf from index 3
-    (no trailing-newline requirement — a body-level '---' horizontal rule on its own line
-    would still be found first if it came before the real close, but frontmatter always
-    closes before any body content), slice from 4 chars past that match, then strip(). Do
-    NOT reuse _frontmatter_block's delimiter logic here — it requires an exact '\\n---\\n'
-    match and never trims, which leaves an extra leading '\\n' in the body for every file
-    using the standard '---\\n\\n<body>' shape and throws off this function's line-number
-    reporting by one.
+    @earendil-works/pi-coding-agent@0.84.2): normalize newlines ('\\r\\n' then '\\r' -> '\\n',
+    same as Pi's normalizeNewlines) before any offset math, find the closing '---' via
+    indexOf from index 3, slice from 4 chars past that match, then strip(). Do NOT reuse
+    _frontmatter_block's delimiter logic here — it requires an exact '\\n---\\n' match and
+    never trims, which leaves an extra leading '\\n' in the body for every file using the
+    standard '---\\n\\n<body>' shape.
     """
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
     if not text.startswith("---"):
-        return text
+        return text, 1
     end = text.find("\n---", 3)
     if end == -1:
-        return text
-    return text[end + 4 :].strip()
+        return text, 1
+    raw_body = text[end + 4 :]
+    stripped = raw_body.strip()
+    leading_offset = raw_body.index(stripped) if stripped else len(raw_body)
+    body_start_line = text.count("\n", 0, end + 4 + leading_offset) + 1
+    return stripped, body_start_line
 
 
 def test_all_frontmatter_is_strict_yaml_parseable():
@@ -236,7 +242,7 @@ def test_no_pi_argument_substitution_hazard_in_commands():
 
     This allowlists the single legal token rather than blocklisting known-bad ones: `$@`,
     `$1`, `${2:-x}`, `${@:1:2}` all trip this without being enumerated, and so does any
-    alternation Pi adds to the regex later. `$0` (issue #606) is the hazard this guard was
+    alternation Pi adds to the regex later. `$0` is the hazard this guard was
     written for — Pi replaces it with the empty string, silently corrupting any awk script
     that uses `$0` as its whole-record variable. The fix is `$(0)`, valid in every awk and
     invisible to this regex; see the comment above `PI_SUBSTITUTE_ARGS_RE`.
@@ -244,10 +250,10 @@ def test_no_pi_argument_substitution_hazard_in_commands():
     violations = []
     paths = sorted(COMMANDS_DIR.glob("*.md")) + sorted(SHARED_DIR.rglob("*.md"))
     for path in paths:
-        body = _body_after_frontmatter(path)
+        body, body_start_line = _body_after_frontmatter(path)
         for match in PI_SUBSTITUTE_ARGS_RE.finditer(body):
             if match.group(0) != "$ARGUMENTS":
-                line_no = body.count("\n", 0, match.start()) + 1
+                line_no = body_start_line + body.count("\n", 0, match.start())
                 violations.append(f"{path.relative_to(ROOT)}:{line_no}: {match.group(0)!r}")
     assert not violations, (
         "Pi's substituteArgs (dist/core/prompt-templates.js, "
@@ -263,11 +269,14 @@ def test_no_pi_argument_substitution_hazard_in_commands():
 def test_pi_extension_wires_commands_as_prompt_paths():
     """Smoke check only — flagged honestly as text-not-behaviour.
 
-    CI is pytest-only and pi/ has no test runner wired into it, so without this assertion the
-    `promptPaths: [join(root, "commands")]` wiring in pi/extensions/index.ts would have zero
-    coverage and nothing would object to its deletion. This does not exercise the extension at
-    runtime (that requires a live Pi install; see the plan's Verification section) — it only
-    proves the wiring line is still present in source.
+    tests/test_pi_extension.py's test_resources_discover_returns_exactly_the_skills_and_commands_dirs
+    already exercises this wiring behaviourally (it drives the real extension through Node and
+    asserts exact equality on the resources_discover result) — but that test is `@requires_node`
+    and skips locally on Node < 22, and CI's Node pin could itself be removed or narrowed by a
+    future change to .github/workflows/pr.yml without this repo's own tests objecting. This
+    assertion has no such dependency: it only proves the wiring line is present in source, so the
+    `promptPaths: [join(root, "commands")]` wiring in pi/extensions/index.ts keeps *some* coverage
+    — text, not behaviour — even in a pytest-only run where Node isn't available.
     """
     text = PI_EXTENSIONS_INDEX.read_text(encoding="utf-8")
     assert "promptPaths" in text

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -15,6 +15,7 @@ what this repo's frontmatter currently uses. A new key/tool/skill only trips a t
 docs/plugin-platform-decisions.md §2, rather than a closed-form schema.
 """
 
+import re
 from pathlib import Path
 
 import yaml
@@ -26,6 +27,22 @@ AGENTS_DIR = ROOT / "agents"
 SKILLS_DIR = ROOT / "skills"
 COMMANDS_DIR = ROOT / "commands"
 SHARED_DIR = ROOT / "shared"
+PI_EXTENSIONS_INDEX = ROOT / "pi" / "extensions" / "index.ts"
+
+# Transcribed byte-for-byte from `substituteArgs`'s replacement regex in
+# @earendil-works/pi-coding-agent@0.84.2's dist/core/prompt-templates.js (also present,
+# unchanged, on that package's `src/core/prompt-templates.ts` at the same pin). Re-diff this
+# against the installed package (`grep -n substituteArgs pi/node_modules/@earendil-works/
+# pi-coding-agent/dist/core/prompt-templates.js`) whenever `pi/package.json`'s
+# peerDependencies bump changes the pin — the alternation is what silently eats `$0` (issue
+# #606): the final `\$(...|\d+)` branch matches any `$<digits>`, including `$0`, and the
+# matched substring is replaced with `args[-1] ?? ""` — i.e. the empty string, since no
+# template is ever invoked with a 0th positional arg. `$(0)` is the portable escape: it is
+# valid awk (an expression field reference `$(0)` means the same thing as `$0`) but does not
+# match this regex, so Pi's substitution passes it through untouched.
+PI_SUBSTITUTE_ARGS_RE = re.compile(
+    r"\$\{(\d+|ARGUMENTS|@):-([^}]*)\}|\$\{@:(\d+)(?::(\d+))?\}|\$(ARGUMENTS|@|\d+)"
+)
 
 # The complete key vocabulary agents/*.md frontmatter uses today. A new key (e.g. a future
 # Phase 7 `pi:` override block) must be added here deliberately, not discovered by CI red.
@@ -101,6 +118,28 @@ def _frontmatter_block(path):
     if end == -1:
         return None
     return text[3:end]
+
+
+def _body_after_frontmatter(path):
+    """Return the body Pi's own parseFrontmatter would hand to substituteArgs.
+
+    Mirrors dist/utils/frontmatter.js's extractFrontmatter exactly (source at
+    @earendil-works/pi-coding-agent@0.84.2): find the closing '---' via indexOf from index 3
+    (no trailing-newline requirement — a body-level '---' horizontal rule on its own line
+    would still be found first if it came before the real close, but frontmatter always
+    closes before any body content), slice from 4 chars past that match, then strip(). Do
+    NOT reuse _frontmatter_block's delimiter logic here — it requires an exact '\\n---\\n'
+    match and never trims, which leaves an extra leading '\\n' in the body for every file
+    using the standard '---\\n\\n<body>' shape and throws off this function's line-number
+    reporting by one.
+    """
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    return text[end + 4 :].strip()
 
 
 def test_all_frontmatter_is_strict_yaml_parseable():
@@ -188,3 +227,48 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
         f"only on disk: {sorted(skill_ids - SKILL_IDS)}, "
         f"only in SKILL_IDS: {sorted(SKILL_IDS - skill_ids)}"
     )
+
+
+def test_no_pi_argument_substitution_hazard_in_commands():
+    """Every $-token Pi's substituteArgs regex would match, across commands/*.md and
+    shared/**/*.md, must be exactly `$ARGUMENTS` — the one substitution swe-workbench's
+    commands are written to expect.
+
+    This allowlists the single legal token rather than blocklisting known-bad ones: `$@`,
+    `$1`, `${2:-x}`, `${@:1:2}` all trip this without being enumerated, and so does any
+    alternation Pi adds to the regex later. `$0` (issue #606) is the hazard this guard was
+    written for — Pi replaces it with the empty string, silently corrupting any awk script
+    that uses `$0` as its whole-record variable. The fix is `$(0)`, valid in every awk and
+    invisible to this regex; see the comment above `PI_SUBSTITUTE_ARGS_RE`.
+    """
+    violations = []
+    paths = sorted(COMMANDS_DIR.glob("*.md")) + sorted(SHARED_DIR.rglob("*.md"))
+    for path in paths:
+        body = _body_after_frontmatter(path)
+        for match in PI_SUBSTITUTE_ARGS_RE.finditer(body):
+            if match.group(0) != "$ARGUMENTS":
+                line_no = body.count("\n", 0, match.start()) + 1
+                violations.append(f"{path.relative_to(ROOT)}:{line_no}: {match.group(0)!r}")
+    assert not violations, (
+        "Pi's substituteArgs (dist/core/prompt-templates.js, "
+        "@earendil-works/pi-coding-agent@0.84.2) would rewrite these tokens — every "
+        "alternative it matches other than literal `$ARGUMENTS` is replaced with the "
+        "matched positional arg or, if unset, the empty string, silently corrupting the "
+        "command body when swe-workbench's own commands are loaded as Pi prompt templates. "
+        "Use `$(0)` (or otherwise avoid a bare `$<digits>`/`$@`/`${...}` token) instead:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_pi_extension_wires_commands_as_prompt_paths():
+    """Smoke check only — flagged honestly as text-not-behaviour.
+
+    CI is pytest-only and pi/ has no test runner wired into it, so without this assertion the
+    `promptPaths: [join(root, "commands")]` wiring in pi/extensions/index.ts would have zero
+    coverage and nothing would object to its deletion. This does not exercise the extension at
+    runtime (that requires a live Pi install; see the plan's Verification section) — it only
+    proves the wiring line is still present in source.
+    """
+    text = PI_EXTENSIONS_INDEX.read_text(encoding="utf-8")
+    assert "promptPaths" in text
+    assert 'join(root, "commands")' in text

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -205,8 +205,11 @@ def extension_result(tmp_path_factory):
 
 
 @requires_node
-def test_resources_discover_returns_exactly_the_skills_dir(extension_result):
-    assert extension_result["discoverResult"] == {"skillPaths": [str(ROOT / "skills")]}
+def test_resources_discover_returns_exactly_the_skills_and_commands_dirs(extension_result):
+    assert extension_result["discoverResult"] == {
+        "skillPaths": [str(ROOT / "skills")],
+        "promptPaths": [str(ROOT / "commands")],
+    }
 
 
 @requires_node
@@ -260,6 +263,9 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     )
     assert result.returncode == 0, f"driver failed: {result.stderr}"
     parsed = json.loads(result.stdout)
-    assert parsed["discoverResult"] == {"skillPaths": [str(synthetic_root / "skills")]}
+    assert parsed["discoverResult"] == {
+        "skillPaths": [str(synthetic_root / "skills")],
+        "promptPaths": [str(synthetic_root / "commands")],
+    }
     assert str(synthetic_root / "bin") in parsed["pathEntries"]
     assert "systemPrompt" not in (parsed.get("firstInjection") or {})


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Wire `commands/*.md` as Pi prompt templates via `resources_discover`'s `promptPaths` (not the `pi.prompts` manifest key) — the manifest route's loader recurses into subdirectories and would silently publish a future `commands/<subdir>/*.md` as a top-level slash-command, a hazard this repo already hit once (`commands/shared/`, removed in Phase 0). `pi/package.json` is intentionally untouched.
- Fix `commands/converge.md`'s three `$0` occurrences (awk's whole-record variable) to `$(0)` — Pi's `substituteArgs` regex matches bare `$0` and silently replaces it with the empty string, which would corrupt the anchor-validation fallback logic under Pi. `$(0)` is valid, behavior-identical awk (verified byte-for-byte against a synthetic diff) and passes through Pi's substitution untouched.
- Add a closed-form regression guard (`tests/test_pi_contract.py::test_no_pi_argument_substitution_hazard_in_commands`) that scans every `commands/*.md` and `shared/**/*.md` body against Pi's real `substituteArgs` regex and asserts every match is exactly `$ARGUMENTS` — an allowlist, not a blocklist, so it also catches any hazard Pi's regex adds later.
- Add a text-not-behaviour smoke test that `pi/extensions/index.ts` still wires `promptPaths`/`commands`, since `pi/` has no test runner in CI.
- Update `tests/test_pi_extension.py`'s two behavioural `resources_discover` assertions to expect the new `promptPaths` key.

Two scope corrections vs. the ticket as filed (manifest-key wiring → extension wiring; `converge.md` fix pulled into this phase rather than deferred) were posted as a comment on #606 before this PR was opened.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually — ran the `git diff | awk ...` pipeline from `converge.md` with both `$0` and `$(0)` against a synthetic diff; byte-identical output.
- [x] `pytest tests/test_pi_contract.py tests/test_converge_command.py -v` — new guard confirmed RED before the fix, GREEN after; converge's existing 30 tests untouched.

### Type-tailored checks (chore)
- [x] `bash scripts/validate.sh` — 0 issues (pre-existing unrelated line-cap warnings only)
- [x] `pytest tests/ -v` — 2656 passed, 2 skipped
- [x] `npm run typecheck --prefix pi` — clean
- [x] Two independent reviews (requesting-code-review skill + swe-workbench:reviewer subagent) — both APPROVE, no Critical/Important findings; one Medium finding (test helper docstring accuracy / off-by-one line reporting) fixed and re-verified.

Closes #606
