### PR TITLE
[chore] Remove dead shellcheck additional_files list, pin auto-discovery contract

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,11 +117,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Run shellcheck (warning+ on all *.sh + githooks + bin/ wrappers)
+      - name: Run shellcheck (warning+ on *.sh + auto-discovered executable extensionless bash/sh/ksh files)
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         with:
           severity: warning
-          additional_files: 'commit-msg pre-commit pre-push bin/swe-workbench-clean-ephemeral bin/swe-workbench-clean-state-files bin/swe-workbench-diff-line-lookup bin/swe-workbench-doctor bin/swe-workbench-fetch-pr bin/swe-workbench-gh-timeout bin/swe-workbench-new-run-dir bin/swe-workbench-preflight-pr bin/swe-workbench-reap-run-dir bin/swe-workbench-reply-and-resolve bin/swe-workbench-sync-pr-metadata'
           check_together: 'yes'
 
   pytest:

--- a/tests/test_diff_line_lookup_script.py
+++ b/tests/test_diff_line_lookup_script.py
@@ -11,8 +11,8 @@ Behavioral paths under test:
   - Not-found paths (exit 1): absent entirely, found on a context line, found on a removed line
   - Ambiguity (exit 2): multiple matching `+` lines, stdout empty, all candidates on stderr
   - Git-internal modes: default (git diff HEAD), --staged, --range=<rev>
-  - Wiring: SCRIPTS dict, pr.yml shellcheck list, bin/README.md, agents/reviewer.md,
-    workflow-pr-review-post/SKILL.md
+  - Wiring: SCRIPTS dict, shellcheck auto-discovery contract, bin/README.md,
+    agents/reviewer.md, workflow-pr-review-post/SKILL.md
 """
 
 import os
@@ -396,11 +396,16 @@ def test_bin_scripts_dict_contains_diff_line_lookup():
     )
 
 
-def test_pr_yml_shellcheck_list_contains_wrapper():
-    text = (ROOT / ".github" / "workflows" / "pr.yml").read_text()
-    assert "bin/swe-workbench-diff-line-lookup" in text, (
-        ".github/workflows/pr.yml shellcheck additional_files must list "
-        "bin/swe-workbench-diff-line-lookup"
+def test_shellcheck_coverage_contract_contains_wrapper():
+    """Assert the auto-discovery contract behaviorally covers every SCRIPTS entry."""
+    import test_shellcheck_coverage as coverage
+    from test_bin_scripts import SCRIPTS
+
+    covered = {path.name for path, _ in coverage.CANDIDATES}
+    assert set(SCRIPTS) <= covered, (
+        "every test_bin_scripts.SCRIPTS entry must feed the auto-discovery contract — "
+        "together with test_bin_scripts_dict_contains_diff_line_lookup above, that transitively "
+        "proves swe-workbench-diff-line-lookup stays lint-covered after the #641 list removal"
     )
 
 

--- a/tests/test_shellcheck_coverage.py
+++ b/tests/test_shellcheck_coverage.py
@@ -1,0 +1,87 @@
+"""Shellcheck auto-discovery contract for bin/ and .githooks/ scripts (issue #641).
+
+action-shellcheck@2.0.0 lints ANY executable, extensionless file whose shebang matches
+^#! */[^ ]*/(env *)?[abk]*sh — hidden dirs included, additional_files irrelevant (its
+bin/ entries compiled to find -name patterns containing '/', which never match a
+basename). That dead list is removed from pr.yml; this module pins the real precondition
+so an ineligible script fails CI loudly, not silently — exec-bit failures also hit Windows
+checkouts that drop the bit (CI matrix is ubuntu+macos, where git preserves it)."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from test_bin_scripts import SCRIPTS
+
+ROOT = Path(__file__).parent.parent
+BIN = ROOT / "bin"
+GITHOOKS = ROOT / ".githooks"
+PR_YML = ROOT / ".github" / "workflows" / "pr.yml"
+
+# Exact expected .githooks/ contents — a new hook cannot silently appear (or vanish) either.
+HOOKS = frozenset({"commit-msg", "post-merge", "pre-commit", "pre-push"})
+
+# The action's own shebang predicate, verbatim from its composite run step: matches
+# sh/ash/bash/ksh, direct or via env. Notably does NOT match zsh or python3.
+SHEBANG_RE = re.compile(r"^#! */[^ ]*/(env *)?[abk]*sh")
+
+# python3 scripts are exempt from shellcheck (the predicate cannot match them); their hygiene
+# stays pinned in tests/test_bin_scripts.py (py_compile + interpreter checks).
+PYTHON_SHEBANG = "#!/usr/bin/env python3"
+
+# (path, interpreter) for every script whose shellcheck eligibility this contract pins.
+CANDIDATES = sorted(
+    [(BIN / name, interp) for name, interp in SCRIPTS.items()]
+    + [(GITHOOKS / name, None) for name in HOOKS],
+    key=lambda c: c[0],
+)
+CANDIDATE_IDS = [str(path.relative_to(ROOT)) for path, _ in CANDIDATES]
+
+# The pinned action ref whose discovery semantics SHEBANG_RE mirrors verbatim — asserting it
+# forces any version bump to consciously re-check the mirrored predicate against the new source.
+PINNED_ACTION = "action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38"
+
+# Action inputs that would silently shrink discovery without touching eligibility — banned
+# alongside additional_files. Longer alternatives first so alternation anchors correctly.
+MUTE_BUTTONS_RE = re.compile(r"(?m)^\s*(ignore_paths|ignore_names|scandir|ignore)\s*:")
+
+
+def test_githooks_contents_match_hooks_set() -> None:
+    """Pin exact .githooks/ contents so a new hook can't silently appear or vanish."""
+    on_disk = {p.name for p in GITHOOKS.iterdir() if p.is_file()}
+    assert on_disk == HOOKS, f".githooks/ {sorted(on_disk)} != expected {sorted(HOOKS)}"
+
+
+@pytest.mark.parametrize("path,interp", CANDIDATES, ids=CANDIDATE_IDS)
+def test_shellcheck_auto_discovery_preconditions(path: Path, interp: str | None) -> None:
+    """Assert the script satisfies the action's real discovery precondition."""
+    rel = path.relative_to(ROOT)
+    assert "." not in path.name, f"{rel}: dotted filename — auto-discovery skips extensioned files"
+    assert path.stat().st_mode & 0o111, f"{rel}: no exec bit — auto-discovery requires -perm /111"
+    lines = path.read_text().splitlines()
+    first_line = lines[0] if lines else ""
+    assert SHEBANG_RE.match(first_line) or (
+        interp == "python3" and first_line == PYTHON_SHEBANG
+    ), (
+        f"{rel}: shebang {first_line!r} matches neither the action's family "
+        f"({SHEBANG_RE.pattern!r}) nor the python3 exemption — silently unlinted"
+    )
+
+
+def test_pr_yml_keeps_shellcheck_job_without_additional_files() -> None:
+    """Pin the job's wiring, version identity, and forbid every discovery-shrinking input."""
+    text = PR_YML.read_text()
+    assert PINNED_ACTION in text, (
+        f"the shellcheck job must stay on the pinned {PINNED_ACTION} — SHEBANG_RE mirrors that "
+        "version's discovery step verbatim; on a bump, re-verify the mirrored predicate"
+    )
+    assert "additional_files" not in text, (
+        "additional_files is dead weight (#641): auto-discovery already covers every "
+        "eligible script; eligibility is pinned by test_shellcheck_auto_discovery_preconditions"
+    )
+    muted = MUTE_BUTTONS_RE.findall(text)
+    assert not muted, (
+        f"shellcheck job sets discovery-shrinking input(s) {muted} — they silently exclude "
+        "files while every eligibility assertion here stays green (#641's failure mode)"
+    )


### PR DESCRIPTION
## Summary
- Closes #641: the shellcheck job's hand-written `additional_files` list was dead weight — the pinned `ludeeus/action-shellcheck@2.0.0` runs a second discovery pass (`find -type f ! -name '*.*' -perm /111` + shebang regex `^#! */[^ ]*/(env *)?[abk]*sh`) that lints every eligible file regardless of `additional_files`, hidden dirs included. Worse, the list's `bin/` entries compiled to `find -name` patterns containing `/`, which can never match a basename — they never did anything.
- Verified at the source: fetched the action's own `action.yaml` at the pinned SHA `00cae500` and mirrored its predicate verbatim into the new contract test.
- Verified empirically (issue DoD "zero pr.yml edits"): throwaway probe PR #649 added `bin/swe-workbench-probe641` (new script, standard shebang, exec bit) plus an unused var in `.githooks/post-merge` (never listed anywhere) — CI's shellcheck job failed citing **both** files, with no `pr.yml` change on that branch:
  ```
  ./.githooks/post-merge:13:1: warning: PROBE641_POST_MERGE_UNUSED appears unused. Verify use ... [SC2034]
  ./bin/swe-workbench-probe641:5:1: warning: PROBE641_UNUSED_VARIABLE appears unused. Verify use ... [SC2034]
  ```
  (run 32610731626; the probe PR's pytest failure is the deliberate unregistered-filename noise, not a shellcheck signal — that branch is never merged.)
- New `tests/test_shellcheck_coverage.py` pins the **real** eligibility precondition (extensionless + exec bit + bash-family shebang, python3 scripts explicitly exempt) for every `bin/` and `.githooks/` script, pins exact `.githooks/` contents, asserts the pinned action SHA (so a version bump forces re-checking the mirrored predicate), and bans every discovery-shrinking input (`additional_files`, `ignore`, `ignore_paths`, `ignore_names`, `scandir`) from regrowing. A script that becomes unlintable now fails CI loudly instead of silently losing coverage.
- `tests/test_diff_line_lookup_script.py`'s wiring test repointed from grepping the removed list to a behavioral assertion (every `SCRIPTS` entry feeds the contract) — its provable-coverage intent preserved.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Local reproduction of the action's discovery pass matches all 13 bash `bin/` scripts + 4 `.githooks/` hooks; python3 scripts correctly excluded
- [x] Empirical CI probe (PR #649): new `bin/` script + unlisted `.githooks/post-merge` edit both flagged by shellcheck with zero `pr.yml` edits

### Type-tailored checks ([chore])
- [x] `bash scripts/validate.sh` — all checks passed
- [x] `bash scripts/bump-version.sh --audit` — clean
- [x] `pytest tests/ -v` — 2951 passed, 2 skipped (baseline 2929 + 22 new; CI matrix ubuntu+macos)
- [x] Comment scan — 0 must-triage after docstring trim (OVER_CAP finding FIXED, re-run confirms)

Closes #641
