### PR TITLE
[chore] Probe: shellcheck auto-discovery (#641)

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -9,3 +9,5 @@ if command -v rimba >/dev/null 2>&1; then
   fi
 fi
 # END RIMBA HOOK
+
+PROBE641_POST_MERGE_UNUSED=1

--- a/bin/swe-workbench-probe641
+++ b/bin/swe-workbench-probe641
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Throwaway CI probe for issue #641 — proves auto-discovery lints new bin/ scripts
+# with zero pr.yml edits. Deliberately contains an unused variable (SC2034).
+# NEVER MERGE THIS BRANCH.
+PROBE641_UNUSED_VARIABLE=1
+exit 0


### PR DESCRIPTION
## Summary
- Throwaway CI probe for #641 — proves a newly added `bin/` script and an edit to unlisted `.githooks/post-merge` are both linted by shellcheck auto-discovery with zero `pr.yml` edits
- `bin/swe-workbench-probe641` (executable, `#!/usr/bin/env bash`, deliberate unused var → SC2034) and a trailing unused var in `.githooks/post-merge` (unlisted in any workflow input) should both make the `shellcheck` job fail
- Expected: pytest job fails on the probe filename (deliberate); only the shellcheck job's log is the evidence

## Test Plan
- [ ] shellcheck job fails citing `bin/swe-workbench-probe641`
- [ ] shellcheck job fails citing `.githooks/post-merge`

Issue: N/A — throwaway CI probe for #641; never merge
