### PR TITLE
[feat] Pi: subagent dispatch (task tool) (#610)

### DIFF
--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -184,10 +184,10 @@ the record. `"n/a"` never graduates to `"wired"`.
 ## 9. `task` — a first-party subagent dispatcher, not a fork of `pi-subagents`
 
 This plugin needed a way to dispatch any of its `agents/*.md` definitions (`swe-workbench:reviewer`,
-etc.) as a nested Pi session, preserving each agent's declared `tools` and preloaded `skills:`
-content. `pi/extensions/subagent.ts` registers a `task` tool that does exactly this, composing an
-agent's body plus its preloaded skills into a system prompt and running it as a real child `pi -p`
-process via `pi.exec()`.
+etc.) as a nested Pi session, preserving each agent's declared `tools`, preloaded `skills:` content,
+and (when declared) a model matched to its `model:` tier. `pi/extensions/subagent.ts` registers a
+`task` tool that does exactly this, composing an agent's body plus its preloaded skills into a
+system prompt and running it as a real child `pi -p` process via `pi.exec()`.
 
 **swe-workbench does not own a general subagent runtime.** The `pi-subagents` package is the
 supported route for generic delegation on Pi — chains, parallel fan-out, async runs, forked
@@ -229,8 +229,45 @@ in `hooks/bash_guard.sh`, pattern-matching a `pi ... -p`/`--print` invocation, s
 already-audited boundary instead of adding a new one. Not built as part of this dispatcher; tracked
 as a follow-up rather than silently left open.
 
-**Model-tier mapping was cut from scope entirely**, not deferred here — a project-committed
-`.pi/settings.json` reading a `modelTiers` block would be a real exfiltration primitive
-(redirecting subagent traffic to an attacker-chosen provider/endpoint) for near-zero value at zero
-current users. Recorded on the originating issue, not in this file, since there is no partial
-implementation of it to document a boundary around.
+**Model-tier mapping: an agent's `model: haiku|sonnet|opus` frontmatter picks a real model, by
+name, from a table hardcoded in `pi/extensions/model-tier.ts`.** An earlier iteration of this
+decision cut model-tier mapping entirely, on the grounds that a project-committed `.pi/settings.json`
+reading a `modelTiers` block would be a real exfiltration primitive — redirecting subagent traffic
+to an attacker-chosen provider/endpoint via a config surface outside normal code review. That
+concern is real, but it is a property of *where the mapping lives and what it can point at*, not
+of model-tier mapping itself, and the actual implementation avoids it entirely:
+
+- The table (`MODEL_TIER_TABLE`) is code shipped in this plugin's own reviewed source tree
+  (`pi/extensions/`) — the same trust boundary as every guard script path and tool-token mapping
+  already hardcoded elsewhere in this file group, not an independently-editable runtime settings
+  file.
+- Resolution is scoped to `ctx.model.provider` — whichever provider the parent session is already
+  on — and only ever selects among `ctx.scopedModels` (when the session is scoped via
+  `--models`/`enabledModels`) or, when unscoped, `ctx.modelRegistry.getAvailable()` results
+  (models the user has already configured credentials for). It never introduces a new provider,
+  baseUrl, or apiKey; a stale or missing table entry degrades to the parent's own current model
+  unchanged, never to something else.
+- Matching is by substring against `Model.id` (e.g. `"opus"` matches `claude-opus-5`, `"sol"`
+  matches `gpt-5.6-sol`), not exact-version pinning, so a provider's routine model-id version bumps
+  don't silently break the mapping. Substring matching alone is ambiguous, though: the bundled
+  Anthropic catalog carries dated/versioned siblings of a bare flagship id (`claude-opus-4-5`,
+  `claude-opus-4-5-20251101`, `claude-opus-4-6`... alongside `claude-opus-5`, all containing
+  `"opus"`), in catalog order rather than recency order — a plain first-match would silently
+  resolve to a stale snapshot. Resolution picks the *shortest* matching id instead: a
+  dated/versioned sibling is always the bare id plus extra suffix characters, so it can never be
+  shorter, making this a reliable, provider-catalog-agnostic tiebreak rather than a
+  version-pinning hack. `tests/test_pi_extension.py`'s anthropic fixture reproduces the real
+  bundled catalog's ambiguity verbatim to lock this in.
+
+`tests/test_pi_contract.py::test_model_tiers_are_inventoried` and
+`test_model_tier_table_is_exhaustive_over_known_tiers` ratchet the tier vocabulary and each
+provider row against the live `agents/*.md` inventory, the same pattern §2 already uses for tool
+tokens and skill ids.
+
+**Preloaded skills state their own resolvable directory.** A skill's body sometimes points at its
+own `examples/` subdirectory ("see `examples/` for a worked implementation..." —
+`swe-workbench:principle-solid`, `swe-workbench:principle-ddd`, etc.) without stating a path a
+reader could actually resolve. `composeSystemPrompt` now prepends each preloaded skill's absolute
+on-disk directory to its section header — not inlining `examples/` content (that stays on-demand,
+fetched by the dispatched agent's own `read` tool if it decides the pointer is relevant), just
+making the pointer resolvable instead of dead.

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -221,15 +221,16 @@ a clear, actionable rejection back — steering it to stop and report the blocke
 response — instead of either silently guessing (no signal at all) or the tool being simply absent
 from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
 
-**Accepted gap, not closed here — tracked as issue #632.** `--exclude-tools task,subagent` blocks
+**Accepted gap, not closed here — tracked as a follow-up.** `--exclude-tools task,subagent` blocks
 recursion only through the `task`/`subagent` tool-call surface. An agent granted `Bash` (20 of the
 22 `agents/*.md` definitions — the large majority of real dispatches, not an edge case) can still
 shell out to `pi -p ...` directly inside a dispatched child, which spawns a fresh child session
 with `task` re-registered and no `--exclude-tools` at all — no argv flag on that child prevents a
 further, unbounded level of recursion this way. Closing it belongs in `hooks/bash_guard.sh`,
 pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an already-audited boundary
-instead of adding a new one. Not built as part of this dispatcher — see #632 for the concrete
-tracked follow-up.
+instead of adding a new one. Not built as part of this dispatcher — tracked separately (see the
+open "Close bash-escape-hatch recursion gap in task dispatcher" issue) rather than silently left
+open.
 
 **Model-tier mapping: an agent's `model: haiku|sonnet|opus` frontmatter picks a real model, by
 name, from a table hardcoded in `pi/extensions/model-tier.ts`.** An earlier iteration of this

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -221,13 +221,15 @@ a clear, actionable rejection back — steering it to stop and report the blocke
 response — instead of either silently guessing (no signal at all) or the tool being simply absent
 from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
 
-**Accepted gap, not closed here.** An agent granted `Bash` (`swe-workbench:reviewer`,
-`swe-workbench:refactorer`, `swe-workbench:migrator`, `swe-workbench:senior-engineer`) can still
-shell out to `pi -p ...` directly inside a dispatched child — no argv
-flag on that child prevents a further, unbounded level of recursion this way. Closing it belongs
-in `hooks/bash_guard.sh`, pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an
-already-audited boundary instead of adding a new one. Not built as part of this dispatcher; tracked
-as a follow-up rather than silently left open.
+**Accepted gap, not closed here — tracked as issue #632.** `--exclude-tools task,subagent` blocks
+recursion only through the `task`/`subagent` tool-call surface. An agent granted `Bash` (20 of the
+22 `agents/*.md` definitions — the large majority of real dispatches, not an edge case) can still
+shell out to `pi -p ...` directly inside a dispatched child, which spawns a fresh child session
+with `task` re-registered and no `--exclude-tools` at all — no argv flag on that child prevents a
+further, unbounded level of recursion this way. Closing it belongs in `hooks/bash_guard.sh`,
+pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an already-audited boundary
+instead of adding a new one. Not built as part of this dispatcher — see #632 for the concrete
+tracked follow-up.
 
 **Model-tier mapping: an agent's `model: haiku|sonnet|opus` frontmatter picks a real model, by
 name, from a table hardcoded in `pi/extensions/model-tier.ts`.** An earlier iteration of this

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -180,3 +180,57 @@ Recorded as an explicit `"n/a"` decision — mirroring §6 and §7 — rather th
 Unlike §6, this is not a `HOOK_PI_STATUS` row: that inventory is keyed to `hooks/*.sh|py` and
 asserted exhaustive against that directory; `swe-workbench-lsp` lives in `bin/`, so this section is
 the record. `"n/a"` never graduates to `"wired"`.
+
+## 9. `task` — a first-party subagent dispatcher, not a fork of `pi-subagents`
+
+Issue #610 asked for a way to dispatch any of this plugin's `agents/*.md` definitions
+(`swe-workbench:reviewer`, etc.) as a nested Pi session, preserving each agent's declared `tools`
+and preloaded `skills:` content. `pi/extensions/subagent.ts` registers a `task` tool that does
+exactly this, composing an agent's body plus its preloaded skills into a system prompt and running
+it as a real child `pi -p` process via `pi.exec()`.
+
+**swe-workbench does not own a general subagent runtime.** The `pi-subagents` package is the
+supported route for generic delegation on Pi — chains, parallel fan-out, async runs, forked
+context, resume/status. `task` is not a competitor to that package or a wrapper around it; it
+exists for one narrower, structural reason: `pi-subagents`' `skills:` field only makes a skill
+*available* to a dispatched agent (an XML manifest the agent can `read` on demand), it never
+preloads a skill's body into the child's context — verified directly against that package's
+published source (`src/agents/skills.ts`'s `buildSkillInjection`, used by every real dispatch path
+in it). This repo's `agents/*.md` convention requires preload (`docs/skill-preload.md`) — every
+one of the 22 agents carries a `skills:` block, several with a dozen or more entries a dispatched
+agent is expected to already have in context on turn one, not fetch on demand. `pi-subagents`
+being installed alongside `task` is expected and fine; the two solve different problems.
+
+**Recursion guard: `--exclude-tools task,subagent` on the child's argv, not a depth env var.**
+Verified against the installed SDK's `agent-session.js`: an excluded tool is never added to the
+child's tool registry at construction time, so nothing running inside that child session can
+resurrect it — an out-of-band, unforgeable control, unlike an env var the child's own `bash` tool
+could unset. `subagent` (that package's own tool name) is excluded defensively alongside `task`
+in case both are installed together. This was confirmed live, not just read from source: a
+zero-model-call probe (a `session_start` handler calling `getActiveTools()` then `shutdown()`
+before any prompt is sent, run through the real `pi` binary) showed a registered tool present in
+the active set with no `--exclude-tools` and absent with it — see
+`tests/test_pi_contract.py::test_exclude_tools_structurally_prevents_task_tool_activation`.
+
+**`ask_user_question` is granted to every dispatched agent, deliberately, even though it always
+fails.** Every child runs in `-p`/`--no-session` print mode, where `ctx.hasUI` is `false` — so a
+call to `ask_user_question` always throws `"...requires an interactive UI..."`
+(`pi/extensions/ask-user.ts`). Granting it anyway is intentional: the thrown message is the point.
+It gives a dispatched agent a named way to signal "I hit a decision only a human can make" and get
+a clear, actionable rejection back — steering it to stop and report the blocker in its final
+response — instead of either silently guessing (no signal at all) or the tool being simply absent
+from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
+
+**Accepted gap, not closed here.** An agent granted `Bash` (`swe-workbench:reviewer`,
+`swe-workbench:refactorer`, `swe-workbench:migrator`, `swe-workbench:senior-engineer`) can still
+shell out to `pi -p ...` directly inside a dispatched child — no argv
+flag on that child prevents a further, unbounded level of recursion this way. Closing it belongs
+in `hooks/bash_guard.sh`, pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an
+already-audited boundary instead of adding a new one. Not built as part of #610; tracked as a
+follow-up rather than silently left open.
+
+**Model-tier mapping was cut from #610's scope entirely**, not deferred here — a project-committed
+`.pi/settings.json` reading a `modelTiers` block would be a real exfiltration primitive
+(redirecting subagent traffic to an attacker-chosen provider/endpoint) for near-zero value at zero
+current users. Recorded on the issue, not in this file, since there is no partial implementation
+of it to document a boundary around.

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -183,11 +183,11 @@ the record. `"n/a"` never graduates to `"wired"`.
 
 ## 9. `task` — a first-party subagent dispatcher, not a fork of `pi-subagents`
 
-Issue #610 asked for a way to dispatch any of this plugin's `agents/*.md` definitions
-(`swe-workbench:reviewer`, etc.) as a nested Pi session, preserving each agent's declared `tools`
-and preloaded `skills:` content. `pi/extensions/subagent.ts` registers a `task` tool that does
-exactly this, composing an agent's body plus its preloaded skills into a system prompt and running
-it as a real child `pi -p` process via `pi.exec()`.
+This plugin needed a way to dispatch any of its `agents/*.md` definitions (`swe-workbench:reviewer`,
+etc.) as a nested Pi session, preserving each agent's declared `tools` and preloaded `skills:`
+content. `pi/extensions/subagent.ts` registers a `task` tool that does exactly this, composing an
+agent's body plus its preloaded skills into a system prompt and running it as a real child `pi -p`
+process via `pi.exec()`.
 
 **swe-workbench does not own a general subagent runtime.** The `pi-subagents` package is the
 supported route for generic delegation on Pi — chains, parallel fan-out, async runs, forked
@@ -226,11 +226,11 @@ from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
 shell out to `pi -p ...` directly inside a dispatched child — no argv
 flag on that child prevents a further, unbounded level of recursion this way. Closing it belongs
 in `hooks/bash_guard.sh`, pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an
-already-audited boundary instead of adding a new one. Not built as part of #610; tracked as a
-follow-up rather than silently left open.
+already-audited boundary instead of adding a new one. Not built as part of this dispatcher; tracked
+as a follow-up rather than silently left open.
 
-**Model-tier mapping was cut from #610's scope entirely**, not deferred here — a project-committed
+**Model-tier mapping was cut from scope entirely**, not deferred here — a project-committed
 `.pi/settings.json` reading a `modelTiers` block would be a real exfiltration primitive
 (redirecting subagent traffic to an attacker-chosen provider/endpoint) for near-zero value at zero
-current users. Recorded on the issue, not in this file, since there is no partial implementation
-of it to document a boundary around.
+current users. Recorded on the originating issue, not in this file, since there is no partial
+implementation of it to document a boundary around.

--- a/pi/extensions/agent-spec.ts
+++ b/pi/extensions/agent-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure parsing/composition for this plugin's agents/*.md convention, plus thin I/O wrappers.
+ *
+ * Layer: domain, same posture as tool-vocab.ts. This file must import NOTHING from the Pi SDK,
+ * not even as a type — only node:fs/node:path, plus a relative import of RENAME_TABLE from
+ * ./tool-vocab.ts (also SDK-free). subagent.ts owns everything that touches Pi itself.
+ *
+ * agents/*.md frontmatter is a fixed, uniform 5-key shape across all 22 files today (name,
+ * description, model, tools, skills) — `tools:` is always one comma-separated inline string,
+ * `skills:` is always a YAML block sequence of `swe-workbench:<id>` entries. This is a small
+ * purpose-built extractor for exactly that shape, not a general YAML parser — it mirrors
+ * scripts/validate.py's parse_frontmatter() key/item regexes so the two hand-rolled parsers
+ * can't silently diverge on what a line means.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { RENAME_TABLE } from "./tool-vocab.ts";
+
+export interface AgentSpec {
+  readonly name: string;
+  readonly description: string;
+  readonly tools: readonly string[];
+  readonly skillIds: readonly string[];
+  readonly body: string;
+}
+
+const SKILL_NAMESPACE_PREFIX = "swe-workbench:";
+
+/** Tool tokens with no Pi tool equivalent — dropped rather than renamed. Exported so
+ *  tests/test_pi_contract.py can assert exhaustiveness over TOOL_TOKENS. */
+export const DROP_TOKENS = new Set(["Skill", "WebFetch"]);
+
+const FM_KEY_RE = /^([\w-]+):\s*(.*)$/;
+const FM_ITEM_RE = /^-\s+(.*\S)\s*$/;
+
+/** Mirrors the installed Pi SDK's dist/utils/frontmatter.js extractFrontmatter (kept as prose
+ *  here, deliberately not a code dependency — see this file's own header): normalize newlines,
+ *  find the closing '---' via indexOf from index 3, slice from 4 chars past that match, then
+ *  strip() the body. Throws (rather than degrading) on a missing/malformed block — every file
+ *  this is called on is one of this plugin's own bundled resources, not untrusted input, so a
+ *  malformed one is a bug to surface, not a case to silently tolerate. */
+function splitFrontmatter(rawText: string): { frontmatter: string; body: string } {
+  const text = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!text.startsWith("---")) {
+    throw new Error("expected a '---' frontmatter block at the start of the file");
+  }
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) {
+    throw new Error("frontmatter block has no closing '---'");
+  }
+  return { frontmatter: text.slice(3, end), body: text.slice(end + 4).trim() };
+}
+
+/** Parses exactly this plugin's agents/*.md frontmatter shape: `tools:` a comma-separated
+ *  inline string, `skills:` a block sequence, everything else a plain scalar. Pure. */
+export function parseAgentSpec(text: string): AgentSpec {
+  const { frontmatter, body } = splitFrontmatter(text);
+
+  const scalars: Record<string, string> = {};
+  const lists: Record<string, string[]> = {};
+  let pending: string | null = null;
+
+  for (const rawLine of frontmatter.split("\n")) {
+    const stripped = rawLine.trim();
+    if (stripped === "") continue;
+
+    if (pending !== null) {
+      const item = FM_ITEM_RE.exec(stripped);
+      if (item) {
+        (lists[pending] ??= []).push(item[1].trim());
+        continue;
+      }
+    }
+
+    const key = FM_KEY_RE.exec(stripped);
+    if (key) {
+      const name = key[1].toLowerCase();
+      const value = key[2].trim();
+      scalars[name] = value;
+      pending = value === "" ? name : null;
+    } else {
+      pending = null;
+    }
+  }
+
+  const name = scalars.name;
+  const description = scalars.description;
+  if (!name) throw new Error("agent frontmatter missing required 'name' key");
+  if (!description) throw new Error("agent frontmatter missing required 'description' key");
+
+  const tools = scalars.tools
+    ? scalars.tools
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+    : [];
+  const skillIds = lists.skills ?? [];
+
+  return { name, description, tools, skillIds, body };
+}
+
+/** Translates Claude Code tool tokens (as found in an agent's `tools:` frontmatter) into Pi
+ *  tool names, via RENAME_TABLE for tokens with a real Pi equivalent and DROP_TOKENS for tokens
+ *  with none. Throws on any token that is neither — exhaustive over this repo's known token
+ *  vocabulary, no silent gaps — and throws if the translated result is empty (an empty --tools
+ *  allowlist would silently mute every tool in the dispatched child session). Pure; order- and
+ *  duplicate-preserving beyond de-duplication. */
+export function translateToolTokens(tokens: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const translated: string[] = [];
+  for (const token of tokens) {
+    const renamed = RENAME_TABLE.find(([cc]) => cc === token)?.[1];
+    if (renamed !== undefined) {
+      if (!seen.has(renamed)) {
+        seen.add(renamed);
+        translated.push(renamed);
+      }
+      continue;
+    }
+    if (DROP_TOKENS.has(token)) continue;
+    throw new Error(`translateToolTokens: no Pi mapping (rename or drop) for tool token "${token}"`);
+  }
+  if (translated.length === 0) {
+    throw new Error(
+      "translateToolTokens: translated result is empty — refusing to build an empty --tools allowlist",
+    );
+  }
+  return translated;
+}
+
+/** Composes an agent's system prompt: its own body, followed by each preloaded skill's
+ *  (frontmatter-stripped) body in `skills:` order. Pure string composition. */
+export function composeSystemPrompt(
+  spec: Pick<AgentSpec, "body">,
+  skills: ReadonlyArray<{ readonly id: string; readonly body: string }>,
+): string {
+  const sections = [spec.body.trim()];
+  for (const skill of skills) {
+    sections.push(`## Preloaded skill: ${skill.id}\n\n${skill.body.trim()}`);
+  }
+  return sections.join("\n\n---\n\n");
+}
+
+/** Reads and parses agents/<name>.md from this plugin's own bundled resource tree. */
+export function readAgentSpec(root: string, name: string): AgentSpec {
+  const text = readFileSync(join(root, "agents", `${name}.md`), "utf8");
+  return parseAgentSpec(text);
+}
+
+/** Reads a preloaded skill's body (frontmatter stripped, preload-canary and everything after
+ *  kept — that marker is docs/skill-preload.md's mechanism for verifying preload actually
+ *  happened, so it must survive into the composed prompt). `skillId` may be namespaced
+ *  (`swe-workbench:<id>`) or bare; the namespace prefix is stripped before resolving the path. */
+export function readSkillBody(root: string, skillId: string): string {
+  const bareId = skillId.startsWith(SKILL_NAMESPACE_PREFIX)
+    ? skillId.slice(SKILL_NAMESPACE_PREFIX.length)
+    : skillId;
+  const text = readFileSync(join(root, "skills", bareId, "SKILL.md"), "utf8");
+  return splitFrontmatter(text).body;
+}
+
+/** Lists agent ids (basenames, no .md) under agents/ — for a "not found, available: ..." error. */
+export function listAgentNames(root: string): string[] {
+  return readdirSync(join(root, "agents"), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.slice(0, -".md".length))
+    .sort();
+}

--- a/pi/extensions/agent-spec.ts
+++ b/pi/extensions/agent-spec.ts
@@ -19,12 +19,21 @@ import { RENAME_TABLE } from "./tool-vocab.ts";
 export interface AgentSpec {
   readonly name: string;
   readonly description: string;
+  /** Raw `model:` frontmatter value, e.g. "haiku"/"sonnet"/"opus" — not validated against
+   *  KNOWN_MODEL_TIERS (model-tier.ts) here; callers use isKnownModelTier() before acting on
+   *  it. Undefined when the agent has no `model:` key. */
+  readonly model: string | undefined;
   readonly tools: readonly string[];
   readonly skillIds: readonly string[];
   readonly body: string;
 }
 
 const SKILL_NAMESPACE_PREFIX = "swe-workbench:";
+
+/** Strips the `swe-workbench:` namespace prefix from a skill id, if present. */
+function bareSkillId(skillId: string): string {
+  return skillId.startsWith(SKILL_NAMESPACE_PREFIX) ? skillId.slice(SKILL_NAMESPACE_PREFIX.length) : skillId;
+}
 
 /** Tool tokens with no Pi tool equivalent — dropped rather than renamed. Exported so
  *  tests/test_pi_contract.py can assert exhaustiveness over TOOL_TOKENS. */
@@ -95,8 +104,9 @@ export function parseAgentSpec(text: string): AgentSpec {
         .filter((t) => t.length > 0)
     : [];
   const skillIds = lists.skills ?? [];
+  const model = scalars.model;
 
-  return { name, description, tools, skillIds, body };
+  return { name, description, model, tools, skillIds, body };
 }
 
 /** Translates Claude Code tool tokens (as found in an agent's `tools:` frontmatter) into Pi
@@ -129,14 +139,22 @@ export function translateToolTokens(tokens: readonly string[]): string[] {
 }
 
 /** Composes an agent's system prompt: its own body, followed by each preloaded skill's
- *  (frontmatter-stripped) body in `skills:` order. Pure string composition. */
+ *  (frontmatter-stripped) body in `skills:` order. `dir` is each skill's absolute on-disk
+ *  directory — stated in the section header (not inlined content) so a relative pointer the
+ *  skill's own body makes (e.g. "see `examples/` for...") is resolvable by a dispatched child
+ *  that has `read`, instead of being a dead reference with no path context. Pure string
+ *  composition. */
 export function composeSystemPrompt(
   spec: Pick<AgentSpec, "body">,
-  skills: ReadonlyArray<{ readonly id: string; readonly body: string }>,
+  skills: ReadonlyArray<{ readonly id: string; readonly body: string; readonly dir: string }>,
 ): string {
   const sections = [spec.body.trim()];
   for (const skill of skills) {
-    sections.push(`## Preloaded skill: ${skill.id}\n\n${skill.body.trim()}`);
+    sections.push(
+      `## Preloaded skill: ${skill.id}\n` +
+        `(relative paths this skill's body mentions, e.g. \`examples/...\`, resolve against: ${skill.dir})\n\n` +
+        skill.body.trim(),
+    );
   }
   return sections.join("\n\n---\n\n");
 }
@@ -152,11 +170,14 @@ export function readAgentSpec(root: string, name: string): AgentSpec {
  *  happened, so it must survive into the composed prompt). `skillId` may be namespaced
  *  (`swe-workbench:<id>`) or bare; the namespace prefix is stripped before resolving the path. */
 export function readSkillBody(root: string, skillId: string): string {
-  const bareId = skillId.startsWith(SKILL_NAMESPACE_PREFIX)
-    ? skillId.slice(SKILL_NAMESPACE_PREFIX.length)
-    : skillId;
-  const text = readFileSync(join(root, "skills", bareId, "SKILL.md"), "utf8");
+  const text = readFileSync(join(root, "skills", bareSkillId(skillId), "SKILL.md"), "utf8");
   return splitFrontmatter(text).body;
+}
+
+/** The absolute directory a skill's own relative path mentions (`examples/...`) resolve
+ *  against. Pure path join — does not check the directory exists. */
+export function skillDir(root: string, skillId: string): string {
+  return join(root, "skills", bareSkillId(skillId));
 }
 
 /** Lists agent ids (basenames, no .md) under agents/ — for a "not found, available: ..." error. */

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -116,16 +116,12 @@ export default function (pi: ExtensionAPI): void {
   let warnedMissingAnchor = false;
   let cachedPreamble: string | undefined;
 
-  // Computed lazily (on first before_agent_start, not at factory-invocation time) and cached.
-  // `SWE_WORKBENCH_PI_TOOLS` alone is NOT enough to decide this: registerSubagent() still calls
-  // pi.registerTool() unconditionally whenever the kill switch is off, even in a dispatched
-  // child whose own argv carries `--exclude-tools task,subagent` — the child re-runs this same
-  // index.ts, the kill switch env var is still unset there, but the real tool registry has
-  // already filtered `task` out (see docs/plugin-platform-decisions.md §9's recursion-guard
-  // section). Only pi.getActiveTools(), read after all extensions have finished registering
-  // their tools, reflects that filtering — checking the env var here would tell every
-  // dispatched agent to use a `task` tool that was deliberately removed from its own
-  // function-calling surface.
+  // Computed lazily (on first before_agent_start) and cached. `SWE_WORKBENCH_PI_TOOLS` alone
+  // is not enough: a dispatched child re-runs this same index.ts with the kill switch still
+  // unset, but its own argv carries `--exclude-tools task,subagent` — the real tool registry
+  // has already filtered `task` out by the time extensions finish registering (see
+  // docs/plugin-platform-decisions.md §9). Only pi.getActiveTools() reflects that; the env var
+  // alone would tell a dispatched agent to use a tool deliberately removed from its surface.
   function getPreamble(): string {
     if (cachedPreamble === undefined) {
       const taskToolRegistered = pi.getActiveTools().includes(TASK_TOOL_NAME);

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -33,6 +33,7 @@ import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerAskUser } from "./ask-user.ts";
 import { registerGuards } from "./guards.ts";
+import { registerSubagent, TASK_TOOL_NAME } from "./subagent.ts";
 import { toolVocabSection } from "./tool-vocab.ts";
 
 class PluginRootNotFoundError extends Error {
@@ -103,16 +104,35 @@ export default function (pi: ExtensionAPI): void {
   // Only the bin-scripts section depends on bin/README.md; toolVocabSection is pure and never
   // fails, so it must NOT be dragged down by a missing/unreadable README — Tier-1 vocabulary
   // prose (including the anti-hallucination rule) stays on unconditionally, same posture as
-  // ask-user.ts's kill switch. composePreamble is still called exactly once, so the single
-  // PREAMBLE_MARKER dedup check keeps proving something real.
+  // ask-user.ts's kill switch. composePreamble (via getPreamble() below) is still computed
+  // exactly once per session (cached after first call), so the single PREAMBLE_MARKER dedup
+  // check keeps proving something real.
   const currentScripts = readCurrentScripts(binDir);
   const binSection =
     currentScripts === null
       ? []
       : [{ title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts }];
-  const preamble = composePreamble([...binSection, toolVocabSection(root)]);
 
   let warnedMissingAnchor = false;
+  let cachedPreamble: string | undefined;
+
+  // Computed lazily (on first before_agent_start, not at factory-invocation time) and cached.
+  // `SWE_WORKBENCH_PI_TOOLS` alone is NOT enough to decide this: registerSubagent() still calls
+  // pi.registerTool() unconditionally whenever the kill switch is off, even in a dispatched
+  // child whose own argv carries `--exclude-tools task,subagent` — the child re-runs this same
+  // index.ts, the kill switch env var is still unset there, but the real tool registry has
+  // already filtered `task` out (see docs/plugin-platform-decisions.md §9's recursion-guard
+  // section). Only pi.getActiveTools(), read after all extensions have finished registering
+  // their tools, reflects that filtering — checking the env var here would tell every
+  // dispatched agent to use a `task` tool that was deliberately removed from its own
+  // function-calling surface.
+  function getPreamble(): string {
+    if (cachedPreamble === undefined) {
+      const taskToolRegistered = pi.getActiveTools().includes(TASK_TOOL_NAME);
+      cachedPreamble = composePreamble([...binSection, toolVocabSection(root, taskToolRegistered)]);
+    }
+    return cachedPreamble;
+  }
 
   pi.on("resources_discover", () => ({
     skillPaths: [join(root, "skills")],
@@ -132,7 +152,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("before_agent_start", (event) => {
     if (event.systemPrompt.includes(PREAMBLE_MARKER)) return;
-    return { systemPrompt: event.systemPrompt + preamble };
+    return { systemPrompt: event.systemPrompt + getPreamble() };
   });
 
   // registerGuards must register first: emitToolCall (runner.js:701) runs tool_call handlers in
@@ -143,4 +163,5 @@ export default function (pi: ExtensionAPI): void {
   // and return undefined on throw.
   registerGuards(pi, root);
   registerAskUser(pi);
+  registerSubagent(pi, root);
 }

--- a/pi/extensions/model-tier.ts
+++ b/pi/extensions/model-tier.ts
@@ -1,0 +1,87 @@
+/**
+ * Model-tier resolution: maps a Claude-Code-style tier name (an agent's `model:` frontmatter
+ * value — haiku/sonnet/opus) to a concrete Pi model, by name, per provider.
+ *
+ * Layer: domain, same SDK-free posture as agent-spec.ts and tool-vocab.ts — only plain data and
+ * pure functions here, no Pi SDK import, not even as a type. subagent.ts supplies real SDK
+ * `Model` objects (mapped to the local ModelCandidate shape) and owns everything that actually
+ * queries ctx.modelRegistry.
+ */
+
+/** The only `model:` values agents/*.md frontmatter uses today (ratcheted against the live
+ *  inventory in tests/test_pi_contract.py's MODEL_TIERS, the same pattern as TOOL_TOKENS). */
+export const KNOWN_MODEL_TIERS = ["haiku", "sonnet", "opus"] as const;
+export type ModelTier = (typeof KNOWN_MODEL_TIERS)[number];
+
+export function isKnownModelTier(value: string | undefined): value is ModelTier {
+  return value !== undefined && (KNOWN_MODEL_TIERS as readonly string[]).includes(value);
+}
+
+/** Structurally shaped like the Pi SDK's `Model<Api>` (provider/id) but NOT imported from it —
+ *  this file stays SDK-free (see header). subagent.ts maps real SDK `Model` objects into this
+ *  shape before calling resolveModelForTier. */
+export interface ModelCandidate {
+  readonly provider: string;
+  readonly id: string;
+}
+
+/** Per-provider tier -> model-id-substring pattern(s), by name — not cost. Hardcoded editorial
+ *  content, not scanned from disk or a runtime-editable settings file: see
+ *  docs/plugin-platform-decisions.md §9 for the full trust-boundary rationale (this table lives
+ *  in reviewed source, resolution never leaves the parent's own provider/authenticated models).
+ *  Multiple patterns for one tier (zai's haiku row) are tried in priority order. */
+export const MODEL_TIER_TABLE: Readonly<Record<string, Readonly<Record<ModelTier, readonly string[]>>>> = {
+  anthropic: {
+    opus: ["opus"],
+    sonnet: ["sonnet"],
+    haiku: ["haiku"],
+  },
+  "openai-codex": {
+    opus: ["sol"],
+    sonnet: ["terra"],
+    haiku: ["luna"],
+  },
+  zai: {
+    opus: ["glm-5.3"],
+    sonnet: ["glm-5.3"],
+    haiku: ["glm-5.2-highspeed", "glm-5.2"],
+  },
+};
+
+/** Among candidates whose id contains `pattern`, returns the one with the SHORTEST id —
+ *  disambiguates real-world catalog collisions where a bare tier pattern (e.g. "opus") also
+ *  matches older dated/versioned siblings of the intended model (e.g. Anthropic's bundled
+ *  catalog carries "claude-opus-4-5", "claude-opus-4-5-20251101", "claude-opus-4-6",
+ *  "claude-opus-4-7", and "claude-opus-4-8" alongside the intended "claude-opus-5" — all six
+ *  contain the substring "opus", in catalog (not chronological) order, so a naive first-match
+ *  would silently resolve to a stale, non-flagship snapshot). The intended bare id is always the
+ *  shortest match: any dated/versioned variant is strictly the bare id plus extra suffix
+ *  characters, so it can never be shorter. Undefined if no candidate matches. */
+function shortestMatch(pattern: string, candidates: readonly ModelCandidate[]): ModelCandidate | undefined {
+  return candidates
+    .filter((c) => c.id.includes(pattern))
+    .reduce<ModelCandidate | undefined>(
+      (best, candidate) => (best === undefined || candidate.id.length < best.id.length ? candidate : best),
+      undefined,
+    );
+}
+
+/** Resolves a Claude-Code-style model tier to one of `candidates` via MODEL_TIER_TABLE, by
+ *  name — never by cost or capability inference. `candidates` should already be filtered to one
+ *  provider (subagent.ts filters to the parent session's active provider); `provider` selects
+ *  which row of MODEL_TIER_TABLE to use. Returns undefined when the provider has no table entry,
+ *  the tier has no pattern for it, or none of its patterns match an available candidate — the
+ *  caller is expected to fall back to the parent's current model in every undefined case. Pure. */
+export function resolveModelForTier(
+  provider: string,
+  tier: ModelTier,
+  candidates: readonly ModelCandidate[],
+): ModelCandidate | undefined {
+  const patterns = MODEL_TIER_TABLE[provider]?.[tier];
+  if (!patterns) return undefined;
+  for (const pattern of patterns) {
+    const match = shortestMatch(pattern, candidates);
+    if (match) return match;
+  }
+  return undefined;
+}

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -1,28 +1,33 @@
 /**
  * Registers `task`, a first-party subagent dispatcher: runs one of this plugin's agents/*.md
- * definitions as a nested `pi` child process, with that agent's declared tools and preloaded
- * skills composed into its system prompt.
+ * definitions as a nested `pi` child process, with that agent's declared tools, preloaded
+ * skills, and (when its `model:` frontmatter names a known tier) a resolved model composed into
+ * its dispatch.
  *
  * Exists because pi-subagents' `skills:` field only makes a skill *available* (an XML manifest
  * read on demand via its own `read` tool) — it never preloads skill body into context, which
  * this repo's agents/*.md convention requires (docs/skill-preload.md). See
- * docs/plugin-platform-decisions.md §9 for the full rationale and the accepted `bash`-escape-
- * hatch recursion gap.
+ * docs/plugin-platform-decisions.md §9 for the full rationale, the model-tier-mapping safety
+ * posture, and the accepted `bash`-escape-hatch recursion gap.
  *
  * Everything that touches Pi itself (argv construction, pi.exec, temp-file lifecycle, tool
- * registration) lives here. agent-spec.ts stays SDK-free — see its own file header.
+ * registration, model-registry queries) lives here. agent-spec.ts and model-tier.ts stay
+ * SDK-free — see their own file headers.
  */
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import {
+  type AgentSpec,
   composeSystemPrompt,
   listAgentNames,
   readAgentSpec,
   readSkillBody,
+  skillDir,
   translateToolTokens,
 } from "./agent-spec.ts";
+import { isKnownModelTier, type ModelCandidate, resolveModelForTier } from "./model-tier.ts";
 
 /** Single source of truth for the tool's registered name — consumed both by pi.registerTool()
  *  below and by the `--exclude-tools` argv builder, so a rename can't silently desync
@@ -66,6 +71,30 @@ const TASK_PARAMS_SCHEMA = {
   additionalProperties: false,
 } as ToolDefinition["parameters"];
 
+/** Decides which model to dispatch the child with. Undefined `ctx.model` -> undefined (today's
+ *  omit-the-flag fallback). Otherwise: an unrecognized/missing `spec.model` tier, a provider with
+ *  no MODEL_TIER_TABLE row, or no available candidate matching the row's pattern(s) all degrade
+ *  to the parent's own active model unchanged — this function never throws and never reaches for
+ *  a provider other than `ctx.model.provider`. Candidates come from `ctx.scopedModels` when the
+ *  session is scoped (`--models`/`enabledModels`) — an explicit session-level restriction that
+ *  tier resolution must respect, not bypass — and fall back to the full
+ *  `ctx.modelRegistry.getAvailable()` catalog only when no scoping is configured (`scopedModels`
+ *  is documented as empty in that case). */
+function resolveTargetModel(
+  ctx: ExtensionContext,
+  spec: Pick<AgentSpec, "model">,
+): { provider: string; id: string } | undefined {
+  if (!ctx.model) return undefined;
+  const parent = { provider: ctx.model.provider, id: ctx.model.id };
+  if (!isKnownModelTier(spec.model)) return parent;
+
+  const pool = ctx.scopedModels.length > 0 ? ctx.scopedModels.map((sm) => sm.model) : ctx.modelRegistry.getAvailable();
+  const candidates: ModelCandidate[] = pool
+    .filter((m) => m.provider === parent.provider)
+    .map((m) => ({ provider: m.provider, id: m.id }));
+  return resolveModelForTier(parent.provider, spec.model, candidates) ?? parent;
+}
+
 export function registerSubagent(pi: ExtensionAPI, root: string): void {
   // Same Tier-2 kill switch as ask-user.ts's registerAskUser — an immutable config read at
   // registration time, gating tool registration only. Tier-1 vocabulary prose stays unconditional.
@@ -102,7 +131,7 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
       // could make, instead of silently guessing.
       const toolNames = Array.from(new Set([...translated, "ask_user_question"]));
 
-      const skills = spec.skillIds.map((id) => ({ id, body: readSkillBody(root, id) }));
+      const skills = spec.skillIds.map((id) => ({ id, body: readSkillBody(root, id), dir: skillDir(root, id) }));
       const systemPrompt = composeSystemPrompt(spec, skills);
 
       const tmpDir = mkdtempSync(join(tmpdir(), "swe-workbench-subagent-"));
@@ -121,8 +150,9 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
           `${TASK_TOOL_NAME},${PI_SUBAGENTS_TOOL_NAME}`,
           "--no-session",
         ];
-        if (ctx.model) {
-          args.push("--model", `${ctx.model.provider}/${ctx.model.id}`);
+        const targetModel = resolveTargetModel(ctx, spec);
+        if (targetModel) {
+          args.push("--model", `${targetModel.provider}/${targetModel.id}`);
         }
 
         const result = await pi.exec("pi", args, { cwd: ctx.cwd, timeout: TASK_TIMEOUT_MS, signal });

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -96,13 +96,10 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
 
       const spec = readAgentSpec(root, agent);
       const translated = translateToolTokens(spec.tools);
-      // ask_user_question is granted even though no agent declares it and the child (always
-      // print-mode, ctx.hasUI: false) is structurally guaranteed to reject any call to it — the
-      // rejection message itself is the point: it steers the dispatched agent to stop and report
-      // the blocking decision back to us, instead of silently guessing when it hits one that
-      // only a user could make. Registering the tool costs nothing (translated tokens already
-      // dominate the system prompt's "Available tools" documentation) and gives the model a
-      // named way to signal "I need a human here" rather than no signal at all.
+      // ask_user_question is granted even though it's structurally guaranteed to fail: the
+      // child always runs in print mode (ctx.hasUI: false), so any call throws. That thrown
+      // message is the point — it steers a dispatched agent to report a decision only a human
+      // could make, instead of silently guessing.
       const toolNames = Array.from(new Set([...translated, "ask_user_question"]));
 
       const skills = spec.skillIds.map((id) => ({ id, body: readSkillBody(root, id) }));

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -43,10 +43,15 @@ const OUTPUT_CAP_CHARS = 50_000;
 
 /** Applied to both the success path's stdout and the failure path's stderr — a dispatched
  *  child's output (or its error output on a bad exit) becomes part of the PARENT model's
- *  context, so an uncapped dump either way is the same context-bloat risk. */
-function capOutput(text: string): string {
+ *  context, so an uncapped dump either way is the same context-bloat risk. `.slice()` is a
+ *  UTF-16 code-unit cut, which can land inside a surrogate pair (e.g. an emoji) right at the
+ *  boundary — the trailing `.replace()` drops a lone leading surrogate left dangling by that
+ *  cut, so the result is never an ill-formed UTF-16 string. Exported for direct unit testing —
+ *  a lone surrogate does not survive a stdout/JSON/UTF-8 round trip intact, so this specific
+ *  Unicode edge case needs to be tested in-process, not via the full exec path. */
+export function capOutput(text: string): string {
   return text.length > OUTPUT_CAP_CHARS
-    ? `${text.slice(0, OUTPUT_CAP_CHARS)}\n\n[truncated — output exceeded ${OUTPUT_CAP_CHARS} chars]`
+    ? `${text.slice(0, OUTPUT_CAP_CHARS).replace(/[\uD800-\uDBFF]$/, "")}\n\n[truncated — output exceeded ${OUTPUT_CAP_CHARS} chars]`
     : text;
 }
 

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -1,0 +1,161 @@
+/**
+ * Registers `task`, a first-party subagent dispatcher: runs one of this plugin's agents/*.md
+ * definitions as a nested `pi` child process, with that agent's declared tools and preloaded
+ * skills composed into its system prompt.
+ *
+ * Exists because pi-subagents' `skills:` field only makes a skill *available* (an XML manifest
+ * read on demand via its own `read` tool) — it never preloads skill body into context, which
+ * this repo's agents/*.md convention requires (docs/skill-preload.md). See
+ * docs/plugin-platform-decisions.md §9 for the full rationale and the accepted `bash`-escape-
+ * hatch recursion gap.
+ *
+ * Everything that touches Pi itself (argv construction, pi.exec, temp-file lifecycle, tool
+ * registration) lives here. agent-spec.ts stays SDK-free — see its own file header.
+ */
+import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import {
+  composeSystemPrompt,
+  listAgentNames,
+  readAgentSpec,
+  readSkillBody,
+  translateToolTokens,
+} from "./agent-spec.ts";
+
+/** Single source of truth for the tool's registered name — consumed both by pi.registerTool()
+ *  below and by the `--exclude-tools` argv builder, so a rename can't silently desync
+ *  registration from the recursion guard. */
+export const TASK_TOOL_NAME = "task";
+
+/** pi-subagents' own tool name (verified against its published source), excluded defensively
+ *  alongside TASK_TOOL_NAME in case the user also has that package installed. */
+const PI_SUBAGENTS_TOOL_NAME = "subagent";
+
+const TASK_TIMEOUT_MS = 15 * 60 * 1000;
+const OUTPUT_CAP_CHARS = 50_000;
+
+/** Applied to both the success path's stdout and the failure path's stderr — a dispatched
+ *  child's output (or its error output on a bad exit) becomes part of the PARENT model's
+ *  context, so an uncapped dump either way is the same context-bloat risk. */
+function capOutput(text: string): string {
+  return text.length > OUTPUT_CAP_CHARS
+    ? `${text.slice(0, OUTPUT_CAP_CHARS)}\n\n[truncated — output exceeded ${OUTPUT_CAP_CHARS} chars]`
+    : text;
+}
+
+interface TaskParams {
+  agent: string;
+  prompt: string;
+}
+
+const TASK_PARAMS_SCHEMA = {
+  type: "object",
+  properties: {
+    agent: {
+      type: "string",
+      description: "The agents/*.md agent id to dispatch, e.g. \"reviewer\" or \"debugger\".",
+    },
+    prompt: {
+      type: "string",
+      description: "The task/prompt to hand the dispatched agent.",
+    },
+  },
+  required: ["agent", "prompt"],
+  additionalProperties: false,
+} as ToolDefinition["parameters"];
+
+export function registerSubagent(pi: ExtensionAPI, root: string): void {
+  // Same Tier-2 kill switch as ask-user.ts's registerAskUser — an immutable config read at
+  // registration time, gating tool registration only. Tier-1 vocabulary prose stays unconditional.
+  if (process.env.SWE_WORKBENCH_PI_TOOLS === "0") return;
+
+  pi.registerTool({
+    name: TASK_TOOL_NAME,
+    label: "Task",
+    description:
+      "Dispatch one of this plugin's agents/*.md agents (e.g. \"reviewer\", \"debugger\") as a " +
+      "nested Pi session, with that agent's declared tools and preloaded skills. Runs to " +
+      "completion and returns its final text response.",
+    promptSnippet:
+      'task(agent, prompt): dispatch a named agents/*.md agent (e.g. task({ agent: "reviewer", ' +
+      'prompt: "..." })) as a nested session and get its final response back.',
+    promptGuidelines: [
+      "Only dispatch an agent id that actually exists under agents/*.md — an unknown id fails " +
+        "with the available list rather than guessing.",
+    ],
+    parameters: TASK_PARAMS_SCHEMA,
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const { agent, prompt } = params as unknown as TaskParams;
+
+      const available = listAgentNames(root);
+      if (!available.includes(agent)) {
+        throw new Error(`task: unknown agent "${agent}" — available agents: ${available.join(", ")}`);
+      }
+
+      const spec = readAgentSpec(root, agent);
+      const translated = translateToolTokens(spec.tools);
+      // ask_user_question is granted even though no agent declares it and the child (always
+      // print-mode, ctx.hasUI: false) is structurally guaranteed to reject any call to it — the
+      // rejection message itself is the point: it steers the dispatched agent to stop and report
+      // the blocking decision back to us, instead of silently guessing when it hits one that
+      // only a user could make. Registering the tool costs nothing (translated tokens already
+      // dominate the system prompt's "Available tools" documentation) and gives the model a
+      // named way to signal "I need a human here" rather than no signal at all.
+      const toolNames = Array.from(new Set([...translated, "ask_user_question"]));
+
+      const skills = spec.skillIds.map((id) => ({ id, body: readSkillBody(root, id) }));
+      const systemPrompt = composeSystemPrompt(spec, skills);
+
+      const tmpDir = mkdtempSync(join(tmpdir(), "swe-workbench-subagent-"));
+      const promptFile = join(tmpDir, "system-prompt.md");
+      try {
+        writeFileSync(promptFile, systemPrompt, { mode: 0o600 });
+
+        const args = [
+          "-p",
+          prompt,
+          "--append-system-prompt",
+          promptFile,
+          "--tools",
+          toolNames.join(","),
+          "--exclude-tools",
+          `${TASK_TOOL_NAME},${PI_SUBAGENTS_TOOL_NAME}`,
+          "--no-session",
+        ];
+        if (ctx.model) {
+          args.push("--model", `${ctx.model.provider}/${ctx.model.id}`);
+        }
+
+        const result = await pi.exec("pi", args, { cwd: ctx.cwd, timeout: TASK_TIMEOUT_MS, signal });
+
+        if (result.code !== 0) {
+          const stderr = capOutput(result.stderr.trim()) || "(no stderr)";
+          throw new Error(
+            `task: dispatched agent "${agent}" exited ${result.code}${result.killed ? " (killed)" : ""} — ${stderr}`,
+          );
+        }
+
+        return {
+          content: [{ type: "text" as const, text: capOutput(result.stdout) }],
+          details: { code: result.code, killed: result.killed },
+        };
+      } finally {
+        // Unlink then rmdir AFTER pi.exec() resolves, never before — a missing file at read
+        // time makes Pi's resolvePromptInput silently use the literal path string as the
+        // prompt instead of erroring, which would corrupt the child's system prompt silently.
+        try {
+          unlinkSync(promptFile);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+        }
+        try {
+          rmdirSync(tmpDir);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+        }
+      }
+    },
+  });
+}

--- a/pi/extensions/tool-vocab.ts
+++ b/pi/extensions/tool-vocab.ts
@@ -7,8 +7,9 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-/** Exactly Pi's built-in tools that correspond to a Claude Code tool this repo's prose names. */
-const RENAME_TABLE: ReadonlyArray<readonly [string, string]> = [
+/** Exactly Pi's built-in tools that correspond to a Claude Code tool this repo's prose names.
+ *  Exported for subagent.ts's tool-token translator (agent-spec.ts's translateToolTokens). */
+export const RENAME_TABLE: ReadonlyArray<readonly [string, string]> = [
   ["Read", "read"],
   ["Write", "write"],
   ["Edit", "edit"],
@@ -71,30 +72,55 @@ const WORKTREE_SECTION =
   "prose offers `EnterWorktree` with a `cd <absolute-path>` fallback, on Pi the `cd` branch " +
   "is *the* mechanism, not a last resort — always use it.";
 
-// Verbatim from superpowers:using-superpowers' Pi reference (references/pi-tools.md): the
-// no-subagent-tool and no-task-list paragraphs, so a Pi session never invents a capability Pi
-// core does not ship.
-const ANTI_HALLUCINATION_SECTION =
-  "Pi core does not ship a standard subagent tool. The `pi-subagents` package is a strong " +
-  "optional companion and provides a `subagent` tool with single-agent, chain, parallel, " +
-  "async, forked-context, and resume/status workflows. If no subagent tool is available, do " +
-  "not fabricate `Task` calls; execute sequentially in the current session or explain that the " +
-  "optional subagent capability is not installed.\n\n" +
+// The task-list paragraph is verbatim from superpowers:using-superpowers' Pi reference
+// (references/pi-tools.md), so a Pi session never invents a capability Pi core does not ship.
+const TASK_LIST_SECTION =
   "Pi core does not ship a standard task-list tool. If a todo/task extension is installed, use " +
   "its documented tool. Otherwise use Superpowers plan files, checklists in Markdown, or a " +
   "repo-local `TODO.md` for task tracking. Older Superpowers docs may refer to `TodoWrite`; " +
   "treat that as the task-tracking action above.";
 
+// Also verbatim from that same reference: the no-subagent-tool paragraph, used only when this
+// plugin's own `task` tool (pi/extensions/subagent.ts) is NOT registered.
+const NO_SUBAGENT_TOOL_PARAGRAPH =
+  "Pi core does not ship a standard subagent tool. The `pi-subagents` package is a strong " +
+  "optional companion and provides a `subagent` tool with single-agent, chain, parallel, " +
+  "async, forked-context, and resume/status workflows. If no subagent tool is available, do " +
+  "not fabricate `Task` calls; execute sequentially in the current session or explain that the " +
+  "optional subagent capability is not installed.";
+
+// Used when subagent.ts's `task` tool IS registered — names the real tool instead of telling
+// the model not to fabricate one.
+const TASK_TOOL_PARAGRAPH =
+  "This plugin registers its own `task` tool: `task(agent, prompt)` dispatches any of this " +
+  'plugin\'s `agents/*.md` definitions (e.g. `task({ agent: "reviewer", prompt: "..." })`) as ' +
+  "a nested Pi session, running with that agent's declared tools and preloaded skills. Use it " +
+  "for subagent dispatch. The `pi-subagents` package (if also installed) provides its own, " +
+  "separate `subagent` tool for generic delegation — `task` is this plugin's first-party " +
+  "alternative, not a wrapper around it.";
+
+function antiHallucinationSection(taskToolRegistered: boolean): string {
+  const subagentParagraph = taskToolRegistered ? TASK_TOOL_PARAGRAPH : NO_SUBAGENT_TOOL_PARAGRAPH;
+  return `${subagentParagraph}\n\n${TASK_LIST_SECTION}`;
+}
+
 /** Returns the {title, body}-shaped section composePreamble expects for the CC->Pi tool
- *  vocabulary this repo's shared prose (skills/, commands/, agents/) assumes. */
-export function toolVocabSection(root: string): { title: string; body: string } {
+ *  vocabulary this repo's shared prose (skills/, commands/, agents/) assumes.
+ *  `taskToolRegistered` should mirror whether subagent.ts's `task` tool was actually registered
+ *  this session (index.ts computes this once from the same kill switch registerSubagent reads),
+ *  so the preamble never tells the model to fabricate `Task` calls while a real `task` tool is
+ *  live, nor names a `task` tool that was never registered. */
+export function toolVocabSection(
+  root: string,
+  taskToolRegistered = false,
+): { title: string; body: string } {
   const body = [
     renameTableSection(),
     skillLegendSection(root),
     ASK_USER_QUESTION_SECTION,
     EXIT_PLAN_MODE_SECTION,
     WORKTREE_SECTION,
-    ANTI_HALLUCINATION_SECTION,
+    antiHallucinationSection(taskToolRegistered),
   ].join("\n\n");
   return { title: "Claude Code -> Pi tool vocabulary", body };
 }

--- a/pi/extensions/tool-vocab.ts
+++ b/pi/extensions/tool-vocab.ts
@@ -106,10 +106,11 @@ function antiHallucinationSection(taskToolRegistered: boolean): string {
 
 /** Returns the {title, body}-shaped section composePreamble expects for the CC->Pi tool
  *  vocabulary this repo's shared prose (skills/, commands/, agents/) assumes.
- *  `taskToolRegistered` should mirror whether subagent.ts's `task` tool was actually registered
- *  this session (index.ts computes this once from the same kill switch registerSubagent reads),
- *  so the preamble never tells the model to fabricate `Task` calls while a real `task` tool is
- *  live, nor names a `task` tool that was never registered. */
+ *  `taskToolRegistered` should reflect whether `task` is actually live in this session's tool
+ *  registry (index.ts derives it from `pi.getActiveTools()`, not just the kill switch — a
+ *  dispatched child can have `task` registered yet excluded via its own argv), so the preamble
+ *  never tells the model to fabricate `Task` calls while `task` is live, nor names a `task`
+ *  tool that isn't actually callable. */
 export function toolVocabSection(
   root: string,
   taskToolRegistered = false,

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -57,6 +57,11 @@ PI_SUBSTITUTE_ARGS_RE = re.compile(
 # Phase 7 `pi:` override block) must be added here deliberately, not discovered by CI red.
 FRONTMATTER_KEYS = {"name", "description", "model", "tools", "skills"}
 
+# Union of every agents/*.md `model:` value. Mirrors model-tier.ts's KNOWN_MODEL_TIERS — a new
+# tier value on disk not also added to that module's MODEL_TIER_TABLE would resolve to nothing
+# for every provider, silently falling back to the parent's model with zero signal.
+MODEL_TIERS = {"haiku", "sonnet", "opus"}
+
 # Union of every comma-separated token across all agents/*.md `tools:` lines. Grows only
 # when an agent's frontmatter is edited to grant a new tool — not on every agent edit.
 TOOL_TOKENS = {
@@ -241,6 +246,23 @@ def test_tool_tokens_and_skill_ids_are_inventoried():
         "agents/*.md skill ids have drifted from the inventory — "
         f"only on disk: {sorted(skill_ids - SKILL_IDS)}, "
         f"only in SKILL_IDS: {sorted(SKILL_IDS - skill_ids)}"
+    )
+
+
+def test_model_tiers_are_inventoried():
+    tiers = set()
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        fm = validate.parse_frontmatter(path)
+        assert fm is not None, f"{path} has no parseable frontmatter"
+        model = fm.get("model")
+        if model:
+            tiers.add(model)
+    assert tiers == MODEL_TIERS, (
+        "agents/*.md model tiers have drifted from the inventory — "
+        f"only on disk: {sorted(tiers - MODEL_TIERS)}, "
+        f"only in MODEL_TIERS: {sorted(MODEL_TIERS - tiers)}. A new tier value must also be "
+        "added to model-tier.ts's KNOWN_MODEL_TIERS and MODEL_TIER_TABLE, or it silently "
+        "resolves to nothing for every provider."
     )
 
 
@@ -614,6 +636,7 @@ def test_ask_user_ts_has_no_typebox_import():
 # ---------------------------------------------------------------------------
 
 AGENT_SPEC_TS = EXTENSIONS_DIR / "agent-spec.ts"
+MODEL_TIER_TS = EXTENSIONS_DIR / "model-tier.ts"
 SUBAGENT_TS = EXTENSIONS_DIR / "subagent.ts"
 
 
@@ -626,6 +649,16 @@ def test_agent_spec_ts_never_references_pi():
     text = AGENT_SPEC_TS.read_text(encoding="utf-8")
     assert "pi-coding-agent" not in text, "agent-spec.ts must not reference the Pi SDK at all"
     assert "node:child_process" not in text, "agent-spec.ts must not spawn processes — that is subagent.ts's job"
+
+
+def test_model_tier_ts_never_references_pi():
+    """model-tier.ts is the domain layer for tier->model resolution: pure data and pure
+    functions, no Pi SDK reference and no process spawning — subagent.ts owns querying
+    ctx.modelRegistry and everything else that touches Pi. Same posture, same test shape, as
+    test_agent_spec_ts_never_references_pi above."""
+    text = MODEL_TIER_TS.read_text(encoding="utf-8")
+    assert "pi-coding-agent" not in text, "model-tier.ts must not reference the Pi SDK at all"
+    assert "node:child_process" not in text, "model-tier.ts must not spawn processes — that is subagent.ts's job"
 
 
 _TRANSLATION_TABLE_DRIVER = """
@@ -671,6 +704,49 @@ def test_task_tool_translation_table_is_exhaustive_over_tool_tokens():
         "RENAME_TABLE/DROP_TOKENS carries tokens beyond agents/*.md's live TOOL_TOKENS vocabulary "
         f"other than the known LS entry (see this test's docstring): {sorted(extra)}"
     )
+
+
+_MODEL_TIER_TABLE_DUMP_DRIVER = """
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.argv[2]).href);
+console.log(JSON.stringify({
+  knownTiers: mod.KNOWN_MODEL_TIERS,
+  tableTiersByProvider: Object.fromEntries(
+    Object.entries(mod.MODEL_TIER_TABLE).map(([provider, row]) => [provider, Object.keys(row)]),
+  ),
+}));
+"""
+
+
+@requires_node
+def test_model_tier_table_is_exhaustive_over_known_tiers():
+    """model-tier.ts's own KNOWN_MODEL_TIERS must equal the live MODEL_TIERS ratchet, and every
+    provider row in MODEL_TIER_TABLE must cover all three tiers — a provider entry missing a
+    tier would silently resolve to undefined (parent-model fallback) for that tier only, which
+    is easy to miss without an exhaustiveness check."""
+    import tempfile
+
+    node = shutil.which("node")
+    assert node is not None
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "model-tier-table-dump.mjs"
+        driver.write_text(_MODEL_TIER_TABLE_DUMP_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(EXTENSIONS_DIR / "model-tier.ts")],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    dumped = json.loads(result.stdout)
+    assert set(dumped["knownTiers"]) == MODEL_TIERS, (
+        f"model-tier.ts's KNOWN_MODEL_TIERS ({sorted(dumped['knownTiers'])}) has drifted from "
+        f"the live agents/*.md inventory ({sorted(MODEL_TIERS)})"
+    )
+    for provider, tiers in dumped["tableTiersByProvider"].items():
+        assert set(tiers) == MODEL_TIERS, (
+            f"MODEL_TIER_TABLE[{provider!r}] covers {sorted(tiers)}, missing "
+            f"{sorted(MODEL_TIERS - set(tiers))} — an uncovered tier silently falls back to the "
+            "parent's model for that provider only"
+        )
 
 
 _TASK_SCHEMA_DRIVER = """

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -706,6 +706,54 @@ def test_task_tool_translation_table_is_exhaustive_over_tool_tokens():
     )
 
 
+_REAL_AGENTS_PARSE_DRIVER = """
+import { pathToFileURL } from "node:url";
+const [, , agentSpecPath, root] = process.argv;
+const mod = await import(pathToFileURL(agentSpecPath).href);
+
+const out = {};
+for (const name of mod.listAgentNames(root)) {
+  try {
+    const spec = mod.readAgentSpec(root, name);
+    const translated = mod.translateToolTokens(spec.tools);
+    out[name] = { ok: true, toolCount: translated.length };
+  } catch (err) {
+    out[name] = { ok: false, message: String(err && err.message) };
+  }
+}
+console.log(JSON.stringify(out));
+"""
+
+
+@requires_node
+def test_real_agents_parse_and_translate_without_throwing():
+    """Drives the REAL hand-rolled TS parser (readAgentSpec/translateToolTokens) against every
+    actual agents/*.md file on disk — not the synthetic fixtures test_pi_extension.py's parser
+    tests use, and not validate.py's separate lenient Python parser (which the exhaustiveness
+    ratchets above cross-check against instead of the TS one). A frontmatter edit that's valid
+    under the Python parser's rules but breaks an assumption the TS regex parser makes (e.g. a
+    block-style `tools:` sequence instead of the assumed inline comma string) would otherwise
+    stay CI-green and only surface as a runtime throw the first time that agent is actually
+    dispatched via `task` — the exact 'frontmatter drift should fail CI, not silently break at
+    dispatch time' failure mode this repo's Pi port is designed to avoid."""
+    import tempfile
+
+    node = shutil.which("node")
+    assert node is not None
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "real-agents-parse-dump.mjs"
+        driver.write_text(_REAL_AGENTS_PARSE_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(AGENT_SPEC_TS), str(ROOT)],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    dumped = json.loads(result.stdout)
+    assert dumped, "no agents/*.md files were discovered — listAgentNames or ROOT is likely wrong"
+    failures = {name: r["message"] for name, r in dumped.items() if not r["ok"]}
+    assert not failures, f"real agents/*.md files failed to parse/translate via the TS parser: {failures}"
+
+
 _MODEL_TIER_TABLE_DUMP_DRIVER = """
 import { pathToFileURL } from "node:url";
 const mod = await import(pathToFileURL(process.argv[2]).href);

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -606,3 +606,169 @@ def test_ask_user_ts_has_no_typebox_import():
         "ask-user.ts must derive its parameter type from the SDK's own ToolDefinition re-export, "
         "never by importing typebox directly — see the file's own module docstring for why"
     )
+
+
+# ---------------------------------------------------------------------------
+# #610: task-tool dispatcher (agent-spec.ts + subagent.ts). Layering boundary, translation-table
+# exhaustiveness, and a live zero-LLM probe of the --exclude-tools recursion guard.
+# ---------------------------------------------------------------------------
+
+AGENT_SPEC_TS = EXTENSIONS_DIR / "agent-spec.ts"
+SUBAGENT_TS = EXTENSIONS_DIR / "subagent.ts"
+
+
+def test_agent_spec_ts_never_references_pi():
+    """agent-spec.ts is the domain layer for #610's task tool: it may read this plugin's own
+    agents/*.md and skills/*/SKILL.md files, but must never reference the Pi SDK or spawn a
+    process — that's subagent.ts's job. Stricter than the generic bare-specifier test above (which
+    permits `import type`): this scans the whole file text, so it would also catch a stray
+    reference in a comment or a future non-import usage, not just an import statement."""
+    text = AGENT_SPEC_TS.read_text(encoding="utf-8")
+    assert "pi-coding-agent" not in text, "agent-spec.ts must not reference the Pi SDK at all"
+    assert "node:child_process" not in text, "agent-spec.ts must not spawn processes — that is subagent.ts's job"
+
+
+_TRANSLATION_TABLE_DRIVER = """
+import { pathToFileURL } from "node:url";
+const [, , toolVocabPath, agentSpecPath] = process.argv;
+const toolVocab = await import(pathToFileURL(toolVocabPath).href);
+const agentSpec = await import(pathToFileURL(agentSpecPath).href);
+console.log(JSON.stringify({
+  renameKeys: toolVocab.RENAME_TABLE.map(([cc]) => cc),
+  dropTokens: [...agentSpec.DROP_TOKENS],
+}));
+"""
+
+
+@requires_node
+def test_task_tool_translation_table_is_exhaustive_over_tool_tokens():
+    """Every token in TOOL_TOKENS (the live inventory of agents/*.md `tools:` values) must have
+    a mapping — via RENAME_TABLE (rename) or DROP_TOKENS (drop) — so a future 8th/9th tool token
+    can't silently fall through translateToolTokens un-mapped. The reverse direction is checked
+    too, but with one documented exception: RENAME_TABLE carries `LS` for tool-vocab.ts's general
+    CC->Pi prose even though no agent's `tools:` frontmatter currently grants LS — a real Pi
+    rename target, not drift, so it is the one allowed extra rather than asserted away."""
+    import tempfile
+
+    node = shutil.which("node")
+    assert node is not None
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "translation-table-dump.mjs"
+        driver.write_text(_TRANSLATION_TABLE_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(EXTENSIONS_DIR / "tool-vocab.ts"), str(AGENT_SPEC_TS)],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    dumped = json.loads(result.stdout)
+    mapped = set(dumped["renameKeys"]) | set(dumped["dropTokens"])
+
+    missing = TOOL_TOKENS - mapped
+    assert not missing, f"TOOL_TOKENS not covered by RENAME_TABLE/DROP_TOKENS: {sorted(missing)}"
+
+    extra = mapped - TOOL_TOKENS
+    assert extra == {"LS"}, (
+        "RENAME_TABLE/DROP_TOKENS carries tokens beyond agents/*.md's live TOOL_TOKENS vocabulary "
+        f"other than the known LS entry (see this test's docstring): {sorted(extra)}"
+    )
+
+
+_TASK_SCHEMA_DRIVER = """
+import { pathToFileURL } from "node:url";
+const mod = await import(pathToFileURL(process.argv[2]).href);
+let registered;
+const stubPi = { registerTool(tool) { registered = tool; } };
+mod.registerSubagent(stubPi, process.argv[3]);
+console.log(JSON.stringify({
+  parameters: registered.parameters,
+  hasPromptSnippet: typeof registered.promptSnippet === "string" && registered.promptSnippet.length > 0,
+  name: registered.name,
+}));
+"""
+
+
+@requires_node
+def test_task_tool_parameters_is_a_plain_json_schema_object():
+    node = shutil.which("node")
+    assert node is not None
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        driver = Path(tmp) / "task-schema-dump.mjs"
+        driver.write_text(_TASK_SCHEMA_DRIVER, encoding="utf-8")
+        result = subprocess.run(
+            [node, "--experimental-strip-types", str(driver), str(SUBAGENT_TS), tmp],
+            capture_output=True, text=True, env=_CLEAN_ENV, timeout=30,
+        )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    dumped = json.loads(result.stdout)
+    assert dumped["name"] == "task"
+    parameters = dumped["parameters"]
+    assert isinstance(parameters, dict), "parameters must serialize as a plain JSON object"
+    assert parameters.get("type") == "object"
+    assert set(parameters.get("required", [])) == {"agent", "prompt"}
+    assert dumped["hasPromptSnippet"] is True, (
+        "custom tools are omitted from the system prompt's Available tools section without a "
+        "promptSnippet — task must always carry one"
+    )
+
+
+_EXCLUDE_TOOLS_PROBE_WRAPPER = """
+import {{ registerSubagent }} from {subagent_path};
+
+export default function (pi) {{
+  registerSubagent(pi, {root});
+  pi.on("session_start", (event, ctx) => {{
+    const active = pi.getActiveTools();
+    process.stderr.write("PROBE_ACTIVE_TOOLS:" + JSON.stringify(active) + "\\n");
+    ctx.shutdown();
+  }});
+}}
+"""
+
+
+def test_exclude_tools_structurally_prevents_task_tool_activation(tmp_path_factory):
+    """Live-CLI, zero-model-call probe: registers the REAL task tool (subagent.ts's
+    registerSubagent) via the real `pi` binary, and confirms `--exclude-tools task,subagent`
+    keeps it out of pi.getActiveTools() — the exact mechanism subagent.ts's own argv relies on
+    for its recursion guard (verified against dist/core/agent-session.js's isAllowedTool: an
+    excluded tool is never added to the tool registry at construction time, so it cannot be
+    resurrected from inside the child session). A session_start handler calls ctx.shutdown()
+    before any prompt is sent — `pi -p` with zero message args never calls session.prompt(), so
+    this makes no network or model call.
+
+    No pi/node_modules and no global `pi` install exists in this repo's pytest CI job today
+    (only the separate typecheck-pi job runs `npm ci --prefix pi`, and no job installs `pi`
+    globally) — this test provides real coverage on any developer machine with `pi` installed,
+    and will start providing CI coverage automatically if a future CI change adds a `pi`
+    install step to the pytest job. Skipping here is a documented, intentional trade-off, not a
+    silent no-op."""
+    pi_bin = shutil.which("pi")
+    if pi_bin is None:
+        pytest.skip("requires a global `pi` CLI on PATH — not provisioned in this repo's pytest CI job")
+
+    wrapper = tmp_path_factory.mktemp("pi-exclude-tools-probe") / "probe.ts"
+    wrapper.write_text(
+        _EXCLUDE_TOOLS_PROBE_WRAPPER.format(
+            subagent_path=json.dumps(str(SUBAGENT_TS)),
+            root=json.dumps(str(ROOT)),
+        ),
+        encoding="utf-8",
+    )
+
+    def run_probe(exclude):
+        args = [pi_bin, "-p", "--extension", str(wrapper), "--no-session", "--mode", "text"]
+        if exclude:
+            args += ["--exclude-tools", "task,subagent"]
+        result = subprocess.run(args, capture_output=True, text=True, env=dict(_CLEAN_ENV), timeout=30)
+        assert result.returncode == 0, f"probe failed: {result.stderr}"
+        marker = "PROBE_ACTIVE_TOOLS:"
+        line = next((l for l in result.stderr.splitlines() if l.startswith(marker)), None)
+        assert line is not None, f"probe never reported active tools; stderr={result.stderr!r}"
+        return json.loads(line[len(marker):])
+
+    with_task = run_probe(exclude=False)
+    assert "task" in with_task, f"expected task active with no --exclude-tools, got {with_task}"
+
+    excluded = run_probe(exclude=True)
+    assert "task" not in excluded, f"--exclude-tools task,subagent failed to exclude task: {excluded}"

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -609,7 +609,7 @@ def test_ask_user_ts_has_no_typebox_import():
 
 
 # ---------------------------------------------------------------------------
-# #610: task-tool dispatcher (agent-spec.ts + subagent.ts). Layering boundary, translation-table
+# task-tool dispatcher (agent-spec.ts + subagent.ts). Layering boundary, translation-table
 # exhaustiveness, and a live zero-LLM probe of the --exclude-tools recursion guard.
 # ---------------------------------------------------------------------------
 
@@ -618,7 +618,7 @@ SUBAGENT_TS = EXTENSIONS_DIR / "subagent.ts"
 
 
 def test_agent_spec_ts_never_references_pi():
-    """agent-spec.ts is the domain layer for #610's task tool: it may read this plugin's own
+    """agent-spec.ts is the domain layer for the task tool: it may read this plugin's own
     agents/*.md and skills/*/SKILL.md files, but must never reference the Pi SDK or spawn a
     process — that's subagent.ts's job. Stricter than the generic bare-specifier test above (which
     permits `import type`): this scans the whole file text, so it would also catch a stray

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1367,6 +1367,48 @@ def test_subagent_nonzero_exit_surfaces_stderr(subagent_root, tmp_path_factory):
     assert "boom" in result["execFails"]["message"]
 
 
+_CAP_OUTPUT_DRIVER = """
+import { pathToFileURL } from "node:url";
+const [, , modPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const mod = await import(pathToFileURL(modPath).href);
+console.log(JSON.stringify({
+  underCap: mod.capOutput(config.shortText),
+  emojiBoundary: mod.capOutput(config.emojiBoundaryText),
+  plainBoundary: mod.capOutput(config.plainBoundaryText),
+}));
+"""
+
+
+@requires_node
+def test_cap_output_does_not_split_a_surrogate_pair_at_the_boundary(tmp_path_factory):
+    """capOutput's slice() is a UTF-16 code-unit cut, tested directly (not through the full
+    exec/JSON/stdout-UTF-8 round trip — a lone surrogate does not survive that pipeline intact,
+    so this Unicode edge case has to be verified in-process). A surrogate pair (an emoji)
+    straddling the OUTPUT_CAP_CHARS boundary must not leave a lone leading surrogate dangling in
+    the truncated result — the resulting string must stay well-formed UTF-16 throughout."""
+    emoji = "\U0001F600"  # 2 UTF-16 code units — the high surrogate lands exactly at index 49999
+    config = {
+        "shortText": "hello",
+        "emojiBoundaryText": ("a" * 49999) + emoji + "TAIL",
+        "plainBoundaryText": "b" * 50010,
+    }
+    result = _run_node(_CAP_OUTPUT_DRIVER, [str(SUBAGENT_TS), json.dumps(config)], tmp_path_factory, label="pi-cap-output-driver")
+
+    assert result["underCap"] == "hello", "text under the cap must pass through unchanged"
+
+    emoji_boundary = result["emojiBoundary"]
+    assert not any(0xD800 <= ord(c) <= 0xDFFF for c in emoji_boundary), (
+        "a lone surrogate leaked into the truncated output — ill-formed UTF-16"
+    )
+    assert emoji_boundary.startswith("a" * 49999)
+    assert "[truncated" in emoji_boundary
+
+    plain_boundary = result["plainBoundary"]
+    assert plain_boundary.startswith("b" * 50000)
+    assert "[truncated" in plain_boundary
+
+
 @requires_node
 def test_subagent_tiered_agent_resolves_model_via_tier_table(subagent_root, tmp_path_factory):
     """End-to-end: tiered-agent's `model: haiku` frontmatter, combined with ctx.model on

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -345,6 +345,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
         "tool-vocab.ts",
         "ask-user.ts",
         "agent-spec.ts",
+        "model-tier.ts",
         "subagent.ts",
     ):
         (synthetic_index.parent / helper).write_text(
@@ -1082,6 +1083,7 @@ def test_ask_user_no_ui_fails_loudly_without_calling_input(tmp_path_factory):
 
 SUBAGENT_TS = ROOT / "pi" / "extensions" / "subagent.ts"
 AGENT_SPEC_TS = ROOT / "pi" / "extensions" / "agent-spec.ts"
+MODEL_TIER_TS = ROOT / "pi" / "extensions" / "model-tier.ts"
 
 _SUBAGENT_DRIVER = """
 import { existsSync, readFileSync } from "node:fs";
@@ -1092,6 +1094,7 @@ const config = JSON.parse(configJson);
 const mod = await import(pathToFileURL(modPath).href);
 
 const execCalls = [];
+const modelRegistryCalls = [];
 const stubPi = {
   registerTool(tool) { this._registered = tool; },
   async exec(command, args, options) {
@@ -1120,8 +1123,18 @@ function lastPromptFile() {
   return last.args[idx + 1];
 }
 
-async function run(agent, prompt, model) {
-  const ctx = { cwd: config.cwd, model };
+async function run(agent, prompt, model, availableModels, scopedModels) {
+  const ctx = {
+    cwd: config.cwd,
+    model,
+    scopedModels: scopedModels || [],
+    modelRegistry: {
+      getAvailable() {
+        modelRegistryCalls.push(availableModels || []);
+        return availableModels || [];
+      },
+    },
+  };
   try {
     const result = await registered.execute("tc1", { agent, prompt }, undefined, undefined, ctx);
     return { ok: true, result };
@@ -1150,6 +1163,47 @@ if (registered) {
 
   execCalls.length = 0;
   out.execFails = await run("real-agent", "hi");
+
+  const anthropicCandidates = [
+    { provider: "anthropic", id: "claude-haiku-4-5" },
+    { provider: "anthropic", id: "claude-sonnet-5" },
+    { provider: "anthropic", id: "claude-opus-5" },
+  ];
+  const mixedProviderCandidates = [
+    ...anthropicCandidates,
+    { provider: "openai-codex", id: "gpt-5.6-luna" },
+  ];
+
+  execCalls.length = 0;
+  out.tieredAgentResolvesHaiku = await run(
+    "tiered-agent", "hi", { provider: "anthropic", id: "claude-sonnet-5" }, anthropicCandidates,
+  );
+  out.tieredAgentExecCalls = execCalls.slice();
+
+  execCalls.length = 0;
+  out.tieredAgentIgnoresOtherProviderCandidates = await run(
+    "tiered-agent", "hi", { provider: "anthropic", id: "claude-sonnet-5" }, mixedProviderCandidates,
+  );
+  out.tieredAgentIgnoresOtherProviderExecCalls = execCalls.slice();
+
+  execCalls.length = 0;
+  out.untieredAgentFallsBackToParentModel = await run(
+    "real-agent", "hi", { provider: "anthropic", id: "claude-sonnet-5" }, anthropicCandidates,
+  );
+  out.untieredAgentFallsBackExecCalls = execCalls.slice();
+
+  // ctx.scopedModels restricts the session to only claude-sonnet-5 — the haiku-tier candidate
+  // exists in the full modelRegistry catalog but is NOT in scope, so resolution must respect
+  // the restriction (fall back to the parent model) rather than reaching past it.
+  const sonnetOnlyScope = [{ model: { provider: "anthropic", id: "claude-sonnet-5" } }];
+
+  execCalls.length = 0;
+  modelRegistryCalls.length = 0;
+  out.scopedModelsRestrictsResolution = await run(
+    "tiered-agent", "hi", { provider: "anthropic", id: "claude-sonnet-5" }, anthropicCandidates, sonnetOnlyScope,
+  );
+  out.scopedModelsExecCalls = execCalls.slice();
+  out.scopedModelsBypassedModelRegistry = modelRegistryCalls.length === 0;
 }
 console.log(JSON.stringify(out));
 """
@@ -1177,6 +1231,16 @@ def _write_synthetic_agents_root(tmp_path_factory):
         "tools: Skill\n"
         "---\n\n"
         "Empty tools agent body.\n",
+        encoding="utf-8",
+    )
+    (agents / "tiered-agent.md").write_text(
+        "---\n"
+        "name: tiered-agent\n"
+        "description: test agent with a known model tier\n"
+        "model: haiku\n"
+        "tools: Read\n"
+        "---\n\n"
+        "Tiered agent body.\n",
         encoding="utf-8",
     )
     skill_dir = root / "skills" / "fake-skill"
@@ -1279,6 +1343,9 @@ def test_subagent_composed_prompt_contains_agent_body_and_preloaded_skill_conten
 
 @requires_node
 def test_subagent_passes_model_when_ctx_model_defined(subagent_root, tmp_path_factory):
+    """real-agent has no `model:` frontmatter tier, so this exercises the fallback path:
+    ctx.model is passed through to --model unchanged. The tier-resolution path is covered
+    separately below (tiered-agent)."""
     result = _subagent_result(subagent_root, tmp_path_factory)
     args = result["withModelExecCalls"][0]["args"]
     model_idx = args.index("--model")
@@ -1298,6 +1365,58 @@ def test_subagent_nonzero_exit_surfaces_stderr(subagent_root, tmp_path_factory):
     result = _subagent_result(subagent_root, tmp_path_factory, exec_behavior="failure")
     assert result["execFails"]["ok"] is False
     assert "boom" in result["execFails"]["message"]
+
+
+@requires_node
+def test_subagent_tiered_agent_resolves_model_via_tier_table(subagent_root, tmp_path_factory):
+    """End-to-end: tiered-agent's `model: haiku` frontmatter, combined with ctx.model on
+    anthropic and a fabricated ctx.modelRegistry.getAvailable() candidate list, must resolve to
+    the haiku-tier candidate — not the parent's own (sonnet) model."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["tieredAgentResolvesHaiku"]["ok"] is True
+    args = result["tieredAgentExecCalls"][0]["args"]
+    model_idx = args.index("--model")
+    assert args[model_idx + 1] == "anthropic/claude-haiku-4-5"
+
+
+@requires_node
+def test_subagent_tiered_agent_ignores_other_provider_candidates(subagent_root, tmp_path_factory):
+    """The candidate list handed to resolveModelForTier must already be filtered to
+    ctx.model.provider — an openai-codex candidate must never leak into an anthropic
+    resolution, even when both are present in ctx.modelRegistry.getAvailable()'s raw result."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["tieredAgentIgnoresOtherProviderCandidates"]["ok"] is True
+    args = result["tieredAgentIgnoresOtherProviderExecCalls"][0]["args"]
+    model_idx = args.index("--model")
+    assert args[model_idx + 1] == "anthropic/claude-haiku-4-5"
+
+
+@requires_node
+def test_subagent_untiered_agent_falls_back_to_parent_model(subagent_root, tmp_path_factory):
+    """real-agent has no `model:` tier — even with a populated modelRegistry available, the
+    resolved model must be the parent's own (ctx.model) unchanged, not something derived from
+    the tier table."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["untieredAgentFallsBackToParentModel"]["ok"] is True
+    args = result["untieredAgentFallsBackExecCalls"][0]["args"]
+    model_idx = args.index("--model")
+    assert args[model_idx + 1] == "anthropic/claude-sonnet-5"
+
+
+@requires_node
+def test_subagent_respects_scoped_models_over_full_registry(subagent_root, tmp_path_factory):
+    """A session-scoped model list (ctx.scopedModels, from --models/enabledModels) must win over
+    the full ctx.modelRegistry.getAvailable() catalog — a haiku candidate that exists in the full
+    catalog but was never scoped into this session must not be reachable, and resolveTargetModel
+    must not even query the full registry when scoping is configured."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["scopedModelsRestrictsResolution"]["ok"] is True
+    args = result["scopedModelsExecCalls"][0]["args"]
+    model_idx = args.index("--model")
+    assert args[model_idx + 1] == "anthropic/claude-sonnet-5", (
+        "haiku isn't in scope, so resolution must fall back to the parent's (sonnet) model"
+    )
+    assert result["scopedModelsBypassedModelRegistry"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1333,8 +1452,8 @@ const out = {
   composeMultiSkills: mod.composeSystemPrompt(
     { body: "Agent body." },
     [
-      { id: "swe-workbench:a", body: "Skill A body." },
-      { id: "swe-workbench:b", body: "Skill B body." },
+      { id: "swe-workbench:a", body: "Skill A body.", dir: "/fake/skills/a" },
+      { id: "swe-workbench:b", body: "Skill B body.", dir: "/fake/skills/b" },
     ],
   ),
 };
@@ -1432,3 +1551,156 @@ def test_compose_system_prompt_with_multiple_skills_preserves_order(agent_spec_r
     b_idx = composed.index("Skill B body.")
     assert body_idx < a_idx < b_idx, "skills must appear after the agent body, in skills: order"
     assert "swe-workbench:a" in composed and "swe-workbench:b" in composed
+
+
+@requires_node
+def test_compose_system_prompt_states_each_skills_resolvable_directory(agent_spec_result):
+    """A skill's body can point at its own examples/ (or similar) with a bare relative path —
+    the composed section must state the skill's absolute directory so a dispatched child with
+    `read` can actually resolve that pointer, not just see a dead reference."""
+    composed = agent_spec_result["composeMultiSkills"]
+    assert "/fake/skills/a" in composed
+    assert "/fake/skills/b" in composed
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: model-tier.ts's pure functions directly. No stub `pi`/`ctx` needed.
+# ---------------------------------------------------------------------------
+
+_MODEL_TIER_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const mod = await import(pathToFileURL(modPath).href);
+
+const out = {
+  knownTiers: {
+    haiku: mod.isKnownModelTier("haiku"),
+    sonnet: mod.isKnownModelTier("sonnet"),
+    opus: mod.isKnownModelTier("opus"),
+    other: mod.isKnownModelTier("gpt-5"),
+    undef: mod.isKnownModelTier(undefined),
+  },
+};
+for (const [label, { provider, tier, candidates }] of Object.entries(config.cases)) {
+  out[label] = mod.resolveModelForTier(provider, tier, candidates) ?? null;
+}
+console.log(JSON.stringify(out));
+"""
+
+
+def _model_tier_result(tmp_path_factory):
+    # Verbatim id list + order from the installed SDK's bundled Anthropic catalog
+    # (pi/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/
+    # providers/data/anthropic.json) — NOT a clean one-id-per-tier fixture. This is deliberate:
+    # multiple ids share the "opus"/"sonnet"/"haiku" substring (dated/versioned siblings of the
+    # bare flagship id), in catalog order, not chronological or shortest-first order. A resolver
+    # that just took the first substring match would silently pick a stale snapshot here — this
+    # fixture is what actually caught that bug during review.
+    anthropic_candidates = [
+        {"provider": "anthropic", "id": "claude-fable-5"},
+        {"provider": "anthropic", "id": "claude-haiku-4-5"},
+        {"provider": "anthropic", "id": "claude-haiku-4-5-20251001"},
+        {"provider": "anthropic", "id": "claude-opus-4-5"},
+        {"provider": "anthropic", "id": "claude-opus-4-5-20251101"},
+        {"provider": "anthropic", "id": "claude-opus-4-6"},
+        {"provider": "anthropic", "id": "claude-opus-4-7"},
+        {"provider": "anthropic", "id": "claude-opus-4-8"},
+        {"provider": "anthropic", "id": "claude-opus-5"},
+        {"provider": "anthropic", "id": "claude-sonnet-4-5"},
+        {"provider": "anthropic", "id": "claude-sonnet-4-5-20250929"},
+        {"provider": "anthropic", "id": "claude-sonnet-4-6"},
+        {"provider": "anthropic", "id": "claude-sonnet-5"},
+    ]
+    codex_candidates = [
+        {"provider": "openai-codex", "id": "gpt-5.6-luna"},
+        {"provider": "openai-codex", "id": "gpt-5.6-sol"},
+        {"provider": "openai-codex", "id": "gpt-5.6-terra"},
+        {"provider": "openai-codex", "id": "gpt-5.4-mini"},
+    ]
+    zai_full_candidates = [
+        {"provider": "zai", "id": "glm-5.3"},
+        {"provider": "zai", "id": "glm-5.2"},
+        {"provider": "zai", "id": "glm-5.2-highspeed"},
+    ]
+    zai_no_highspeed_candidates = [
+        {"provider": "zai", "id": "glm-5.3"},
+        {"provider": "zai", "id": "glm-5.2"},
+    ]
+    config = {
+        "cases": {
+            "anthropicOpus": {"provider": "anthropic", "tier": "opus", "candidates": anthropic_candidates},
+            "anthropicSonnet": {"provider": "anthropic", "tier": "sonnet", "candidates": anthropic_candidates},
+            "anthropicHaiku": {"provider": "anthropic", "tier": "haiku", "candidates": anthropic_candidates},
+            "codexOpus": {"provider": "openai-codex", "tier": "opus", "candidates": codex_candidates},
+            "codexSonnet": {"provider": "openai-codex", "tier": "sonnet", "candidates": codex_candidates},
+            "codexHaiku": {"provider": "openai-codex", "tier": "haiku", "candidates": codex_candidates},
+            "zaiOpus": {"provider": "zai", "tier": "opus", "candidates": zai_full_candidates},
+            "zaiSonnet": {"provider": "zai", "tier": "sonnet", "candidates": zai_full_candidates},
+            "zaiHaikuPrefersHighspeed": {"provider": "zai", "tier": "haiku", "candidates": zai_full_candidates},
+            "zaiHaikuFallsBackWithoutHighspeed": {
+                "provider": "zai",
+                "tier": "haiku",
+                "candidates": zai_no_highspeed_candidates,
+            },
+            "unknownProvider": {"provider": "google", "tier": "haiku", "candidates": []},
+            "noMatchingCandidate": {"provider": "anthropic", "tier": "haiku", "candidates": []},
+        },
+    }
+    return _run_node(
+        _MODEL_TIER_DRIVER, [str(MODEL_TIER_TS), json.dumps(config)], tmp_path_factory, label="pi-model-tier-driver"
+    )
+
+
+@requires_node
+def test_is_known_model_tier(tmp_path_factory):
+    result = _model_tier_result(tmp_path_factory)
+    assert result["knownTiers"] == {
+        "haiku": True,
+        "sonnet": True,
+        "opus": True,
+        "other": False,
+        "undef": False,
+    }
+
+
+@requires_node
+def test_resolve_model_for_tier_anthropic(tmp_path_factory):
+    """anthropic_candidates carries the real bundled catalog's dated/versioned siblings
+    (claude-opus-4-5..4-8 alongside claude-opus-5, etc.) — this must still resolve to the bare
+    flagship id via shortestMatch, not whichever same-substring id happens to appear first in
+    catalog order."""
+    result = _model_tier_result(tmp_path_factory)
+    assert result["anthropicOpus"]["id"] == "claude-opus-5"
+    assert result["anthropicSonnet"]["id"] == "claude-sonnet-5"
+    assert result["anthropicHaiku"]["id"] == "claude-haiku-4-5"
+
+
+@requires_node
+def test_resolve_model_for_tier_openai_codex(tmp_path_factory):
+    result = _model_tier_result(tmp_path_factory)
+    assert result["codexOpus"]["id"] == "gpt-5.6-sol"
+    assert result["codexSonnet"]["id"] == "gpt-5.6-terra"
+    assert result["codexHaiku"]["id"] == "gpt-5.6-luna"
+
+
+@requires_node
+def test_resolve_model_for_tier_zai_haiku_prefers_highspeed_then_falls_back(tmp_path_factory):
+    """zai's haiku row lists two patterns in priority order — glm-5.2-highspeed first, plain
+    glm-5.2 as the fallback when the faster variant isn't actually available."""
+    result = _model_tier_result(tmp_path_factory)
+    assert result["zaiOpus"]["id"] == "glm-5.3"
+    assert result["zaiSonnet"]["id"] == "glm-5.3"
+    assert result["zaiHaikuPrefersHighspeed"]["id"] == "glm-5.2-highspeed"
+    assert result["zaiHaikuFallsBackWithoutHighspeed"]["id"] == "glm-5.2"
+
+
+@requires_node
+def test_resolve_model_for_tier_degrades_to_undefined_when_unresolvable(tmp_path_factory):
+    """An unknown provider (no MODEL_TIER_TABLE row) and a known provider with no matching
+    candidate both return undefined — subagent.ts's resolveTargetModel treats undefined as
+    'fall back to the parent's current model unchanged', never as an error."""
+    result = _model_tier_result(tmp_path_factory)
+    assert result["unknownProvider"] is None
+    assert result["noMatchingCandidate"] is None

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -40,15 +40,28 @@ _DRIVER = """
 import { pathToFileURL } from "node:url";
 import { delimiter } from "node:path";
 
-const mod = await import(pathToFileURL(process.argv[2]).href);
+const [, , indexPath, configJson] = process.argv;
+const config = configJson ? JSON.parse(configJson) : {};
+const excludedTools = new Set(config.excludedTools || []);
+
+const mod = await import(pathToFileURL(indexPath).href);
 const factory = mod.default;
 
 const handlers = {};
+const registeredToolNames = [];
 const stubPi = {
   on(event, handler) {
     handlers[event] = handler;
   },
-  registerTool() {},
+  registerTool(tool) {
+    registeredToolNames.push(tool.name);
+  },
+  // Mirrors the real SDK's isAllowedTool: a registered tool this session's own argv excludes
+  // (simulated here via config.excludedTools) is filtered out of the active set even though
+  // registerTool() was called for it — see index.ts's getPreamble() for why this matters.
+  getActiveTools() {
+    return registeredToolNames.filter((name) => !excludedTools.has(name));
+  },
 };
 const stubCtx = { hasUI: true, ui: { notify() {} } };
 
@@ -246,9 +259,40 @@ def test_before_agent_start_injects_tool_vocab_section(extension_result):
 
 
 @requires_node
+def test_before_agent_start_names_task_tool_when_kill_switch_unset(extension_result):
+    """index.ts's getPreamble() reads pi.getActiveTools() — with the kill switch unset (the
+    default) and no --exclude-tools in play, `task` is actually registered AND active, so the
+    preamble must name the real `task` tool, not warn against fabricating one."""
+    injected = extension_result["firstInjection"]["systemPrompt"]
+    assert "`task(agent, prompt)`" in injected
+    assert "fabricate `Task` calls" not in injected
+
+
+@requires_node
+def test_before_agent_start_falls_back_when_task_registered_but_excluded(tmp_path_factory):
+    """Regression test for the dispatched-child case: registerSubagent() still calls
+    pi.registerTool() for `task` whenever SWE_WORKBENCH_PI_TOOLS is unset — including inside a
+    child session whose own argv carries `--exclude-tools task,subagent` (subagent.ts's own
+    recursion guard). The preamble must NOT tell that child to use a `task` tool that has been
+    filtered out of its actual active-tool set — checking pi.getActiveTools() (not the raw env
+    var) is what index.ts's getPreamble() now does to get this right."""
+    result = _run_node(
+        _DRIVER,
+        [str(INDEX_TS), json.dumps({"excludedTools": ["task"]})],
+        tmp_path_factory,
+        label="pi-extension-driver-task-excluded",
+    )
+    injected = result["firstInjection"]["systemPrompt"]
+    assert "fabricate `Task` calls" in injected
+    assert "`task(agent, prompt)`" not in injected
+
+
+@requires_node
 def test_tool_vocab_preamble_survives_the_kill_switch(tmp_path_factory):
     """SWE_WORKBENCH_PI_TOOLS=0 gates Tier-2 tool registration only — the Tier-1 vocabulary
-    prose must stay unconditional, since disabling it makes the session worse, not safer."""
+    prose must stay unconditional, since disabling it makes the session worse, not safer. With
+    the kill switch on, `task` is never registered, so the preamble must fall back to the
+    do-not-fabricate framing rather than naming a tool that isn't actually live."""
     driver = tmp_path_factory.mktemp("pi-extension-driver-kill-switch") / "driver.mjs"
     driver.write_text(_DRIVER, encoding="utf-8")
     node = shutil.which("node")
@@ -264,6 +308,8 @@ def test_tool_vocab_preamble_survives_the_kill_switch(tmp_path_factory):
     injected = parsed["firstInjection"]["systemPrompt"]
     assert "Claude Code -> Pi tool vocabulary" in injected
     assert "| `Read` | `read` |" in injected
+    assert "fabricate `Task` calls" in injected
+    assert "`task(agent, prompt)`" not in injected
 
 
 @requires_node
@@ -292,7 +338,15 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     synthetic_index = synthetic_root / "pi" / "extensions" / "index.ts"
     synthetic_index.parent.mkdir(parents=True)
     synthetic_index.write_text(INDEX_TS.read_text(encoding="utf-8"), encoding="utf-8")
-    for helper in ("guards.ts", "cc-payload.ts", "guard-runner.ts", "tool-vocab.ts", "ask-user.ts"):
+    for helper in (
+        "guards.ts",
+        "cc-payload.ts",
+        "guard-runner.ts",
+        "tool-vocab.ts",
+        "ask-user.ts",
+        "agent-spec.ts",
+        "subagent.ts",
+    ):
         (synthetic_index.parent / helper).write_text(
             (ROOT / "pi" / "extensions" / helper).read_text(encoding="utf-8"), encoding="utf-8"
         )
@@ -835,15 +889,20 @@ def test_adapter_verdict_matches_direct_invocation_for_every_fixture(bash_fixtur
 _TOOL_VOCAB_DRIVER = """
 import { pathToFileURL } from "node:url";
 
-const [, , modPath, root] = process.argv;
+const [, , modPath, root, taskToolRegistered] = process.argv;
 const mod = await import(pathToFileURL(modPath).href);
-const section = mod.toolVocabSection(root);
+const section = taskToolRegistered === undefined
+  ? mod.toolVocabSection(root)
+  : mod.toolVocabSection(root, taskToolRegistered === "true");
 console.log(JSON.stringify(section));
 """
 
 
-def _tool_vocab_section(root, tmp_path_factory):
-    return _run_node(_TOOL_VOCAB_DRIVER, [str(TOOL_VOCAB_TS), str(root)], tmp_path_factory, label="pi-tool-vocab-driver")
+def _tool_vocab_section(root, tmp_path_factory, task_tool_registered=None):
+    args = [str(TOOL_VOCAB_TS), str(root)]
+    if task_tool_registered is not None:
+        args.append("true" if task_tool_registered else "false")
+    return _run_node(_TOOL_VOCAB_DRIVER, args, tmp_path_factory, label="pi-tool-vocab-driver")
 
 
 @requires_node
@@ -858,6 +917,19 @@ def test_tool_vocab_section_has_rename_table_and_legend_rule(tmp_path_factory):
     assert "ExitPlanMode" in section["body"]
     assert "EnterWorktree" in section["body"]
     assert "fabricate `Task` calls" in section["body"]
+
+
+@requires_node
+def test_tool_vocab_section_names_task_tool_when_registered(tmp_path_factory):
+    """taskToolRegistered=true must swap the 'do not fabricate `Task` calls' framing for prose
+    naming the real `task` tool — a stale fabrication warning while `task` is actually live would
+    actively mislead the model."""
+    section = _tool_vocab_section(ROOT, tmp_path_factory, task_tool_registered=True)
+    assert "`task(agent, prompt)`" in section["body"]
+    assert "fabricate `Task` calls" not in section["body"]
+    # Unaffected sections must still be present.
+    assert "| `Read` | `read` |" in section["body"]
+    assert "ask_user_question" in section["body"]
 
 
 @requires_node
@@ -1001,3 +1073,362 @@ def test_ask_user_no_ui_fails_loudly_without_calling_input(tmp_path_factory):
     assert result["noUI"]["ok"] is False
     assert "interactive UI" in result["noUI"]["message"]
     assert result["inputCalls"] == [], "hasUI:false must fail loudly, never silently fall back to ctx.ui.input"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: subagent.ts. Drives the real registerSubagent(pi, root) against a stub
+# ExtensionAPI/ExtensionContext and a synthetic agents/+skills/ tree — no real `pi.exec`, no LLM.
+# ---------------------------------------------------------------------------
+
+SUBAGENT_TS = ROOT / "pi" / "extensions" / "subagent.ts"
+AGENT_SPEC_TS = ROOT / "pi" / "extensions" / "agent-spec.ts"
+
+_SUBAGENT_DRIVER = """
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const mod = await import(pathToFileURL(modPath).href);
+
+const execCalls = [];
+const stubPi = {
+  registerTool(tool) { this._registered = tool; },
+  async exec(command, args, options) {
+    // Read the composed prompt's content HERE, before returning — subagent.ts deletes the temp
+    // file in its own `finally` immediately after this call resolves, so by the time run()
+    // returns to the caller below, the file is already gone.
+    const promptIdx = args.indexOf("--append-system-prompt");
+    const promptFileContent = promptIdx === -1 ? null : readFileSync(args[promptIdx + 1], "utf8");
+    execCalls.push({
+      command, args, promptFileContent,
+      cwd: options && options.cwd, timeout: options && options.timeout,
+    });
+    if (config.execBehavior === "throw") throw new Error("forced exec throw (test)");
+    if (config.execBehavior === "failure") return { stdout: "", stderr: "boom", code: 1, killed: false };
+    return { stdout: "agent output", stderr: "", code: 0, killed: false };
+  },
+};
+
+mod.registerSubagent(stubPi, config.root);
+const registered = stubPi._registered;
+const out = { registered: registered !== undefined, toolName: registered && registered.name };
+
+function lastPromptFile() {
+  const last = execCalls[execCalls.length - 1];
+  const idx = last.args.indexOf("--append-system-prompt");
+  return last.args[idx + 1];
+}
+
+async function run(agent, prompt, model) {
+  const ctx = { cwd: config.cwd, model };
+  try {
+    const result = await registered.execute("tc1", { agent, prompt }, undefined, undefined, ctx);
+    return { ok: true, result };
+  } catch (err) {
+    return { ok: false, message: String(err && err.message) };
+  }
+}
+
+if (registered) {
+  out.notFound = await run("does-not-exist", "hi");
+
+  out.emptyTools = await run("empty-tools-agent", "hi");
+
+  execCalls.length = 0;
+  out.success = await run("real-agent", "hi");
+  out.successExecCalls = execCalls.slice();
+  out.promptFileGoneAfterSuccess = !existsSync(lastPromptFile());
+
+  execCalls.length = 0;
+  out.withModel = await run("real-agent", "hi", { provider: "anthropic", id: "claude-x" });
+  out.withModelExecCalls = execCalls.slice();
+
+  execCalls.length = 0;
+  out.execThrows = await run("real-agent", "hi");
+  out.promptFileGoneAfterThrow = !existsSync(lastPromptFile());
+
+  execCalls.length = 0;
+  out.execFails = await run("real-agent", "hi");
+}
+console.log(JSON.stringify(out));
+"""
+
+
+def _write_synthetic_agents_root(tmp_path_factory):
+    root = tmp_path_factory.mktemp("pi-subagent-root")
+    agents = root / "agents"
+    agents.mkdir()
+    (agents / "real-agent.md").write_text(
+        "---\n"
+        "name: real-agent\n"
+        "description: test agent\n"
+        "tools: Read, Bash\n"
+        "skills:\n"
+        "  - swe-workbench:fake-skill\n"
+        "---\n\n"
+        "Real agent body.\n",
+        encoding="utf-8",
+    )
+    (agents / "empty-tools-agent.md").write_text(
+        "---\n"
+        "name: empty-tools-agent\n"
+        "description: test agent with no mappable tools\n"
+        "tools: Skill\n"
+        "---\n\n"
+        "Empty tools agent body.\n",
+        encoding="utf-8",
+    )
+    skill_dir = root / "skills" / "fake-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: fake-skill\ndescription: test skill\n---\n"
+        "<!-- preload-canary: SWB-PRELOAD-FAKE-SKILL -->\n\nFake skill body.\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _subagent_result(root, tmp_path_factory, *, exec_behavior="success", env=None):
+    config = {"root": str(root), "cwd": str(root), "execBehavior": exec_behavior}
+    node = shutil.which("node")
+    assert node is not None
+    driver = tmp_path_factory.mktemp("pi-subagent-driver") / "driver.mjs"
+    driver.write_text(_SUBAGENT_DRIVER, encoding="utf-8")
+    run_env = dict(_CLEAN_ENV)
+    run_env.update(env or {})
+    result = subprocess.run(
+        [node, "--experimental-strip-types", str(driver), str(SUBAGENT_TS), json.dumps(config)],
+        capture_output=True, text=True, env=run_env, timeout=30,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+@pytest.fixture(scope="module")
+def subagent_root(tmp_path_factory):
+    return _write_synthetic_agents_root(tmp_path_factory)
+
+
+@requires_node
+def test_subagent_registers_by_default(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["registered"] is True
+    assert result["toolName"] == "task"
+
+
+@requires_node
+def test_subagent_kill_switch_skips_registration(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory, env={"SWE_WORKBENCH_PI_TOOLS": "0"})
+    assert result["registered"] is False
+
+
+@requires_node
+def test_subagent_unknown_agent_reports_available_list(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["notFound"]["ok"] is False
+    assert "does-not-exist" in result["notFound"]["message"]
+    assert "empty-tools-agent" in result["notFound"]["message"]
+    assert "real-agent" in result["notFound"]["message"]
+
+
+@requires_node
+def test_subagent_empty_translated_tools_throws_before_exec(subagent_root, tmp_path_factory):
+    """empty-tools-agent's only tool token (Skill) is drop-only — translateToolTokens must
+    throw before pi.exec is ever called, never silently build an empty --tools allowlist."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["emptyTools"]["ok"] is False
+    assert "no Pi mapping" in result["emptyTools"]["message"] or "empty" in result["emptyTools"]["message"]
+
+
+@requires_node
+def test_subagent_success_builds_expected_argv_and_cleans_up_temp_file(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["success"]["ok"] is True
+    assert result["success"]["result"]["content"] == [{"type": "text", "text": "agent output"}]
+
+    call = result["successExecCalls"][0]
+    assert call["command"] == "pi"
+    args = call["args"]
+    assert args[0] == "-p" and args[1] == "hi"
+    assert "--append-system-prompt" in args
+    tools_idx = args.index("--tools")
+    tool_names = set(args[tools_idx + 1].split(","))
+    assert tool_names == {"read", "bash", "ask_user_question"}
+    exclude_idx = args.index("--exclude-tools")
+    assert args[exclude_idx + 1] == "task,subagent"
+    assert "--no-session" in args
+    assert "--model" not in args, "no --model flag when ctx.model is undefined"
+
+    assert result["promptFileGoneAfterSuccess"] is True
+
+
+@requires_node
+def test_subagent_composed_prompt_contains_agent_body_and_preloaded_skill_content(subagent_root, tmp_path_factory):
+    """The whole point of this feature is that a dispatched agent's body AND its preloaded
+    skills actually land in the child's system prompt — not just that some file got written and
+    later deleted. Reads the --append-system-prompt temp file's real content (captured by the
+    driver's stub exec() before subagent.ts's own finally block deletes it) and asserts on it."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    content = result["successExecCalls"][0]["promptFileContent"]
+    assert content is not None
+    assert "Real agent body." in content
+    assert "Fake skill body." in content
+    assert "SWB-PRELOAD-FAKE-SKILL" in content, "the preload-canary marker must survive composition"
+
+
+@requires_node
+def test_subagent_passes_model_when_ctx_model_defined(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    args = result["withModelExecCalls"][0]["args"]
+    model_idx = args.index("--model")
+    assert args[model_idx + 1] == "anthropic/claude-x"
+
+
+@requires_node
+def test_subagent_cleans_up_temp_file_when_exec_throws(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory, exec_behavior="throw")
+    assert result["execThrows"]["ok"] is False
+    assert "forced exec throw" in result["execThrows"]["message"]
+    assert result["promptFileGoneAfterThrow"] is True
+
+
+@requires_node
+def test_subagent_nonzero_exit_surfaces_stderr(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory, exec_behavior="failure")
+    assert result["execFails"]["ok"] is False
+    assert "boom" in result["execFails"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: agent-spec.ts's pure functions (parseAgentSpec, composeSystemPrompt) directly —
+# subagent.ts's integration tests above only exercise the well-formed happy path; these cover
+# parser edge cases (missing required keys, CRLF normalization, zero/multiple skills) that a
+# fixture-driven integration test alone would not catch a regression in.
+# ---------------------------------------------------------------------------
+
+_AGENT_SPEC_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, configJson] = process.argv;
+const config = JSON.parse(configJson);
+const mod = await import(pathToFileURL(modPath).href);
+
+function tryParse(text) {
+  try {
+    return { ok: true, result: mod.parseAgentSpec(text) };
+  } catch (err) {
+    return { ok: false, message: String(err && err.message) };
+  }
+}
+
+const out = {
+  wellFormed: tryParse(config.wellFormedText),
+  missingName: tryParse(config.missingNameText),
+  missingDescription: tryParse(config.missingDescriptionText),
+  crlf: tryParse(config.crlfText),
+  noSkills: tryParse(config.noSkillsText),
+  multiSkills: tryParse(config.multiSkillsText),
+  composeNoSkills: mod.composeSystemPrompt({ body: "Agent body." }, []),
+  composeMultiSkills: mod.composeSystemPrompt(
+    { body: "Agent body." },
+    [
+      { id: "swe-workbench:a", body: "Skill A body." },
+      { id: "swe-workbench:b", body: "Skill B body." },
+    ],
+  ),
+};
+console.log(JSON.stringify(out));
+"""
+
+_WELL_FORMED_TEXT = (
+    "---\nname: sample\ndescription: sample agent\ntools: Read, Bash\n"
+    "skills:\n  - swe-workbench:one\n  - swe-workbench:two\n---\n\nSample agent body.\n"
+)
+_MISSING_NAME_TEXT = "---\ndescription: sample agent\n---\n\nBody.\n"
+_MISSING_DESCRIPTION_TEXT = "---\nname: sample\n---\n\nBody.\n"
+_CRLF_TEXT = "---\r\nname: sample\r\ndescription: sample agent\r\n---\r\n\r\nCRLF body.\r\n"
+_NO_SKILLS_TEXT = "---\nname: sample\ndescription: sample agent\ntools: Read\n---\n\nNo skills body.\n"
+_MULTI_SKILLS_TEXT = (
+    "---\nname: sample\ndescription: sample agent\ntools: Read\n"
+    "skills:\n  - swe-workbench:one\n  - swe-workbench:two\n  - swe-workbench:three\n"
+    "---\n\nMulti skills body.\n"
+)
+
+
+@pytest.fixture(scope="module")
+def agent_spec_result(tmp_path_factory):
+    config = {
+        "wellFormedText": _WELL_FORMED_TEXT,
+        "missingNameText": _MISSING_NAME_TEXT,
+        "missingDescriptionText": _MISSING_DESCRIPTION_TEXT,
+        "crlfText": _CRLF_TEXT,
+        "noSkillsText": _NO_SKILLS_TEXT,
+        "multiSkillsText": _MULTI_SKILLS_TEXT,
+    }
+    return _run_node(
+        _AGENT_SPEC_DRIVER, [str(AGENT_SPEC_TS), json.dumps(config)], tmp_path_factory, label="pi-agent-spec-driver"
+    )
+
+
+@requires_node
+def test_parse_agent_spec_well_formed_extracts_all_fields(agent_spec_result):
+    result = agent_spec_result["wellFormed"]
+    assert result["ok"] is True
+    spec = result["result"]
+    assert spec["name"] == "sample"
+    assert spec["description"] == "sample agent"
+    assert spec["tools"] == ["Read", "Bash"]
+    assert spec["skillIds"] == ["swe-workbench:one", "swe-workbench:two"]
+    assert spec["body"] == "Sample agent body."
+
+
+@requires_node
+def test_parse_agent_spec_missing_name_throws(agent_spec_result):
+    result = agent_spec_result["missingName"]
+    assert result["ok"] is False
+    assert "name" in result["message"]
+
+
+@requires_node
+def test_parse_agent_spec_missing_description_throws(agent_spec_result):
+    result = agent_spec_result["missingDescription"]
+    assert result["ok"] is False
+    assert "description" in result["message"]
+
+
+@requires_node
+def test_parse_agent_spec_normalizes_crlf(agent_spec_result):
+    result = agent_spec_result["crlf"]
+    assert result["ok"] is True
+    assert result["result"]["name"] == "sample"
+    assert result["result"]["body"] == "CRLF body."
+
+
+@requires_node
+def test_parse_agent_spec_empty_skills_list_when_no_skills_key(agent_spec_result):
+    result = agent_spec_result["noSkills"]
+    assert result["ok"] is True
+    assert result["result"]["skillIds"] == []
+
+
+@requires_node
+def test_parse_agent_spec_multiple_skills_preserves_order(agent_spec_result):
+    result = agent_spec_result["multiSkills"]
+    assert result["ok"] is True
+    assert result["result"]["skillIds"] == ["swe-workbench:one", "swe-workbench:two", "swe-workbench:three"]
+
+
+@requires_node
+def test_compose_system_prompt_with_zero_skills_is_just_the_body(agent_spec_result):
+    assert agent_spec_result["composeNoSkills"] == "Agent body."
+
+
+@requires_node
+def test_compose_system_prompt_with_multiple_skills_preserves_order(agent_spec_result):
+    composed = agent_spec_result["composeMultiSkills"]
+    body_idx = composed.index("Agent body.")
+    a_idx = composed.index("Skill A body.")
+    b_idx = composed.index("Skill B body.")
+    assert body_idx < a_idx < b_idx, "skills must appear after the agent body, in skills: order"
+    assert "swe-workbench:a" in composed and "swe-workbench:b" in composed


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Adds a first-party `task` tool (`pi/extensions/subagent.ts` + `pi/extensions/agent-spec.ts`) that dispatches any of this plugin's `agents/*.md` definitions (e.g. `swe-workbench:reviewer`) as a nested Pi child process, preserving that agent's declared `tools:` and preloaded `skills:` content
- The third-party `pi-subagents` package's `skills:` field only makes a skill *available* on demand — it never preloads skill body into context, which this repo's agent convention requires (`docs/skill-preload.md`); this first-party dispatcher exists specifically to close that gap
- Transport is `pi.exec()` (never raw `node:child_process`); recursion through `task`/`subagent` is blocked via `--exclude-tools task,subagent` on the child's argv (verified against the SDK's tool-registry construction, and via a live zero-model-call CLI probe); the composed system prompt is delivered via `--append-system-prompt <tempfile>` (never inline text) to avoid `MAX_ARG_STRLEN` and a silent-overflow failure mode in the SDK's own exec wrapper
- `pi/extensions/tool-vocab.ts` and `index.ts` updated so the anti-hallucination preamble prose correctly names the real `task` tool only when it is actually live in the session's tool registry (checked via `pi.getActiveTools()`, not just the kill-switch env var)
- **Model-tier mapping**: a dispatched agent's `model: haiku/sonnet/opus` frontmatter now resolves to a real per-provider model, via a hardcoded name table in `pi/extensions/model-tier.ts` (`resolveModelForTier`) — scoped to the parent session's active provider (`ctx.model.provider`) and only ever selecting from already-authenticated models (`ctx.scopedModels` when the session is scoped, else `ctx.modelRegistry.getAvailable()`), never a new provider/endpoint/credential; a stale or unresolvable table entry falls back to the parent's own model unchanged
- Preloaded skill sections now state their absolute on-disk directory, so a skill's own bare `examples/` pointer (e.g. `swe-workbench:principle-solid`) is resolvable by a dispatched child with `read`, instead of being a dead reference
- `docs/plugin-platform-decisions.md` §9 records the full design rationale, including the model-tier-mapping safety posture and an accepted, tracked recursion gap: an agent granted `Bash` can still shell out to `pi -p ...` directly for a further, unguarded level of recursion — tracked as a follow-up, not fixed here
- Addressed PR review feedback: a CI test drives the real hand-rolled parser against every actual `agents/*.md` file (not just synthetic fixtures), `capOutput`'s truncation no longer splits a UTF-16 surrogate pair at the cap boundary, and the recursion-gap deferral is now explicit sign-off rather than implicit

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh && npm run typecheck --prefix pi` — 0 issues
- [x] `pytest tests/ -v` — 2768 passed, 2 skipped (pre-existing root-only skips, unrelated)
- [x] Manual end-to-end dispatch against the real `pi` CLI (model `openai-codex/gpt-5.4-mini`): the model called `task` for the `e2e-test-verifier` agent, the child ran with the translated tool set (`read,grep,find,bash,ask_user_question`) and `--exclude-tools task,subagent` visible in the captured argv, and the child's response echoed back the exact `preload-canary` token of its one preloaded skill — confirming real preload injection, not just a passing unit test
- [x] Live zero-model-call CLI probe (`tests/test_pi_contract.py::test_exclude_tools_structurally_prevents_task_tool_activation`) confirms `--exclude-tools` structurally removes the real `task` tool from `pi.getActiveTools()`
- [x] Manual end-to-end model-tier dispatch: parent session running on `openai-codex/gpt-5.4` dispatched a `model: haiku` agent (`e2e-test-verifier`) and the captured child argv showed `--model openai-codex/gpt-5.6-luna`, confirming tier resolution against real, live credentials and a real model registry

### Type-tailored checks (feat)
- [x] New behaviour is covered by tests, not just manually verified
- [x] No existing tool/command behaviour changed unexpectedly

Closes #610
