### PR TITLE
[feat] Block nested pi sessions in bash_guard (#632)

### DIFF
--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -221,16 +221,21 @@ a clear, actionable rejection back — steering it to stop and report the blocke
 response — instead of either silently guessing (no signal at all) or the tool being simply absent
 from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
 
-**Accepted gap, not closed here — tracked as a follow-up.** `--exclude-tools task,subagent` blocks
-recursion only through the `task`/`subagent` tool-call surface. An agent granted `Bash` (20 of the
-22 `agents/*.md` definitions — the large majority of real dispatches, not an edge case) can still
-shell out to `pi -p ...` directly inside a dispatched child, which spawns a fresh child session
-with `task` re-registered and no `--exclude-tools` at all — no argv flag on that child prevents a
-further, unbounded level of recursion this way. Closing it belongs in `hooks/bash_guard.sh`,
-pattern-matching a `pi ... -p`/`--print` invocation, since that reuses an already-audited boundary
-instead of adding a new one. Not built as part of this dispatcher — tracked separately (see the
-open "Close bash-escape-hatch recursion gap in task dispatcher" issue) rather than silently left
-open.
+**Bash-escape-hatch recursion gap: closed via `hooks/bash_guard.sh`, not this dispatcher (#632).**
+`--exclude-tools task,subagent` blocks recursion only through the `task`/`subagent` tool-call
+surface. An agent granted `Bash` (20 of the 22 `agents/*.md` definitions — the large majority of
+real dispatches, not an edge case) could still shell out to `pi -p ...` directly inside a dispatched
+child, which spawns a fresh child session with `task` re-registered and no `--exclude-tools` at
+all — no argv flag on that child prevented a further, unbounded level of recursion this way.
+Closed in `hooks/bash_guard.sh`, which now blocks a segment-scoped `pi ... -p`/`--print` invocation
+(one command segment must carry both a `pi` command token and a `-p`/`--print` flag, so everyday
+commands like `git log -p && pi list` stay allowed) — reusing this already-audited boundary instead
+of adding a new one, since every dispatched agent's `bash` tool call already routes through it
+(`pi/extensions/guards.ts` registers it as a Pi `tool_call` guard unconditionally, and
+`hooks/hooks.json` wires the same script as `PreToolUse:Bash` in Claude Code). `pi.exec()` inside
+this dispatcher is unaffected — it is not a `bash` tool call, so the real dispatch path never
+touches this guard. Non-recursive `pi` subcommands (`pi --version`, `pi list`, `pi auth check`)
+stay allowed.
 
 **Model-tier mapping: an agent's `model: haiku|sonnet|opus` frontmatter picks a real model, by
 name, from a table hardcoded in `pi/extensions/model-tier.ts`.** An earlier iteration of this

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -221,7 +221,7 @@ a clear, actionable rejection back — steering it to stop and report the blocke
 response — instead of either silently guessing (no signal at all) or the tool being simply absent
 from its vocabulary. Costs nothing beyond one line in the `--tools` allowlist.
 
-**Bash-escape-hatch recursion gap: closed via `hooks/bash_guard.sh`, not this dispatcher (#632).**
+**Bash-escape-hatch recursion gap: closed via `hooks/bash_guard.sh`, not this dispatcher.**
 `--exclude-tools task,subagent` blocks recursion only through the `task`/`subagent` tool-call
 surface. An agent granted `Bash` (20 of the 22 `agents/*.md` definitions — the large majority of
 real dispatches, not an edge case) could still shell out to `pi -p ...` directly inside a dispatched

--- a/hooks/bash_guard.sh
+++ b/hooks/bash_guard.sh
@@ -5,12 +5,28 @@
 #   - rm -rf against /, /*, ~, $HOME, /Users[/<user>], /home[/<user>]
 #   - git push --force / -f to main/master/release/*
 #   - git reset --hard on main/master/release/*
+#   - a `pi` invocation carrying -p/--print in the same command segment (nested
+#     non-interactive pi session — the bash escape hatch around the subagent
+#     dispatcher's --exclude-tools recursion guard; see
+#     docs/plugin-platform-decisions.md §9)
 #
-# Short-circuits (exit 0, no greps) for commands that contain neither "rm" nor
-# "git". This is the common case (ls, cat, echo, make, npm, …) and removes the
-# per-call grep tax flagged in #233.
+# Short-circuits (exit 0, no greps) for commands that contain none of "rm",
+# "git", or "pi". This is the common case (ls, cat, echo, make, npm, …) and
+# removes the per-call grep tax flagged in #233.
 #
-# Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal; compound cd (cwd not in hook payload).
+# Out of scope: ${HOME} brace-form; ANSI-C $'...' quoting; path normalization via .. traversal; compound cd (cwd not in hook payload);
+# IFS/word-splitting substitution (e.g. rm${IFS}-rf, pi${IFS}-p) — a shared limitation of the
+# regex/tr token-matching approach across all three detectors (rm, git, pi), not specific to any one.
+# A backslash-escaped quote (e.g. `\"`) inside an already-open double-quoted string desyncs the
+# comment-stripper's quote tracker (pre-existing, predates the pi work, shared by rm/git too) — a
+# `#` that's really inside the string can get treated as a real comment. Indirection that supplies
+# either the `pi` token or the `-p`/`--print` flag from somewhere other than literal argv text
+# (command substitution — `$(which pi) -p x`; parameter expansion — `$P -p x`; another program's
+# output — `echo -p x | xargs pi`) defeats segment-scoping, since the guard only ever sees the
+# unresolved source text — inherent to a text-scanning guard rather than a gap specific to this
+# detector. The `pi` detector matches its command-name token case-insensitively (a case-insensitive
+# filesystem, e.g. macOS's default, resolves "Pi"/"PI" to the same binary); `rm`/`git` do not get the
+# same treatment here — a pre-existing gap, not introduced or widened by this change.
 # --force-with-lease/--force-if-includes intentionally unblocked (#163); force-push after a shell
 # separator (`&& echo main`) may over-block via the folded input (accepted fail-safe); a remote
 # literally named main/master over-blocks. Block 2's push-token scan trusts a small allowlist of
@@ -18,6 +34,9 @@
 # (assumes it takes a separate-word value, e.g. `-o ci.skip`) so an unknown flag's value can never
 # be miscounted as the remote/refspec (#501 senior-engineer consult); an unrecognized flag that
 # actually takes NO value will over-block by one token (fail-safe direction, not a bypass).
+# Quotes are stripped before matching (same fail-safe direction as the force-push over-block
+# above), so a `pi -p` mention inside an unrelated quoted string (e.g. a commit message) can
+# over-block too — accepted, not special-cased.
 
 set -u
 
@@ -26,9 +45,15 @@ if ! cmd=$(jq -r '.tool_input.command // ""'); then
   exit 2
 fi
 
-# Strip shell comments per-line BEFORE folding newlines. A `#` comment ends at
-# its line's newline; folding first would let an early comment swallow a
-# destructive command on a later line (e.g. "echo hi # note\nrm -rf ~").
+# Strip shell comments per-line BEFORE folding newlines or joining backslash
+# continuations. A `#` comment ends at its line's newline; folding first would
+# let an early comment swallow a destructive command on a later line (e.g.
+# "echo hi # note\nrm -rf ~"). A trailing backslash INSIDE a comment has no
+# continuation meaning in real bash either — the comment still ends at the
+# physical newline — so comment-stripping must run BEFORE the backslash-join
+# below, not after: joining first would glue a live command on the next line
+# onto the end of a "# note \"-style comment, and the comment-stripper would
+# then discard it as if it were part of the same comment.
 # Quote-aware: a `#` inside a single- or double-quoted string (e.g. a commit
 # message referencing an issue number, `-m "fix #501"`) is NOT a real shell
 # comment and must not truncate real command text after it (#501 review).
@@ -51,12 +76,36 @@ BEGIN { in_sq = 0; in_dq = 0 }
   print out
 }')
 
+# Join backslash-continued lines AFTER comment-stripping (see above), still
+# BEFORE quote tracking and fast-gate normalization. Real bash removes a
+# trailing backslash-newline entirely — zero characters inserted — so a
+# continuation splitting mid-token (e.g. `r\`⏎`m -rf /`, `p\`⏎`i -p x`)
+# resolves to one contiguous word there too. Folding the newline to a SPACE (as
+# the fast-gate normalization below does for genuine multi-line commands)
+# would leave the token split and let it evade every detector's token match by
+# hiding in the seam; joining here, once, benefits the fast gate and all
+# detectors alike. Parity-aware: real bash only continues on an ODD trailing-
+# backslash count (an unpaired `\` right before the newline) — an EVEN count is
+# N/2 literal escaped-backslash pairs with no continuation at all. Stripping
+# exactly one trailing backslash unconditionally (as an earlier version of this
+# stage did) mis-treats an even count as a continuation too, joining two
+# genuinely separate commands with zero characters between them and erasing
+# the word boundary once the leftover backslash is later deleted by the
+# `tr -d` below — hiding whatever destructive command started the second line
+# from every detector.
+_bj=$(printf '%s' "$_nc" | awk '
+{
+  line = $0; ll = length(line); nb = 0
+  while (nb < ll && substr(line, ll - nb, 1) == "\\") nb++
+  if (nb % 2 == 1) printf "%s", substr(line, 1, ll - 1); else print line
+}')
+
 # Normalise separators AND newlines/tabs/backticks to spaces so rm/git after
 # ; | & \n \t \` are still detected — the fast-gate `case` and the grep
 # detectors must share ONE separator alphabet (gate saw ';|&', grep saw
 # [[:space:]]).
 # shellcheck disable=SC2016  # backtick in tr's SET1 is a literal char, not command substitution
-_norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
+_norm=$(printf '%s' "$_bj" | tr ';|&\n\t`' '      ')
 
 # Fully normalise BEFORE the fast gate, not after: turning "(" and ")" into SPACES (not
 # deleting them) handles $(...), <(...), >(...), and bare (...) uniformly, since whatever
@@ -66,9 +115,16 @@ _norm=$(printf '%s' "$_nc" | tr ';|&\n\t`' '      ')
 # class of gate/detector divergence for quote-wrapped rm.
 norm=$(printf '%s' "$_norm" | tr '()' '  ' | tr -d "'\"[]{}\\\\")
 
+# The "pi" token in the gate is matched with an explicit case-insensitive character class
+# ([Pp][Ii]), not `shopt -s nocasematch` — that shopt would apply to the WHOLE case
+# statement, loosening rm/git's matching too (out of scope here). "Pi"/"PI" resolve to the
+# exact same binary as "pi" on a case-insensitive filesystem (macOS's default) — a plausible
+# typo given the product is styled "Pi" with a capital P elsewhere in this repo's own docs,
+# not just a deliberate evasion. Flags stay case-sensitive (real CLI parsers don't accept
+# "--PRINT" as "--print"), so only the command-name token gets this treatment.
 case "$norm" in
-  rm\ *|*\ rm\ *|*git*) ;;
-  *)                    exit 0 ;;
+  rm\ *|*\ rm\ *|*git*|[Pp][Ii]\ *|*\ [Pp][Ii]\ *|*/[Pp][Ii]\ *) ;;
+  *)                                                             exit 0 ;;
 esac
 
 # shellcheck disable=SC2016  # $HOME in single quotes is intentional: matches literal text, not the shell variable
@@ -92,14 +148,15 @@ fi
 # non-protected refspec (`origin feat`) must stay allowed even from a protected
 # branch — Block 1 already owns explicit protected refspecs.
 if echo "$norm" | grep -Eq 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))'; then
-  # Isolate the FORCE-flagged push invocation from the comment-stripped raw
-  # command ($_nc keeps real separators). Fold the SAME separator alphabet as
-  # $_norm (;|&\n\t, not just ;|&) so a tab/newline-prefixed command doesn't
-  # leak extra tokens onto the push line, and filter to lines that actually
-  # match the force pattern — a chained non-force `git push` (e.g. `git push
-  # origin x && git push --force`) must not be the one inspected for a
-  # refspec, or the real force-push line is skipped entirely (#501 review).
-  push_cmd=$(printf '%s' "$_nc" | tr ';|&\n\t' '\n\n\n\n\n' \
+  # Isolate the FORCE-flagged push invocation from the comment-stripped,
+  # backslash-joined command ($_bj keeps real separators). Fold the SAME
+  # separator alphabet as $_norm (;|&\n\t, not just ;|&) so a tab/newline-
+  # prefixed command doesn't leak extra tokens onto the push line, and filter
+  # to lines that actually match the force pattern — a chained non-force
+  # `git push` (e.g. `git push origin x && git push --force`) must not be the
+  # one inspected for a refspec, or the real force-push line is skipped
+  # entirely (#501 review).
+  push_cmd=$(printf '%s' "$_bj" | tr ';|&\n\t' '\n\n\n\n\n' \
     | grep -E 'git[[:space:]]+push.*(--force([[:space:]]|$)|(^|[[:space:]])-f([[:space:]]|$))' \
     | tr -d "'\"" | head -n1)
   has_refspec=0; seen_positional=0; consume_next=0
@@ -147,5 +204,53 @@ if echo "$norm" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard'; then
       ;;
   esac
 fi
+
+# Nested non-interactive `pi` session — subagent recursion guard. Segment-scoped:
+# a `pi` command token and a -p/--print flag must appear in the SAME segment, so everyday
+# commands like `git log -p && pi list` stay allowed. Segments split on real separators
+# (;|&\n) plus substitution boundaries (`()) so $(pi -p …) is isolated; a literal tab folds
+# to a space (not a break) so `pi<TAB>-p` can't hide across a fake boundary. The whole pass
+# is quote-aware (same in_sq/in_dq state-machine idiom as the comment-stripper above) so a
+# separator character INSIDE a quoted argument (e.g. `pi -m ";" -p x`) is never mistaken for
+# a real segment break — folding separators before stripping quotes was the bug in an
+# earlier version of this block. A backslash-ESCAPED separator (e.g. `pi \; -p x`, a literal
+# argument byte in real bash) must not be treated as a break either — an escaping backslash
+# consumes the NEXT character as a literal and neither is re-examined against the separator
+# or quote-toggle rules, so escaping a `;`/`&`/`(` etc. can't fake a segment boundary and
+# escaping a quote can't fake a close. A REAL (unescaped) newline inside an open quote is
+# also just a literal argument byte (e.g. a multi-line -m message) — awk's own per-record
+# boundary is `\n` unconditionally, so the record split itself must be gated on quote state
+# too, or a multi-line quoted argument fakes a break the exact same way a quoted `;` would.
+# Backslash-continuation joining already happened upstream (in $_bj, shared with the fast
+# gate above), so this pass doesn't need its own. The command-name token is matched
+# case-insensitively below (grep -i on the first stage only) for the same reason the fast
+# gate above does — "Pi"/"PI" resolve to the same binary as "pi" on a case-insensitive
+# filesystem; the -p/--print flag check stays case-sensitive.
+case "$norm" in
+  [Pp][Ii]\ *|*\ [Pp][Ii]\ *|*/[Pp][Ii]\ *)
+    pi_seg=$(printf '%s' "$_bj" | awk '
+      BEGIN { in_sq = 0; in_dq = 0 }
+      {
+        line = $0; n = length(line); out = ""
+        for (i = 1; i <= n; i++) {
+          c = substr(line, i, 1)
+          if (c == "\\" && !in_sq) { i++; if (i <= n) out = out substr(line, i, 1); continue }
+          if (c == "\\") { continue }
+          if (c == "\x27" && !in_dq) { in_sq = !in_sq; continue }
+          if (c == "\"" && !in_sq)  { in_dq = !in_dq; continue }
+          if (c == "[" || c == "]" || c == "{" || c == "}") { continue }
+          if (c == "\t") { out = out " "; continue }
+          if (!in_sq && !in_dq && c ~ /[;|&`()]/) { out = out "\n"; continue }
+          out = out c
+        }
+        if (in_sq || in_dq) printf "%s ", out; else print out
+      }')
+    if printf '%s\n' "$pi_seg" | grep -iE '(^|[[:space:]])([^[:space:]]*/)?pi[[:space:]]' \
+       | grep -Eq '(^|[[:space:]])(-p|--print)([[:space:]]|=|$)'; then
+      echo 'BLOCKED: nested non-interactive pi session (subagent recursion guard)' >&2
+      exit 2
+    fi
+    ;;
+esac
 
 exit 0

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -8,7 +8,8 @@
  * read on demand via its own `read` tool) — it never preloads skill body into context, which
  * this repo's agents/*.md convention requires (docs/skill-preload.md). See
  * docs/plugin-platform-decisions.md §9 for the full rationale, the model-tier-mapping safety
- * posture, and the accepted `bash`-escape-hatch recursion gap.
+ * posture, and how the `bash`-escape-hatch recursion gap is closed (in hooks/bash_guard.sh, not
+ * here).
  *
  * Everything that touches Pi itself (argv construction, pi.exec, temp-file lifecycle, tool
  * registration, model-registry queries) lives here. agent-spec.ts and model-tier.ts stay

--- a/tests/pi_guard_fixtures.py
+++ b/tests/pi_guard_fixtures.py
@@ -45,4 +45,39 @@ BASH_GUARD_FIXTURES: list[tuple[str, bool]] = [
     ("echo `ls`", False),
     ("x=$(date)", False),
     ("echo $(pwd)", False),
+    # nested non-interactive `pi` session — the bash escape hatch around the subagent
+    # dispatcher's --exclude-tools recursion guard
+    ("pi -p 'review this'", True),
+    ("pi --print x", True),
+    ("echo $(pi -p x)", True),
+    ("/usr/local/bin/pi -p x", True),
+    # a separator character embedded inside a QUOTED pi argument must not be treated as a
+    # segment break — this is the vector that defeated the segmenter's first version
+    ('pi -m ";" -p file.txt', True),
+    ('pi --system-prompt "a;b" --print', True),
+    # backslash-continuation join must be parity-aware: an EVEN trailing-backslash count is
+    # literal escaped backslashes, not a continuation — it must not swallow a genuinely
+    # separate command (rm or pi) on the next line
+    ("echo hi\\\\\nrm -rf ~", True),
+    ("echo hi\\\\\npi -p x", True),
+    # a backslash-ESCAPED separator between pi and its flag is a literal argument byte in
+    # real bash, not a real segment break
+    ('pi \\; -p "review this"', True),
+    # a trailing backslash INSIDE a comment has no continuation meaning — the comment must
+    # not absorb a real command on the next physical line
+    ("echo a # note \\\nrm -rf ~", True),
+    ("echo a # note \\\npi -p x", True),
+    # a REAL (unescaped) newline INSIDE a quoted argument is a literal argument byte, not a
+    # segment break — the awk record boundary must respect quote state too
+    ('pi -m "a\nb" -p x', True),
+    # case-insensitive command-name resolution ("Pi"/"PI" resolve to the same binary as "pi"
+    # on a case-insensitive filesystem, e.g. macOS's default) must still be caught
+    ("Pi -p x", True),
+    # flags stay case-sensitive even though the command name doesn't — "--PRINT" is not a
+    # real flag spelling
+    ("Pi --PRINT x", False),
+    # non-recursive pi invocations must stay allowed
+    ("pi --version", False),
+    ("pi list", False),
+    ("git log -p && pi list", False),
 ]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -78,6 +78,15 @@ class TestRmRfBlocker:
         "echo hi\trm -rf /",
         "true\trm -rf /",
         "true;\nrm -Rf $HOME",
+        # backslash-continuation join must be parity-aware: an EVEN trailing-backslash
+        # count is literal escaped backslashes, not a continuation — treating it as one
+        # anyway joins two genuinely separate commands with zero characters between them
+        # and erases the word boundary, hiding the rm on the second line
+        "echo hi\\\\\nrm -rf ~",
+        # a trailing backslash INSIDE a comment has no continuation meaning in real bash —
+        # the comment ends at the physical newline regardless. Joining before stripping
+        # comments would let the comment absorb a real command on the next line
+        "echo a # note \\\nrm -rf ~",
         # comment-strip must run BEFORE the newline fold, else an early
         # comment on line 1 would swallow a destructive rm on line 2
         "git push --force  # note\nrm -rf /",
@@ -409,6 +418,103 @@ class TestHardResetBlocker:
 
 
 # ──────────────────────────────────────────────
+# nested non-interactive `pi` session — bash escape hatch around the
+# subagent dispatcher's --exclude-tools recursion guard
+# ──────────────────────────────────────────────
+
+class TestNestedPiSessionBlocker:
+    @pytest.mark.parametrize("cmd", [
+        # blocked: direct -p/--print invocations
+        'pi -p "review this"',
+        "pi --print \"x\"",
+        # blocked: tab / backslash-continuation segment vectors
+        "pi\t-p x",
+        "pi \\\n-p \"hello\"",
+        # blocked: backtick / $(...) substitution boundaries
+        "`pi -p x`",
+        "$(pi -p y)",
+        "echo $(pi -p x)",
+        # blocked: quoted / path-qualified / prefixed forms
+        '"pi" -p x',
+        'bash -c "pi -p x"',
+        "/usr/local/bin/pi -p x",
+        "npx pi -p hello",
+        "PI_OFFLINE=1 pi -p x",
+        "cd /tmp && pi -p x",
+        "pi --model foo/bar -p prompt",
+        # a separator character embedded inside a QUOTED pi argument must not be treated as
+        # a segment break — the vector that defeated the segmenter's first version
+        'pi -m ";" -p file.txt',
+        'pi --system-prompt "a;b" --print',
+        # a backslash-continuation split mid-token must still resolve to a single "pi" word,
+        # not two separate tokens
+        "p\\\ni -p x",
+        # parity boundary: an EVEN trailing-backslash count is not a continuation — it must
+        # not swallow a separate, genuinely recursive pi invocation on the next line
+        "echo hi\\\\\npi -p x",
+        # a backslash-ESCAPED separator between the pi token and the flag must not be
+        # treated as a real segment break — bash consumes it as a literal argument byte
+        'pi \\; -p "review this"',
+        "pi --model a\\&b -p hi",
+        # a trailing backslash INSIDE a comment has no continuation meaning in real bash —
+        # must not let the comment absorb a real recursive pi call on the next line
+        "echo a # note \\\npi -p x",
+        # a REAL (unescaped) newline INSIDE a quoted argument is a literal argument byte in
+        # bash, not a segment break — a multi-line -m message is the natural shape a
+        # dispatched subagent would actually write
+        'pi -m "a\nb" -p x',
+        'pi "a\nb" --print',
+        # case-insensitive command-name resolution: on a case-insensitive filesystem (macOS
+        # default), "Pi"/"PI" resolve to the same binary as "pi" — the command-NAME token
+        # must be matched case-insensitively even though flags stay case-sensitive
+        "Pi -p x",
+        "PI -p x",
+        "pI --print x",
+    ])
+    def test_blocked(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 2, (
+            f"Expected BLOCKED for {cmd!r}, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    @pytest.mark.parametrize("cmd", [
+        # allowed: non-recursive pi subcommands
+        "pi --version",
+        "pi list",
+        "pi auth check",
+        "pi update self",
+        "pi",
+        # allowed: git -p is unrelated to the pi CLI
+        "git log -p",
+        "git diff -p -- foo",
+        "git log -p && pi list",
+        "git log -p; pi --version",
+        # allowed: pi-shaped substrings that aren't the pi command token
+        "pip install foo",
+        "python -p",
+        "mkdir -p src/api",
+        "docker run -p 8080:80 img",
+        "ls /opt/pi",
+        "grep -rn pi docs/",
+        "cat notes.md # pi -p x",
+        # command-name case-insensitivity must not extend to flags — real CLI parsers are
+        # case-sensitive for flag spellings, so "--PRINT" is not "--print"
+        "Pi --PRINT x",
+        "Pi --version",
+        "PI list",
+    ])
+    def test_allowed(self, guard_script, cmd):
+        result = run_guard(guard_script, cmd)
+        assert result.returncode == 0, (
+            f"Expected ALLOWED for {cmd!r}, got exit {result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert result.stderr == ""
+
+
+# ──────────────────────────────────────────────
 # short-circuit: non-rm/non-git commands skip grep
 # ──────────────────────────────────────────────
 
@@ -430,7 +536,10 @@ class TestShortCircuit:
         run_guard(script, cmd, env=env)
         return trace.read_text() if trace.exists() else ""
 
-    @pytest.mark.parametrize("cmd", ["ls .", "cat foo.txt", "echo hello", "make build"])
+    @pytest.mark.parametrize("cmd", [
+        "ls .", "cat foo.txt", "echo hello", "make build",
+        "pip install foo", "mkdir -p src/api", "python -m pytest",
+    ])
     def test_no_grep_for_safe_commands(self, guard_script, cmd, tmp_path):
         trace = self._run_with_shims(guard_script, cmd, tmp_path)
         assert "jq" in trace, f"Expected jq to run for {cmd!r}"
@@ -441,6 +550,11 @@ class TestShortCircuit:
         trace = self._run_with_shims(guard_script, cmd, tmp_path)
         assert "jq" in trace, f"Expected jq to run for {cmd!r}"
         assert "grep" in trace, f"Expected grep to run for {cmd!r}"
+
+    def test_grep_runs_for_pi(self, guard_script, tmp_path):
+        trace = self._run_with_shims(guard_script, "pi -p x", tmp_path)
+        assert "jq" in trace, "Expected jq to run for 'pi -p x'"
+        assert "grep" in trace, "Expected grep to run for 'pi -p x'"
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extends `hooks/bash_guard.sh` to block a segment-scoped `pi ... -p`/`--print` invocation, closing the bash-escape-hatch recursion gap in the Pi subagent dispatcher (20/22 `agents/*.md` definitions grant `Bash`, letting a dispatched agent shell out to `pi -p ...` directly and spawn an unguarded child with `task` re-registered)
- The segmenter is quote-aware, escape-aware (backslash-escaped separators/quotes don't fake a boundary), parity-aware for backslash-continuation joins, quote-aware on its own record boundary (a real newline inside a quoted argument isn't a break), and matches the command-name token case-insensitively — hardened across four rounds of adversarial review (code reviewer + security-auditor, twice each) that found and fixed real bypasses beyond the initial design
- Updates `docs/plugin-platform-decisions.md` §9 to describe the gap as closed (#632) and `pi/extensions/subagent.ts`'s header comment; `pi.exec()` from the dispatcher itself is untouched since it's not a `bash` tool call

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually (dozens of crafted payloads piped directly into `hooks/bash_guard.sh` during review, covering every fixed bypass and the two accepted out-of-scope gaps)
- [x] `shellcheck --severity=warning hooks/bash_guard.sh` — 0 issues

### Type-tailored checks (feat)
- [x] New behaviour verified: `pi -p`/`--print` invocations (direct, quoted-separator, escaped-separator, backslash-continued, quoted-newline, case-variant) are blocked; non-recursive `pi` subcommands and everyday commands (`git log -p && pi list`, `pip install foo`, `mkdir -p src/api`, `docker run -p`) stay allowed
- [x] Regression fixtures added to `tests/pi_guard_fixtures.py` (shared differential contract, consumed by both the direct-invocation and Pi-adapter test suites) and `tests/test_hooks.py` for every bypass found and fixed during review, each confirmed to fail (RED) against the pre-fix code before the fix landed
- [x] `bash scripts/validate.sh` — all checks passed
- [x] `pytest tests/` — 2836 passed, 2 skipped
- [x] `npm run typecheck --prefix pi` — clean

Closes #632
