### PR TITLE
[feat] Pi: guards + session hooks via event translation (#607)

### DIFF
--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -113,7 +113,7 @@ block, per `bin/README.md`'s "Reference pattern".
 
 ## 6. `worktree_permission_grant.sh` has no Pi equivalent — documented N/A, not deferred
 
-`pi/extensions/guards.ts` (#607) reproduces `bash_guard.sh`, `secret_guard.py`,
+`pi/extensions/guards.ts` reproduces `bash_guard.sh`, `secret_guard.py`,
 `workflow_resume_hint.sh`, and `skill_autoload_hint.sh` on Pi, each exec'ing the unchanged
 Claude Code script. `worktree_permission_grant.sh` is left out deliberately and permanently.
 
@@ -124,4 +124,4 @@ permission *for*.
 
 Recorded as an explicit `"n/a"` row in `tests/test_pi_contract.py`'s `HOOK_PI_STATUS` inventory
 — distinct from `"deferred"` (`skill_usage_record.sh`/`skill_usage_flush.sh`, unwired only until
-`Skill`/subagents exist on Pi, tracked for #608/#610). `"n/a"` never graduates to `"wired"`.
+`Skill`/subagents exist on Pi). `"n/a"` never graduates to `"wired"`.

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -114,22 +114,14 @@ block, per `bin/README.md`'s "Reference pattern".
 ## 6. `worktree_permission_grant.sh` has no Pi equivalent — documented N/A, not deferred
 
 `pi/extensions/guards.ts` (#607) reproduces `bash_guard.sh`, `secret_guard.py`,
-`workflow_resume_hint.sh`, and `skill_autoload_hint.sh` as Pi `tool_call`/`tool_result`/
-`session_start`/`session_compact` handlers, each exec'ing the unchanged Claude Code script.
-`worktree_permission_grant.sh` is the one hook in `hooks/hooks.json` left out — deliberately,
-and permanently, not as a placeholder for a later phase.
+`workflow_resume_hint.sh`, and `skill_autoload_hint.sh` on Pi, each exec'ing the unchanged
+Claude Code script. `worktree_permission_grant.sh` is left out deliberately and permanently.
 
-The hook's entire purpose is to emit `permissionDecision: "allow"` for a
-`PreToolUse:Read|Edit|Write` call so Claude Code's permission-prompt system skips asking about
-paths already inside the active worktree. Pi's own README states "No permission popups" as a
-design decision: there is no `allow`/`deny`/`ask` prompt surface on Pi for a `tool_call` handler
-to target in the first place. A Pi port of this hook would have nothing to grant permission
-*for* — the concept the hook manipulates does not exist on this harness, which is a stronger
-reason than #402's original "declined to port."
+The hook emits `permissionDecision: "allow"` so Claude Code's permission-prompt system skips
+asking about paths inside the active worktree. Pi's README states "No permission popups" — there
+is no prompt surface for a `tool_call` handler to target, so a port would have nothing to grant
+permission *for*.
 
-This is recorded as an explicit `"n/a"` row in `tests/test_pi_contract.py`'s `HOOK_PI_STATUS`
-golden inventory (distinct from `"deferred"`, which `skill_usage_record.sh`/`skill_usage_flush.sh`
-carry — those two are unwired only because the Pi tools they need, `Skill` and subagents, don't
-exist yet and are tracked for #608/#610). `"n/a"` never graduates to `"wired"`; asserting the row
-exists (rather than letting the hook's absence go unmentioned) is what makes the omission a
-decision instead of an oversight.
+Recorded as an explicit `"n/a"` row in `tests/test_pi_contract.py`'s `HOOK_PI_STATUS` inventory
+— distinct from `"deferred"` (`skill_usage_record.sh`/`skill_usage_flush.sh`, unwired only until
+`Skill`/subagents exist on Pi, tracked for #608/#610). `"n/a"` never graduates to `"wired"`.

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -110,3 +110,26 @@ swe-workbench plugin"). The guard has to run *before* anything that depends on `
 `PATH`, which rules out delegating it to a script that is itself only reachable via `PATH`. It
 stays exactly where it is today: one `command -v` line at the top of each skill's first executable
 block, per `bin/README.md`'s "Reference pattern".
+
+## 6. `worktree_permission_grant.sh` has no Pi equivalent — documented N/A, not deferred
+
+`pi/extensions/guards.ts` (#607) reproduces `bash_guard.sh`, `secret_guard.py`,
+`workflow_resume_hint.sh`, and `skill_autoload_hint.sh` as Pi `tool_call`/`tool_result`/
+`session_start`/`session_compact` handlers, each exec'ing the unchanged Claude Code script.
+`worktree_permission_grant.sh` is the one hook in `hooks/hooks.json` left out — deliberately,
+and permanently, not as a placeholder for a later phase.
+
+The hook's entire purpose is to emit `permissionDecision: "allow"` for a
+`PreToolUse:Read|Edit|Write` call so Claude Code's permission-prompt system skips asking about
+paths already inside the active worktree. Pi's own README states "No permission popups" as a
+design decision: there is no `allow`/`deny`/`ask` prompt surface on Pi for a `tool_call` handler
+to target in the first place. A Pi port of this hook would have nothing to grant permission
+*for* — the concept the hook manipulates does not exist on this harness, which is a stronger
+reason than #402's original "declined to port."
+
+This is recorded as an explicit `"n/a"` row in `tests/test_pi_contract.py`'s `HOOK_PI_STATUS`
+golden inventory (distinct from `"deferred"`, which `skill_usage_record.sh`/`skill_usage_flush.sh`
+carry — those two are unwired only because the Pi tools they need, `Skill` and subagents, don't
+exist yet and are tracked for #608/#610). `"n/a"` never graduates to `"wired"`; asserting the row
+exists (rather than letting the hook's absence go unmentioned) is what makes the omission a
+decision instead of an oversight.

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -53,8 +53,8 @@ BEGIN { in_sq = 0; in_dq = 0 }
 
 # Normalise separators AND newlines/tabs/backticks to spaces so rm/git after
 # ; | & \n \t \` are still detected — the fast-gate `case` and the grep
-# detectors must share ONE separator alphabet (the bug in #501: gate saw
-# ';|&', grep saw [[:space:]]).
+# detectors must share ONE separator alphabet (gate saw ';|&', grep saw
+# [[:space:]]).
 # shellcheck disable=SC2016  # backtick in tr's SET1 is a literal char, not command substitution
 _norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 
@@ -62,8 +62,8 @@ _norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 # deleting them) handles $(...), <(...), >(...), and bare (...) uniformly, since whatever
 # preceded "(" no longer occupies the whitespace-or-start position the anchor regex requires.
 # Deleting quotes/brackets/backslashes closes quote-wrapped/backslash-escaped rm ("rm", 'rm',
-# \rm). Gate and detector now both run on this SAME normalized text ($norm), closing the
-# #501-class gate/detector divergence for quote-wrapped rm.
+# \rm). Gate and detector now both run on this SAME normalized text ($norm), closing the same
+# class of gate/detector divergence for quote-wrapped rm.
 norm=$(printf '%s' "$_norm" | tr '()' '  ' | tr -d "'\"[]{}\\")
 
 case "$norm" in

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -64,7 +64,7 @@ _norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 # Deleting quotes/brackets/backslashes closes quote-wrapped/backslash-escaped rm ("rm", 'rm',
 # \rm). Gate and detector now both run on this SAME normalized text ($norm), closing the same
 # class of gate/detector divergence for quote-wrapped rm.
-norm=$(printf '%s' "$_norm" | tr '()' '  ' | tr -d "'\"[]{}\\")
+norm=$(printf '%s' "$_norm" | tr '()' '  ' | tr -d "'\"[]{}\\\\")
 
 case "$norm" in
   rm\ *|*\ rm\ *|*git*) ;;

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -51,15 +51,27 @@ BEGIN { in_sq = 0; in_dq = 0 }
   print out
 }')
 
-# Normalise separators AND newlines/tabs to spaces so rm/git after ; | & \n \t
-# are still detected — the fast-gate `case` and the grep detectors must share
-# ONE separator alphabet (the bug in #501: gate saw ';|&', grep saw [[:space:]]).
-_norm=$(printf '%s' "$_nc" | tr ';|&\n\t' '     ')
+# Normalise separators AND newlines/tabs/backticks to spaces so rm/git after
+# ; | & \n \t \` are still detected — the fast-gate `case` and the grep
+# detectors must share ONE separator alphabet (the bug in #501: gate saw
+# ';|&', grep saw [[:space:]]). Backticks are folded here (not just stripped
+# later) so a backtick-wrapped `rm` both trips the fast-gate's `*\ rm\ *` arm
+# and gets a real whitespace separator ahead of the anchor check below (#607:
+# a bare strip would leave "`rm" with no separator, defeating the anchor).
+# shellcheck disable=SC2016  # backtick in tr's SET1 is a literal char, not command substitution
+_norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 
 case "$_norm" in
   rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;
   *)                              exit 0 ;;
 esac
+
+# Neutralise `$(` before stripping parens: a bare paren-strip turns
+# "$(rm -rf /)" into "$rm -rf /" — the leftover `$` occupies the position
+# the anchor below requires to be whitespace-or-start, silently defeating it
+# (#607). Inserting a space ahead of `(` first means the paren-strip leaves a
+# real separator in front of `rm`.
+_norm=$(printf '%s' "$_norm" | sed 's/\$(/ (/g')
 
 # Strip quotes and bracket metacharacters that could mask paths.
 norm=$(printf '%s' "$_norm" | tr -d "'\"()[]{}")

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -54,27 +54,22 @@ BEGIN { in_sq = 0; in_dq = 0 }
 # Normalise separators AND newlines/tabs/backticks to spaces so rm/git after
 # ; | & \n \t \` are still detected — the fast-gate `case` and the grep
 # detectors must share ONE separator alphabet (the bug in #501: gate saw
-# ';|&', grep saw [[:space:]]). Backticks are folded here (not just stripped
-# later) so a backtick-wrapped `rm` both trips the fast-gate's `*\ rm\ *` arm
-# and gets a real whitespace separator ahead of the anchor check below (#607:
-# a bare strip would leave "`rm" with no separator, defeating the anchor).
+# ';|&', grep saw [[:space:]]).
 # shellcheck disable=SC2016  # backtick in tr's SET1 is a literal char, not command substitution
 _norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 
-case "$_norm" in
-  rm\ *|*\ rm\ *|*\(*rm\ *|*git*) ;;
-  *)                              exit 0 ;;
+# Fully normalise BEFORE the fast gate, not after: turning "(" and ")" into SPACES (not
+# deleting them) handles $(...), <(...), >(...), and bare (...) uniformly, since whatever
+# preceded "(" no longer occupies the whitespace-or-start position the anchor regex requires.
+# Deleting quotes/brackets/backslashes closes quote-wrapped/backslash-escaped rm ("rm", 'rm',
+# \rm). Gate and detector now both run on this SAME normalized text ($norm), closing the
+# #501-class gate/detector divergence for quote-wrapped rm.
+norm=$(printf '%s' "$_norm" | tr '()' '  ' | tr -d "'\"[]{}\\")
+
+case "$norm" in
+  rm\ *|*\ rm\ *|*git*) ;;
+  *)                    exit 0 ;;
 esac
-
-# Neutralise `$(` before stripping parens: a bare paren-strip turns
-# "$(rm -rf /)" into "$rm -rf /" — the leftover `$` occupies the position
-# the anchor below requires to be whitespace-or-start, silently defeating it
-# (#607). Inserting a space ahead of `(` first means the paren-strip leaves a
-# real separator in front of `rm`.
-_norm=$(printf '%s' "$_norm" | sed 's/\$(/ (/g')
-
-# Strip quotes and bracket metacharacters that could mask paths.
-norm=$(printf '%s' "$_norm" | tr -d "'\"()[]{}")
 
 # shellcheck disable=SC2016  # $HOME in single quotes is intentional: matches literal text, not the shell variable
 # [rR] covers both -rf and -Rf (BSD/macOS rm accepts -R as synonym for -r).

--- a/pi/extensions/cc-payload.ts
+++ b/pi/extensions/cc-payload.ts
@@ -1,7 +1,7 @@
 /**
  * Pure translation from Pi's tool-call/session events to the CC-shaped JSON payloads
  * hooks/bash_guard.sh, hooks/secret_guard.py, hooks/workflow_resume_hint.sh, and
- * hooks/skill_autoload_hint.sh already read from stdin (#607).
+ * hooks/skill_autoload_hint.sh already read from stdin.
  *
  * No I/O, no node:child_process, and no runtime import of @earendil-works/pi-coding-agent —
  * only `import type` — so this file stays exercisable under `node --experimental-strip-types`

--- a/pi/extensions/cc-payload.ts
+++ b/pi/extensions/cc-payload.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure translation from Pi's tool-call/session events to the CC-shaped JSON payloads
+ * hooks/bash_guard.sh, hooks/secret_guard.py, hooks/workflow_resume_hint.sh, and
+ * hooks/skill_autoload_hint.sh already read from stdin (#607).
+ *
+ * No I/O, no node:child_process, and no runtime import of @earendil-works/pi-coding-agent —
+ * only `import type`, so this file is exercisable and type-checkable without ever needing to
+ * resolve the SDK package, preserving both the golden-inventory import ratchet
+ * (tests/test_pi_contract.py) and the `node --experimental-strip-types` test harness
+ * (tests/test_pi_extension.py) that elides type-only imports without touching node_modules.
+ */
+import type {
+  BashToolCallEvent,
+  EditToolCallEvent,
+  SessionCompactEvent,
+  SessionStartEvent,
+  WriteToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+
+export type FailPosture = "open" | "closed";
+
+export interface GuardSpec {
+  /** tool_name value the CC-shaped payload carries. null for bash_guard.sh, which reads only
+   *  .tool_input.command and never checks tool_name. */
+  readonly ccToolName: "Write" | "Edit" | null;
+  readonly interpreter: string;
+  readonly scriptRelPath: string;
+  readonly failPosture: FailPosture;
+}
+
+/**
+ * Pi tool name -> the CC hook it must reproduce verbatim. Data, not branching logic, so a
+ * contract test can assert every field directly (interpreter, script path, fail posture, and
+ * the exact "Write"/"Edit" casing secret_guard.py matches by strict string equality).
+ */
+export const GUARD_DISPATCH: Record<"bash" | "write" | "edit", GuardSpec> = {
+  bash: {
+    ccToolName: null,
+    interpreter: "bash",
+    scriptRelPath: "hooks/bash_guard.sh",
+    failPosture: "closed",
+  },
+  write: {
+    ccToolName: "Write",
+    interpreter: "python3",
+    scriptRelPath: "hooks/secret_guard.py",
+    failPosture: "open",
+  },
+  edit: {
+    ccToolName: "Edit",
+    interpreter: "python3",
+    scriptRelPath: "hooks/secret_guard.py",
+    failPosture: "open",
+  },
+};
+
+export function bashPayload(event: BashToolCallEvent): Record<string, unknown> {
+  return { tool_input: { command: event.input.command } };
+}
+
+export function writePayload(event: WriteToolCallEvent): Record<string, unknown> {
+  return {
+    tool_name: GUARD_DISPATCH.write.ccToolName,
+    tool_input: { content: event.input.content, file_path: event.input.path },
+  };
+}
+
+/**
+ * One CC-shaped payload per edits[] element — never joined. secret_guard.py reports a 1-based
+ * line number computed against whatever `new_string` it receives; joining every edits[].newText
+ * into one string would report a line number against a document that was never actually
+ * written, for every element but the first.
+ */
+export function editPayloads(event: EditToolCallEvent): Record<string, unknown>[] {
+  return event.input.edits.map((edit) => ({
+    tool_name: GUARD_DISPATCH.edit.ccToolName,
+    tool_input: { new_string: edit.newText, file_path: event.input.path },
+  }));
+}
+
+export type WorkflowResumeSource = "startup" | "resume" | "compact";
+
+/** hooks/workflow_resume_hint.sh's SessionStart `.source` values it conditions wording on. */
+const SESSION_START_SOURCE: Record<SessionStartEvent["reason"], WorkflowResumeSource> = {
+  startup: "startup",
+  new: "startup",
+  resume: "resume",
+  reload: "resume",
+  fork: "resume",
+};
+
+export function sessionStartSource(event: SessionStartEvent): WorkflowResumeSource {
+  return SESSION_START_SOURCE[event.reason];
+}
+
+/**
+ * session_compact only ever fires because a compaction happened — Pi's own sub-reason
+ * ("manual" | "threshold" | "overflow") is not one workflow_resume_hint.sh reads or branches
+ * on; the hook's `.source` is always "compact" here, matching the SessionStart(compact) matcher
+ * Claude Code wires this hook to.
+ */
+export function sessionCompactSource(_event: SessionCompactEvent): WorkflowResumeSource {
+  return "compact";
+}

--- a/pi/extensions/cc-payload.ts
+++ b/pi/extensions/cc-payload.ts
@@ -4,10 +4,8 @@
  * hooks/skill_autoload_hint.sh already read from stdin (#607).
  *
  * No I/O, no node:child_process, and no runtime import of @earendil-works/pi-coding-agent —
- * only `import type`, so this file is exercisable and type-checkable without ever needing to
- * resolve the SDK package, preserving both the golden-inventory import ratchet
- * (tests/test_pi_contract.py) and the `node --experimental-strip-types` test harness
- * (tests/test_pi_extension.py) that elides type-only imports without touching node_modules.
+ * only `import type` — so this file stays exercisable under `node --experimental-strip-types`
+ * without ever resolving the SDK package.
  */
 import type {
   BashToolCallEvent,
@@ -20,19 +18,15 @@ import type {
 export type FailPosture = "open" | "closed";
 
 export interface GuardSpec {
-  /** tool_name value the CC-shaped payload carries. null for bash_guard.sh, which reads only
-   *  .tool_input.command and never checks tool_name. */
+  /** null for bash_guard.sh, which reads only .tool_input.command and never checks tool_name. */
   readonly ccToolName: "Write" | "Edit" | null;
   readonly interpreter: string;
   readonly scriptRelPath: string;
   readonly failPosture: FailPosture;
 }
 
-/**
- * Pi tool name -> the CC hook it must reproduce verbatim. Data, not branching logic, so a
- * contract test can assert every field directly (interpreter, script path, fail posture, and
- * the exact "Write"/"Edit" casing secret_guard.py matches by strict string equality).
- */
+/** Pi tool name -> the CC hook it must reproduce verbatim. Data, not branching logic, so a
+ *  contract test can assert every field directly. */
 export const GUARD_DISPATCH: Record<"bash" | "write" | "edit", GuardSpec> = {
   bash: {
     ccToolName: null,
@@ -93,12 +87,16 @@ export function sessionStartSource(event: SessionStartEvent): WorkflowResumeSour
   return SESSION_START_SOURCE[event.reason];
 }
 
-/**
- * session_compact only ever fires because a compaction happened — Pi's own sub-reason
- * ("manual" | "threshold" | "overflow") is not one workflow_resume_hint.sh reads or branches
- * on; the hook's `.source` is always "compact" here, matching the SessionStart(compact) matcher
- * Claude Code wires this hook to.
- */
+/** session_compact only ever fires because a compaction happened — Pi's own sub-reason
+ *  ("manual"|"threshold"|"overflow") isn't one the hook reads, so `.source` is always "compact". */
 export function sessionCompactSource(_event: SessionCompactEvent): WorkflowResumeSource {
   return "compact";
+}
+
+export function resumeHintPayload(cwd: string, source: WorkflowResumeSource): Record<string, unknown> {
+  return { cwd, source };
+}
+
+export function skillHintPayload(filePath: string, sessionId: string): Record<string, unknown> {
+  return { tool_input: { file_path: filePath }, session_id: sessionId };
 }

--- a/pi/extensions/guard-runner.ts
+++ b/pi/extensions/guard-runner.ts
@@ -1,15 +1,11 @@
 /**
- * Spawns hooks/*.sh|py unchanged with a CC-shaped JSON payload piped to stdin, and returns
- * their exit code plus captured stdout/stderr. The ONLY file under pi/extensions/ that imports
- * node:child_process (pinned by tests/test_pi_contract.py) — every hook invocation from the Pi
- * adapter funnels through this one auditable process boundary, whether it's a blocking guard
- * (bash_guard.sh, secret_guard.py) or an advisory hint script that emits JSON on stdout
- * (workflow_resume_hint.sh, skill_autoload_hint.sh) (#607).
+ * Spawns hooks/*.sh|py unchanged with a CC-shaped JSON payload piped to stdin, returning exit
+ * code plus stdout/stderr. The ONLY file under pi/extensions/ that imports node:child_process
+ * (pinned by tests/test_pi_contract.py) — every hook invocation funnels through this one
+ * auditable process boundary (#607).
  *
- * No stdin API exists on pi.exec() (the ADR's original sketch) — every one of these hooks reads
- * its payload from stdin, so the transport here is node:child_process.spawn with a piped stdin,
- * argv array (never a shell-interpolated string, which would re-introduce exactly the
- * shell-injection class bash_guard.sh exists to block).
+ * pi.exec() has no stdin API, and every hook reads its payload from stdin — so the transport is
+ * spawn() with a piped stdin and an argv array, never a shell-interpolated string.
  */
 import { spawn } from "node:child_process";
 
@@ -23,9 +19,8 @@ export interface GuardRunOptions {
   readonly interpreter: string;
   readonly scriptPath: string;
   readonly payload: Record<string, unknown>;
-  /** Ambient cwd for the child — load-bearing for bash_guard.sh, which runs
-   *  `git rev-parse --abbrev-ref HEAD` against the process cwd, not any `.cwd` field the JSON
-   *  payload might carry. */
+  /** bash_guard.sh runs `git rev-parse --abbrev-ref HEAD` against this, not any `.cwd` in the
+   *  JSON payload. */
   readonly cwd: string;
   readonly pluginRoot: string;
   readonly signal: AbortSignal | undefined;

--- a/pi/extensions/guard-runner.ts
+++ b/pi/extensions/guard-runner.ts
@@ -1,0 +1,89 @@
+/**
+ * Spawns hooks/*.sh|py unchanged with a CC-shaped JSON payload piped to stdin, and returns
+ * their exit code plus captured stdout/stderr. The ONLY file under pi/extensions/ that imports
+ * node:child_process (pinned by tests/test_pi_contract.py) — every hook invocation from the Pi
+ * adapter funnels through this one auditable process boundary, whether it's a blocking guard
+ * (bash_guard.sh, secret_guard.py) or an advisory hint script that emits JSON on stdout
+ * (workflow_resume_hint.sh, skill_autoload_hint.sh) (#607).
+ *
+ * No stdin API exists on pi.exec() (the ADR's original sketch) — every one of these hooks reads
+ * its payload from stdin, so the transport here is node:child_process.spawn with a piped stdin,
+ * argv array (never a shell-interpolated string, which would re-introduce exactly the
+ * shell-injection class bash_guard.sh exists to block).
+ */
+import { spawn } from "node:child_process";
+
+export interface GuardRunResult {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface GuardRunOptions {
+  readonly interpreter: string;
+  readonly scriptPath: string;
+  readonly payload: Record<string, unknown>;
+  /** Ambient cwd for the child — load-bearing for bash_guard.sh, which runs
+   *  `git rev-parse --abbrev-ref HEAD` against the process cwd, not any `.cwd` field the JSON
+   *  payload might carry. */
+  readonly cwd: string;
+  readonly pluginRoot: string;
+  readonly signal: AbortSignal | undefined;
+}
+
+export type RunGuard = (options: GuardRunOptions) => Promise<GuardRunResult>;
+
+const TIMEOUT_MS = 5_000;
+
+export const runGuard: RunGuard = (options) =>
+  new Promise((resolve, reject) => {
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, AbortSignal.timeout(TIMEOUT_MS)])
+      : AbortSignal.timeout(TIMEOUT_MS);
+
+    const child = spawn(options.interpreter, [options.scriptPath], {
+      cwd: options.cwd,
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: options.pluginRoot },
+      signal,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk;
+    });
+
+    // A guard that exits before its stdin is fully drained raises EPIPE on write/end — it
+    // already decided its verdict, so keep draining for the exit code instead of treating this
+    // as a spawn failure.
+    child.stdin?.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code !== "EPIPE" && !settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    // "close" (not "exit") so stdout/stderr are fully drained before resolving.
+    child.on("close", (code) => {
+      if (!settled) {
+        settled = true;
+        resolve({ code, stdout, stderr });
+      }
+    });
+
+    child.stdin?.write(JSON.stringify(options.payload));
+    child.stdin?.end();
+  });

--- a/pi/extensions/guard-runner.ts
+++ b/pi/extensions/guard-runner.ts
@@ -2,7 +2,7 @@
  * Spawns hooks/*.sh|py unchanged with a CC-shaped JSON payload piped to stdin, returning exit
  * code plus stdout/stderr. The ONLY file under pi/extensions/ that imports node:child_process
  * (pinned by tests/test_pi_contract.py) — every hook invocation funnels through this one
- * auditable process boundary (#607).
+ * auditable process boundary.
  *
  * pi.exec() has no stdin API, and every hook reads its payload from stdin — so the transport is
  * spawn() with a piped stdin and an argv array, never a shell-interpolated string.

--- a/pi/extensions/guards.ts
+++ b/pi/extensions/guards.ts
@@ -1,7 +1,7 @@
 /**
  * Composition root: wires bash_guard.sh/secret_guard.py as Pi tool_call guards, and
  * workflow_resume_hint.sh/skill_autoload_hint.sh as Pi session/tool_result hint sources — all
- * via guard-runner.ts, never reimplemented (#607).
+ * via guard-runner.ts, never reimplemented.
  *
  * `toolName` narrowing uses a manual cast rather than the SDK's `isToolCallEventType` helper so
  * every @earendil-works/pi-coding-agent import here stays `import type`-only (pinned by
@@ -172,11 +172,10 @@ export function registerGuards(pi: ExtensionAPI, root: string, options: Register
     const sessionId = ctx.sessionManager.getSessionId();
     if (!sessionId) {
       // skill_autoload_hint.sh falls back to $$ (the process PID) when session_id is absent —
-      // two Pi sessions sharing one process would then silently share its dedup sentinel,
-      // reproducing #401's cross-session state bleed. Hard error instead of a silent fallback.
+      // two Pi sessions sharing one process would then silently share its dedup sentinel.
       throw new Error(
         "swe-workbench: ctx.sessionManager.getSessionId() returned empty — refusing to call " +
-          "skill_autoload_hint.sh without a session id (#607)",
+          "skill_autoload_hint.sh without a session id",
       );
     }
 

--- a/pi/extensions/guards.ts
+++ b/pi/extensions/guards.ts
@@ -3,11 +3,9 @@
  * workflow_resume_hint.sh/skill_autoload_hint.sh as Pi session/tool_result hint sources — all
  * via guard-runner.ts, never reimplemented (#607).
  *
- * Every hook is executed unchanged; this file only translates events to payloads (cc-payload.ts)
- * and dispatches exit codes to Pi's block/allow/notify vocabulary. Narrowing tool_call/tool_result
- * events by `toolName` uses a manual cast rather than the SDK's `isToolCallEventType` helper —
- * that keeps every @earendil-works/pi-coding-agent import in this file `import type`-only
- * (pinned by tests/test_pi_contract.py), matching pi/extensions/index.ts's existing convention.
+ * `toolName` narrowing uses a manual cast rather than the SDK's `isToolCallEventType` helper so
+ * every @earendil-works/pi-coding-agent import here stays `import type`-only (pinned by
+ * tests/test_pi_contract.py).
  */
 import { join } from "node:path";
 import type {
@@ -25,8 +23,10 @@ import {
   editPayloads,
   GUARD_DISPATCH,
   type GuardSpec,
+  resumeHintPayload,
   sessionCompactSource,
   sessionStartSource,
+  skillHintPayload,
   writePayload,
 } from "./cc-payload.ts";
 import { runGuard as defaultRunGuard, type RunGuard } from "./guard-runner.ts";
@@ -58,6 +58,21 @@ export interface RegisterGuardsOptions {
 export function registerGuards(pi: ExtensionAPI, root: string, options: RegisterGuardsOptions = {}): void {
   const run = options.runGuard ?? defaultRunGuard;
 
+  // Applies a guard's OWN declared posture to a run with no real verdict — spawn
+  // failure/timeout, or an exit code outside {0, 2} (this repo's hooks only ever emit those
+  // two; 127/126/null mean the guard never actually ran). bash_guard.sh fails closed;
+  // secret_guard.py fails open — but never silently, since an unnoticed self-disabled guard is
+  // worse than no guard.
+  function handleGuardFailure(spec: GuardSpec, ctx: ExtensionContext, detail: string): ToolCallEventResult | undefined {
+    if (spec.failPosture === "closed") {
+      return { block: true, reason: `${detail} — blocking (fail-closed)` };
+    }
+    if (ctx.hasUI) {
+      ctx.ui.notify(`${detail} — not blocking (fail-open)`, "warning");
+    }
+    return undefined;
+  }
+
   async function checkGuard(
     spec: GuardSpec,
     payload: Record<string, unknown>,
@@ -73,15 +88,9 @@ export function registerGuards(pi: ExtensionAPI, root: string, options: Register
         pluginRoot: root,
         signal: ctx.signal,
       });
-    } catch {
-      // Spawn failure or timeout — governed by the guard's OWN declared posture, never
-      // conflated with a normal non-zero exit below. bash_guard.sh fails closed (a broken
-      // security control must not silently become "allow everything"); secret_guard.py fails
-      // open (a broken hint must not become a self-inflicted DoS on every write/edit).
-      if (spec.failPosture === "closed") {
-        return { block: true, reason: `${spec.scriptRelPath} could not run — blocking (fail-closed)` };
-      }
-      return undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return handleGuardFailure(spec, ctx, `${spec.scriptRelPath} could not run: ${message}`);
     }
 
     if (result.code === 2) {
@@ -90,13 +99,11 @@ export function registerGuards(pi: ExtensionAPI, root: string, options: Register
     if (result.code === 0) {
       return undefined;
     }
-    if (ctx.hasUI) {
-      ctx.ui.notify(
-        `${spec.scriptRelPath} exited ${result.code} — not blocking: ${result.stderr.trim()}`,
-        "warning",
-      );
-    }
-    return undefined;
+    return handleGuardFailure(
+      spec,
+      ctx,
+      `${spec.scriptRelPath} exited ${result.code} unexpectedly: ${result.stderr.trim()}`,
+    );
   }
 
   pi.on("tool_call", async (event, ctx) => {
@@ -141,14 +148,19 @@ export function registerGuards(pi: ExtensionAPI, root: string, options: Register
     pi.sendMessage({ customType, content, display: false }, { deliverAs });
   }
 
+  // Gated on project trust: workflow_resume_hint.sh injects repo-committed
+  // `.claude/cache/workflow-state/<branch>.json` content into model context, so an untrusted
+  // repo shouldn't reach the model this way.
   pi.on("session_start", async (event, ctx) => {
+    if (!ctx.isProjectTrusted()) return;
     const source = sessionStartSource(event as SessionStartEvent);
-    await emitHint(RESUME_HINT_SCRIPT, { cwd: ctx.cwd, source }, ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
+    await emitHint(RESUME_HINT_SCRIPT, resumeHintPayload(ctx.cwd, source), ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
   });
 
   pi.on("session_compact", async (event, ctx) => {
+    if (!ctx.isProjectTrusted()) return;
     const source = sessionCompactSource(event as SessionCompactEvent);
-    await emitHint(RESUME_HINT_SCRIPT, { cwd: ctx.cwd, source }, ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
+    await emitHint(RESUME_HINT_SCRIPT, resumeHintPayload(ctx.cwd, source), ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
   });
 
   pi.on("tool_result", async (event, ctx) => {
@@ -170,7 +182,7 @@ export function registerGuards(pi: ExtensionAPI, root: string, options: Register
 
     await emitHint(
       SKILL_HINT_SCRIPT,
-      { tool_input: { file_path: filePath }, session_id: sessionId },
+      skillHintPayload(filePath, sessionId),
       ctx,
       "swe-workbench:skill-autoload-hint",
       "steer",

--- a/pi/extensions/guards.ts
+++ b/pi/extensions/guards.ts
@@ -1,0 +1,180 @@
+/**
+ * Composition root: wires bash_guard.sh/secret_guard.py as Pi tool_call guards, and
+ * workflow_resume_hint.sh/skill_autoload_hint.sh as Pi session/tool_result hint sources — all
+ * via guard-runner.ts, never reimplemented (#607).
+ *
+ * Every hook is executed unchanged; this file only translates events to payloads (cc-payload.ts)
+ * and dispatches exit codes to Pi's block/allow/notify vocabulary. Narrowing tool_call/tool_result
+ * events by `toolName` uses a manual cast rather than the SDK's `isToolCallEventType` helper —
+ * that keeps every @earendil-works/pi-coding-agent import in this file `import type`-only
+ * (pinned by tests/test_pi_contract.py), matching pi/extensions/index.ts's existing convention.
+ */
+import { join } from "node:path";
+import type {
+  BashToolCallEvent,
+  EditToolCallEvent,
+  ExtensionAPI,
+  ExtensionContext,
+  SessionCompactEvent,
+  SessionStartEvent,
+  ToolCallEventResult,
+  WriteToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import {
+  bashPayload,
+  editPayloads,
+  GUARD_DISPATCH,
+  type GuardSpec,
+  sessionCompactSource,
+  sessionStartSource,
+  writePayload,
+} from "./cc-payload.ts";
+import { runGuard as defaultRunGuard, type RunGuard } from "./guard-runner.ts";
+
+const RESUME_HINT_SCRIPT = "hooks/workflow_resume_hint.sh";
+const SKILL_HINT_SCRIPT = "hooks/skill_autoload_hint.sh";
+
+interface HookSpecificOutput {
+  hookSpecificOutput?: { additionalContext?: string };
+}
+
+/** Parses a hint script's stdout envelope; absent/malformed/empty stdout is a silent no-op —
+ *  these are advisory hooks, not guards, and never block or throw on their own output shape. */
+function parseAdditionalContext(stdout: string): string | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed) return undefined;
+  try {
+    return (JSON.parse(trimmed) as HookSpecificOutput).hookSpecificOutput?.additionalContext;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface RegisterGuardsOptions {
+  /** Injectable so tests can force a spawn failure without touching the real hooks/ scripts. */
+  runGuard?: RunGuard;
+}
+
+export function registerGuards(pi: ExtensionAPI, root: string, options: RegisterGuardsOptions = {}): void {
+  const run = options.runGuard ?? defaultRunGuard;
+
+  async function checkGuard(
+    spec: GuardSpec,
+    payload: Record<string, unknown>,
+    ctx: ExtensionContext,
+  ): Promise<ToolCallEventResult | undefined> {
+    let result;
+    try {
+      result = await run({
+        interpreter: spec.interpreter,
+        scriptPath: join(root, spec.scriptRelPath),
+        payload,
+        cwd: ctx.cwd,
+        pluginRoot: root,
+        signal: ctx.signal,
+      });
+    } catch {
+      // Spawn failure or timeout — governed by the guard's OWN declared posture, never
+      // conflated with a normal non-zero exit below. bash_guard.sh fails closed (a broken
+      // security control must not silently become "allow everything"); secret_guard.py fails
+      // open (a broken hint must not become a self-inflicted DoS on every write/edit).
+      if (spec.failPosture === "closed") {
+        return { block: true, reason: `${spec.scriptRelPath} could not run — blocking (fail-closed)` };
+      }
+      return undefined;
+    }
+
+    if (result.code === 2) {
+      return { block: true, reason: result.stderr.trim() || `${spec.scriptRelPath}: blocked` };
+    }
+    if (result.code === 0) {
+      return undefined;
+    }
+    if (ctx.hasUI) {
+      ctx.ui.notify(
+        `${spec.scriptRelPath} exited ${result.code} — not blocking: ${result.stderr.trim()}`,
+        "warning",
+      );
+    }
+    return undefined;
+  }
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (event.toolName === "bash") {
+      return checkGuard(GUARD_DISPATCH.bash, bashPayload(event as BashToolCallEvent), ctx);
+    }
+    if (event.toolName === "write") {
+      return checkGuard(GUARD_DISPATCH.write, writePayload(event as WriteToolCallEvent), ctx);
+    }
+    if (event.toolName === "edit") {
+      for (const payload of editPayloads(event as EditToolCallEvent)) {
+        const result = await checkGuard(GUARD_DISPATCH.edit, payload, ctx);
+        if (result?.block) return result; // short-circuit at the first blocked edits[] element
+      }
+    }
+    return undefined;
+  });
+
+  async function emitHint(
+    scriptRelPath: string,
+    payload: Record<string, unknown>,
+    ctx: ExtensionContext,
+    customType: string,
+    deliverAs: "nextTurn" | "steer",
+  ): Promise<void> {
+    let result;
+    try {
+      result = await run({
+        interpreter: "bash",
+        scriptPath: join(root, scriptRelPath),
+        payload,
+        cwd: ctx.cwd,
+        pluginRoot: root,
+        signal: ctx.signal,
+      });
+    } catch {
+      return; // advisory-only: fail open, same as the hook's own Claude Code posture
+    }
+    if (result.code !== 0) return;
+    const content = parseAdditionalContext(result.stdout);
+    if (!content) return;
+    pi.sendMessage({ customType, content, display: false }, { deliverAs });
+  }
+
+  pi.on("session_start", async (event, ctx) => {
+    const source = sessionStartSource(event as SessionStartEvent);
+    await emitHint(RESUME_HINT_SCRIPT, { cwd: ctx.cwd, source }, ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
+  });
+
+  pi.on("session_compact", async (event, ctx) => {
+    const source = sessionCompactSource(event as SessionCompactEvent);
+    await emitHint(RESUME_HINT_SCRIPT, { cwd: ctx.cwd, source }, ctx, "swe-workbench:workflow-resume-hint", "nextTurn");
+  });
+
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.toolName !== "read" && event.toolName !== "write" && event.toolName !== "edit") return undefined;
+
+    const filePath = (event.input as { path?: unknown }).path;
+    if (typeof filePath !== "string" || !filePath) return undefined;
+
+    const sessionId = ctx.sessionManager.getSessionId();
+    if (!sessionId) {
+      // skill_autoload_hint.sh falls back to $$ (the process PID) when session_id is absent —
+      // two Pi sessions sharing one process would then silently share its dedup sentinel,
+      // reproducing #401's cross-session state bleed. Hard error instead of a silent fallback.
+      throw new Error(
+        "swe-workbench: ctx.sessionManager.getSessionId() returned empty — refusing to call " +
+          "skill_autoload_hint.sh without a session id (#607)",
+      );
+    }
+
+    await emitHint(
+      SKILL_HINT_SCRIPT,
+      { tool_input: { file_path: filePath }, session_id: sessionId },
+      ctx,
+      "swe-workbench:skill-autoload-hint",
+      "steer",
+    );
+    return undefined;
+  });
+}

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { registerGuards } from "./guards.ts";
 
 class PluginRootNotFoundError extends Error {
   constructor(startDir: string) {
@@ -114,4 +115,6 @@ export default function (pi: ExtensionAPI): void {
     if (event.systemPrompt.includes(PREAMBLE_MARKER)) return;
     return { systemPrompt: event.systemPrompt + preamble };
   });
+
+  registerGuards(pi, root);
 }

--- a/pi/tsconfig.json
+++ b/pi/tsconfig.json
@@ -9,7 +9,9 @@
     "noEmit": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["extensions/**/*.ts"]
 }

--- a/tests/pi_guard_fixtures.py
+++ b/tests/pi_guard_fixtures.py
@@ -1,0 +1,35 @@
+"""Shared fixture set for hooks/bash_guard.sh's #607 acceptance criterion:
+
+  For this fixture set (including the #401 backtick/$(...) vectors bash_guard.sh now closes),
+  the verdict produced through the Pi adapter must be identical to the verdict produced by
+  invoking the guard script directly with the equivalent Claude-Code-shaped payload.
+
+A single source shared by tests/test_hooks.py (direct invocation) and
+tests/test_pi_extension.py (through pi/extensions/guards.ts) — a future change to
+hooks/bash_guard.sh's semantics has to update the expectation here, and both suites re-verify
+against it, or CI fails on whichever one goes stale.
+
+Each entry is (command, expect_blocked). expect_blocked=True means exit 2 + "BLOCKED" in
+stderr directly, or {block: true} through the Pi adapter.
+"""
+
+BASH_GUARD_FIXTURES: list[tuple[str, bool]] = [
+    ("rm -rf /", True),
+    ("rm -rf ~", True),
+    ("rm -rf $HOME", True),
+    ("sudo rm -rf /", True),
+    ("rm -rf /Users/foo", True),
+    # #401 bypass vectors — the reason this fixture set exists as a differential contract
+    ("`rm -rf /`", True),
+    ("var=`rm -rf /`", True),
+    ("$(rm -rf /)", True),
+    ("var=$(rm -rf /)", True),
+    ("echo `rm -rf /`", True),
+    ("echo $(rm -rf /)", True),
+    # allow-list, including legitimate backtick/$(...) subshells with no rm inside
+    ("ls -la", False),
+    ("rm -rf ./build", False),
+    ("rm -rf node_modules", False),
+    ("echo `ls`", False),
+    ("x=$(date)", False),
+]

--- a/tests/pi_guard_fixtures.py
+++ b/tests/pi_guard_fixtures.py
@@ -1,6 +1,6 @@
-"""Shared fixture set for hooks/bash_guard.sh's #607 acceptance criterion:
+"""Shared fixture set for hooks/bash_guard.sh's differential acceptance criterion:
 
-  For this fixture set (including the #401 backtick/$(...) vectors bash_guard.sh now closes),
+  For this fixture set (including the backtick/$(...) vectors bash_guard.sh now closes),
   the verdict produced through the Pi adapter must be identical to the verdict produced by
   invoking the guard script directly with the equivalent Claude-Code-shaped payload.
 
@@ -19,15 +19,16 @@ BASH_GUARD_FIXTURES: list[tuple[str, bool]] = [
     ("rm -rf $HOME", True),
     ("sudo rm -rf /", True),
     ("rm -rf /Users/foo", True),
-    # #401 bypass vectors — the reason this fixture set exists as a differential contract
+    # backtick/$(...) rm -rf bypass vectors — the reason this fixture set exists as a
+    # differential contract
     ("`rm -rf /`", True),
     ("var=`rm -rf /`", True),
     ("$(rm -rf /)", True),
     ("var=$(rm -rf /)", True),
     ("echo `rm -rf /`", True),
     ("echo $(rm -rf /)", True),
-    # same bypass CLASS, found by #607's post-fix security review: process substitution
-    # (`<(...)`/`>(...)`) has the identical "(" shape and was left open by a $(-only patch
+    # same bypass class: process substitution (`<(...)`/`>(...)`) has the identical "(" shape
+    # and was left open by a $(-only patch
     ("<(rm -rf ~)", True),
     (">(rm -rf /)", True),
     ("echo <(rm -rf /Users/bob)", True),

--- a/tests/pi_guard_fixtures.py
+++ b/tests/pi_guard_fixtures.py
@@ -26,10 +26,22 @@ BASH_GUARD_FIXTURES: list[tuple[str, bool]] = [
     ("var=$(rm -rf /)", True),
     ("echo `rm -rf /`", True),
     ("echo $(rm -rf /)", True),
+    # same bypass CLASS, found by #607's post-fix security review: process substitution
+    # (`<(...)`/`>(...)`) has the identical "(" shape and was left open by a $(-only patch
+    ("<(rm -rf ~)", True),
+    (">(rm -rf /)", True),
+    ("echo <(rm -rf /Users/bob)", True),
+    # quote-wrapped / backslash-escaped rm — found by the same review: the fast-gate case
+    # used to run on pre-quote-strip text, so a quote immediately before "rm" defeated it
+    ('"rm" -rf ~', True),
+    ("'rm' -rf $HOME", True),
+    ('bash -c "rm -rf /"', True),
+    ("\\rm -rf ~", True),
     # allow-list, including legitimate backtick/$(...) subshells with no rm inside
     ("ls -la", False),
     ("rm -rf ./build", False),
     ("rm -rf node_modules", False),
     ("echo `ls`", False),
     ("x=$(date)", False),
+    ("echo $(pwd)", False),
 ]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -93,6 +93,14 @@ class TestRmRfBlocker:
         # swallow real command text that follows on the SAME physical line
         # (issue #501 re-review finding)
         'git commit -m "line one\n# note" && rm -rf ~',
+        # #401 bypass vectors — backtick and $(...) subshells previously
+        # slipped past both the fast-gate and the anchor regex (issue #607)
+        "`rm -rf /`",
+        "var=`rm -rf /`",
+        "$(rm -rf /)",
+        "var=$(rm -rf /)",
+        "echo `rm -rf /`",
+        "echo $(rm -rf /)",
     ])
     def test_blocked(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)
@@ -115,6 +123,10 @@ class TestRmRfBlocker:
         "rm -rf /homestead",
         "echo hi\nrm -rf ./build",
         "true\trm -rf ./build",
+        # legitimate backtick/$(...) subshells with no rm inside must stay allowed
+        "echo `ls`",
+        "x=$(date)",
+        "echo $(pwd)",
     ])
     def test_allowed(self, guard_script, cmd):
         result = run_guard(guard_script, cmd)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from conftest import _CLEAN_ENV
+from pi_guard_fixtures import BASH_GUARD_FIXTURES
 
 GUARD = Path(__file__).parent.parent / "hooks" / "bash_guard.sh"
 
@@ -609,3 +610,24 @@ class TestSkillAutoloadHookWiring:
         assert go_result.stdout.strip(), "Go hint should have been emitted"
         assert "language-python" in py_result.stdout
         assert "language-go" in go_result.stdout
+
+
+# ──────────────────────────────────────────────
+# #607 differential acceptance criterion — direct-invocation half. tests/test_pi_extension.py
+# runs the SAME BASH_GUARD_FIXTURES set through pi/extensions/guards.ts and asserts an
+# identical verdict; a future guard-semantics change has to update pi_guard_fixtures.py and
+# both suites re-verify against it.
+# ──────────────────────────────────────────────
+
+class TestDifferentialFixtures:
+    @pytest.mark.parametrize("cmd,expect_blocked", BASH_GUARD_FIXTURES)
+    def test_direct_invocation_matches_expected_verdict(self, guard_script, cmd, expect_blocked):
+        result = run_guard(guard_script, cmd)
+        if expect_blocked:
+            assert result.returncode == 2 and "BLOCKED" in result.stderr, (
+                f"expected BLOCKED for {cmd!r}, got exit {result.returncode}: {result.stderr!r}"
+            )
+        else:
+            assert result.returncode == 0 and result.stderr == "", (
+                f"expected ALLOWED for {cmd!r}, got exit {result.returncode}: {result.stderr!r}"
+            )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -94,8 +94,8 @@ class TestRmRfBlocker:
         # swallow real command text that follows on the SAME physical line
         # (issue #501 re-review finding)
         'git commit -m "line one\n# note" && rm -rf ~',
-        # #401 bypass vectors — backtick and $(...) subshells previously
-        # slipped past both the fast-gate and the anchor regex (issue #607)
+        # backtick and $(...) subshells previously slipped past both the fast-gate and the
+        # anchor regex
         "`rm -rf /`",
         "var=`rm -rf /`",
         "$(rm -rf /)",
@@ -613,7 +613,7 @@ class TestSkillAutoloadHookWiring:
 
 
 # ──────────────────────────────────────────────
-# #607 differential acceptance criterion — direct-invocation half. tests/test_pi_extension.py
+# Differential acceptance criterion — direct-invocation half. tests/test_pi_extension.py
 # runs the SAME BASH_GUARD_FIXTURES set through pi/extensions/guards.ts and asserts an
 # identical verdict; a future guard-semantics change has to update pi_guard_fixtures.py and
 # both suites re-verify against it.

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -1,4 +1,5 @@
-"""Contract tests for the swe-workbench <-> Pi Coding Agent frontmatter boundary (issue #605).
+"""Contract tests for the swe-workbench <-> Pi Coding Agent frontmatter boundary (issue #605)
+and, below, the guard/hint event-translation boundary (issue #607).
 
 ADR-0001's runtime adapter (pi/) reads agents/*.md, skills/*/SKILL.md, and commands/*.md
 frontmatter through Pi's own YAML parser — which is strict. scripts/validate.py's
@@ -15,17 +16,26 @@ what this repo's frontmatter currently uses. A new key/tool/skill only trips a t
 docs/plugin-platform-decisions.md §2, rather than a closed-form schema.
 """
 
+import json
+import os
+import re
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 import validate
+from conftest import _CLEAN_ENV
 
 ROOT = Path(__file__).parent.parent
 AGENTS_DIR = ROOT / "agents"
 SKILLS_DIR = ROOT / "skills"
 COMMANDS_DIR = ROOT / "commands"
 SHARED_DIR = ROOT / "shared"
+EXTENSIONS_DIR = ROOT / "pi" / "extensions"
+HOOKS_DIR = ROOT / "hooks"
 
 # The complete key vocabulary agents/*.md frontmatter uses today. A new key (e.g. a future
 # Phase 7 `pi:` override block) must be added here deliberately, not discovered by CI red.
@@ -187,4 +197,223 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
         "agents/*.md skill ids have drifted from the inventory — "
         f"only on disk: {sorted(skill_ids - SKILL_IDS)}, "
         f"only in SKILL_IDS: {sorted(SKILL_IDS - skill_ids)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard/hint event-translation contract (issue #607). Golden-inventory ratchets over
+# pi/extensions/*.ts — module-level literals asserted equal to what's on disk, per
+# docs/plugin-platform-decisions.md §2. These fail only when THIS repo's adapter drifts from
+# the invariants #607's design settled on, never on an upstream SDK addition.
+# ---------------------------------------------------------------------------
+
+_EXTENSION_TS_FILES = sorted(EXTENSIONS_DIR.glob("*.ts"))
+_NON_INDEX_TS_FILES = [p for p in _EXTENSION_TS_FILES if p.name != "index.ts"]
+
+_PACKAGE_IMPORT_RE = re.compile(
+    # [^}]* (not a DOTALL .*?) so this cannot swallow past the FIRST closing brace it meets —
+    # a lazy .*? still crosses unrelated statements in between when the file has multiple
+    # `import ... from "..."` blocks between the first "import" keyword and this package name.
+    r'import\s+(type\s+)?\{[^}]*\}\s+from\s+["\']@earendil-works/pi-coding-agent["\']',
+)
+
+
+def test_every_sdk_import_under_extensions_is_type_only():
+    """A plain (non-type) import of a runtime SDK symbol would defeat the
+    `node --experimental-strip-types` test harness the moment it's exercised outside a
+    node_modules-having checkout, and — per this repo's own established convention in
+    pi/extensions/index.ts — is never actually needed: every narrowing this adapter does uses
+    a manual `toolName === "..."` check plus a type cast instead of the SDK's
+    `isToolCallEventType` runtime helper."""
+    violations = []
+    for path in _EXTENSION_TS_FILES:
+        text = path.read_text(encoding="utf-8")
+        for match in _PACKAGE_IMPORT_RE.finditer(text):
+            if match.group(1) is None:
+                violations.append(f"{path.relative_to(ROOT)}: {match.group(0)!r}")
+    assert not violations, (
+        "every import of @earendil-works/pi-coding-agent under pi/extensions/ must be "
+        f"`import type` — found non-type-only import(s):\n" + "\n".join(violations)
+    )
+
+
+def test_node_child_process_imported_in_exactly_guard_runner():
+    importers = []
+    for path in _EXTENSION_TS_FILES:
+        text = path.read_text(encoding="utf-8")
+        if re.search(r'from\s+["\']node:child_process["\']', text) or "require(\"node:child_process\")" in text:
+            importers.append(path.name)
+    assert importers == ["guard-runner.ts"], (
+        "node:child_process must be imported in exactly guard-runner.ts — the sole auditable "
+        f"process-spawn boundary for the adapter; found it imported in: {importers}"
+    )
+
+
+def test_no_shell_true_under_extensions():
+    violations = [
+        str(p.relative_to(ROOT)) for p in _EXTENSION_TS_FILES if re.search(r"shell\s*:\s*true", p.read_text(encoding="utf-8"))
+    ]
+    assert not violations, f"shell: true is forbidden under pi/extensions/ — found in: {violations}"
+
+
+def test_extension_ts_files_excluding_index_stay_under_line_cap():
+    """A volume bound, not a semantic guard-logic detector — no regex reliably distinguishes
+    genuine guard logic from an unusually long comment or type block, and one that tried would
+    either miss unusual patterns or false-positive on prose. Bounded line count plus the
+    child_process/shell:true ratchets above give real containment without pretending to detect
+    reimplemented guard logic directly."""
+    LINE_CAP = 250
+    violations = []
+    for path in _NON_INDEX_TS_FILES:
+        n = len(path.read_text(encoding="utf-8").splitlines())
+        if n > LINE_CAP:
+            violations.append(f"{path.name}: {n} lines")
+    assert not violations, f"pi/extensions/*.ts files (excluding index.ts) must stay <= {LINE_CAP} lines: {violations}"
+
+
+def _node_major_version():
+    node = shutil.which("node")
+    if node is None:
+        return None
+    result = subprocess.run([node, "--version"], capture_output=True, text=True, env=_CLEAN_ENV, timeout=10)
+    return int(result.stdout.strip().lstrip("v").split(".")[0])
+
+
+_NODE_MAJOR = _node_major_version()
+_NODE_TOO_OLD = _NODE_MAJOR is None or _NODE_MAJOR < 22
+
+if _NODE_TOO_OLD and os.environ.get("CI"):
+    pytest.fail(
+        "Node >= 22 required for pi contract tests that dump GUARD_DISPATCH but not found (or "
+        "too old) in CI — check the pytest job's actions/setup-node step",
+        pytrace=False,
+    )
+
+requires_node = pytest.mark.skipif(
+    _NODE_TOO_OLD, reason="requires Node >= 22 (--experimental-strip-types) to import cc-payload.ts"
+)
+
+_DUMP_DISPATCH_DRIVER = """
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.argv[2]).href);
+console.log(JSON.stringify(mod.GUARD_DISPATCH));
+"""
+
+
+@pytest.fixture(scope="module")
+def guard_dispatch():
+    if _NODE_TOO_OLD:
+        pytest.skip("requires Node >= 22")
+    import tempfile
+
+    node = shutil.which("node")
+    assert node is not None
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "dump.mjs"
+        driver.write_text(_DUMP_DISPATCH_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(EXTENSIONS_DIR / "cc-payload.ts")],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@requires_node
+def test_guard_dispatch_script_paths_exist_and_are_executable(guard_dispatch):
+    for tool, spec in guard_dispatch.items():
+        script_path = ROOT / spec["scriptRelPath"]
+        assert script_path.exists(), f"{tool}: {spec['scriptRelPath']} does not exist"
+        # os.access(X_OK), never an exact-mode check — a umask-002 checkout legitimately
+        # produces 0775 for an executable file, which an exact `& 0o111` comparison would flag.
+        assert os.access(script_path, os.X_OK), f"{tool}: {spec['scriptRelPath']} is not executable"
+
+
+@requires_node
+def test_guard_dispatch_tool_name_casing_is_pinned(guard_dispatch):
+    """secret_guard.py matches tool_name by exact string equality against "Write"/"Edit" — a
+    lowercase leak here would silently no-op the guard while every other test stays green."""
+    assert guard_dispatch["bash"]["ccToolName"] is None
+    assert guard_dispatch["write"]["ccToolName"] == "Write"
+    assert guard_dispatch["edit"]["ccToolName"] == "Edit"
+
+
+@requires_node
+def test_guard_dispatch_fail_postures_are_pinned(guard_dispatch):
+    assert guard_dispatch["bash"]["failPosture"] == "closed"
+    assert guard_dispatch["write"]["failPosture"] == "open"
+    assert guard_dispatch["edit"]["failPosture"] == "open"
+
+
+# Every JSON field path each hook actually reads (verified against hooks/*.sh|py source below),
+# and every field path the adapter's CC-shaped payloads carry for the Pi tool that reaches it.
+# A hook reading a field the adapter never sends would silently no-op that behavior on Pi.
+REFERENCED_FIELDS = {
+    "bash_guard.sh": {"tool_input.command"},
+    "secret_guard.py": {"tool_name", "tool_input.content", "tool_input.file_path", "tool_input.new_string"},
+    "workflow_resume_hint.sh": {"cwd", "source"},
+    "skill_autoload_hint.sh": {"tool_input.file_path", "session_id"},
+}
+ADAPTER_PAYLOAD_FIELDS = {
+    "bash_guard.sh": {"tool_input.command"},
+    "secret_guard.py": {"tool_name", "tool_input.content", "tool_input.file_path", "tool_input.new_string"},
+    "workflow_resume_hint.sh": {"cwd", "source"},
+    "skill_autoload_hint.sh": {"tool_input.file_path", "session_id"},
+}
+
+
+def test_referenced_fields_are_a_subset_of_adapter_payload_fields():
+    for hook, referenced in REFERENCED_FIELDS.items():
+        carried = ADAPTER_PAYLOAD_FIELDS[hook]
+        assert referenced <= carried, (
+            f"{hook} reads field(s) {referenced - carried} that the adapter's payload for it "
+            "never carries — that field would silently always read empty on Pi"
+        )
+
+
+def test_referenced_fields_actually_appear_in_hook_source():
+    """Sanity-checks REFERENCED_FIELDS against the real script text so a hook edit that renames
+    or drops a field trips this ratchet, instead of the literal silently going stale."""
+    sources = {
+        "bash_guard.sh": (HOOKS_DIR / "bash_guard.sh").read_text(encoding="utf-8"),
+        "secret_guard.py": (HOOKS_DIR / "secret_guard.py").read_text(encoding="utf-8"),
+        "workflow_resume_hint.sh": (HOOKS_DIR / "workflow_resume_hint.sh").read_text(encoding="utf-8"),
+        "skill_autoload_hint.sh": (HOOKS_DIR / "skill_autoload_hint.sh").read_text(encoding="utf-8"),
+    }
+    for hook, fields in REFERENCED_FIELDS.items():
+        text = sources[hook]
+        for field in fields:
+            leaf = field.rsplit(".", 1)[-1]
+            assert leaf in text, f"{hook}: expected field leaf {leaf!r} (from {field!r}) not found in source"
+
+
+# hooks/*.sh|py -> Pi wiring status. "wired": translated by guards.ts this phase. "n/a": the
+# concept the hook manipulates does not exist on Pi (documented in
+# docs/plugin-platform-decisions.md §6). "deferred": not wired yet because the Pi tool it needs
+# (Skill / subagents) doesn't exist until #608/#610 — tracked there, not here.
+HOOK_PI_STATUS = {
+    "bash_guard.sh": "wired",
+    "secret_guard.py": "wired",
+    "workflow_resume_hint.sh": "wired",
+    "skill_autoload_hint.sh": "wired",
+    "worktree_permission_grant.sh": "n/a",
+    "skill_usage_record.sh": "deferred",
+    "skill_usage_flush.sh": "deferred",
+}
+
+
+def test_every_hook_script_has_a_pi_status_row():
+    on_disk = {p.name for p in HOOKS_DIR.glob("*.sh")} | {p.name for p in HOOKS_DIR.glob("*.py")}
+    assert on_disk == set(HOOK_PI_STATUS), (
+        "hooks/*.sh|py has drifted from the Pi-wiring inventory — "
+        f"only on disk: {sorted(on_disk - set(HOOK_PI_STATUS))}, "
+        f"only in HOOK_PI_STATUS: {sorted(set(HOOK_PI_STATUS) - on_disk)}"
+    )
+
+
+def test_worktree_permission_grant_is_explicitly_not_applicable():
+    assert HOOK_PI_STATUS["worktree_permission_grant.sh"] == "n/a", (
+        "worktree_permission_grant.sh's PreToolUse permissionDecision output has no target on "
+        "Pi (README.md: 'No permission popups') — this must stay an explicit N/A, not silently "
+        "absent from the inventory"
     )

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -1,5 +1,5 @@
 """Contract tests for the swe-workbench <-> Pi Coding Agent frontmatter boundary (issue #605)
-and, below, the guard/hint event-translation boundary (issue #607).
+and, below, the guard/hint event-translation boundary.
 
 ADR-0001's runtime adapter (pi/) reads agents/*.md, skills/*/SKILL.md, and commands/*.md
 frontmatter through Pi's own YAML parser — which is strict. scripts/validate.py's
@@ -245,7 +245,7 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
 
 
 # ---------------------------------------------------------------------------
-# Guard/hint event-translation contract (issue #607). Golden-inventory ratchets over
+# Guard/hint event-translation contract. Golden-inventory ratchets over
 # pi/extensions/*.ts — module-level literals asserted equal to what's on disk, per
 # docs/plugin-platform-decisions.md §2.
 # ---------------------------------------------------------------------------

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -203,8 +203,7 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
 # ---------------------------------------------------------------------------
 # Guard/hint event-translation contract (issue #607). Golden-inventory ratchets over
 # pi/extensions/*.ts — module-level literals asserted equal to what's on disk, per
-# docs/plugin-platform-decisions.md §2. These fail only when THIS repo's adapter drifts from
-# the invariants #607's design settled on, never on an upstream SDK addition.
+# docs/plugin-platform-decisions.md §2.
 # ---------------------------------------------------------------------------
 
 _EXTENSION_TS_FILES = sorted(EXTENSIONS_DIR.glob("*.ts"))
@@ -219,12 +218,9 @@ _PACKAGE_IMPORT_RE = re.compile(
 
 
 def test_every_sdk_import_under_extensions_is_type_only():
-    """A plain (non-type) import of a runtime SDK symbol would defeat the
-    `node --experimental-strip-types` test harness the moment it's exercised outside a
-    node_modules-having checkout, and — per this repo's own established convention in
-    pi/extensions/index.ts — is never actually needed: every narrowing this adapter does uses
-    a manual `toolName === "..."` check plus a type cast instead of the SDK's
-    `isToolCallEventType` runtime helper."""
+    """Every narrowing this adapter does uses a manual `toolName === "..."` check plus a type
+    cast instead of the SDK's `isToolCallEventType` runtime helper, so no import here needs to
+    be a value import."""
     violations = []
     for path in _EXTENSION_TS_FILES:
         text = path.read_text(encoding="utf-8")
@@ -296,12 +292,37 @@ requires_node = pytest.mark.skipif(
 _DUMP_DISPATCH_DRIVER = """
 import { pathToFileURL } from "node:url";
 const mod = await import(pathToFileURL(process.argv[2]).href);
-console.log(JSON.stringify(mod.GUARD_DISPATCH));
+
+function flatten(obj, prefix) {
+  const out = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) out.push(...flatten(v, path));
+    else out.push(path);
+  }
+  return out;
+}
+
+const bashEvent = { input: { command: "x" } };
+const writeEvent = { input: { content: "x", path: "y" } };
+const editEvent = { input: { path: "y", edits: [{ oldText: "a", newText: "b" }] } };
+
+const fields = {
+  "bash_guard.sh": flatten(mod.bashPayload(bashEvent)),
+  "secret_guard.py": [
+    ...flatten(mod.writePayload(writeEvent)),
+    ...flatten(mod.editPayloads(editEvent)[0]),
+  ],
+  "workflow_resume_hint.sh": flatten(mod.resumeHintPayload("cwd-value", "startup")),
+  "skill_autoload_hint.sh": flatten(mod.skillHintPayload("path-value", "session-value")),
+};
+
+console.log(JSON.stringify({ dispatch: mod.GUARD_DISPATCH, fields }));
 """
 
 
 @pytest.fixture(scope="module")
-def guard_dispatch():
+def cc_payload_dump():
     if _NODE_TOO_OLD:
         pytest.skip("requires Node >= 22")
     import tempfile
@@ -317,6 +338,11 @@ def guard_dispatch():
         )
     assert result.returncode == 0, f"driver failed: {result.stderr}"
     return json.loads(result.stdout)
+
+
+@pytest.fixture(scope="module")
+def guard_dispatch(cc_payload_dump):
+    return cc_payload_dump["dispatch"]
 
 
 @requires_node
@@ -345,26 +371,19 @@ def test_guard_dispatch_fail_postures_are_pinned(guard_dispatch):
     assert guard_dispatch["edit"]["failPosture"] == "open"
 
 
-# Every JSON field path each hook actually reads (verified against hooks/*.sh|py source below),
-# and every field path the adapter's CC-shaped payloads carry for the Pi tool that reaches it.
-# A hook reading a field the adapter never sends would silently no-op that behavior on Pi.
+# Every JSON field path each hook actually reads, verified against hooks/*.sh|py source below.
 REFERENCED_FIELDS = {
     "bash_guard.sh": {"tool_input.command"},
     "secret_guard.py": {"tool_name", "tool_input.content", "tool_input.file_path", "tool_input.new_string"},
     "workflow_resume_hint.sh": {"cwd", "source"},
     "skill_autoload_hint.sh": {"tool_input.file_path", "session_id"},
 }
-ADAPTER_PAYLOAD_FIELDS = {
-    "bash_guard.sh": {"tool_input.command"},
-    "secret_guard.py": {"tool_name", "tool_input.content", "tool_input.file_path", "tool_input.new_string"},
-    "workflow_resume_hint.sh": {"cwd", "source"},
-    "skill_autoload_hint.sh": {"tool_input.file_path", "session_id"},
-}
 
 
-def test_referenced_fields_are_a_subset_of_adapter_payload_fields():
+@requires_node
+def test_referenced_fields_are_a_subset_of_adapter_payload_fields(cc_payload_dump):
     for hook, referenced in REFERENCED_FIELDS.items():
-        carried = ADAPTER_PAYLOAD_FIELDS[hook]
+        carried = set(cc_payload_dump["fields"][hook])
         assert referenced <= carried, (
             f"{hook} reads field(s) {referenced - carried} that the adapter's payload for it "
             "never carries — that field would silently always read empty on Pi"

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -304,6 +304,7 @@ const stubCtx = {
   hasUI: true,
   cwd: config.cwd,
   signal: undefined,
+  isProjectTrusted: () => true,
   ui: { notify: (msg, level) => notifications.push({ msg, level }) },
   sessionManager: { getSessionId: () => config.sessionId },
 };
@@ -553,6 +554,68 @@ def test_forced_spawn_failure_secret_guard_fails_open(tmp_path_factory):
     result = _run_node(_GUARDS_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-spawn-fail-2")
     assert result["out"].get("writeBlocked") is None  # secret_guard.py's spawn failure must fail OPEN
     assert result["out"].get("editShortCircuit") is None
+
+
+_REAL_SPAWN_FAILURE_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardRunnerPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { runGuard } = await import(pathToFileURL(guardRunnerPath).href);
+
+try {
+  await runGuard({
+    interpreter: config.interpreter,
+    scriptPath: config.scriptPath,
+    payload: {},
+    cwd: config.cwd,
+    pluginRoot: config.cwd,
+    signal: undefined,
+  });
+  console.log(JSON.stringify({ threw: false }));
+} catch (err) {
+  console.log(JSON.stringify({ threw: true, message: String(err && err.message) }));
+}
+"""
+
+
+@requires_node
+def test_guard_runner_real_spawn_rejects_on_nonexistent_interpreter(tmp_path_factory):
+    """Exercises guard-runner.ts's ACTUAL child_process.spawn -> child.on("error") -> reject
+    wiring — not the injected-mock failure path the tests above use. This is the highest-stakes
+    branch in the diff (it's what governs bash_guard.sh's fail-closed posture) and must be
+    covered by more than a fake throwing function standing in for it."""
+    config = {
+        "interpreter": "/nonexistent/interpreter-xyz-607",
+        "scriptPath": str(ROOT / "hooks" / "bash_guard.sh"),
+        "cwd": str(ROOT),
+    }
+    result = _run_node(
+        _REAL_SPAWN_FAILURE_DRIVER,
+        [str(GUARD_RUNNER_TS), json.dumps(config)],
+        tmp_path_factory,
+        label="pi-guard-runner-real-spawn-fail",
+    )
+    assert result["threw"] is True
+
+
+@requires_node
+def test_missing_script_exits_127_and_bash_guard_still_fails_closed(tmp_path_factory):
+    """A missing/unreadable hooks/bash_guard.sh makes bash itself exit 127 — spawn() succeeds
+    (bash exists), so this is NOT a JS-level spawn failure. Regression coverage: an exit code
+    outside {0, 2} used to fall straight through to allow. Uses the REAL (uninjected) runGuard."""
+    synthetic_root = tmp_path_factory.mktemp("pi-missing-script-root")
+    # deliberately no hooks/ directory at all under synthetic_root
+    config = {"root": str(synthetic_root), "cwd": str(ROOT), "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts")}
+    result = _run_node(
+        _GUARDS_DRIVER,
+        [str(GUARDS_TS), json.dumps({**config, "guardRunnerPath": str(GUARD_RUNNER_TS), "sessionId": "sess-missing-script", "secretContent": _SECRET_CONTENT, "forceSpawnFailure": False})],
+        tmp_path_factory,
+        label="pi-guards-missing-script",
+    )
+    blocked = result["out"]["bashAllowed"]  # "ls -la" — a totally safe command
+    assert blocked is not None and blocked["block"] is True
+    assert "fail-closed" in blocked["reason"]
 
 
 @requires_node

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -509,9 +509,79 @@ def test_edit_guard_checks_one_payload_per_edits_element_and_short_circuits(guar
     )
 
 
+_SESSION_START_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardsPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { registerGuards } = await import(pathToFileURL(guardsPath).href);
+
+const handlers = {};
+const sent = [];
+const stubPi = {
+  on(event, handler) { handlers[event] = handler; },
+  sendMessage(message, options) { sent.push({ message, options }); },
+};
+registerGuards(stubPi, config.root, {});
+
+const stubCtx = {
+  hasUI: true,
+  cwd: config.cwd,
+  signal: undefined,
+  isProjectTrusted: () => true,
+  ui: { notify() {} },
+  sessionManager: { getSessionId: () => "sess-resume-hint" },
+};
+
+await handlers["session_start"]({ type: "session_start", reason: "startup" }, stubCtx);
+console.log(JSON.stringify({ sent }));
+"""
+
+
 @requires_node
-def test_session_start_emits_resume_hint_via_send_message(guards_result):
-    sent = guards_result["out"]["sentAfterSessionStart"]
+def test_session_start_emits_resume_hint_via_send_message(tmp_path_factory):
+    """Builds its own git repo + workflow-state checkpoint rather than running against ROOT —
+    workflow_resume_hint.sh only emits an advisory when a fresh checkpoint exists for the
+    current branch, OR when cwd is a linked git worktree with no checkpoint. Relying on ROOT's
+    ambient worktree-ness made this test pass locally (inside a rimba worktree) but fail in CI
+    (a plain checkout, is_linked_worktree=0, no advisory)."""
+    import subprocess
+
+    repo_dir = tmp_path_factory.mktemp("pi-resume-hint-repo") / "repo"
+    repo_dir.mkdir()
+    branch = "feature/pi-resume-hint-test"
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=repo_dir, env=_CLEAN_ENV, check=True)
+    (repo_dir / "README").write_text("init", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo_dir, env=_CLEAN_ENV, check=True)
+    subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", "-c", "user.email=t@t.com", "-c", "user.name=T",
+         "commit", "-qm", "init"],
+        cwd=repo_dir, env=_CLEAN_ENV, check=True,
+    )
+
+    state_dir = repo_dir / ".claude" / "cache" / "workflow-state"
+    state_dir.mkdir(parents=True)
+    state = {
+        "version": 1,
+        "skill": "swe-workbench:workflow-development",
+        "mode": "B",
+        "phase": "3",
+        "phase_label": "Verify",
+        "completed_phases": ["1", "2"],
+        "context": {
+            "branch": branch, "worktree_root": None, "pr": None,
+            "base": None, "head_sha": None, "decision": None, "notes": "checkpoint",
+        },
+        "updated_at": "2026-08-21T00:00:00Z",
+    }
+    safe_branch = branch.replace("/", "-")
+    (state_dir / f"{safe_branch}.json").write_text(json.dumps(state), encoding="utf-8")
+
+    config = {"root": str(ROOT), "cwd": str(repo_dir)}
+    result = _run_node(
+        _SESSION_START_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-session-start-hint"
+    )
+    sent = result["sent"]
     assert len(sent) == 1
     assert sent[0]["message"]["customType"] == "swe-workbench:workflow-resume-hint"
     assert sent[0]["message"]["display"] is False

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -23,7 +23,15 @@ from conftest import _CLEAN_ENV
 ROOT = Path(__file__).parent.parent
 PACKAGE_JSON = ROOT / "pi" / "package.json"
 INDEX_TS = ROOT / "pi" / "extensions" / "index.ts"
+GUARDS_TS = ROOT / "pi" / "extensions" / "guards.ts"
+GUARD_RUNNER_TS = ROOT / "pi" / "extensions" / "guard-runner.ts"
 BIN_README = ROOT / "bin" / "README.md"
+
+# Concatenated (not a single literal) so this fixture's shape never appears contiguous in this
+# file's own source — this file is not on secret_guard.py's allowlist (unlike
+# tests/test_secret_guard.py), and the live PreToolUse:Write hook on the session authoring this
+# file would otherwise block the edit that introduces it.
+_SECRET_CONTENT = "API_KEY" + '="abcdefghijklmnop1234"'
 
 _DRIVER = """
 import { pathToFileURL } from "node:url";
@@ -246,6 +254,10 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     synthetic_index = synthetic_root / "pi" / "extensions" / "index.ts"
     synthetic_index.parent.mkdir(parents=True)
     synthetic_index.write_text(INDEX_TS.read_text(encoding="utf-8"), encoding="utf-8")
+    for helper in ("guards.ts", "cc-payload.ts", "guard-runner.ts"):
+        (synthetic_index.parent / helper).write_text(
+            (ROOT / "pi" / "extensions" / helper).read_text(encoding="utf-8"), encoding="utf-8"
+        )
 
     driver = tmp_path_factory.mktemp("pi-extension-driver-missing-readme") / "driver.mjs"
     driver.write_text(_DRIVER, encoding="utf-8")
@@ -263,3 +275,376 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     assert parsed["discoverResult"] == {"skillPaths": [str(synthetic_root / "skills")]}
     assert str(synthetic_root / "bin") in parsed["pathEntries"]
     assert "systemPrompt" not in (parsed.get("firstInjection") or {})
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: guards.ts driving the REAL hooks/bash_guard.sh + hooks/secret_guard.py +
+# hooks/workflow_resume_hint.sh + hooks/skill_autoload_hint.sh through guard-runner.ts's real
+# spawn (issue #607). Everything below drives the actual scripts, not a mock — the acceptance
+# criterion is that the adapter reproduces the same verdict a direct Claude-Code-shaped
+# invocation would get, not that its own translation logic is internally self-consistent.
+# ---------------------------------------------------------------------------
+
+_GUARDS_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardsPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { registerGuards } = await import(pathToFileURL(guardsPath).href);
+const { runGuard: realRunGuard } = await import(pathToFileURL(config.guardRunnerPath).href);
+
+const handlers = {};
+const sentMessages = [];
+const notifications = [];
+const stubPi = {
+  on(event, handler) { handlers[event] = handler; },
+  sendMessage(message, options) { sentMessages.push({ message, options }); },
+};
+const stubCtx = {
+  hasUI: true,
+  cwd: config.cwd,
+  signal: undefined,
+  ui: { notify: (msg, level) => notifications.push({ msg, level }) },
+  sessionManager: { getSessionId: () => config.sessionId },
+};
+
+let runGuardCallCount = 0;
+const runGuard = config.forceSpawnFailure
+  ? async () => { throw new Error("forced spawn failure (test)"); }
+  : async (options) => { runGuardCallCount++; return realRunGuard(options); };
+
+registerGuards(stubPi, config.root, { runGuard });
+
+async function toolCall(toolName, input) {
+  return handlers["tool_call"]({ type: "tool_call", toolCallId: "t", toolName, input }, stubCtx);
+}
+
+const out = {};
+out.bashBlocked = await toolCall("bash", { command: "rm -rf /" });
+out.bashAllowed = await toolCall("bash", { command: "ls -la" });
+out.bashBacktickBlocked = await toolCall("bash", { command: "`rm -rf /`" });
+out.writeBlocked = await toolCall("write", { path: "/tmp/f.py", content: config.secretContent });
+out.writeAllowed = await toolCall("write", { path: "/tmp/f.py", content: "print(1)" });
+
+runGuardCallCount = 0;
+out.editShortCircuit = await toolCall("edit", {
+  path: "/tmp/f.py",
+  edits: [
+    { oldText: "a", newText: config.secretContent },
+    { oldText: "b", newText: "safe" },
+  ],
+});
+out.editRunGuardCalls = runGuardCallCount;
+
+out.sessionStart = await handlers["session_start"]({ type: "session_start", reason: "startup" }, stubCtx);
+out.sentAfterSessionStart = sentMessages.slice();
+
+sentMessages.length = 0;
+out.toolResult = await handlers["tool_result"](
+  { type: "tool_result", toolCallId: "t2", toolName: "edit", input: { path: config.tsFilePath }, content: [], isError: false },
+  stubCtx,
+);
+out.sentAfterToolResult = sentMessages.slice();
+
+console.log(JSON.stringify({ out, notifications }));
+"""
+
+_TWO_SESSION_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardsPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { registerGuards } = await import(pathToFileURL(guardsPath).href);
+
+const handlers = {};
+const stubPi = { on(event, handler) { handlers[event] = handler; }, sendMessage() {} };
+
+registerGuards(stubPi, config.root, {});
+
+const results = [];
+for (const sessionId of config.sessionIds) {
+  const sent = [];
+  const ctx = {
+    hasUI: true,
+    cwd: config.cwd,
+    signal: undefined,
+    ui: { notify() {} },
+    sessionManager: { getSessionId: () => sessionId },
+  };
+  const originalSendMessage = stubPi.sendMessage;
+  stubPi.sendMessage = (message, options) => sent.push({ message, options });
+  await handlers["tool_result"](
+    { type: "tool_result", toolCallId: "t", toolName: "edit", input: { path: config.tsFilePath }, content: [], isError: false },
+    ctx,
+  );
+  stubPi.sendMessage = originalSendMessage;
+  results.push({ sessionId, sentCount: sent.length });
+}
+
+console.log(JSON.stringify(results));
+"""
+
+_EMPTY_SESSION_ID_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardsPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { registerGuards } = await import(pathToFileURL(guardsPath).href);
+
+const handlers = {};
+const stubPi = { on(event, handler) { handlers[event] = handler; }, sendMessage() {} };
+registerGuards(stubPi, config.root, {});
+
+const ctx = {
+  hasUI: true,
+  cwd: config.cwd,
+  signal: undefined,
+  ui: { notify() {} },
+  sessionManager: { getSessionId: () => "" },
+};
+
+try {
+  await handlers["tool_result"](
+    { type: "tool_result", toolCallId: "t", toolName: "edit", input: { path: config.tsFilePath }, content: [], isError: false },
+    ctx,
+  );
+  console.log(JSON.stringify({ threw: false }));
+} catch (err) {
+  console.log(JSON.stringify({ threw: true, message: String(err && err.message) }));
+}
+"""
+
+
+def _run_node(driver_src, args, tmp_path_factory, *, label):
+    if _NODE_MAJOR is None or _NODE_MAJOR < 22:
+        pytest.skip("requires Node >= 22")
+    driver = tmp_path_factory.mktemp(label) / "driver.mjs"
+    driver.write_text(driver_src, encoding="utf-8")
+    node = shutil.which("node")
+    assert node is not None
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), *args],
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@pytest.fixture(scope="module")
+def guards_result(tmp_path_factory):
+    import uuid
+
+    config = {
+        "root": str(ROOT),
+        "guardRunnerPath": str(GUARD_RUNNER_TS),
+        "cwd": str(ROOT),
+        # unique per test run — skill_autoload_hint.sh's dedup sentinel is keyed by
+        # session+skill and persists on disk across repeated pytest invocations on the same
+        # machine/day, so a fixed literal here would flake on a second run.
+        "sessionId": f"sess-guards-fixture-{uuid.uuid4().hex}",
+        "secretContent": _SECRET_CONTENT,
+        "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts"),
+        "forceSpawnFailure": False,
+    }
+    return _run_node(_GUARDS_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-driver")
+
+
+@requires_node
+def test_bash_guard_blocks_rm_rf_via_adapter(guards_result):
+    assert guards_result["out"]["bashBlocked"] == {
+        "block": True,
+        "reason": "BLOCKED: destructive rm against root or home",
+    }
+
+
+@requires_node
+def test_bash_guard_allows_safe_command_via_adapter(guards_result):
+    assert guards_result["out"].get("bashAllowed") is None
+
+
+@requires_node
+def test_bash_guard_blocks_401_backtick_vector_via_adapter(guards_result):
+    """Regression coverage for the #401 bypass this PR's hooks/bash_guard.sh fix closes,
+    driven through the real Pi adapter rather than invoking the script directly."""
+    assert guards_result["out"]["bashBacktickBlocked"] == {
+        "block": True,
+        "reason": "BLOCKED: destructive rm against root or home",
+    }
+
+
+@requires_node
+def test_secret_guard_blocks_write_with_secret_via_adapter(guards_result):
+    result = guards_result["out"]["writeBlocked"]
+    assert result["block"] is True
+    assert "BLOCKED: hardcoded secret detected" in result["reason"]
+
+
+@requires_node
+def test_secret_guard_allows_clean_write_via_adapter(guards_result):
+    assert guards_result["out"].get("writeAllowed") is None
+
+
+@requires_node
+def test_edit_guard_checks_one_payload_per_edits_element_and_short_circuits(guards_result):
+    """The blocked edits[] element is FIRST, so only ONE guard-runner call should happen —
+    proving payloads are per-element (not joined) and the loop stops at the first block."""
+    result = guards_result["out"]["editShortCircuit"]
+    assert result["block"] is True
+    assert "line 1" in result["reason"], (
+        "block reason must report a line number against the single new_string that was "
+        "actually sent, not a fabricated line number from a joined multi-edit document"
+    )
+    assert guards_result["out"]["editRunGuardCalls"] == 1, (
+        "guard-runner must not be invoked for edits[] elements after the first block"
+    )
+
+
+@requires_node
+def test_session_start_emits_resume_hint_via_send_message(guards_result):
+    sent = guards_result["out"]["sentAfterSessionStart"]
+    assert len(sent) == 1
+    assert sent[0]["message"]["customType"] == "swe-workbench:workflow-resume-hint"
+    assert sent[0]["message"]["display"] is False
+    assert sent[0]["options"]["deliverAs"] == "nextTurn"
+    assert isinstance(sent[0]["message"]["content"], str) and sent[0]["message"]["content"]
+
+
+@requires_node
+def test_tool_result_emits_skill_hint_via_send_message_steer(guards_result):
+    sent = guards_result["out"]["sentAfterToolResult"]
+    assert len(sent) == 1
+    assert sent[0]["message"]["customType"] == "swe-workbench:skill-autoload-hint"
+    assert sent[0]["options"]["deliverAs"] == "steer"
+    assert "language-typescript" in sent[0]["message"]["content"]
+
+
+@requires_node
+def test_forced_spawn_failure_bash_guard_fails_closed(tmp_path_factory):
+    """Without this test, a `catch { return {} }` that silently flips fail-closed to fail-open
+    would still pass every happy-path test above."""
+    config = {
+        "root": str(ROOT),
+        "guardRunnerPath": str(GUARD_RUNNER_TS),
+        "cwd": str(ROOT),
+        "sessionId": "sess-spawn-fail",
+        "secretContent": _SECRET_CONTENT,
+        "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts"),
+        "forceSpawnFailure": True,
+    }
+    result = _run_node(_GUARDS_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-spawn-fail")
+    assert result["out"]["bashBlocked"]["block"] is True
+    assert result["out"]["bashAllowed"]["block"] is True  # every bash call blocks when the guard itself cannot run
+
+
+@requires_node
+def test_forced_spawn_failure_secret_guard_fails_open(tmp_path_factory):
+    config = {
+        "root": str(ROOT),
+        "guardRunnerPath": str(GUARD_RUNNER_TS),
+        "cwd": str(ROOT),
+        "sessionId": "sess-spawn-fail",
+        "secretContent": _SECRET_CONTENT,
+        "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts"),
+        "forceSpawnFailure": True,
+    }
+    result = _run_node(_GUARDS_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-spawn-fail-2")
+    assert result["out"].get("writeBlocked") is None  # secret_guard.py's spawn failure must fail OPEN
+    assert result["out"].get("editShortCircuit") is None
+
+
+@requires_node
+def test_skill_hint_session_id_is_hard_required_not_pid_fallback(tmp_path_factory):
+    """An empty session id must never silently fall back to skill_autoload_hint.sh's $$ PID
+    sentinel — two Pi sessions sharing one process would then share dedup state (#401 redux)."""
+    config = {"root": str(ROOT), "cwd": str(ROOT), "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts")}
+    result = _run_node(
+        _EMPTY_SESSION_ID_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-empty-session"
+    )
+    assert result["threw"] is True
+    assert "session id" in result["message"].lower()
+
+
+@requires_node
+def test_skill_hint_two_sessions_share_no_adapter_level_dedup_state(tmp_path_factory):
+    """Session A hints once, then is suppressed on a second call for the SAME session (that
+    dedup lives entirely in skill_autoload_hint.sh's own filesystem sentinel). Session B, with a
+    different id, must still get a hint despite A already being fully hinted — proving the
+    adapter itself holds no cross-session Set/Map of its own."""
+    import uuid
+
+    session_a = f"sess-a-{uuid.uuid4().hex}"
+    session_b = f"sess-b-{uuid.uuid4().hex}"
+    config = {
+        "root": str(ROOT),
+        "cwd": str(ROOT),
+        "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts"),
+        "sessionIds": [session_a, session_a, session_b],
+    }
+    results = _run_node(
+        _TWO_SESSION_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-two-session"
+    )
+    assert [r["sessionId"] for r in results] == [session_a, session_a, session_b]
+    assert results[0]["sentCount"] == 1, "session A's first tool_result must produce a hint"
+    assert results[1]["sentCount"] == 0, "session A's second tool_result for the same file must be deduped"
+    assert results[2]["sentCount"] == 1, "session B must still get a hint despite session A already being fully hinted"
+
+
+# ---------------------------------------------------------------------------
+# #607 differential acceptance criterion — Pi-adapter half. tests/test_hooks.py runs the SAME
+# pi_guard_fixtures.BASH_GUARD_FIXTURES set by invoking hooks/bash_guard.sh directly; this
+# drives the identical fixture set through pi/extensions/guards.ts and asserts an identical
+# block/allow verdict.
+# ---------------------------------------------------------------------------
+
+_BASH_FIXTURES_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , guardsPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const { registerGuards } = await import(pathToFileURL(guardsPath).href);
+
+const handlers = {};
+const stubPi = { on(event, handler) { handlers[event] = handler; }, sendMessage() {} };
+registerGuards(stubPi, config.root, {});
+
+const stubCtx = {
+  hasUI: true,
+  cwd: config.cwd,
+  signal: undefined,
+  ui: { notify() {} },
+  sessionManager: { getSessionId: () => "sess-differential" },
+};
+
+const results = [];
+for (const command of config.commands) {
+  const result = await handlers["tool_call"]({ type: "tool_call", toolCallId: "t", toolName: "bash", input: { command } }, stubCtx);
+  results.push(result ? { blocked: true, reason: result.reason } : { blocked: false });
+}
+
+console.log(JSON.stringify(results));
+"""
+
+
+@pytest.fixture(scope="module")
+def bash_fixtures_via_adapter(tmp_path_factory):
+    from pi_guard_fixtures import BASH_GUARD_FIXTURES
+
+    config = {"root": str(ROOT), "cwd": str(ROOT), "commands": [cmd for cmd, _ in BASH_GUARD_FIXTURES]}
+    return _run_node(
+        _BASH_FIXTURES_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-bash-fixtures-driver"
+    )
+
+
+@requires_node
+def test_adapter_verdict_matches_direct_invocation_for_every_fixture(bash_fixtures_via_adapter):
+    from pi_guard_fixtures import BASH_GUARD_FIXTURES
+
+    assert len(bash_fixtures_via_adapter) == len(BASH_GUARD_FIXTURES)
+    mismatches = []
+    for (cmd, expect_blocked), result in zip(BASH_GUARD_FIXTURES, bash_fixtures_via_adapter):
+        if result["blocked"] != expect_blocked:
+            mismatches.append(f"{cmd!r}: expected blocked={expect_blocked}, adapter returned {result}")
+    assert not mismatches, "adapter verdict diverged from direct-invocation verdict:\n" + "\n".join(mismatches)

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -286,9 +286,9 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
 # ---------------------------------------------------------------------------
 # Behavioural: guards.ts driving the REAL hooks/bash_guard.sh + hooks/secret_guard.py +
 # hooks/workflow_resume_hint.sh + hooks/skill_autoload_hint.sh through guard-runner.ts's real
-# spawn (issue #607). Everything below drives the actual scripts, not a mock — the acceptance
-# criterion is that the adapter reproduces the same verdict a direct Claude-Code-shaped
-# invocation would get, not that its own translation logic is internally self-consistent.
+# spawn. Everything below drives the actual scripts, not a mock — the acceptance criterion is
+# that the adapter reproduces the same verdict a direct Claude-Code-shaped invocation would
+# get, not that its own translation logic is internally self-consistent.
 # ---------------------------------------------------------------------------
 
 _GUARDS_DRIVER = """
@@ -474,7 +474,7 @@ def test_bash_guard_allows_safe_command_via_adapter(guards_result):
 
 @requires_node
 def test_bash_guard_blocks_401_backtick_vector_via_adapter(guards_result):
-    """Regression coverage for the #401 bypass this PR's hooks/bash_guard.sh fix closes,
+    """Regression coverage for the backtick rm -rf bypass hooks/bash_guard.sh now closes,
     driven through the real Pi adapter rather than invoking the script directly."""
     assert guards_result["out"]["bashBacktickBlocked"] == {
         "block": True,
@@ -627,7 +627,7 @@ def test_missing_script_exits_127_and_bash_guard_still_fails_closed(tmp_path_fac
 @requires_node
 def test_skill_hint_session_id_is_hard_required_not_pid_fallback(tmp_path_factory):
     """An empty session id must never silently fall back to skill_autoload_hint.sh's $$ PID
-    sentinel — two Pi sessions sharing one process would then share dedup state (#401 redux)."""
+    sentinel — two Pi sessions sharing one process would then share dedup state."""
     config = {"root": str(ROOT), "cwd": str(ROOT), "tsFilePath": str(ROOT / "pi" / "extensions" / "index.ts")}
     result = _run_node(
         _EMPTY_SESSION_ID_DRIVER, [str(GUARDS_TS), json.dumps(config)], tmp_path_factory, label="pi-guards-empty-session"
@@ -662,7 +662,7 @@ def test_skill_hint_two_sessions_share_no_adapter_level_dedup_state(tmp_path_fac
 
 
 # ---------------------------------------------------------------------------
-# #607 differential acceptance criterion — Pi-adapter half. tests/test_hooks.py runs the SAME
+# Differential acceptance criterion — Pi-adapter half. tests/test_hooks.py runs the SAME
 # pi_guard_fixtures.BASH_GUARD_FIXTURES set by invoking hooks/bash_guard.sh directly; this
 # drives the identical fixture set through pi/extensions/guards.ts and asserts an identical
 # block/allow verdict.


### PR DESCRIPTION
## Summary
- Fixes `hooks/bash_guard.sh` to block backtick, `$(...)`, process-substitution (`<(...)`/`>(...)`), and quote-wrapped/backslash-escaped `rm -rf` bypasses (issue #401, previously closed NOT_PLANNED without the underlying bug ever being fixed).
- Adds a Pi Coding Agent adapter (`pi/extensions/cc-payload.ts`, `guard-runner.ts`, `guards.ts`) that reproduces `hooks/bash_guard.sh` and `hooks/secret_guard.py` on Pi by exec'ing them unchanged via `node:child_process` — never reimplementing guard logic in TypeScript — and translates Pi's session/tool-result events into `hooks/workflow_resume_hint.sh`/`hooks/skill_autoload_hint.sh` calls delivered via `pi.sendMessage`.
- `bash_guard.sh` fails closed on spawn/exit failure (a broken security control blocks rather than silently allowing); `secret_guard.py` fails open, but never silently.
- `session_start`/`session_compact` resume hints are gated on `ctx.isProjectTrusted()` since they inject repo-committed checkpoint content into model context.
- Adds golden-inventory contract ratchets (`tests/test_pi_contract.py`) and behavioural tests (`tests/test_pi_extension.py`) driving the real hooks end-to-end, plus a differential fixture set (`tests/pi_guard_fixtures.py`) shared with `tests/test_hooks.py` so the Pi adapter's verdict is asserted identical to a direct `bash_guard.sh` invocation.
- Documents `hooks/worktree_permission_grant.sh` as permanently N/A on Pi (no permission-prompt surface to target) in `docs/plugin-platform-decisions.md` §6 and as an explicit row in the contract test inventory. `skill_usage_record.sh`/`skill_usage_flush.sh` stay unwired, deferred to #608/#610 (Skill tool and subagents don't exist on Pi yet).

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `shellcheck --severity=warning hooks/*.sh` — 0 issues
- [x] `npm run typecheck --prefix pi` — 0 errors
- [x] `pytest tests/ -q` — 2713 passed, 2 skipped (pre-existing, unrelated)
- [x] Live-verified `hooks/bash_guard.sh` against the full #401 vector set plus the process-substitution/quote-wrap vectors found in post-implementation security review — all block; existing allow-list still passes
- [x] Live-verified the Pi adapter end-to-end (`node --experimental-strip-types`) against real `bash_guard.sh`/`secret_guard.py`/`workflow_resume_hint.sh`/`skill_autoload_hint.sh` — block/allow verdicts match direct invocation, fail-closed/fail-open postures confirmed under forced spawn failure

### Type-tailored checks (feat)
- [x] New behavior (guard/hint translation to Pi) has dedicated test coverage, not just incidental coverage from other tests
- [x] Edge cases covered: per-`edits[]` payload splitting with short-circuit on first block, empty `session_id` hard error, two-Pi-sessions-in-one-process dedup independence, forced spawn failure fail-closed vs fail-open

Closes #607
