### PR TITLE
[feat] Pi: tool vocabulary + ask_user_question (#608)

### DIFF
--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -125,3 +125,27 @@ permission *for*.
 Recorded as an explicit `"n/a"` row in `tests/test_pi_contract.py`'s `HOOK_PI_STATUS` inventory
 — distinct from `"deferred"` (`skill_usage_record.sh`/`skill_usage_flush.sh`, unwired only until
 `Skill`/subagents exist on Pi). `"n/a"` never graduates to `"wired"`.
+
+## 7. `EnterWorktree`/`ExitWorktree` have no Pi equivalent — documented N/A, not deferred
+
+The tool-vocabulary preamble (`pi/extensions/tool-vocab.ts`) maps every Claude Code tool name
+this repo's prose uses to a Pi equivalent, except one: there is no Pi primitive that anchors a
+session to a different working directory the way `EnterWorktree`/`ExitWorktree` do.
+
+`dist/core/session-cwd.d.ts` only validates that a session's recorded cwd still exists on disk
+(`getMissingSessionCwdIssue`, `assertSessionCwdExists`) — it never changes it.
+`ExtensionContext.cwd` (`dist/core/extensions/types.d.ts`) is a plain read-only `string`; neither
+`ExtensionContext` nor `ExtensionCommandContext` exposes a `setCwd`. There is nothing for a
+worktree-anchoring tool to call.
+
+A `cd`-shelling tool named `EnterWorktree` would be worse than none: `skills/workflow-worktree-session/SKILL.md`
+teaches a specific cd-vs-`EnterWorktree` distinction — `cd` only anchors the Bash subprocess's
+cwd, while `EnterWorktree` re-anchors session-level caches (plans dir, memory dir) that `cd`
+cannot touch. A tool that shells out to `cd` under the `EnterWorktree` name would claim the
+stronger guarantee while delivering only the weaker one, silently breaking that diagnostic for
+every Pi session.
+
+No prose edit and no new tool. `tool-vocab.ts`'s worktree note tells the model the `cd
+<absolute-path>` fallback documented in `skills/workflow-worktree-session/SKILL.md` (lines 30 and
+87 as of this writing) is *the* mechanism on Pi, not a last resort. Recorded as an explicit
+`"n/a"`-shaped decision here — mirroring §6 — rather than left implicit.

--- a/pi/extensions/ask-user.ts
+++ b/pi/extensions/ask-user.ts
@@ -1,0 +1,153 @@
+/**
+ * Registers `ask_user_question`, Pi's counterpart to Claude Code's `AskUserQuestion`. Mirrors
+ * guards.ts's `registerGuards(pi, root)` shape so index.ts stays a flat composition root.
+ *
+ * The schema below is written as a plain JSON-Schema object literal, not built with TypeBox —
+ * `wrapToolDefinition` (dist/core/tools/tool-definition-wrapper.js) copies `definition.parameters`
+ * through to the runtime verbatim, and nothing on the tool-registration path runs TypeBox's
+ * `Value.Check`/`Compile` against it. Importing the typebox package as a value would also break
+ * the pytest driver, which runs this file under `node --experimental-strip-types` with no
+ * bundler and no node_modules alias resolution for that package's nested install location.
+ * `ToolDefinition["parameters"]` (a type-only reference into the SDK's own re-export) gives the
+ * exact same `TSchema` type — an empty interface every object literal already satisfies —
+ * without that import.
+ */
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+interface AskUserOption {
+  label: string;
+  description?: string;
+}
+
+interface AskUserQuestionItem {
+  question: string;
+  header: string;
+  multiSelect: boolean;
+  options: AskUserOption[];
+}
+
+interface AskUserQuestionParams {
+  questions: AskUserQuestionItem[];
+}
+
+const QUESTIONS_SCHEMA = {
+  type: "object",
+  properties: {
+    questions: {
+      type: "array",
+      minItems: 1,
+      maxItems: 4,
+      items: {
+        type: "object",
+        properties: {
+          question: { type: "string", description: "The complete question to ask the user." },
+          header: { type: "string", description: "Short label (<=12 chars) shown as a chip." },
+          multiSelect: {
+            type: "boolean",
+            description: "Must be false — ask_user_question does not support multi-select.",
+          },
+          options: {
+            type: "array",
+            minItems: 2,
+            maxItems: 4,
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                description: { type: "string" },
+              },
+              required: ["label"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["question", "header", "options", "multiSelect"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["questions"],
+  additionalProperties: false,
+} as ToolDefinition["parameters"];
+
+function optionLabel(option: AskUserOption): string {
+  return option.description ? `${option.label} — ${option.description}` : option.label;
+}
+
+export function registerAskUser(pi: ExtensionAPI): void {
+  // Read once per process at registration time — an immutable config read, not the #401
+  // module-state anti-pattern (nothing here mutates after this check). Gates Tier-2 tool
+  // registration only; Tier-1 vocabulary prose (tool-vocab.ts) stays on unconditionally.
+  if (process.env.SWE_WORKBENCH_PI_TOOLS === "0") return;
+
+  pi.registerTool({
+    name: "ask_user_question",
+    label: "Ask User Question",
+    description:
+      "Ask the user one or more fixed-option questions and return their picks. Use only when " +
+      "a decision genuinely belongs to the user — never as a substitute for a reasonable default.",
+    promptSnippet:
+      "ask_user_question(questions): present the user 1-4 fixed-option questions (2-4 options " +
+      "each) and get their picks back. Use when blocked on a decision only the user can make.",
+    promptGuidelines: [
+      "Never fabricate a free-text \"Other\" option — ask_user_question only supports fixed choices.",
+      "Each question is single-select. To collect more than one choice per question, ask " +
+        "separate sequential single-select questions instead of setting multiSelect.",
+    ],
+    parameters: QUESTIONS_SCHEMA,
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      if (!ctx.hasUI) {
+        throw new Error(
+          "ask_user_question requires an interactive UI, but none is available in this mode " +
+            "(print/json). Re-run interactively, or supply the decision directly in the prompt " +
+            "instead of asking.",
+        );
+      }
+
+      const { questions } = params as unknown as AskUserQuestionParams;
+      const multiSelectQuestion = questions.find((q) => q.multiSelect);
+      if (multiSelectQuestion) {
+        throw new Error(
+          `ask_user_question: multiSelect is not supported — re-ask "${multiSelectQuestion.question}" ` +
+            "as sequential single-select questions instead.",
+        );
+      }
+
+      // answers[] is keyed by question text (see below) — a duplicate would silently overwrite
+      // an earlier answer with no error surfaced, one of the user's picks vanishing unnoticed.
+      const seen = new Set<string>();
+      const duplicate = questions.find((q) => {
+        if (seen.has(q.question)) return true;
+        seen.add(q.question);
+        return false;
+      });
+      if (duplicate) {
+        throw new Error(
+          `ask_user_question: duplicate question text "${duplicate.question}" — each question ` +
+            "in one call must be distinct text, since answers are returned keyed by question.",
+        );
+      }
+
+      const answers: Record<string, string> = {};
+      for (const q of questions) {
+        const choice = await ctx.ui.select(
+          q.question,
+          q.options.map(optionLabel),
+          { signal },
+        );
+        if (choice === undefined) {
+          throw new Error(
+            `ask_user_question: the user dismissed "${q.question}" without choosing an option — ` +
+              "stop and check in with the user rather than assuming an answer.",
+          );
+        }
+        answers[q.question] = choice;
+      }
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(answers) }],
+        details: answers,
+      };
+    },
+  });
+}

--- a/pi/extensions/ask-user.ts
+++ b/pi/extensions/ask-user.ts
@@ -75,9 +75,9 @@ function optionLabel(option: AskUserOption): string {
 }
 
 export function registerAskUser(pi: ExtensionAPI): void {
-  // Read once per process at registration time — an immutable config read, not the #401
-  // module-state anti-pattern (nothing here mutates after this check). Gates Tier-2 tool
-  // registration only; Tier-1 vocabulary prose (tool-vocab.ts) stays on unconditionally.
+  // Read once per process at registration time — an immutable config read, not a module-state
+  // anti-pattern (nothing here mutates after this check). Gates Tier-2 tool registration only;
+  // Tier-1 vocabulary prose (tool-vocab.ts) stays on unconditionally.
   if (process.env.SWE_WORKBENCH_PI_TOOLS === "0") return;
 
   pi.registerTool({

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -138,9 +138,9 @@ export default function (pi: ExtensionAPI): void {
   // registerGuards must register first: emitToolCall (runner.js:701) runs tool_call handlers in
   // registration order and short-circuits only on `block: true`, so a later-registered guard
   // would be a silent security regression. registerAskUser adds no tool_call handler today, but
-  // a future one (#609/#610) must be added after this line too — and emitToolCall has no
-  // try/catch around a handler's body (unlike emitUserBash), so any future tool_call handler
-  // must wrap its own body and return undefined on throw.
+  // a future one must be added after this line too — and emitToolCall has no try/catch around a
+  // handler's body (unlike emitUserBash), so any future tool_call handler must wrap its own body
+  // and return undefined on throw.
   registerGuards(pi, root);
   registerAskUser(pi);
 }

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -31,7 +31,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { registerAskUser } from "./ask-user.ts";
 import { registerGuards } from "./guards.ts";
+import { toolVocabSection } from "./tool-vocab.ts";
 
 class PluginRootNotFoundError extends Error {
   constructor(startDir: string) {
@@ -74,8 +76,9 @@ function extractCurrentScripts(readmeText: string): string | null {
 /**
  * Reads bin/README.md and extracts the "## Current scripts" section. Returns null on any
  * failure (file missing/unreadable, or heading missing) — this is a doc file, not load-bearing
- * for PATH exposure or skill discovery, so its absence must degrade the preamble feature alone,
- * never take down the whole extension.
+ * for PATH exposure or skill discovery, so its absence must degrade only the bin-scripts row of
+ * the preamble, never take down the whole extension or the rest of the preamble (in particular,
+ * toolVocabSection's content — including the anti-hallucination rule — must still be injected).
  */
 function readCurrentScripts(binDir: string): string | null {
   let readmeText: string;
@@ -97,13 +100,17 @@ export default function (pi: ExtensionAPI): void {
     process.env.PATH = [...pathEntries, binDir].join(delimiter);
   }
 
+  // Only the bin-scripts section depends on bin/README.md; toolVocabSection is pure and never
+  // fails, so it must NOT be dragged down by a missing/unreadable README — Tier-1 vocabulary
+  // prose (including the anti-hallucination rule) stays on unconditionally, same posture as
+  // ask-user.ts's kill switch. composePreamble is still called exactly once, so the single
+  // PREAMBLE_MARKER dedup check keeps proving something real.
   const currentScripts = readCurrentScripts(binDir);
-  const preamble =
+  const binSection =
     currentScripts === null
-      ? null
-      : composePreamble([
-          { title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts },
-        ]);
+      ? []
+      : [{ title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts }];
+  const preamble = composePreamble([...binSection, toolVocabSection(root)]);
 
   let warnedMissingAnchor = false;
 
@@ -113,7 +120,7 @@ export default function (pi: ExtensionAPI): void {
   }));
 
   pi.on("session_start", (_event, ctx: ExtensionContext) => {
-    if (preamble === null && !warnedMissingAnchor && ctx.hasUI) {
+    if (currentScripts === null && !warnedMissingAnchor && ctx.hasUI) {
       warnedMissingAnchor = true;
       ctx.ui.notify(
         "swe-workbench: bin/README.md's '## Current scripts' section could not be read — the " +
@@ -124,10 +131,16 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("before_agent_start", (event) => {
-    if (preamble === null) return;
     if (event.systemPrompt.includes(PREAMBLE_MARKER)) return;
     return { systemPrompt: event.systemPrompt + preamble };
   });
 
+  // registerGuards must register first: emitToolCall (runner.js:701) runs tool_call handlers in
+  // registration order and short-circuits only on `block: true`, so a later-registered guard
+  // would be a silent security regression. registerAskUser adds no tool_call handler today, but
+  // a future one (#609/#610) must be added after this line too — and emitToolCall has no
+  // try/catch around a handler's body (unlike emitUserBash), so any future tool_call handler
+  // must wrap its own body and return undefined on throw.
   registerGuards(pi, root);
+  registerAskUser(pi);
 }

--- a/pi/extensions/tool-vocab.ts
+++ b/pi/extensions/tool-vocab.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure text for the Claude-Code -> Pi tool-vocabulary preamble section.
+ *
+ * Layer: domain. This file must import NOTHING from the Pi SDK, not even as a type — only
+ * node:fs/node:path. Composing it into the system prompt (composePreamble) is index.ts's job.
+ */
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Exactly Pi's built-in tools that correspond to a Claude Code tool this repo's prose names. */
+const RENAME_TABLE: ReadonlyArray<readonly [string, string]> = [
+  ["Read", "read"],
+  ["Write", "write"],
+  ["Edit", "edit"],
+  ["Bash", "bash"],
+  ["Grep", "grep"],
+  ["Glob", "find"],
+  ["LS", "ls"],
+];
+
+function renameTableSection(): string {
+  const rows = RENAME_TABLE.map(([cc, pi]) => `| \`${cc}\` | \`${pi}\` |`).join("\n");
+  return (
+    "Claude Code tool names this repo's skills/commands/agents prose uses map to these Pi " +
+    "built-ins:\n\n| Claude Code | Pi |\n| --- | --- |\n" +
+    rows
+  );
+}
+
+/** Directory names under skills/ that contain a SKILL.md — by construction the exact set Phase
+ *  1's resources_discover hands Pi via skillPaths, so this legend cannot drift from it. Returns
+ *  null (never throws) on any read failure, mirroring index.ts's readCurrentScripts posture. */
+function readSkillIds(root: string): string[] | null {
+  try {
+    return readdirSync(join(root, "skills"), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(join(root, "skills", entry.name, "SKILL.md")))
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return null;
+  }
+}
+
+function skillLegendSection(root: string): string {
+  const rule =
+    "Where prose writes `swe-workbench:<id>`, the Pi equivalent is `/skill:<id>` — the " +
+    "`swe-workbench:` prefix is a Claude Code namespace, not part of the Pi skill id.";
+  const superpowersNote =
+    "This repo's prose also delegates to `superpowers:<id>` skills (e.g. " +
+    "`superpowers:brainstorming`, `superpowers:executing-plans`) — Pi does not bundle " +
+    "Superpowers. Install it as its own Pi package first (`pi install " +
+    "git:github.com/obra/superpowers`); the same drop-the-namespace-prefix rule then applies: " +
+    "`superpowers:<id>` -> `/skill:<id>`.";
+  const ids = readSkillIds(root);
+  const withList = ids === null ? rule : `${rule} Available ids: ${ids.join(", ")}.`;
+  return `${withList} ${superpowersNote}`;
+}
+
+const ASK_USER_QUESTION_SECTION =
+  "`AskUserQuestion` is `ask_user_question` on Pi — same intent (present the user a small set " +
+  "of options and get a single choice back), different tool name.";
+
+const EXIT_PLAN_MODE_SECTION =
+  "Pi has no plan mode, so there is no `ExitPlanMode` tool call. Where prose says \"before " +
+  "`ExitPlanMode`\" or \"passed to `ExitPlanMode`\", read it as \"before you begin editing " +
+  "files.\" The `## Workflow` section embedding obligation that prose attaches to that moment " +
+  "is unchanged.";
+
+const WORKTREE_SECTION =
+  "Pi has no session-anchoring tool (no `EnterWorktree`/`ExitWorktree` equivalent). Where " +
+  "prose offers `EnterWorktree` with a `cd <absolute-path>` fallback, on Pi the `cd` branch " +
+  "is *the* mechanism, not a last resort — always use it.";
+
+// Verbatim from superpowers:using-superpowers' Pi reference (references/pi-tools.md): the
+// no-subagent-tool and no-task-list paragraphs, so a Pi session never invents a capability Pi
+// core does not ship.
+const ANTI_HALLUCINATION_SECTION =
+  "Pi core does not ship a standard subagent tool. The `pi-subagents` package is a strong " +
+  "optional companion and provides a `subagent` tool with single-agent, chain, parallel, " +
+  "async, forked-context, and resume/status workflows. If no subagent tool is available, do " +
+  "not fabricate `Task` calls; execute sequentially in the current session or explain that the " +
+  "optional subagent capability is not installed.\n\n" +
+  "Pi core does not ship a standard task-list tool. If a todo/task extension is installed, use " +
+  "its documented tool. Otherwise use Superpowers plan files, checklists in Markdown, or a " +
+  "repo-local `TODO.md` for task tracking. Older Superpowers docs may refer to `TodoWrite`; " +
+  "treat that as the task-tracking action above.";
+
+/** Returns the {title, body}-shaped section composePreamble expects for the CC->Pi tool
+ *  vocabulary this repo's shared prose (skills/, commands/, agents/) assumes. */
+export function toolVocabSection(root: string): { title: string; body: string } {
+  const body = [
+    renameTableSection(),
+    skillLegendSection(root),
+    ASK_USER_QUESTION_SECTION,
+    EXIT_PLAN_MODE_SECTION,
+    WORKTREE_SECTION,
+    ANTI_HALLUCINATION_SECTION,
+  ].join("\n\n");
+  return { title: "Claude Code -> Pi tool vocabulary", body };
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ import pytest
 # Tests that want to exercise the session-scratchpad path opt in explicitly via
 # env={**_CLEAN_ENV, "CLAUDE_CODE_SESSION_ID": "<fake-uuid>"}.
 #
+# SWE_WORKBENCH_PI_TOOLS is also stripped: it's the pi/extensions/ask-user.ts kill switch. If a
+# developer or CI shell happens to export it (plausible while testing the kill switch itself),
+# every "registers by default" test in tests/test_pi_extension.py and test_pi_contract.py would
+# fail unexpectedly on an unrelated ambient value. Tests that want to exercise the kill switch
+# opt in explicitly via env={**_CLEAN_ENV, "SWE_WORKBENCH_PI_TOOLS": "0"}.
+#
 # Snapshot: built once from os.environ at pytest collection time. Session-scoped
 # fixtures that mutate GIT_* vars after import will not be reflected here.
 #
@@ -44,6 +50,7 @@ _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
         if not k.startswith("GIT_")
         and k != "GITHUB_STEP_SUMMARY"
         and k != "CLAUDE_CODE_SESSION_ID"
+        and k != "SWE_WORKBENCH_PI_TOOLS"
     }
     | {
         "GIT_CONFIG_NOSYSTEM": "1",

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -253,27 +253,49 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
 _EXTENSION_TS_FILES = sorted(EXTENSIONS_DIR.glob("*.ts"))
 _NON_INDEX_TS_FILES = [p for p in _EXTENSION_TS_FILES if p.name != "index.ts"]
 
-_PACKAGE_IMPORT_RE = re.compile(
+_IMPORT_FROM_RE = re.compile(
     # [^}]* (not a DOTALL .*?) so this cannot swallow past the FIRST closing brace it meets —
     # a lazy .*? still crosses unrelated statements in between when the file has multiple
-    # `import ... from "..."` blocks between the first "import" keyword and this package name.
-    r'import\s+(type\s+)?\{[^}]*\}\s+from\s+["\']@earendil-works/pi-coding-agent["\']',
+    # `import ... from "..."` blocks in one file. The `\*\s+as\s+\S+` alternative is required
+    # separately from `\S+` — for `import * as Type from "typebox"`, `\S+` greedily consumes
+    # only `*` (stops at the following space), and then `\s+from` fails to match "as Type
+    # from...", so the WHOLE alternation fails at that position with no backtrack into a
+    # shorter match; without this explicit alternative a namespace import silently never
+    # matches at all, rather than merely mis-capturing.
+    r'import\s+(type\s+)?(?:\{[^}]*\}|\*\s+as\s+\S+|\S+)\s+from\s+["\']([^"\']+)["\']',
 )
 
+# Bare side-effect imports (`import "polyfill"`) have no `from` clause at all, so they never
+# match _IMPORT_FROM_RE regardless of alternation — a structurally separate pattern, not a gap
+# in the one above.
+_IMPORT_SIDE_EFFECT_RE = re.compile(r'import\s+(type\s+)?["\']([^"\']+)["\']')
 
-def test_every_sdk_import_under_extensions_is_type_only():
-    """Every narrowing this adapter does uses a manual `toolName === "..."` check plus a type
-    cast instead of the SDK's `isToolCallEventType` runtime helper, so no import here needs to
-    be a value import."""
+
+def test_no_extension_file_has_a_value_import_of_a_bare_specifier():
+    """Every @earendil-works/pi-coding-agent import here is `import type` (this adapter narrows
+    tool events with a manual `toolName === "..."` check plus a cast, never the SDK's
+    `isToolCallEventType` runtime helper) — but the real rationale is broader than that one
+    package: tests/test_pi_extension.py and test_pi_contract.py drive these files under
+    `node --experimental-strip-types`, which has no bundler, no jiti, and no node_modules alias
+    resolution beyond plain Node module resolution. A value import of ANY bare specifier (a
+    package name, not `node:*` or a relative `./*.ts` path) breaks that harness the same way a
+    value import of the SDK would — e.g. `import { Type } from "typebox"` would sail through the
+    old package-name-hardcoded check while still breaking every pytest run. Zero violations
+    today; this is a pure strengthening, not a behavior change."""
     violations = []
     for path in _EXTENSION_TS_FILES:
         text = path.read_text(encoding="utf-8")
-        for match in _PACKAGE_IMPORT_RE.finditer(text):
-            if match.group(1) is None:
+        for pattern in (_IMPORT_FROM_RE, _IMPORT_SIDE_EFFECT_RE):
+            for match in pattern.finditer(text):
+                is_type_only, specifier = match.group(1), match.group(2)
+                if is_type_only is not None:
+                    continue
+                if specifier.startswith("node:") or specifier.startswith("./") or specifier.startswith("../"):
+                    continue
                 violations.append(f"{path.relative_to(ROOT)}: {match.group(0)!r}")
     assert not violations, (
-        "every import of @earendil-works/pi-coding-agent under pi/extensions/ must be "
-        f"`import type` — found non-type-only import(s):\n" + "\n".join(violations)
+        "pi/extensions/*.ts must not value-import any bare specifier (only `node:*` or a "
+        f"relative `./*.ts` import may be a value import) — found:\n" + "\n".join(violations)
     )
 
 
@@ -452,8 +474,8 @@ def test_referenced_fields_actually_appear_in_hook_source():
 
 # hooks/*.sh|py -> Pi wiring status. "wired": translated by guards.ts this phase. "n/a": the
 # concept the hook manipulates does not exist on Pi (documented in
-# docs/plugin-platform-decisions.md §6). "deferred": not wired yet because the Pi tool it needs
-# (Skill / subagents) doesn't exist until #608/#610 — tracked there, not here.
+# docs/plugin-platform-decisions.md §6). "deferred": not wired yet because the Pi capability it
+# needs (subagents) doesn't exist yet — tracked on the follow-up issue, not here.
 HOOK_PI_STATUS = {
     "bash_guard.sh": "wired",
     "secret_guard.py": "wired",
@@ -528,3 +550,59 @@ def test_pi_extension_wires_commands_as_prompt_paths():
     text = PI_EXTENSIONS_INDEX.read_text(encoding="utf-8")
     assert "promptPaths" in text
     assert 'join(root, "commands")' in text
+
+
+# ---------------------------------------------------------------------------
+# ask_user_question schema-as-data ratchet. Pins pi/extensions/ask-user.ts's parameters to a
+# plain JSON-Schema object literal — never a TypeBox value import — since
+# @earendil-works/pi-ai's constrained-sampling.js (getJsonSchemaToolParameters, ~line 112 as of
+# pi-coding-agent@0.84.2) returns `tool.parameters` verbatim to the provider and nothing on the
+# registration path (dist/core/tools/tool-definition-wrapper.js) runs TypeBox's
+# Value.Check/Compile against it. Re-diff that citation directly if this test ever needs to
+# change: `grep -n getJsonSchemaToolParameters` against the installed pi-ai package.
+# ---------------------------------------------------------------------------
+
+_ASK_USER_SCHEMA_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const mod = await import(pathToFileURL(process.argv[2]).href);
+let registered;
+const stubPi = { registerTool(tool) { registered = tool; } };
+mod.registerAskUser(stubPi);
+console.log(JSON.stringify({ parameters: registered.parameters, hasPromptSnippet: typeof registered.promptSnippet === "string" && registered.promptSnippet.length > 0 }));
+"""
+
+ASK_USER_TS = EXTENSIONS_DIR / "ask-user.ts"
+
+
+@requires_node
+def test_ask_user_question_parameters_is_a_plain_json_schema_object():
+    node = shutil.which("node")
+    assert node is not None
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "ask-user-schema-dump.mjs"
+        driver.write_text(_ASK_USER_SCHEMA_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(ASK_USER_TS)],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    dumped = json.loads(result.stdout)
+    parameters = dumped["parameters"]
+    assert isinstance(parameters, dict), "parameters must serialize as a plain JSON object"
+    assert parameters.get("type") == "object"
+    assert "questions" in parameters.get("properties", {})
+    assert dumped["hasPromptSnippet"] is True, (
+        "custom tools are omitted from the system prompt's Available tools section without a "
+        "promptSnippet — ask_user_question must always carry one"
+    )
+
+
+def test_ask_user_ts_has_no_typebox_import():
+    text = ASK_USER_TS.read_text(encoding="utf-8")
+    assert '"typebox"' not in text and "'typebox'" not in text, (
+        "ask-user.ts must derive its parameter type from the SDK's own ToolDefinition re-export, "
+        "never by importing typebox directly — see the file's own module docstring for why"
+    )

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -25,7 +25,10 @@ PACKAGE_JSON = ROOT / "pi" / "package.json"
 INDEX_TS = ROOT / "pi" / "extensions" / "index.ts"
 GUARDS_TS = ROOT / "pi" / "extensions" / "guards.ts"
 GUARD_RUNNER_TS = ROOT / "pi" / "extensions" / "guard-runner.ts"
+TOOL_VOCAB_TS = ROOT / "pi" / "extensions" / "tool-vocab.ts"
+ASK_USER_TS = ROOT / "pi" / "extensions" / "ask-user.ts"
 BIN_README = ROOT / "bin" / "README.md"
+SKILLS_DIR = ROOT / "skills"
 
 # Concatenated (not a single literal) so this fixture's shape never appears contiguous in this
 # file's own source — this file is not on secret_guard.py's allowlist (unlike
@@ -45,6 +48,7 @@ const stubPi = {
   on(event, handler) {
     handlers[event] = handler;
   },
+  registerTool() {},
 };
 const stubCtx = { hasUI: true, ui: { notify() {} } };
 
@@ -234,6 +238,35 @@ def test_before_agent_start_injects_marker_and_first_script_row(extension_result
 
 
 @requires_node
+def test_before_agent_start_injects_tool_vocab_section(extension_result):
+    injected = extension_result["firstInjection"]["systemPrompt"]
+    assert "Claude Code -> Pi tool vocabulary" in injected
+    assert "| `Read` | `read` |" in injected
+    assert "ask_user_question" in injected
+
+
+@requires_node
+def test_tool_vocab_preamble_survives_the_kill_switch(tmp_path_factory):
+    """SWE_WORKBENCH_PI_TOOLS=0 gates Tier-2 tool registration only — the Tier-1 vocabulary
+    prose must stay unconditional, since disabling it makes the session worse, not safer."""
+    driver = tmp_path_factory.mktemp("pi-extension-driver-kill-switch") / "driver.mjs"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    node = shutil.which("node")
+    assert node is not None
+    run_env = dict(_CLEAN_ENV)
+    run_env["SWE_WORKBENCH_PI_TOOLS"] = "0"
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), str(INDEX_TS)],
+        capture_output=True, text=True, env=run_env, timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    injected = parsed["firstInjection"]["systemPrompt"]
+    assert "Claude Code -> Pi tool vocabulary" in injected
+    assert "| `Read` | `read` |" in injected
+
+
+@requires_node
 def test_before_agent_start_does_not_duplicate_on_already_injected_prompt(extension_result):
     # Second call received a prompt that already contains the marker; it must be a no-op.
     # A void handler return serializes as an absent key, not JSON null.
@@ -247,7 +280,9 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
 
     Regression test: the extension used to read bin/README.md unguarded, so a missing file
     threw synchronously inside the factory — which fails the whole extension, not just the
-    system-prompt preamble feature (the one failure mode the code already degrades for).
+    bin-scripts row of the preamble (the one failure mode the code already degrades for). The
+    rest of the preamble — tool-vocab.ts's content, including the anti-hallucination rule —
+    must still be injected; only the bin-scripts row disappears.
     """
     synthetic_root = tmp_path_factory.mktemp("pi-synthetic-root")
     (synthetic_root / ".claude-plugin").mkdir()
@@ -257,7 +292,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     synthetic_index = synthetic_root / "pi" / "extensions" / "index.ts"
     synthetic_index.parent.mkdir(parents=True)
     synthetic_index.write_text(INDEX_TS.read_text(encoding="utf-8"), encoding="utf-8")
-    for helper in ("guards.ts", "cc-payload.ts", "guard-runner.ts"):
+    for helper in ("guards.ts", "cc-payload.ts", "guard-runner.ts", "tool-vocab.ts", "ask-user.ts"):
         (synthetic_index.parent / helper).write_text(
             (ROOT / "pi" / "extensions" / helper).read_text(encoding="utf-8"), encoding="utf-8"
         )
@@ -280,7 +315,10 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
         "promptPaths": [str(synthetic_root / "commands")],
     }
     assert str(synthetic_root / "bin") in parsed["pathEntries"]
-    assert "systemPrompt" not in (parsed.get("firstInjection") or {})
+    injected = parsed["firstInjection"]["systemPrompt"]
+    assert "<!-- swe-workbench:pi-bin-preamble -->" in injected
+    assert "swe-workbench-clean-ephemeral" not in injected, "bin-scripts row must be absent"
+    assert "Claude Code -> Pi tool vocabulary" in injected, "tool-vocab section must still inject"
 
 
 # ---------------------------------------------------------------------------
@@ -787,3 +825,179 @@ def test_adapter_verdict_matches_direct_invocation_for_every_fixture(bash_fixtur
         if result["blocked"] != expect_blocked:
             mismatches.append(f"{cmd!r}: expected blocked={expect_blocked}, adapter returned {result}")
     assert not mismatches, "adapter verdict diverged from direct-invocation verdict:\n" + "\n".join(mismatches)
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: tool-vocab.ts. Pure text generation — no stub `pi`/`ctx` needed, but still
+# imported through Node under --experimental-strip-types since it is a .ts module.
+# ---------------------------------------------------------------------------
+
+_TOOL_VOCAB_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, root] = process.argv;
+const mod = await import(pathToFileURL(modPath).href);
+const section = mod.toolVocabSection(root);
+console.log(JSON.stringify(section));
+"""
+
+
+def _tool_vocab_section(root, tmp_path_factory):
+    return _run_node(_TOOL_VOCAB_DRIVER, [str(TOOL_VOCAB_TS), str(root)], tmp_path_factory, label="pi-tool-vocab-driver")
+
+
+@requires_node
+def test_tool_vocab_section_has_rename_table_and_legend_rule(tmp_path_factory):
+    section = _tool_vocab_section(ROOT, tmp_path_factory)
+    assert section["title"] == "Claude Code -> Pi tool vocabulary"
+    for cc_name, pi_name in [("Read", "read"), ("Write", "write"), ("Edit", "edit"), ("Bash", "bash"), ("Grep", "grep"), ("Glob", "find"), ("LS", "ls")]:
+        assert f"`{cc_name}`" in section["body"] and f"`{pi_name}`" in section["body"]
+    assert "swe-workbench:<id>" in section["body"] and "/skill:<id>" in section["body"]
+    assert "superpowers:<id>" in section["body"]
+    assert "ask_user_question" in section["body"]
+    assert "ExitPlanMode" in section["body"]
+    assert "EnterWorktree" in section["body"]
+    assert "fabricate `Task` calls" in section["body"]
+
+
+@requires_node
+def test_tool_vocab_generated_skill_id_list_matches_disk(tmp_path_factory):
+    section = _tool_vocab_section(ROOT, tmp_path_factory)
+    on_disk = sorted(p.parent.name for p in SKILLS_DIR.glob("*/SKILL.md"))
+    for skill_id in on_disk:
+        assert skill_id in section["body"], f"{skill_id} missing from the generated skill legend"
+
+
+@requires_node
+def test_tool_vocab_missing_skills_dir_degrades_to_rule_without_list(tmp_path_factory):
+    """A root with no skills/ directory at all must not throw — the legend degrades to the bare
+    rule, mirroring index.ts's readCurrentScripts posture for a missing bin/README.md."""
+    synthetic_root = tmp_path_factory.mktemp("pi-tool-vocab-no-skills")
+    section = _tool_vocab_section(synthetic_root, tmp_path_factory)
+    assert "swe-workbench:<id>" in section["body"]
+    assert "Available ids:" not in section["body"]
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: ask-user.ts. Drives the real registerAskUser(pi) against a stub ExtensionAPI/
+# ExtensionContext — no LLM, no real TUI.
+# ---------------------------------------------------------------------------
+
+_ASK_USER_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const mod = await import(pathToFileURL(modPath).href);
+
+let registered;
+const stubPi = { registerTool(tool) { registered = tool; } };
+mod.registerAskUser(stubPi);
+
+const out = { registered: registered !== undefined };
+if (registered) {
+  const inputCalls = [];
+  const selectCalls = [];
+  function makeCtx(hasUI) {
+    return {
+      hasUI,
+      ui: {
+        select: async (title, options) => { selectCalls.push({ title, options }); return options[0]; },
+        input: async (...args) => { inputCalls.push(args); return "SHOULD-NEVER-HAPPEN"; },
+      },
+    };
+  }
+  async function run(hasUI, params) {
+    try {
+      const result = await registered.execute("tc1", params, undefined, undefined, makeCtx(hasUI));
+      return { ok: true, result };
+    } catch (err) {
+      return { ok: false, message: String(err && err.message) };
+    }
+  }
+  out.singleSelect = await run(true, config.singleParams);
+  out.multiSelect = await run(true, config.multiParams);
+  out.duplicate = await run(true, config.duplicateParams);
+  out.noUI = await run(false, config.singleParams);
+  out.selectCalls = selectCalls;
+  out.inputCalls = inputCalls;
+}
+console.log(JSON.stringify(out));
+"""
+
+
+def _ask_user_result(env, tmp_path_factory):
+    config = {
+        "singleParams": {
+            "questions": [
+                {"question": "Pick one", "header": "Pick", "multiSelect": False, "options": [{"label": "A", "description": "desc A"}, {"label": "B"}]},
+            ]
+        },
+        "multiParams": {
+            "questions": [{"question": "Pick many", "header": "Many", "multiSelect": True, "options": [{"label": "A"}, {"label": "B"}]}]
+        },
+        "duplicateParams": {
+            "questions": [
+                {"question": "Same text", "header": "Q1", "multiSelect": False, "options": [{"label": "A"}, {"label": "B"}]},
+                {"question": "Same text", "header": "Q2", "multiSelect": False, "options": [{"label": "C"}, {"label": "D"}]},
+            ]
+        },
+    }
+    node = shutil.which("node")
+    assert node is not None
+    driver = tmp_path_factory.mktemp("pi-ask-user-driver") / "driver.mjs"
+    driver.write_text(_ASK_USER_DRIVER, encoding="utf-8")
+    run_env = dict(_CLEAN_ENV)
+    run_env.update(env)
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), str(ASK_USER_TS), json.dumps(config)],
+        capture_output=True, text=True, env=run_env, timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@requires_node
+def test_ask_user_registers_by_default(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["registered"] is True
+
+
+@requires_node
+def test_ask_user_kill_switch_skips_registration(tmp_path_factory):
+    result = _ask_user_result({"SWE_WORKBENCH_PI_TOOLS": "0"}, tmp_path_factory)
+    assert result["registered"] is False
+
+
+@requires_node
+def test_ask_user_single_select_returns_the_choice_via_ctx_ui_select(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["singleSelect"]["ok"] is True
+    assert result["singleSelect"]["result"]["details"] == {"Pick one": "A — desc A"}
+    assert result["selectCalls"][0]["options"] == ["A — desc A", "B"]
+    assert result["inputCalls"] == [], "ask_user_question must never fall back to ctx.ui.input"
+
+
+@requires_node
+def test_ask_user_multi_select_is_rejected_with_a_remedy(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["multiSelect"]["ok"] is False
+    assert "sequential single-select" in result["multiSelect"]["message"]
+
+
+@requires_node
+def test_ask_user_duplicate_question_text_is_rejected(tmp_path_factory):
+    """answers[] is keyed by question text — a duplicate would silently overwrite an earlier
+    answer with no error, one of the user's picks vanishing unnoticed. Must reject up front,
+    before any ctx.ui.select call."""
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["duplicate"]["ok"] is False
+    assert "duplicate question" in result["duplicate"]["message"]
+
+
+@requires_node
+def test_ask_user_no_ui_fails_loudly_without_calling_input(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["noUI"]["ok"] is False
+    assert "interactive UI" in result["noUI"]["message"]
+    assert result["inputCalls"] == [], "hasUI:false must fail loudly, never silently fall back to ctx.ui.input"


### PR DESCRIPTION
## Summary
- Add `pi/extensions/tool-vocab.ts` (pure, SDK-free) — the Tier-1 vocabulary preamble: CC->Pi tool rename table, `swe-workbench:`/`superpowers:` skill-id legend (generated at runtime from `skills/*/SKILL.md`), `AskUserQuestion`/`ExitPlanMode`/`EnterWorktree` notes, and Superpowers' anti-hallucination rule verbatim.
- Add `pi/extensions/ask-user.ts` — registers `ask_user_question`, the one Tier-2 gap that's earned: a real backing primitive (`ctx.ui.select`) and a content contract (`commands/review.md:103`) that forbids a free-text fallback. Rejects `multiSelect`, duplicate question text, and no-UI contexts by throwing (never silently defaulting); gated by a `SWE_WORKBENCH_PI_TOOLS=0` kill switch that leaves Tier-1 prose unaffected.
- Wire both into `pi/extensions/index.ts`; the tool-vocab section injects unconditionally, independent of `bin/README.md` readability (only the bin-scripts row degrades on its own).
- Widen the bare-specifier import ratchet, pin the ask_user_question schema as plain JSON-Schema data (never TypeBox), and add behavioural coverage for both new files in `tests/test_pi_contract.py` / `tests/test_pi_extension.py`.
- Strip `SWE_WORKBENCH_PI_TOOLS` from `tests/conftest.py`'s `_CLEAN_ENV` to prevent ambient-env leakage into subprocess tests.
- Document `EnterWorktree`/`ExitWorktree` having no Pi equivalent as `docs/plugin-platform-decisions.md` §7.

Scope was corrected against the live tree before implementation (8 Mode-A activators not 10, `validate.py:469` not `:448`) and several items were deliberately cut with a replacement artifact each (`Skill` tool, `EnterWorktree`/`ExitWorktree`, a Pi-only plan gate, `skill_usage_*` wiring) — see the scope-correction comment on #608 for full rationale.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually

### Type-tailored checks (feat)
- [x] `bash scripts/validate.sh && npm run typecheck --prefix pi` — 0 issues
- [x] `pytest tests/ -q` — 2728/2728 pass (2 skipped, pre-existing)
- [x] Zero-LLM probe via the real `pi` CLI (`pi -e pi/extensions/index.ts -e <probe> -p "/swb-probe"`, extension-command dispatch, no provider tokens): injected preamble contains the rename table, and the generated skill-id list exactly matches `skills/*/SKILL.md` on disk (60/60, no diff)
- [x] Real `pi` CLI confirms `ask_user_question` is a genuinely active tool (`pi.getActiveTools()`/`getAllTools()`), with `promptGuidelines` present and `parameters.type === "object"` (plain JSON-Schema, not TypeBox-branded)
- [x] Kill-switch check against the real CLI: `SWE_WORKBENCH_PI_TOOLS=0` removes `ask_user_question` from active tools while the Tier-1 vocabulary preamble still fully injects
- [x] Both required reviewers (`superpowers:requesting-code-review` and `swe-workbench:reviewer`) ran in parallel; every Critical/Important/Medium finding fixed and re-verified (anti-hallucination text made truly verbatim, tool-vocab preamble decoupled from `bin/README.md` failure, import-ratchet regex widened for namespace/side-effect imports, `SWE_WORKBENCH_PI_TOOLS` env leakage closed, duplicate-question-text rejection added)

Closes #608
