### PR TITLE
[chore] Wire bump-version.sh --audit into CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Validate plugin files
         run: bash scripts/validate.sh
+      - name: Audit for undeclared version literals
+        run: bash scripts/bump-version.sh --audit
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,9 @@ It checks:
 - Dependency-flow graph (`check_no_cycles`) — action-cued `` `swe-workbench:<id>` `` activations must not form cycles across commands, skills, and agents. See `docs/extending.md` (`## Dependency flow`) for the allowed layering rules that this check enforces.
 - Bare actionable references (`check_bare_actionable_refs`) — every skill/agent id in any `*.md` file outside `tests/` and outside fenced code must use the namespaced `` `swe-workbench:<id>` `` form, including prose, catalog tables, README enumerations, and a file naming itself; the only opt-out is `<!-- validate: prose-ref -->` on a genuinely non-dispatch line.
 
-The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`).
+The same checks run in CI on every PR (`validate-plugin-files` job in `.github/workflows/pr.yml`). That
+job also runs `bash scripts/bump-version.sh --audit`, which fails the PR if the current version string
+appears in a file not declared in `.version-bump.json`.
 
 ## Testing locally
 
@@ -117,6 +119,9 @@ Run the release script from a clean `main`:
 ```
 
 It bumps every file declared in `.version-bump.json` (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the root `package.json`), opens a PR, waits for CI to pass, auto-merges, then pushes a `v*.*.*` tag. The tag push triggers `.github/workflows/release.yml`, which validates the manifests and publishes a GitHub Release with auto-generated notes.
+
+The `bump-version.sh --audit` check described above (see "Validator") is enforced per-PR, so a stray
+hardcoded version literal is caught well before the release script ever runs.
 
 ## Pi adapter
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -91,6 +91,21 @@ case "$MODE" in
       [[ "$1" == "$prefix" || "$1" == "$prefix"/* ]]
     }
 
+    # Any-depth matching is EXCLUDES-only: a bare DECLARED_PATHS entry like "package.json" must
+    # stay anchored (via the unmodified _under_prefix), or vendor/package.json would wrongly
+    # count as declared and a real undeclared hit would go unreported.
+    _matches_exclude() {
+      local candidate="$1" entry="$2"
+      if _under_prefix "$candidate" "$entry"; then
+        return 0
+      fi
+      local name="${entry%/}"
+      if [[ "$name" == */* ]]; then
+        return 1
+      fi
+      [[ "$candidate" == *"/${name}" || "$candidate" == *"/${name}/"* ]]
+    }
+
     UNDECLARED=()
     for hit in "${HITS[@]}"; do
       skip=0
@@ -102,7 +117,7 @@ case "$MODE" in
       done
       if [[ "$skip" -eq 0 ]]; then
         for ex in "${EXCLUDES[@]}"; do
-          if _under_prefix "$hit" "$ex"; then
+          if _matches_exclude "$hit" "$ex"; then
             skip=1
             break
           fi

--- a/tests/test_bump_version_sh.py
+++ b/tests/test_bump_version_sh.py
@@ -11,6 +11,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import yaml
+
 from conftest import _CLEAN_ENV
 
 ROOT = Path(__file__).parent.parent
@@ -141,3 +143,75 @@ class TestAuditMode:
         result = _run(tmp_path, "--audit")
         assert result.returncode == 0, result.stderr
         assert "plugin.json" not in result.stdout
+
+    def test_bare_exclude_entry_matches_nested_directory(self, tmp_path):
+        """Regression test for the live false positive: _under_prefix() anchors every exclude
+        entry at the repo root, so a bare exclude like "node_modules" only matched a top-level
+        node_modules/ — not a nested one like pi/node_modules/, which npm creates for
+        version-conflicting subpackages and which can outlive the refactor that created it."""
+        _make_fixture_tree(tmp_path, exclude=["node_modules"])
+        nm = tmp_path / "pi" / "node_modules" / "@types" / "node"
+        nm.mkdir(parents=True)
+        (nm / "fs.d.ts").write_text("since v1.0.0\n", encoding="utf-8")
+        result = _run(tmp_path, "--audit")
+        assert result.returncode == 0, result.stderr
+
+    def test_bare_exclude_entry_with_trailing_slash_matches_nested_directory(self, tmp_path):
+        """Regression test: a bare exclude entry written the idiomatic .gitignore way, with a
+        trailing slash ("node_modules/"), must match at any depth too — same as the no-slash
+        spelling above. _matches_exclude's "does this entry contain a path component" check must
+        run on the slash-stripped name, not the raw entry, or the trailing slash itself gets
+        misread as a path separator and the entry is wrongly treated as root-anchored-only."""
+        _make_fixture_tree(tmp_path, exclude=["node_modules/"])
+        nm = tmp_path / "pi" / "node_modules" / "@types" / "node"
+        nm.mkdir(parents=True)
+        (nm / "fs.d.ts").write_text("since v1.0.0\n", encoding="utf-8")
+        result = _run(tmp_path, "--audit")
+        assert result.returncode == 0, result.stderr
+
+    def test_anchored_exclude_entry_does_not_match_nested_directory(self, tmp_path):
+        """A slash-bearing exclude entry stays root-anchored — the depth-agnostic matching added
+        for bare names must not leak into entries that already specify a path."""
+        _make_fixture_tree(tmp_path, exclude=["build/cache"])
+        nested = tmp_path / "vendor" / "build" / "cache"
+        nested.mkdir(parents=True)
+        (nested / "x.md").write_text("version 1.0.0 hardcoded here\n", encoding="utf-8")
+        result = _run(tmp_path, "--audit")
+        assert result.returncode != 0
+        assert "vendor/build/cache/x.md" in result.stderr
+
+    def test_bare_exclude_entry_does_not_match_a_path_segment_with_extra_suffix(self, tmp_path):
+        """The any-depth match must require a full path-segment boundary: an exclude entry
+        "cache" must not match a differently-named segment like "cache2" just because it shares
+        a prefix."""
+        _make_fixture_tree(tmp_path, exclude=["cache"])
+        nested = tmp_path / "vendor" / "cache2"
+        nested.mkdir(parents=True)
+        (nested / "x.md").write_text("version 1.0.0 hardcoded here\n", encoding="utf-8")
+        result = _run(tmp_path, "--audit")
+        assert result.returncode != 0
+        assert "vendor/cache2/x.md" in result.stderr
+
+    def test_nested_file_sharing_a_declared_basename_is_still_flagged(self, tmp_path):
+        """Declared-path matching (_under_prefix, used for DECLARED_PATHS) must NOT inherit the
+        any-depth exclude behaviour: a bare declared path like "package.json" should still only
+        exempt the root-level file, or a real undeclared vendor/package.json would silently pass."""
+        _make_fixture_tree(tmp_path)
+        vendor = tmp_path / "vendor"
+        vendor.mkdir()
+        (vendor / "package.json").write_text('{"version": "1.0.0"}\n', encoding="utf-8")
+        result = _run(tmp_path, "--audit")
+        assert result.returncode != 0
+        assert "vendor/package.json" in result.stderr
+
+
+class TestCiWiring:
+    def test_audit_is_wired_into_pr_validation_workflow(self):
+        workflow_path = ROOT / ".github" / "workflows" / "pr.yml"
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        job = workflow["jobs"]["validate-plugin-files"]
+        run_steps = [step.get("run", "") for step in job["steps"]]
+        assert any("bump-version.sh --audit" in run for run in run_steps), (
+            "validate-plugin-files must run `bump-version.sh --audit` — a required job, "
+            "so the gate actually blocks merges"
+        )


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Fix `scripts/bump-version.sh --audit`'s exclude matching so a bare entry (e.g. `node_modules`) matches at any depth, `.gitignore`-style, while declared-manifest-path matching stays root-anchored
- Wire `bash scripts/bump-version.sh --audit` into the existing `validate-plugin-files` job in `.github/workflows/pr.yml` (no new job — that job is already a required check)
- Add regression tests for the new exclude-matching behaviour and a YAML-parse test asserting the audit step lands in `validate-plugin-files` specifically
- Document the new gate in `CONTRIBUTING.md`

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually
- [x] `bash scripts/bump-version.sh --audit` passes clean on the live tree (the `pi/node_modules` false positive is gone)

### Type-tailored checks (chore)
- [x] `shellcheck scripts/bump-version.sh` — 0 issues
- [x] `bash scripts/validate.sh` — all checks pass
- [x] `pytest tests/ -v` — 2860 passed, 2 skipped (unrelated)
- [x] Negative check: a scratch file containing the current version string fails the audit, naming the file (reverted after)

<!-- Link to the GitHub issue this PR addresses.
     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>

     If no issue applies, DELETE the "Closes #" line and replace it with
     a standalone line:
         Issue: N/A
     Preferred (more useful for reviewers):
         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">

     The following WILL fail CI:
       - leaving "Closes #" empty with no replacement
       - deleting the line entirely with nothing in its place
       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
Closes #639
