### PR TITLE
[fix] Create address-feedback worktree on the PR branch (#643)

### DIFF
--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -107,7 +107,7 @@ If `$WT` is not yet set, check whether a worktree for `$PR_BRANCH` already exist
 ```bash
 if [ -z "$WT" ]; then
   EXISTING_WT=$(git worktree list --porcelain \
-    | awk 'BEGIN{wt=""} /^worktree /{wt=$2} /^branch refs\/heads\/'"$PR_BRANCH"'/{print wt; exit}')
+    | awk -v b="refs/heads/$PR_BRANCH" 'BEGIN{wt=""} /^worktree /{wt=$2} $0 == "branch " b {print wt; exit}')
   if [ -n "$EXISTING_WT" ] && [ -d "$EXISTING_WT" ]; then
     WT="$EXISTING_WT"
     REUSED_WT=1
@@ -118,15 +118,18 @@ fi
 If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree **on the PR branch itself** (`$PR_BRANCH`), so commits pushed in Phase 4 update the PR directly (`git push -u origin "$PR_BRANCH"` — never a throwaway task branch):
 
 ```bash
-git fetch origin "$PR_BRANCH" 2>/dev/null || true  # task-mode rimba add does not fetch; origin/$PR_BRANCH must be current
+git fetch origin "$PR_BRANCH" || echo "⚠ fetch of $PR_BRANCH failed — fork PR? see Failure modes"  # task-mode rimba add does not fetch; origin/$PR_BRANCH must be current
 WT=""
 if command -v rimba >/dev/null 2>&1; then
   if git show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
     # Local branch exists (kept by a prior run's Phase 7) — checkout preserves unpushed crash-recovery commits.
     WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
     mkdir -p "$(dirname "$WT")"
-    git worktree add "$WT" "$PR_BRANCH"
-    rimba deps install "$PR_BRANCH" 2>/dev/null || echo "⚠ rimba deps install failed — install deps manually before running tests."
+    git worktree add "$WT" "$PR_BRANCH" || WT=""
+    # Reconcile vs origin: ff-only when strictly behind (PR advanced between runs); warn when diverged.
+    [ -n "$WT" ] && git merge-base --is-ancestor "$PR_BRANCH" "origin/$PR_BRANCH" && git -C "$WT" merge --ff-only "origin/$PR_BRANCH"
+    [ -n "$WT" ] && ! git merge-base --is-ancestor "origin/$PR_BRANCH" "$PR_BRANCH" && echo "⚠ local $PR_BRANCH diverged from origin/$PR_BRANCH — rebase before Phase 4."
+    rimba deps install "$PR_BRANCH" || echo "⚠ rimba deps install failed — install deps manually before running tests."
   else
     RIMBA_OUT=$(rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH" 2>&1)
     WT=$(printf '%s\n' "$RIMBA_OUT" | awk '/Path:/{print $2}')
@@ -134,9 +137,7 @@ if command -v rimba >/dev/null 2>&1; then
       WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD)
       if [ "$WT_BRANCH" != "$PR_BRANCH" ]; then
         # rimba re-prefixed a non-conventional name (feature/<name>) — wrong branch; tear down and fall through to git.
-        rimba remove "$WT_BRANCH" --force >/dev/null 2>&1
-        git worktree remove --force "$WT" >/dev/null 2>&1
-        git branch -D "$WT_BRANCH" >/dev/null 2>&1
+        rimba remove "$WT_BRANCH" --force >/dev/null 2>&1; git worktree remove --force "$WT" >/dev/null 2>&1
         WT=""
       fi
     else
@@ -145,12 +146,12 @@ if command -v rimba >/dev/null 2>&1; then
     fi
   fi
 fi
-if [ -z "$WT" ]; then
-  # rimba absent/failed/re-prefixed — create directly; || covers a local branch existing after teardown.
+if [ -z "$WT" ]; then  # rimba absent/failed/re-prefixed; || covers a local branch existing after teardown
   WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
   mkdir -p "$(dirname "$WT")"
   git worktree add -b "$PR_BRANCH" "$WT" "origin/$PR_BRANCH" 2>/dev/null || git worktree add "$WT" "$PR_BRANCH"
 fi
+[ -e "$WT/.git" ] || { echo "worktree creation failed at $WT"; exit 1; }
 ```
 
 No `--skip-deps`/`--skip-hooks` anywhere on the create path — rimba installs dependencies and runs `post_create` hooks so the worktree is fully initialized with no separate repository-specific bootstrap step. Wait for `rimba add` to complete before running tests in the worktree.

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -280,14 +280,14 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 | Reply REST fails (404 — comment deleted) | HTTP 404 | Skip that thread, log "skipped (comment deleted)". |
 | Resolve mutation fails | GraphQL error | Reply already posted — log "reply posted but resolve failed". Continue. Do not roll back the reply. |
 | rimba re-prefixes a non-conventional PR branch name (worktree on `feature/<name>` ≠ `$PR_BRANCH`) | Post-create branch verification mismatch | Remove the mis-branched worktree, fall back to `git worktree add -b "$PR_BRANCH" … "origin/$PR_BRANCH"`. |
-| Fork PR — branch exists only on the fork remote | `git fetch origin "$PR_BRANCH"` fails / `origin/$PR_BRANCH` missing | Out of scope (issue #643): add the fork remote manually (`git remote add gh-fork-<owner> …`) and check out the PR head by hand, then re-run. |
+| Fork PR — branch exists only on the fork remote | `git fetch origin "$PR_BRANCH"` fails / `origin/$PR_BRANCH` missing | Out of scope: add the fork remote manually (`git remote add gh-fork-<owner> …`) and check out the PR head by hand, then re-run. |
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---|---|
 | Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
-| Pass `--skip-deps --skip-hooks` on the Phase 2 create | Never pass either flag — rimba must install deps and run hooks so the worktree is fully initialized with no separate bootstrap step (issue #643). |
+| Pass `--skip-deps --skip-hooks` on the Phase 2 create | Never pass either flag — rimba must install deps and run hooks so the worktree is fully initialized with no separate bootstrap step. |
 | Create the worktree on a throwaway task branch (`rimba add pr:$PR --task …`) | Use `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` so the worktree is on the PR branch itself — Phase 4 pushes update the PR directly. |
 | Leave the worktree behind after skill exits | Phase 7 always removes it — skip Phase 7 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
 | Deleting `$PR_BRANCH` directly in Phase 7 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -92,7 +92,7 @@ If a prior triage save exists at `/tmp/swe-workbench-address-feedback/${PR}-tria
 
 ### Phase 2 — Worktree
 
-First, check whether the current branch already matches the PR head — if so, reuse the current worktree instead of creating a new one:
+First refresh the remote ref — run `git fetch origin "$PR_BRANCH" || echo "⚠ fetch of $PR_BRANCH failed — fork PR? see Failure modes"` — every path below (the guards' reconcile, the create block's `--source`) needs a current `origin/$PR_BRANCH`. Then check whether the current branch already matches the PR head — if so, reuse the current worktree instead of creating a new one:
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" = "$PR_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
@@ -118,7 +118,6 @@ fi
 If `$WT` is set by either check above, skip the create block below, run the shared reconcile block after it, then proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree **on the PR branch itself** (`$PR_BRANCH`), so commits pushed in Phase 4 update the PR directly (`git push -u origin "$PR_BRANCH"` — never a throwaway task branch):
 
 ```bash
-git fetch origin "$PR_BRANCH" || echo "⚠ fetch of $PR_BRANCH failed — fork PR? see Failure modes"  # task-mode rimba add does not fetch; origin/$PR_BRANCH must be current
 WT=""
 if command -v rimba >/dev/null 2>&1; then
   if git show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
@@ -149,7 +148,7 @@ fi
 Shared reconcile for **every** Phase 2 path (reused crash-leftovers go stale; fresh creates are no-ops):
 ```bash
 if [ -n "$WT" ] && git merge-base --is-ancestor "$PR_BRANCH" "origin/$PR_BRANCH"; then git -C "$WT" merge --ff-only "origin/$PR_BRANCH" >/dev/null 2>&1 || echo "⚠ fast-forward of $PR_BRANCH failed"; fi
-[ -n "$WT" ] && ! git merge-base --is-ancestor "origin/$PR_BRANCH" "$PR_BRANCH" && echo "⚠ local $PR_BRANCH diverged from origin/$PR_BRANCH — rebase before Phase 4."
+[ -n "$WT" ] && git show-ref --verify --quiet "refs/remotes/origin/$PR_BRANCH" && ! git merge-base --is-ancestor "origin/$PR_BRANCH" "$PR_BRANCH" && echo "⚠ local $PR_BRANCH diverged from origin/$PR_BRANCH — rebase before Phase 4."
 command -v rimba >/dev/null 2>&1 && rimba deps install "$PR_BRANCH" || echo "⚠ rimba deps install failed — install deps manually before running tests."
 ```
 

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -115,7 +115,7 @@ if [ -z "$WT" ]; then
   fi
 fi
 ```
-If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree **on the PR branch itself** (`$PR_BRANCH`), so commits pushed in Phase 4 update the PR directly (`git push -u origin "$PR_BRANCH"` — never a throwaway task branch):
+If `$WT` is set by either check above, skip the create block below, run the shared reconcile block after it, then proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree **on the PR branch itself** (`$PR_BRANCH`), so commits pushed in Phase 4 update the PR directly (`git push -u origin "$PR_BRANCH"` — never a throwaway task branch):
 
 ```bash
 git fetch origin "$PR_BRANCH" || echo "⚠ fetch of $PR_BRANCH failed — fork PR? see Failure modes"  # task-mode rimba add does not fetch; origin/$PR_BRANCH must be current
@@ -124,12 +124,7 @@ if command -v rimba >/dev/null 2>&1; then
   if git show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
     # Local branch exists (kept by a prior run's Phase 7) — checkout preserves unpushed crash-recovery commits.
     WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
-    mkdir -p "$(dirname "$WT")"
     git worktree add "$WT" "$PR_BRANCH" || WT=""
-    # Reconcile vs origin: ff-only when strictly behind (PR advanced between runs); warn when diverged.
-    [ -n "$WT" ] && git merge-base --is-ancestor "$PR_BRANCH" "origin/$PR_BRANCH" && git -C "$WT" merge --ff-only "origin/$PR_BRANCH"
-    [ -n "$WT" ] && ! git merge-base --is-ancestor "origin/$PR_BRANCH" "$PR_BRANCH" && echo "⚠ local $PR_BRANCH diverged from origin/$PR_BRANCH — rebase before Phase 4."
-    rimba deps install "$PR_BRANCH" || echo "⚠ rimba deps install failed — install deps manually before running tests."
   else
     RIMBA_OUT=$(rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH" 2>&1)
     WT=$(printf '%s\n' "$RIMBA_OUT" | awk '/Path:/{print $2}')
@@ -137,21 +132,25 @@ if command -v rimba >/dev/null 2>&1; then
       WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD)
       if [ "$WT_BRANCH" != "$PR_BRANCH" ]; then
         # rimba re-prefixed a non-conventional name (feature/<name>) — wrong branch; tear down and fall through to git.
-        rimba remove "$WT_BRANCH" --force >/dev/null 2>&1; git worktree remove --force "$WT" >/dev/null 2>&1
-        WT=""
+        rimba remove "$WT_BRANCH" --force >/dev/null 2>&1; git worktree remove --force "$WT" >/dev/null 2>&1; WT=""
       fi
     else
-      echo "rimba add failed: $RIMBA_OUT"
-      WT=""
+      echo "rimba add failed: $RIMBA_OUT"; WT=""
     fi
   fi
 fi
 if [ -z "$WT" ]; then  # rimba absent/failed/re-prefixed; || covers a local branch existing after teardown
   WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
-  mkdir -p "$(dirname "$WT")"
   git worktree add -b "$PR_BRANCH" "$WT" "origin/$PR_BRANCH" 2>/dev/null || git worktree add "$WT" "$PR_BRANCH"
 fi
 [ -e "$WT/.git" ] || { echo "worktree creation failed at $WT"; exit 1; }
+```
+
+Shared reconcile for **every** Phase 2 path (reused crash-leftovers go stale; fresh creates are no-ops):
+```bash
+if [ -n "$WT" ] && git merge-base --is-ancestor "$PR_BRANCH" "origin/$PR_BRANCH"; then git -C "$WT" merge --ff-only "origin/$PR_BRANCH" >/dev/null 2>&1 || echo "⚠ fast-forward of $PR_BRANCH failed"; fi
+[ -n "$WT" ] && ! git merge-base --is-ancestor "origin/$PR_BRANCH" "$PR_BRANCH" && echo "⚠ local $PR_BRANCH diverged from origin/$PR_BRANCH — rebase before Phase 4."
+command -v rimba >/dev/null 2>&1 && rimba deps install "$PR_BRANCH" || echo "⚠ rimba deps install failed — install deps manually before running tests."
 ```
 
 No `--skip-deps`/`--skip-hooks` anywhere on the create path — rimba installs dependencies and runs `post_create` hooks so the worktree is fully initialized with no separate repository-specific bootstrap step. Wait for `rimba add` to complete before running tests in the worktree.
@@ -290,7 +289,7 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 |---|---|
 | Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
 | Pass `--skip-deps --skip-hooks` on the Phase 2 create | Never pass either flag — rimba must install deps and run hooks so the worktree is fully initialized with no separate bootstrap step (issue #643). |
-| Create the worktree on a throwaway task branch (`rimba add pr:$PR --task …`) | Use `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` so the worktree is on the PR branch itself — Phase 4 pushes then update the PR directly. |
+| Create the worktree on a throwaway task branch (`rimba add pr:$PR --task …`) | Use `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` so the worktree is on the PR branch itself — Phase 4 pushes update the PR directly. |
 | Leave the worktree behind after skill exits | Phase 7 always removes it — skip Phase 7 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
 | Deleting `$PR_BRANCH` directly in Phase 7 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -115,22 +115,47 @@ if [ -z "$WT" ]; then
   fi
 fi
 ```
-If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree:
+If `$WT` is set by either check above, skip the rest of Phase 2 and proceed to Phase 3 — when the tree was dirty (first guard only), a non-blocking warning was already emitted; the user may stash before Phase 4 commits. Otherwise create a new durable worktree **on the PR branch itself** (`$PR_BRANCH`), so commits pushed in Phase 4 update the PR directly (`git push -u origin "$PR_BRANCH"` — never a throwaway task branch):
 
-**When rimba is available** (preferred):
 ```bash
-RIMBA_OUT=$(rimba add "pr:$PR" --task "address-feedback-$PR" --skip-deps --skip-hooks 2>&1)
-WT=$(printf '%s\n' "$RIMBA_OUT" | awk '/Path:/{print $2}')
-[ -d "$WT" ] || { echo "rimba add failed: $RIMBA_OUT"; exit 1; }
+git fetch origin "$PR_BRANCH" 2>/dev/null || true  # task-mode rimba add does not fetch; origin/$PR_BRANCH must be current
+WT=""
+if command -v rimba >/dev/null 2>&1; then
+  if git show-ref --verify --quiet "refs/heads/$PR_BRANCH"; then
+    # Local branch exists (kept by a prior run's Phase 7) — checkout preserves unpushed crash-recovery commits.
+    WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
+    mkdir -p "$(dirname "$WT")"
+    git worktree add "$WT" "$PR_BRANCH"
+    rimba deps install "$PR_BRANCH" 2>/dev/null || echo "⚠ rimba deps install failed — install deps manually before running tests."
+  else
+    RIMBA_OUT=$(rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH" 2>&1)
+    WT=$(printf '%s\n' "$RIMBA_OUT" | awk '/Path:/{print $2}')
+    if [ -n "$WT" ] && [ -d "$WT" ]; then
+      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD)
+      if [ "$WT_BRANCH" != "$PR_BRANCH" ]; then
+        # rimba re-prefixed a non-conventional name (feature/<name>) — wrong branch; tear down and fall through to git.
+        rimba remove "$WT_BRANCH" --force >/dev/null 2>&1
+        git worktree remove --force "$WT" >/dev/null 2>&1
+        git branch -D "$WT_BRANCH" >/dev/null 2>&1
+        WT=""
+      fi
+    else
+      echo "rimba add failed: $RIMBA_OUT"
+      WT=""
+    fi
+  fi
+fi
+if [ -z "$WT" ]; then
+  # rimba absent/failed/re-prefixed — create directly; || covers a local branch existing after teardown.
+  WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
+  mkdir -p "$(dirname "$WT")"
+  git worktree add -b "$PR_BRANCH" "$WT" "origin/$PR_BRANCH" 2>/dev/null || git worktree add "$WT" "$PR_BRANCH"
+fi
 ```
-**When rimba is absent** (fallback):
-```bash
-WT="$HOME/.local/share/swe-workbench/address-feedback-${PR}"
-mkdir -p "$(dirname "$WT")"
-git fetch origin "${PR_BRANCH}"
-git worktree add "$WT" "${PR_BRANCH}"
-```
-This worktree is **disposable** — fixes are committed and pushed to the PR branch in Phase 4, so the work lives on the remote, not the worktree. Phase 7 removes it on every exit (success, Q-quit, or error). If removal fails, a fallback is attempted; see Phase 7 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 7 before stopping.
+
+No `--skip-deps`/`--skip-hooks` anywhere on the create path — rimba installs dependencies and runs `post_create` hooks so the worktree is fully initialized with no separate repository-specific bootstrap step. Wait for `rimba add` to complete before running tests in the worktree.
+
+This worktree is **disposable but sits on the PR branch itself** — Phase 4 commits and pushes from it update the PR directly, so the work lives on the PR branch, not a throwaway task branch. Phase 7 removes the worktree on every exit (success, Q-quit, or error) but **keeps the local `$PR_BRANCH`**: it is the owner's actual PR head branch, and keeping it preserves unpushed commits if a prior run crashed mid-Phase-4 (the next run checks that branch out instead of re-creating it). Never delete `$PR_BRANCH` (e.g. via `git branch -D`). If removal fails, a fallback is attempted; see Phase 7 for details. If the skill exits with an unrecoverable error at any point after this phase, run Phase 7 before stopping.
 
 ### Phase 3 — Triage digest
 
@@ -229,9 +254,10 @@ Run on every exit that occurs after a worktree was **created** in Phase 2 (succe
 if [ "${REUSED_WT:-0}" = "1" ]; then
   echo "Reused existing worktree at $WT — skipping cleanup (nothing was created)."
 else
-  # positional arg matches the --task label set in Phase 2 ("address-feedback-$PR")
-  if rimba remove "address-feedback-$PR" --force 2>/dev/null; then
-    echo "Cleaned up worktree address-feedback-$PR."
+  # task = the PR branch (Phase 2 creates the worktree on $PR_BRANCH); --keep-branch
+  # preserves the local PR head branch — rimba remove deletes the branch without it.
+  if rimba remove "$PR_BRANCH" --force --keep-branch 2>/dev/null; then
+    echo "Cleaned up worktree for $PR_BRANCH (local branch kept)."
   else
     # $WT is set in Phase 2 (both rimba and fallback paths); do not re-assign here
     git worktree remove --force "$WT" 2>/dev/null; swe-workbench-clean-ephemeral "$WT" 2>/dev/null
@@ -254,13 +280,16 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 | Worktree removal fails (rimba absent or busy) | `rimba remove` non-zero | Attempt `git worktree remove --force` fallback; log warning; do not block. |
 | Reply REST fails (404 — comment deleted) | HTTP 404 | Skip that thread, log "skipped (comment deleted)". |
 | Resolve mutation fails | GraphQL error | Reply already posted — log "reply posted but resolve failed". Continue. Do not roll back the reply. |
+| rimba re-prefixes a non-conventional PR branch name (worktree on `feature/<name>` ≠ `$PR_BRANCH`) | Post-create branch verification mismatch | Remove the mis-branched worktree, fall back to `git worktree add -b "$PR_BRANCH" … "origin/$PR_BRANCH"`. |
+| Fork PR — branch exists only on the fork remote | `git fetch origin "$PR_BRANCH"` fails / `origin/$PR_BRANCH` missing | Out of scope (issue #643): add the fork remote manually (`git remote add gh-fork-<owner> …`) and check out the PR head by hand, then re-run. |
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---|---|
 | Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
-| Omit `--skip-deps --skip-hooks` on the rimba call | Always pass both flags — same as other worktree-creating skills. Deps can be installed manually in the worktree if needed. |
+| Pass `--skip-deps --skip-hooks` on the Phase 2 create | Never pass either flag — rimba must install deps and run hooks so the worktree is fully initialized with no separate bootstrap step (issue #643). |
+| Create the worktree on a throwaway task branch (`rimba add pr:$PR --task …`) | Use `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` so the worktree is on the PR branch itself — Phase 4 pushes then update the PR directly. |
 | Leave the worktree behind after skill exits | Phase 7 always removes it — skip Phase 7 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
 | Deleting `$PR_BRANCH` directly in Phase 7 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -354,6 +354,16 @@ def test_address_feedback_skill_create_reconciles_stale_local_branch():
         'SKILL.md Phase 2 must gate on the worktree existing ([ -e "$WT/.git" ]) before '
         "proceeding — a dangling $WT fails confusingly in Phase 4 and mis-cleans in Phase 7"
     )
+    assert 'git show-ref --verify --quiet "refs/remotes/origin/$PR_BRANCH"' in text, (
+        "the diverged warning must be gated on the remote ref existing — a missing ref "
+        "(failed fetch / fork PR) must not be misreported as divergence"
+    )
+    fetch_idx = text.find('git fetch origin "$PR_BRANCH"')
+    guard_idx = text.find('CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)')
+    assert fetch_idx != -1 and guard_idx != -1 and fetch_idx < guard_idx, (
+        "the fetch must run before the reuse guards — guard-path reconcile compares against "
+        "origin/$PR_BRANCH and needs a current ref"
+    )
     assert "skip the create block below, run the shared reconcile block after it" in text, (
         "SKILL.md Phase 2 reuse guards must route through the shared reconcile — a crash-leftover "
         "worktree can be stale (PR advanced between runs) on reuse paths too"

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -270,7 +270,10 @@ def test_address_feedback_skill_create_uses_pr_branch_task_form():
         'SKILL.md Phase 2 must invoke: rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH" — '
         "the task-form add names the branch after the PR branch itself"
     )
-    phase2 = text[text.find("### Phase 2") : text.find("### Phase 3")]
+    phase2_start = text.find("### Phase 2")
+    phase2_end = text.find("### Phase 3")
+    assert phase2_start != -1 and phase2_end != -1, "Phase 2/Phase 3 headings must exist"
+    phase2 = text[phase2_start:phase2_end]
     assert "pr:$PR" not in phase2, (
         "Phase 2 must not use the pr:<num> task form for worktree creation — it creates a "
         "throwaway branch off the PR head, so pushes never update the PR"
@@ -336,6 +339,23 @@ def test_address_feedback_skill_create_verifies_branch_and_falls_back():
     )
 
 
+def test_address_feedback_skill_create_reconciles_stale_local_branch():
+    """Existing-branch checkout must reconcile against origin — ff-only when behind, warn when diverged."""
+    text = _skill_text_with_references()
+    assert 'git -C "$WT" merge --ff-only "origin/$PR_BRANCH"' in text, (
+        "SKILL.md Phase 2 must fast-forward a strictly-behind local $PR_BRANCH — "
+        "otherwise Phase 4 pushes are rejected non-FF when the PR advanced between runs"
+    )
+    assert 'diverged from origin' in text, (
+        "SKILL.md Phase 2 must warn loudly when local $PR_BRANCH diverged from origin "
+        "(needs rebase before Phase 4)"
+    )
+    assert '[ -e "$WT/.git" ]' in text, (
+        'SKILL.md Phase 2 must gate on the worktree existing ([ -e "$WT/.git" ]) before '
+        "proceeding — a dangling $WT fails confusingly in Phase 4 and mis-cleans in Phase 7"
+    )
+
+
 def test_address_feedback_skill_disposable_paragraph_on_pr_branch():
     """Prose must state the worktree sits on the PR branch; cleanup keeps the branch (crash recovery)."""
     text = _skill_text_with_references()
@@ -351,9 +371,9 @@ def test_address_feedback_skill_disposable_paragraph_on_pr_branch():
 def test_address_feedback_skill_failure_modes_fork_limitation():
     """Failure modes must carry the cross-fork limitation note (forks out of scope, issue #643)."""
     text = _skill_text_with_references()
-    assert re.search(r"fork", text, re.IGNORECASE), (
-        "SKILL.md Failure modes must note the cross-fork limitation — the create path "
-        "sources from origin; fork-only branches are out of scope"
+    assert "gh-fork-<owner>" in text, (
+        "SKILL.md Failure modes must note the cross-fork limitation (gh-fork-<owner> manual "
+        "workaround) — the create path sources from origin; fork-only branches are out of scope"
     )
 
 
@@ -437,10 +457,11 @@ def test_address_feedback_skill_reuses_existing_worktree_on_main():
         "SKILL.md Phase 2 must scan 'git worktree list --porcelain' to find an existing "
         "worktree for $PR_BRANCH when the current branch does not match (e.g. session on main)"
     )
-    # Must look up the branch ref inside the porcelain output (awk escapes the slashes).
-    assert r"refs\/heads\/" in text, (
-        r"SKILL.md Phase 2 must match 'refs\/heads\/$PR_BRANCH' in the awk pattern "
-        "to locate the correct registered worktree in porcelain output"
+    # Must look up the branch ref inside the porcelain output (branch passed as an awk
+    # variable — a regex-interpolated branch name breaks on "/" in conventional names).
+    assert 'awk -v b="refs/heads/$PR_BRANCH"' in text, (
+        'SKILL.md Phase 2 must pass the branch to awk via -v (exact $0 == "branch " b match) — '
+        "interpolating $PR_BRANCH into a regex literal dies on slashed branch names"
     )
     # Must set REUSED_WT=1 on a match, same as the first guard.
     assert re.search(r"EXISTING_WT.*\n.*REUSED_WT=1|REUSED_WT=1.*EXISTING_WT", text, re.DOTALL), (

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -236,11 +236,14 @@ def test_address_feedback_skill_phase6_preserves_trailer():
 # --- Cleanup (Phase 7) tests — AC#1, AC#2, AC#3 from issue #291 ---
 
 def test_address_feedback_skill_cleans_up_worktree():
-    """Phase 7 must include rimba remove "address-feedback-$PR" --force (AC#1)."""
+    """Phase 7 must remove the worktree via rimba but KEEP the PR branch (issue #643)."""
     text = SKILL_MD.read_text()
-    assert re.search(r'rimba remove ["\']?address-feedback-\$PR["\']? --force', text), (
-        'SKILL.md Phase 7 must include: rimba remove "address-feedback-$PR" --force — '
-        "the worktree is disposable; fixes are on the remote branch after Phase 4"
+    assert re.search(
+        r'rimba remove ["\']?\$PR_BRANCH["\']? --force --keep-branch', text
+    ), (
+        'SKILL.md Phase 7 must include: rimba remove "$PR_BRANCH" --force --keep-branch — '
+        "the worktree is disposable but the local PR head branch must be preserved "
+        "(rimba remove deletes the branch without --keep-branch)"
     )
 
 
@@ -255,6 +258,102 @@ def test_address_feedback_skill_cleanup_failure_tolerant():
         text, re.IGNORECASE
     ), (
         "SKILL.md Phase 7 must state that cleanup failure is non-blocking (warn, do not block, continue)"
+    )
+
+
+# --- Worktree create-path contract — issue #643 ---
+
+def test_address_feedback_skill_create_uses_pr_branch_task_form():
+    """Phase 2 must create the worktree from the PR branch name, not the pr:<num> task form (AC#1)."""
+    text = _skill_text_with_references()
+    assert 'rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"' in text, (
+        'SKILL.md Phase 2 must invoke: rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH" — '
+        "the task-form add names the branch after the PR branch itself"
+    )
+    phase2 = text[text.find("### Phase 2") : text.find("### Phase 3")]
+    assert "pr:$PR" not in phase2, (
+        "Phase 2 must not use the pr:<num> task form for worktree creation — it creates a "
+        "throwaway branch off the PR head, so pushes never update the PR"
+    )
+    assert '--task "address-feedback-$PR"' not in text, (
+        "SKILL.md must not pass --task address-feedback-$PR — the worktree must land on "
+        "the PR branch itself"
+    )
+
+
+def test_address_feedback_skill_create_omits_skip_flags():
+    """Phase 2 create must let rimba fully initialize — no --skip-deps/--skip-hooks (AC#2/#3)."""
+    text = _skill_text_with_references()
+    # No rimba add invocation may carry either skip flag.
+    for m in re.finditer(r"rimba add[^\n]*", text):
+        assert "--skip-deps" not in m.group(0), (
+            f"rimba add must not pass --skip-deps: {m.group(0)!r}"
+        )
+        assert "--skip-hooks" not in m.group(0), (
+            f"rimba add must not pass --skip-hooks: {m.group(0)!r}"
+        )
+    assert re.search(r"Never pass either flag|must not pass either", text), (
+        "Common-mistakes table must forbid skip flags on the Phase 2 create so rimba "
+        "installs deps and runs hooks with no separate bootstrap step"
+    )
+
+
+def test_address_feedback_skill_create_fetches_pr_branch_first():
+    """Task-form rimba add does not fetch — Phase 2 must fetch origin/$PR_BRANCH itself."""
+    text = _skill_text_with_references()
+    assert 'git fetch origin "$PR_BRANCH"' in text, (
+        'SKILL.md Phase 2 must run: git fetch origin "$PR_BRANCH" before rimba add — '
+        "task-mode add never fetches, and --source origin/$PR_BRANCH must be current"
+    )
+
+
+def test_address_feedback_skill_create_handles_existing_local_branch():
+    """Local branch already present → git worktree add checkout + rimba deps install (no re-add error)."""
+    text = _skill_text_with_references()
+    assert 'git show-ref --verify --quiet "refs/heads/$PR_BRANCH"' in text, (
+        "SKILL.md Phase 2 must probe refs/heads/$PR_BRANCH — rimba add hard-errors "
+        "'branch already exists' when the local PR branch is present"
+    )
+    assert 'git worktree add "$WT" "$PR_BRANCH"' in text, (
+        'SKILL.md Phase 2 must check out the existing local branch: git worktree add "$WT" "$PR_BRANCH"'
+    )
+    assert 'rimba deps install "$PR_BRANCH"' in text, (
+        "SKILL.md Phase 2 must run rimba deps install on the existing-branch path so it "
+        "still gets dependency installation without a separate bootstrap step"
+    )
+
+
+def test_address_feedback_skill_create_verifies_branch_and_falls_back():
+    """Post-create verification: worktree branch must equal $PR_BRANCH; mismatch → git fallback."""
+    text = _skill_text_with_references()
+    assert 'WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD)' in text, (
+        "SKILL.md Phase 2 must verify the checked-out branch after rimba add — rimba "
+        "re-prefixes non-conventional branch names (DefaultPrefixType is feature/)"
+    )
+    assert 'git worktree add -b "$PR_BRANCH" "$WT" "origin/$PR_BRANCH"' in text, (
+        'SKILL.md Phase 2 fallback must create the branch directly: '
+        'git worktree add -b "$PR_BRANCH" "$WT" "origin/$PR_BRANCH"'
+    )
+
+
+def test_address_feedback_skill_disposable_paragraph_on_pr_branch():
+    """Prose must state the worktree sits on the PR branch; cleanup keeps the branch (crash recovery)."""
+    text = _skill_text_with_references()
+    assert "on the PR branch itself" in text, (
+        "SKILL.md must explain the worktree is on the PR branch itself — pushes update the PR directly"
+    )
+    assert "keeps the local" in text and "$PR_BRANCH" in text, (
+        "SKILL.md must state cleanup keeps the local $PR_BRANCH (unpushed commits from a "
+        "crashed run survive; the branch is the owner's PR head)"
+    )
+
+
+def test_address_feedback_skill_failure_modes_fork_limitation():
+    """Failure modes must carry the cross-fork limitation note (forks out of scope, issue #643)."""
+    text = _skill_text_with_references()
+    assert re.search(r"fork", text, re.IGNORECASE), (
+        "SKILL.md Failure modes must note the cross-fork limitation — the create path "
+        "sources from origin; fork-only branches are out of scope"
     )
 
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -354,6 +354,15 @@ def test_address_feedback_skill_create_reconciles_stale_local_branch():
         'SKILL.md Phase 2 must gate on the worktree existing ([ -e "$WT/.git" ]) before '
         "proceeding — a dangling $WT fails confusingly in Phase 4 and mis-cleans in Phase 7"
     )
+    assert "skip the create block below, run the shared reconcile block after it" in text, (
+        "SKILL.md Phase 2 reuse guards must route through the shared reconcile — a crash-leftover "
+        "worktree can be stale (PR advanced between runs) on reuse paths too"
+    )
+    gate_idx = text.find('[ -e "$WT/.git" ]')
+    ff_idx = text.find('merge --ff-only')
+    assert gate_idx != -1 and ff_idx != -1 and gate_idx < ff_idx, (
+        "the shared reconcile (ff-only) must run after the create-flow existence gate"
+    )
 
 
 def test_address_feedback_skill_disposable_paragraph_on_pr_branch():


### PR DESCRIPTION
## Ticket context: #643

**Title:** [bug] Use PR branch for uninitialized rimba worktrees
**Type / Status:** bug — OPEN
**Summary:** `workflow-address-feedback` Phase 2 created its worktree via `rimba add pr:<num> --task address-feedback-<num> --skip-deps --skip-hooks`, landing on a throwaway branch off the PR head (Phase 4 pushes never updated the PR) with initialization skipped (separate bootstrap needed).
**Acceptance criteria:** create from the PR branch name, omit both skip flags, no separate bootstrap step, existing-worktree behavior unchanged.
**Source:** https://github.com/lugassawan/swe-workbench/issues/643

---

## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Phase 2 now creates the worktree **on the PR branch itself**: `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` with no `--skip-deps`/`--skip-hooks`, so rimba fully initializes (deps + hooks) and no separate bootstrap step is needed (was `rimba add pr:$PR --task address-feedback-$PR --skip-deps --skip-hooks`, which landed on a throwaway branch so Phase 4 pushes never updated the PR).
- Guarded create path: remote ref fetched at Phase 2 entry; existing local branch (kept by a prior run's cleanup) is checked out via plain `git worktree add` + `rimba deps install`; post-create branch verification catches rimba re-prefixing non-conventional names (`feature/<name>`) and falls back to `git worktree add -b`; a shared reconcile block (ff-only when behind, diverged warning gated on the remote ref existing) runs on every path; `[ -e "$WT/.git" ]` existence gate.
- Phase 7 cleanup now runs `rimba remove "$PR_BRANCH" --force --keep-branch` — rimba deletes the branch by default, which would have destroyed the PR head branch; the awk reuse-guard no longer breaks on slashed branch names (`-v b=` exact match); Common-mistakes and Failure-modes rows updated (incl. the cross-fork out-of-scope note).
- Regression tests: 9 new/updated text-assertion tests pin the invocation, skip-flag ban, keep-branch, reconcile, existence gate, awk form, and fork note.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [ ] Changed skills/commands/agents load without errors
- [ ] Full suite green: `pytest tests/ -q` — 2959 passed, 2 skipped (baseline 2951 + 8 net-new)
- [ ] Red-green verified: the 8 contract tests failed against the old SKILL.md, pass after the fix
- [ ] Examples in the diff were exercised manually

### Type-tailored checks (fix)
- [ ] Reproduce: on a PR without a local worktree, Phase 2 previously emitted `rimba add pr:<num> --task address-feedback-<num> --skip-deps --skip-hooks`
- [ ] Verify: Phase 2 now emits `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` with no skip flags; worktree HEAD == `$PR_BRANCH`; `rimba deps install` resolves the plain-git worktree (verified empirically)
- [ ] Verify: reuse-guard paths (already on PR branch / existing worktree) still short-circuit creation and route through the shared reconcile block

<!-- Link to the GitHub issue this PR addresses. -->
Closes #643
