### PR TITLE
[feat] Show agent names in Pi task activity display (#646)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,27 @@
 {
   "name": "swe-workbench-pi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swe-workbench-pi",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.84.2",
+        "@earendil-works/pi-tui": "0.84.2",
         "@types/node": "^26.2.0",
         "typescript": "^7.0.2"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.84.2 <1"
+        "@earendil-works/pi-coding-agent": ">=0.84.2 <1",
+        "@earendil-works/pi-tui": ">=0.84.2 <1"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-coding-agent": {
+          "optional": true
+        },
+        "@earendil-works/pi-tui": {
           "optional": true
         }
       }
@@ -1973,6 +1978,20 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
@@ -2321,6 +2340,32 @@
       ],
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,19 @@
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.84.2",
+    "@earendil-works/pi-tui": "0.84.2",
     "@types/node": "^26.2.0",
     "typescript": "^7.0.2"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.84.2 <1"
+    "@earendil-works/pi-coding-agent": ">=0.84.2 <1",
+    "@earendil-works/pi-tui": ">=0.84.2 <1"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "@earendil-works/pi-tui": {
       "optional": true
     }
   }

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -29,11 +29,11 @@ import {
   translateToolTokens,
 } from "./agent-spec.ts";
 import { isKnownModelTier, type ModelCandidate, resolveModelForTier } from "./model-tier.ts";
+import { sanitizeAgentId, TASK_TOOL_NAME, taskRenderCall } from "./task-call-line.ts";
 
-/** Single source of truth for the tool's registered name — consumed both by pi.registerTool()
- *  below and by the `--exclude-tools` argv builder, so a rename can't silently desync
- *  registration from the recursion guard. */
-export const TASK_TOOL_NAME = "task";
+// Re-exported so the behavioural pytest driver and index.ts (which import only this
+// module) keep a single import surface for the task tool — rendering and tool name included.
+export { composeTaskCallLine, renderTaskCall, TASK_TOOL_NAME } from "./task-call-line.ts";
 
 /** pi-subagents' own tool name (verified against its published source), excluded defensively
  *  alongside TASK_TOOL_NAME in case the user also has that package installed. */
@@ -121,12 +121,17 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
         "with the available list rather than guessing.",
     ],
     parameters: TASK_PARAMS_SCHEMA,
+    renderCall: taskRenderCall,
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const { agent, prompt } = params as unknown as TaskParams;
 
       const available = listAgentNames(root);
       if (!available.includes(agent)) {
-        throw new Error(`task: unknown agent "${agent}" — available agents: ${available.join(", ")}`);
+        // Sanitized echo: this message becomes tool-output content that pi renders unescaped,
+        // so a control/bidi payload in the rejected id must not reach the terminal verbatim.
+        throw new Error(
+          `task: unknown agent "${sanitizeAgentId(agent)}" — available agents: ${available.join(", ")}`,
+        );
       }
 
       const spec = readAgentSpec(root, agent);

--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -127,8 +127,6 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
 
       const available = listAgentNames(root);
       if (!available.includes(agent)) {
-        // Sanitized echo: this message becomes tool-output content that pi renders unescaped,
-        // so a control/bidi payload in the rejected id must not reach the terminal verbatim.
         throw new Error(
           `task: unknown agent "${sanitizeAgentId(agent)}" — available agents: ${available.join(", ")}`,
         );

--- a/pi/extensions/task-call-line.ts
+++ b/pi/extensions/task-call-line.ts
@@ -1,0 +1,101 @@
+/**
+ * The `task` activity call-line renderer (#646): composes and renders `task · <agent>` for
+ * the tool-call row so concurrent dispatched agents are distinguishable at a glance.
+ *
+ * Split out of subagent.ts (not merged into it) because that file carries the whole dispatch
+ * pipeline and sits at the repo's per-file line cap; this module is the render seam only —
+ * subagent.ts registers the renderCall, this file owns everything below it. Like subagent.ts
+ * (and unlike SDK-free agent-spec.ts/model-tier.ts), this module touches Pi SDK types.
+ *
+ * Stripper invariant: every `@earendil-works/*` import here is TYPE-ONLY, so
+ * `node --experimental-strip-types` behavioural tests run with no node_modules. The one
+ * runtime specifier — pi-tui, for the Text constructor — is a fire-and-forget dynamic
+ * import resolved by Pi's own jiti alias map (loader.js maps core packages for extensions);
+ * where it cannot resolve, the renderer throws and Pi's ToolExecutionComponent swaps in its
+ * plain createCallFallback() heading, byte-identical to the pre-#646 display.
+ */
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Text } from "@earendil-works/pi-tui";
+
+/** Single source of truth for the tool's registered name — subagent.ts consumes this for
+ *  both pi.registerTool() and the `--exclude-tools` argv builder, so a rename can't silently
+ *  desync registration from the recursion guard. */
+export const TASK_TOOL_NAME = "task";
+
+/** The subset of Pi's Theme the call-line renderer needs — interface segregation so the
+ *  pure formatter stays testable against a two-method stub (and so a future Theme superset
+ *  still satisfies it structurally). */
+export type CallLineTheme = Pick<Theme, "fg" | "bold">;
+
+/** pi-tui's Text constructor, obtained lazily (see `textCtor` below). Typed from the
+ *  type-only import so the memoized slot and the exported renderer share the real shape
+ *  without any runtime resolution of the specifier at module scope. */
+type TextCtor = typeof Text;
+
+/** Resolved once per process by the fire-and-forget dynamic import below. Dynamic (not
+ *  static) because every top-level specifier in this directory must stay strippable by
+ *  `node --experimental-strip-types` with no node_modules present — the behavioural pytest
+ *  layer depends on that invariant. Real pi resolves the specifier through its jiti alias
+ *  map; the nodeless stripper environment does not, the import rejects, and `undefined`
+ *  here means renderCall falls back to Pi's own plain heading via its documented
+ *  catch-and-swap contract. Never re-attempted on failure. */
+let textCtor: TextCtor | undefined;
+void import("@earendil-works/pi-tui")
+  .then((mod) => {
+    textCtor = mod.Text;
+  })
+  .catch(() => {
+    /* unresolvable in this environment — plain-heading fallback, by design */
+  });
+
+/** Terminal-spoofing chars with no place in a rendered agent id: C0/C1/DEL controls
+ *  (ESC/OSC/newline — screen-clear and title spoofing), zero-width and bidi format chars
+ *  (ZWSP, ALM, LRM/RLM, RLO/LRO and isolates — visual reordering), and the Unicode
+ *  separators. Legitimate ids are [a-z0-9-], so nothing valid is ever lost. */
+const UNSAFE_ID_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069]/g;
+
+/** Strips UNSAFE_ID_CHARS — shared by the render path and subagent.ts's unknown-agent error,
+ *  since both surface the id to the terminal before/without validation having sanitized it. */
+export function sanitizeAgentId(agent: string): string {
+  return agent.replace(UNSAFE_ID_CHARS, "");
+}
+
+/** Composes the `task` activity call line as `task · <agent>`: the toolTitle segment is
+ *  byte-identical to Pi's own createCallFallback() formula (tool-execution.js), so the
+ *  enriched line is literally the fallback heading plus a muted suffix. The agent segment is
+ *  stripped of terminal-spoofing chars — renderCall fires on mid-stream args BEFORE
+ *  execute() validates the id, and pi-tui's ANSI wrapping preserves embedded escapes.
+ *  Exported pure for the same reason as subagent.ts's capOutput — the nodeless pytest
+ *  driver can exercise it directly. */
+export function composeTaskCallLine(agent: string, theme: CallLineTheme): string {
+  const safe = sanitizeAgentId(agent);
+  return theme.fg("toolTitle", theme.bold(TASK_TOOL_NAME)) + theme.fg("muted", ` · ${safe}`);
+}
+
+/** Renders the task call line for a tool-call display. Throws — deliberately — when no
+ *  agent name is present (partial mid-stream args, blank agent, or an id that strips to
+ *  empty) or when pi-tui's Text could not be resolved: Pi's ToolExecutionComponent catches
+ *  renderer throws and swaps in its own createCallFallback() heading, which is exactly the
+ *  pre-#646 display. That throw-as-degradation is the SDK's documented fallback contract,
+ *  not an error path. Exported with an injectable constructor so the resolved path is
+ *  testable without pi-tui present. */
+export function renderTaskCall(args: unknown, theme: CallLineTheme, ctor: TextCtor | undefined): Text {
+  // `in`-narrowing keeps this cast-free under unknown (TS narrows to object & Record<"agent", unknown>).
+  const agent =
+    typeof args === "object" && args !== null && "agent" in args && typeof args.agent === "string"
+      ? args.agent.trim()
+      : "";
+  // Empty-after-strip (control-only id) must fall back too, or the line degrades to a
+  // dangling "task · " separator.
+  if (agent === "" || sanitizeAgentId(agent) === "") {
+    throw new Error("task renderCall: no agent name available — framework fallback applies");
+  }
+  if (ctor === undefined) throw new Error("task renderCall: pi-tui unavailable — framework fallback applies");
+  return new ctor(composeTaskCallLine(agent, theme), 0, 0);
+}
+
+/** The renderCall subagent.ts registers — renderTaskCall bound to the module's memoized
+ *  Text constructor. */
+export function taskRenderCall(args: unknown, theme: CallLineTheme): Text {
+  return renderTaskCall(args, theme, textCtor);
+}

--- a/pi/extensions/task-call-line.ts
+++ b/pi/extensions/task-call-line.ts
@@ -1,44 +1,29 @@
 /**
- * The `task` activity call-line renderer (#646): composes and renders `task · <agent>` for
- * the tool-call row so concurrent dispatched agents are distinguishable at a glance.
+ * The `task` call-line renderer (#646): renders `task · <agent>` so concurrent dispatched
+ * agents are distinguishable at a glance. Split from subagent.ts (at the line cap).
  *
- * Split out of subagent.ts (not merged into it) because that file carries the whole dispatch
- * pipeline and sits at the repo's per-file line cap; this module is the render seam only —
- * subagent.ts registers the renderCall, this file owns everything below it. Like subagent.ts
- * (and unlike SDK-free agent-spec.ts/model-tier.ts), this module touches Pi SDK types.
- *
- * Stripper invariant: every `@earendil-works/*` import here is TYPE-ONLY, so
- * `node --experimental-strip-types` behavioural tests run with no node_modules. The one
- * runtime specifier — pi-tui, for the Text constructor — is a fire-and-forget dynamic
- * import resolved by Pi's own jiti alias map (loader.js maps core packages for extensions);
- * where it cannot resolve, the renderer throws and Pi's ToolExecutionComponent swaps in its
- * plain createCallFallback() heading, byte-identical to the pre-#646 display.
+ * Stripper invariant: every `@earendil-works/*` import is type-only, so pytest runs under
+ * `node --experimental-strip-types` with no node_modules; the one runtime specifier
+ * (pi-tui below) resolves via Pi's jiti alias map in real sessions.
  */
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { Text } from "@earendil-works/pi-tui";
 
-/** Single source of truth for the tool's registered name — subagent.ts consumes this for
- *  both pi.registerTool() and the `--exclude-tools` argv builder, so a rename can't silently
- *  desync registration from the recursion guard. */
+/** Single source of truth for the registered tool name — consumed by pi.registerTool(),
+ *  the `--exclude-tools` argv builder, and the call line below, so a rename can't desync
+ *  them. */
 export const TASK_TOOL_NAME = "task";
 
-/** The subset of Pi's Theme the call-line renderer needs — interface segregation so the
- *  pure formatter stays testable against a two-method stub (and so a future Theme superset
- *  still satisfies it structurally). */
+/** Just the two members the renderer needs, so the pure formatter stays testable against
+ *  a two-method stub theme. */
 export type CallLineTheme = Pick<Theme, "fg" | "bold">;
 
-/** pi-tui's Text constructor, obtained lazily (see `textCtor` below). Typed from the
- *  type-only import so the memoized slot and the exported renderer share the real shape
- *  without any runtime resolution of the specifier at module scope. */
+/** pi-tui's Text constructor type — type-only, never resolved at module scope. */
 type TextCtor = typeof Text;
 
-/** Resolved once per process by the fire-and-forget dynamic import below. Dynamic (not
- *  static) because every top-level specifier in this directory must stay strippable by
- *  `node --experimental-strip-types` with no node_modules present — the behavioural pytest
- *  layer depends on that invariant. Real pi resolves the specifier through its jiti alias
- *  map; the nodeless stripper environment does not, the import rejects, and `undefined`
- *  here means renderCall falls back to Pi's own plain heading via its documented
- *  catch-and-swap contract. Never re-attempted on failure. */
+/** Resolved once per process by the dynamic import below — dynamic because a static import
+ *  would break the stripper invariant above. Undefined (unresolvable here) keeps every
+ *  renderCall on the framework-fallback path; never re-attempted on failure. */
 let textCtor: TextCtor | undefined;
 void import("@earendil-works/pi-tui")
   .then((mod) => {
@@ -48,45 +33,36 @@ void import("@earendil-works/pi-tui")
     /* unresolvable in this environment — plain-heading fallback, by design */
   });
 
-/** Terminal-spoofing chars with no place in a rendered agent id: C0/C1/DEL controls
- *  (ESC/OSC/newline — screen-clear and title spoofing), zero-width and bidi format chars
- *  (ZWSP, ALM, LRM/RLM, RLO/LRO and isolates — visual reordering), and the Unicode
- *  separators. Legitimate ids are [a-z0-9-], so nothing valid is ever lost. */
+/** Terminal/bidi-spoofing chars (controls, RLO/ALM/ZWSP, isolates, separators) with no
+ *  place in a rendered id — legitimate ids are [a-z0-9-], so nothing valid is lost. */
 const UNSAFE_ID_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069]/g;
 
-/** Strips UNSAFE_ID_CHARS — shared by the render path and subagent.ts's unknown-agent error,
- *  since both surface the id to the terminal before/without validation having sanitized it. */
+/** Shared by this render path and subagent.ts's unknown-agent error — both surface the id
+ *  to the terminal before validation sanitizes it. */
 export function sanitizeAgentId(agent: string): string {
   return agent.replace(UNSAFE_ID_CHARS, "");
 }
 
-/** Composes the `task` activity call line as `task · <agent>`: the toolTitle segment is
- *  byte-identical to Pi's own createCallFallback() formula (tool-execution.js), so the
- *  enriched line is literally the fallback heading plus a muted suffix. The agent segment is
- *  stripped of terminal-spoofing chars — renderCall fires on mid-stream args BEFORE
- *  execute() validates the id, and pi-tui's ANSI wrapping preserves embedded escapes.
- *  Exported pure for the same reason as subagent.ts's capOutput — the nodeless pytest
- *  driver can exercise it directly. */
+/** Composes the call line: the toolTitle segment is byte-identical to Pi's own
+ *  createCallFallback() formula, so the enriched line is the fallback heading plus a muted
+ *  agent suffix. Exported pure so the nodeless pytest driver can exercise it directly. */
 export function composeTaskCallLine(agent: string, theme: CallLineTheme): string {
   const safe = sanitizeAgentId(agent);
   return theme.fg("toolTitle", theme.bold(TASK_TOOL_NAME)) + theme.fg("muted", ` · ${safe}`);
 }
 
-/** Renders the task call line for a tool-call display. Throws — deliberately — when no
- *  agent name is present (partial mid-stream args, blank agent, or an id that strips to
- *  empty) or when pi-tui's Text could not be resolved: Pi's ToolExecutionComponent catches
- *  renderer throws and swaps in its own createCallFallback() heading, which is exactly the
- *  pre-#646 display. That throw-as-degradation is the SDK's documented fallback contract,
- *  not an error path. Exported with an injectable constructor so the resolved path is
- *  testable without pi-tui present. */
+/** Renders the task call line. Throws — deliberately — when no agent name is present
+ *  (partial mid-stream args, blank, or strips-to-empty) or Text is unresolved: Pi's
+ *  ToolExecutionComponent catches renderer throws and swaps in its createCallFallback()
+ *  heading, byte-identical to the pre-#646 display. Injectable ctor so the resolved path
+ *  is testable without pi-tui. */
 export function renderTaskCall(args: unknown, theme: CallLineTheme, ctor: TextCtor | undefined): Text {
-  // `in`-narrowing keeps this cast-free under unknown (TS narrows to object & Record<"agent", unknown>).
+  // Narrowing (not casting) args from unknown — casts are forbidden here.
   const agent =
     typeof args === "object" && args !== null && "agent" in args && typeof args.agent === "string"
       ? args.agent.trim()
       : "";
-  // Empty-after-strip (control-only id) must fall back too, or the line degrades to a
-  // dangling "task · " separator.
+  // A control-only id strips to empty — fall back rather than render a dangling "task · ".
   if (agent === "" || sanitizeAgentId(agent) === "") {
     throw new Error("task renderCall: no agent name available — framework fallback applies");
   }
@@ -94,8 +70,7 @@ export function renderTaskCall(args: unknown, theme: CallLineTheme, ctor: TextCt
   return new ctor(composeTaskCallLine(agent, theme), 0, 0);
 }
 
-/** The renderCall subagent.ts registers — renderTaskCall bound to the module's memoized
- *  Text constructor. */
+/** The renderCall subagent.ts registers — renderTaskCall bound to the memoized ctor. */
 export function taskRenderCall(args: unknown, theme: CallLineTheme): Text {
   return renderTaskCall(args, theme, textCtor);
 }

--- a/pi/extensions/task-call-line.ts
+++ b/pi/extensions/task-call-line.ts
@@ -1,5 +1,5 @@
 /**
- * The `task` call-line renderer (#646): renders `task · <agent>` so concurrent dispatched
+ * The `task` call-line renderer: renders `task · <agent>` so concurrent dispatched
  * agents are distinguishable at a glance. Split from subagent.ts (at the line cap).
  *
  * Stripper invariant: every `@earendil-works/*` import is type-only, so pytest runs under
@@ -54,7 +54,7 @@ export function composeTaskCallLine(agent: string, theme: CallLineTheme): string
 /** Renders the task call line. Throws — deliberately — when no agent name is present
  *  (partial mid-stream args, blank, or strips-to-empty) or Text is unresolved: Pi's
  *  ToolExecutionComponent catches renderer throws and swaps in its createCallFallback()
- *  heading, byte-identical to the pre-#646 display. Injectable ctor so the resolved path
+ *  heading, byte-identical to the pre-change display. Injectable ctor so the resolved path
  *  is testable without pi-tui. */
 export function renderTaskCall(args: unknown, theme: CallLineTheme, ctor: TextCtor | undefined): Text {
   // Narrowing (not casting) args from unknown — casts are forbidden here.

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -179,7 +179,7 @@ def test_package_json_values():
         "every consumer's tree for an import that is type-only and elided at runtime"
     )
 
-    # #646: pi-tui is type-only at compile time — pi resolves it at runtime via its jiti
+    # pi-tui is type-only at compile time — pi resolves it at runtime via its jiti
     # alias map. Pin lockstep with the SDK: a divergent pin typechecks a shape pi never loads.
     tui_dev_pin = data["devDependencies"]["@earendil-works/pi-tui"]
     assert re.fullmatch(r"\d+\.\d+\.\d+", tui_dev_pin), (
@@ -1184,7 +1184,7 @@ if (registered) {
   // output — same pre-validation threat model as the render path.
   out.notFoundPoisoned = await run("ev\\x1bil\\u202e", "hi");
 
-  // #646 renderCall probes. This driver runs under plain `node --experimental-strip-types`
+  // renderCall probes. This driver runs under plain `node --experimental-strip-types`
   // with no pi jiti alias map, so the module's dynamic pi-tui import is unsettled or
   // rejected at probe time — the registered renderCall takes the fallback-throw branch in
   // that state, which is Pi's framework-fallback contract (tool-execution.js catches and

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -179,6 +179,26 @@ def test_package_json_values():
         "every consumer's tree for an import that is type-only and elided at runtime"
     )
 
+    # #646: pi-tui is type-only at compile time — pi resolves it at runtime via its jiti
+    # alias map. Pin lockstep with the SDK: a divergent pin typechecks a shape pi never loads.
+    tui_dev_pin = data["devDependencies"]["@earendil-works/pi-tui"]
+    assert re.fullmatch(r"\d+\.\d+\.\d+", tui_dev_pin), (
+        f"pi-tui devDependencies pin must be an exact X.Y.Z version, got {tui_dev_pin!r}"
+    )
+    assert tui_dev_pin == dev_pin, (
+        f"pi-tui dev pin ({tui_dev_pin!r}) must equal the pi-coding-agent pin ({dev_pin!r}) — "
+        "pi nests and publishes them lockstep; a divergent pin typechecks against a shape the "
+        "host never provides"
+    )
+    assert data["peerDependencies"]["@earendil-works/pi-tui"] == peer_range, (
+        "pi-tui peer range must mirror the pi-coding-agent entry — same compatibility envelope, "
+        "same anti-untested-major ceiling"
+    )
+    assert data["peerDependenciesMeta"]["@earendil-works/pi-tui"]["optional"] is True, (
+        "pi resolves pi-tui for extensions itself (jiti alias map); an npm auto-install into "
+        "consumers would be redundant payload for a specifier npm never needs to resolve"
+    )
+
 
 def test_package_json_has_no_forbidden_pi_keys():
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
@@ -360,6 +380,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
         "ask-user.ts",
         "agent-spec.ts",
         "model-tier.ts",
+        "task-call-line.ts",
         "subagent.ts",
     ):
         (synthetic_index.parent / helper).write_text(
@@ -1159,6 +1180,47 @@ async function run(agent, prompt, model, availableModels, scopedModels) {
 
 if (registered) {
   out.notFound = await run("does-not-exist", "hi");
+  // execute()'s unknown-agent error must strip the id before interpolating it into tool
+  // output — same pre-validation threat model as the render path.
+  out.notFoundPoisoned = await run("ev\\x1bil\\u202e", "hi");
+
+  // #646 renderCall probes. This driver runs under plain `node --experimental-strip-types`
+  // with no pi jiti alias map, so the module's dynamic pi-tui import is unsettled or
+  // rejected at probe time — the registered renderCall takes the fallback-throw branch in
+  // that state, which is Pi's framework-fallback contract (tool-execution.js catches and
+  // swaps in createCallFallback). The resolved path is proven through the exported pure
+  // renderer with an injected fake Text ctor instead.
+  const stubTheme = {
+    fg: (token, s) => `<${token}>${s}</${token}>`,
+    bold: (s) => `**${s}**`,
+  };
+  out.composedLine = typeof mod.composeTaskCallLine === "function"
+    ? mod.composeTaskCallLine("reviewer", stubTheme)
+    : null;
+  // Mid-stream args reach renderCall BEFORE execute() validates the agent id, so the
+  // formatter itself must neutralize control and bidi/format chars (ESC/OSC/newline, RLO,
+  // ZWSP) — the row is already on screen by the time an invalid id would be rejected.
+  out.composedLineStripped = typeof mod.composeTaskCallLine === "function"
+    ? mod.composeTaskCallLine("rev\\x1biewer\\u202e\\u061c\\u200b\\u0007\\n", stubTheme)
+    : null;
+  class FakeText {
+    constructor(text, paddingX, paddingY) { this.text = text; this.px = paddingX; this.py = paddingY; }
+  }
+  out.hasRenderCall = typeof registered.renderCall === "function";
+  const probe = (fn) => {
+    try { return { threw: false, value: fn() }; } catch (err) { return { threw: true, message: String(err && err.message) }; }
+  };
+  // A control-only agent id strips to an empty segment — the enriched line would degrade
+  // to "task \u00b7 " with a dangling separator, so the renderer must fall back instead.
+  out.renderControlOnlyAgent = probe(() => mod.renderTaskCall({ agent: "\\x1b" }, stubTheme, FakeText));
+  out.renderNamedNoCtor = probe(() => registered.renderCall({ agent: "reviewer", prompt: "hi" }, stubTheme));
+  out.renderUnnamed = probe(() => registered.renderCall({ prompt: "hi" }, stubTheme));
+  out.renderBlankAgent = probe(() => registered.renderCall({ agent: "   ", prompt: "hi" }, stubTheme));
+  out.renderTaskCallMissingCtor = probe(() => mod.renderTaskCall({ agent: "reviewer" }, stubTheme, undefined));
+  out.renderTaskCallResolved = probe(() => {
+    const c = mod.renderTaskCall({ agent: "code-impl" }, stubTheme, FakeText);
+    return { text: c.text, px: c.px, py: c.py };
+  });
 
   out.emptyTools = await run("empty-tools-agent", "hi");
 
@@ -1302,12 +1364,99 @@ def test_subagent_kill_switch_skips_registration(subagent_root, tmp_path_factory
 
 
 @requires_node
+def test_task_call_line_composes_tool_title_and_agent_identity(subagent_root, tmp_path_factory):
+    """Assert composeTaskCallLine reproduces Pi's createCallFallback() toolTitle segment
+    plus a muted agent suffix."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["composedLine"] == "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
+    assert result["hasRenderCall"] is True, "task must register a renderCall override"
+
+
+@requires_node
+def test_task_call_line_strips_control_chars_from_unvalidated_agent_arg(subagent_root, tmp_path_factory):
+    """Assert the composed line neutralizes control and bidi/format chars in the agent id.
+
+    renderCall fires on mid-stream args before execute() validation, so ESC/OSC/newline and
+    RLO/ZWSP injection must be stripped in the formatter itself (screen-clear, title, and
+    visual-reorder spoofing guard).
+    """
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["composedLineStripped"] == "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
+
+
+@requires_node
+def test_task_render_call_falls_back_when_agent_strips_to_empty(subagent_root, tmp_path_factory):
+    """Assert a control-only agent id falls back rather than rendering a dangling separator."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["renderControlOnlyAgent"]["threw"] is True
+    assert "task" in result["renderControlOnlyAgent"]["message"]
+
+
+@requires_node
+def test_task_render_call_throws_to_framework_fallback_without_pi_tui(subagent_root, tmp_path_factory):
+    """Assert the degrade contract: with no Text constructor, renderCall throws so Pi swaps
+    in its own fallback heading."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["hasRenderCall"] is True
+    # Explicit-undefined ctor is environment-independent: must always throw with a message
+    # naming the tool (Pi's fallback swaps in the plain heading; the message is ours).
+    assert result["renderTaskCallMissingCtor"]["threw"] is True
+    assert "task" in result["renderTaskCallMissingCtor"]["message"]
+    # The registered renderCall races the pi-tui import: nodeless CI must take the throw
+    # (fallback) branch; where pi-tui resolved, it must return the enriched component instead.
+    named = result["renderNamedNoCtor"]
+    if named["threw"]:
+        assert "task" in named["message"]
+    else:
+        assert named["value"] is not None, "resolved path must return a component, not undefined"
+
+
+@requires_node
+def test_task_render_call_throws_for_missing_or_blank_agent(subagent_root, tmp_path_factory):
+    """Assert renderCall falls back (throws) for absent, partial, or blank agent args."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    assert result["hasRenderCall"] is True
+    assert result["renderUnnamed"]["threw"] is True
+    assert "task" in result["renderUnnamed"]["message"], (
+        "must be the renderer's deliberate fallback throw, not a TypeError from a missing function"
+    )
+    assert result["renderBlankAgent"]["threw"] is True
+    assert "task" in result["renderBlankAgent"]["message"]
+
+
+@requires_node
+def test_task_render_task_call_builds_text_with_composed_line_and_zero_padding(subagent_root, tmp_path_factory):
+    """Assert the resolved path builds a Text with the composed line and (0, 0) padding."""
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    outcome = result["renderTaskCallResolved"]
+    assert outcome["threw"] is False
+    resolved = outcome["value"]
+    assert resolved["text"] == "<toolTitle>**task**</toolTitle><muted> · code-impl</muted>"
+    assert [resolved["px"], resolved["py"]] == [0, 0]
+
+
+@requires_node
 def test_subagent_unknown_agent_reports_available_list(subagent_root, tmp_path_factory):
     result = _subagent_result(subagent_root, tmp_path_factory)
     assert result["notFound"]["ok"] is False
     assert "does-not-exist" in result["notFound"]["message"]
     assert "empty-tools-agent" in result["notFound"]["message"]
     assert "real-agent" in result["notFound"]["message"]
+
+
+@requires_node
+def test_subagent_unknown_agent_error_strips_poisoned_id(subagent_root, tmp_path_factory):
+    """Assert the unknown-agent error strips control/format chars before interpolation.
+
+    The message becomes tool-output content rendered unescaped, so a raw ESC/RLO in the
+    echoed id would spoof the terminal through the result row.
+    """
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    poisoned = result["notFoundPoisoned"]
+    assert poisoned["ok"] is False
+    assert "\x1b" not in poisoned["message"]
+    assert "\u202e" not in poisoned["message"]
+    assert '"evil"' in poisoned["message"], "stripped id must remain identifiable"
 
 
 @requires_node


### PR DESCRIPTION
## Summary
- The `task` tool now registers a `renderCall` override so the activity row shows `task · <agent>` (e.g. `task · reviewer`) instead of the generic `task` heading, making concurrent dispatched agents distinguishable at a glance (#646).
- Rendering lives in a new `pi/extensions/task-call-line.ts` (split from subagent.ts, which sits at the repo's 250-line cap): a pure `composeTaskCallLine` formatter plus `renderTaskCall`, with pi-tui's `Text` resolved by a fire-and-forget dynamic import — real pi resolves it via its jiti alias map; where it cannot resolve, the renderer throws and Pi's own catch-and-swap substitutes `createCallFallback()`, byte-identical to the pre-change heading (throw-as-degradation is the SDK's documented fallback contract).
- The agent segment is sanitized (C0/C1/DEL controls, bidi/format chars incl. RLO/ALM/ZWSP, Unicode separators) because renderCall fires on mid-stream args before `execute()` validates the id; the unknown-agent error echoes a sanitized id for the same reason. A control-only id falls back rather than rendering a dangling separator.
- `package.json` adds `@earendil-works/pi-tui` (devPin 0.84.2 lockstep with the SDK pin, peer `>=0.84.2 <1`, optional) for typechecking; CI is unchanged — the pytest job still runs without npm ci, and the behavioural driver keeps the stripper invariant (type-only top-level imports).
- Strictly additive display-wise: verified against pi 0.84.2's tool-execution.js that definition-backed tools already rendered the bare fallback heading, so nothing about the existing row is lost — only the agent identity is added.

## Test Plan
- [x] `pytest tests/ -v` — 2958 passed, 2 skipped (incl. 7 new tests: composition formula parity with `createCallFallback`, control/bidi-char stripping, strips-to-empty fallback, missing/blank/partial-arg fallback throws, resolved-path FakeText construction with `(0, 0)` padding, sanitized unknown-agent error, package.json pi-tui pin/peer/optional contract)
- [x] `npm run typecheck` — `tsc --noEmit` clean
- [x] Comment scan — 0 must-triage after compressing 2 over-cap comments
- [x] Nodeless behavioural driver exercised both fallback branches; enriched branch verified standalone (real Text component returned once the dynamic import settles)

### Type-tailored checks (feat)
- [x] New behaviour pinned by failing-first tests (every renderer test observed RED before GREEN)
- [x] Fallback path reproduces the exact pre-change display (formula asserted equal to Pi's own)
- [x] No change to task dispatch semantics — argv/integration tests untouched and green

Closes #646
