### PR TITLE
[chore] Bump version to 0.1.32

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "swe-workbench",
       "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "source": "./",
       "author": {
         "name": "Lugas Septiawan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "swe-workbench-pi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "type": "module",
   "description": "swe-workbench: senior-engineer toolkit for Claude Code and the Pi Coding Agent",
   "pi": {
-    "extensions": ["./pi/extensions/index.ts"]
+    "extensions": [
+      "./pi/extensions/index.ts"
+    ]
   },
   "files": [
     ".claude-plugin",
@@ -31,6 +33,8 @@
     "@earendil-works/pi-coding-agent": ">=0.84.2 <1"
   },
   "peerDependenciesMeta": {
-    "@earendil-works/pi-coding-agent": { "optional": true }
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Bump version: `0.1.31` → `0.1.32`
- Tag `v0.1.32` will be pushed automatically once this merges, triggering `.github/workflows/release.yml` to publish a GitHub Release.

## Test Plan
- [x] CI (pr.yml) passes
- [x] Tag-triggered release workflow publishes `v0.1.32`

N/A