### PR TITLE
[chore] Extract commit safety preflight into a runtime command

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -28,6 +28,7 @@ full implementation, invocable directly by its bare `swe-workbench-<name>` comma
 | `swe-workbench-lsp` | Stdlib-only LSP JSON-RPC client — semantic code navigation (`refs`/`def`/`impl`/`callers`/`callees`/`hover`/`symbols`/`wsymbols`/`check`) reachable via `Bash` regardless of whether the harness's own `LSP` tool is wired up for subagents |
 | `swe-workbench-new-run-dir` | Allocate a mode-0700 run-scoped scratch dir under `/tmp/swe-workbench-run/` (`mktemp -d`, explicit template); also runs the age-gated (24h) orphan sweep at allocation time |
 | `swe-workbench-pr-review-submit` | Posting mechanism for workflow-pr-review-post's `## Post` section: fetch review threads (paginated), Jaccard dedup + 👍 reactions, diff-line pre-validate, pr-level batching, self-review/diff-scoping decision flip, atomic Reviews-API submit with a bounded 422 retry and a per-comment fallback. `--findings-json <path\|->` in; `printf %q`-quoted `KEY=VALUE` lines out |
+| `swe-workbench-preflight-commit` | Read-only preflight over the staged file set for `swe-workbench:workflow-commit-and-pr`: one JSON snapshot classifying secret-shaped filenames (`suspicious`) and whether every staged path is documentation-only (`docs_only`); fails closed — a non-zero exit never means "clean" |
 | `swe-workbench-reap-run-dir` | Safe `rm -rf` for a single run-scoped scratch dir allocated by `swe-workbench-new-run-dir` (depth-exactly-one, name-shape, ownership, and `.git`-absence checks) |
 | `swe-workbench-reap-session-scratch` | Platform-neutral content-clear (directory preserved) for a verified current-session scratch target, authorized by exactly one packaged session scratch adapter; ambiguous or unsafe resolution is a zero-count no-op |
 | `swe-workbench-session-scratch-adapter-claude` | Claude Code session scratch adapter |
@@ -37,14 +38,19 @@ full implementation, invocable directly by its bare `swe-workbench-<name>` comma
 | `swe-workbench-sweep-residuals` | PR-scoped residual-artifact backstop for `swe-workbench:workflow-cleanup-merged` Step 5 — force-removes leftover worktrees, state files, run dirs, and session-scratch entries for a merged PR number |
 | `swe-workbench-sync-pr-metadata` | Apply a revised title and/or body to an existing PR (address-feedback Phase 6 drift sync) |
 
-`swe-workbench-comment-scan`, `swe-workbench-lsp`, and `swe-workbench-pr-review-submit` are the
-three scripts in this directory with a `#!/usr/bin/env python3` shebang instead of
-`#!/usr/bin/env bash`. `comment-scan` is a pure diff-in/findings-out function (no git calls of its
-own; see `shared/agents/comment-scan.md` for the canonical diff command); `pr-review-submit` does
-call `git`/`gh` but needed Python's JSON and multi-call state-machine handling (422 retry,
-read-your-write confirmation) more than bash's process-spawning idioms; `lsp` speaks JSON-RPC
-framing to a spawned language server subprocess, which needs a real threaded reader loop bash
-can't give it. Same bare-command convention applies; only the interpreter differs.
+`swe-workbench-comment-scan`, `swe-workbench-lsp`, `swe-workbench-pr-review-submit`, and
+`swe-workbench-preflight-commit` are the four scripts in this directory with a
+`#!/usr/bin/env python3` shebang instead of `#!/usr/bin/env bash`. `comment-scan` is a pure
+diff-in/findings-out function (no git calls of its own; see `shared/agents/comment-scan.md` for
+the canonical diff command); `pr-review-submit` does call `git`/`gh` but needed Python's JSON and
+multi-call state-machine handling (422 retry, read-your-write confirmation) more than bash's
+process-spawning idioms; `lsp` speaks JSON-RPC framing to a spawned language server subprocess,
+which needs a real threaded reader loop bash can't give it; `preflight-commit` classifies
+NUL-delimited raw staged paths and emits JSON — bash would need `jq` for escaping arbitrary path
+bytes and a second regex dialect (Oniguruma) for matching, a second engine to audit in a security
+gate that should have exactly one. Unlike `comment-scan` (advisory, correctly fails open),
+`preflight-commit` fails closed: a git error is a hard non-zero exit with nothing on stdout, never
+a silent "clean". Same bare-command convention applies; only the interpreter differs.
 
 ## Reference pattern
 

--- a/bin/swe-workbench-preflight-commit
+++ b/bin/swe-workbench-preflight-commit
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Read-only preflight over the staged file set for workflow-commit-and-pr.
+
+Classifies the currently staged git file set in a single pass — filename patterns
+that commonly hold secrets, and whether every staged path is documentation-only for
+the purposes of a `[no ci]` commit marker — and prints one JSON object to stdout:
+`{"staged": [...], "suspicious": [...], "docs_only": bool}`.
+
+The suspicious scan is a FILENAME HEURISTIC, not a content scan. A clean result means
+"no obvious filename red flags" — not proof the staged content is secret-free.
+
+Fails closed: if the staged set cannot be read, this exits non-zero and prints nothing on
+stdout. A non-zero exit never means "clean".
+
+Exit codes: 0 classified (findings or not) | 1 could not classify | 2 bad invocation.
+
+Usage: swe-workbench-preflight-commit [--help]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+# POSIX ERE carried over verbatim from the shell gate this replaces, with $ -> \Z
+# (Python's $ also matches before a trailing newline; \Z is absolute end-of-string).
+SUSPICIOUS_RE = re.compile(
+    r"(^|/)([^/]*\.env(\.|\Z)|.+\.pem\Z|.+\.key\Z|credentials\.json\Z|secrets?\.[a-z]+\Z)",
+    re.IGNORECASE,  # Unicode-aware [a-z] widens detection only — deliberate, fail-safe.
+)
+TEMPLATE_SUFFIXES = (".example", ".sample", ".template", ".dist")
+RUNTIME_MARKDOWN_RE = re.compile(r"^(commands|skills|agents)/")
+# The .github alternative is subsumed by the leading \.md\Z (every path it matches also ends
+# in .md). Kept verbatim as the surviving record of the narrower intent the prose describes.
+DOCS_RE = re.compile(r"\.md\Z|^docs/|^\.github/[^/]*\.md\Z")
+_CONTROL = {chr(c) for c in range(0x20)} | {"\x7f"}
+
+
+def has_control_char(path: str) -> bool:
+    return any(c in _CONTROL for c in path)
+
+
+def is_suspicious(path: str) -> bool:
+    if has_control_char(path):  # never excludable, always flagged
+        return True
+    return bool(SUSPICIOUS_RE.search(path)) and not path.lower().endswith(TEMPLATE_SUFFIXES)
+
+
+def is_docs(path: str) -> bool:
+    if has_control_char(path):
+        return False
+    return not RUNTIME_MARKDOWN_RE.search(path) and bool(DOCS_RE.search(path))
+
+
+def classify_suspicious(paths: list[str]) -> list[str]:
+    return [p for p in paths if is_suspicious(p)]
+
+
+def is_docs_only(paths: list[str]) -> bool:
+    return bool(paths) and all(is_docs(p) for p in paths)
+
+
+def read_staged_paths() -> list[str]:
+    """The only subprocess call in this module. -z yields raw, unquoted paths —
+    without it, git escapes '"', '\\', and non-ASCII bytes under core.quotePath,
+    which walks a secret-shaped filename right past the suspicious scan. No HEAD
+    argument: `git diff --staged` compares the index to HEAD on its own, including
+    on an unborn HEAD (a repo's first commit), where passing HEAD would exit 128."""
+    result = subprocess.run(
+        ["git", "diff", "--staged", "--name-only", "-z"],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff --staged --name-only -z failed")
+    return [p for p in result.stdout.split("\0") if p]
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+
+    if argv:
+        if len(argv) == 1 and argv[0] in ("--help", "-h"):
+            print(__doc__)
+            return 0
+        print(
+            f"swe-workbench-preflight-commit: unexpected argument(s): {' '.join(argv)}",
+            file=sys.stderr,
+        )
+        print("Usage: swe-workbench-preflight-commit [--help]", file=sys.stderr)
+        return 2
+
+    try:
+        staged = read_staged_paths()
+    except (RuntimeError, OSError) as exc:
+        # OSError also catches a missing/non-executable git binary (FileNotFoundError,
+        # PermissionError) — without it that case propagates an unhandled traceback
+        # instead of this module's own stderr format, though the exit code and empty
+        # stdout still fail closed either way.
+        print(f"swe-workbench-preflight-commit: {exc}", file=sys.stderr)
+        return 1
+
+    result = {
+        "staged": staged,
+        "suspicious": classify_suspicious(staged),
+        "docs_only": is_docs_only(staged),
+    }
+    # ensure_ascii=True (the default) escapes non-ASCII to \uXXXX so stdout encoding
+    # can never raise on a staged path containing arbitrary bytes.
+    json.dump(result, sys.stdout, ensure_ascii=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/workflow-commit-and-pr/SKILL.md
+++ b/skills/workflow-commit-and-pr/SKILL.md
@@ -89,11 +89,10 @@ Detect the host repo's branch convention via 3-tier probe. **Tier 1:** run `git 
 
 ## Pre-commit gate: suspicious staged files
 
-Before the commit preview (or before running `git commit`), scan the staged
-file set for filenames that commonly hold secrets. This is a commit-layer
-twin of the PreToolUse Write/Edit hook: that hook catches secrets the agent
-introduces at authoring time; this gate catches secrets staged by anyone (a
-human running `git add`, an IDE that auto-stages, or any other tool) before
+Before the commit preview (or before running `git commit`), classify the staged file
+set. This is a commit-layer twin of the PreToolUse Write/Edit hook: that hook catches
+secrets the agent introduces at authoring time; this gate catches secrets staged by
+anyone (a human running `git add`, an IDE that auto-stages, or any other tool) before
 commit.
 
 The scan is a filename heuristic, not a content scan — it cannot catch a
@@ -101,25 +100,36 @@ secret pasted inside an otherwise innocuous `config.yaml`. False negatives
 are expected; treat a clean scan as "no obvious filename red flags", not
 "safe to commit".
 
-**Scan command** (run before `[no ci]` is computed):
+**Classify once** (covers this gate, the empty-staging check, and `## Doc-only [no ci]
+rule` below — one snapshot of the staged set, exactly one `git diff --staged` call in
+the whole flow):
 
 ```bash
-SUSPICIOUS=$(git diff --staged --name-only \
-  | grep -iE '(^|/)([^/]*\.env(\.|$)|.+\.pem$|.+\.key$|credentials\.json$|secrets?\.[a-z]+$)' \
-  | grep -ivE '\.(example|sample|template|dist)$' \
-  || true)
+command -v swe-workbench-preflight-commit >/dev/null 2>&1 || {
+  echo "swe-workbench runtime commands not on PATH — reinstall or update the swe-workbench plugin." >&2
+  exit 1
+}
+PREFLIGHT=$(swe-workbench-preflight-commit) || {
+  echo "swe-workbench-preflight-commit could not classify the staged set — see stderr above. Non-zero exit never means \"clean\"; do not proceed as if it were." >&2
+  exit 1
+}
 ```
 
-The exclusion pass (`*.example`, `*.sample`, `*.template`, `*.dist`)
-prevents false-positives on `.env` template variants (e.g. `.env.example`,
-`.env.sample`). Files like `secrets.example.yaml` are already excluded by
-the positive pattern (which requires a single trailing extension), so the
-exclusion pass is not their gate.
+`$PREFLIGHT` is one JSON object with three fields: `staged` (every staged path),
+`suspicious` (the subset that looks secret-shaped by filename), and `docs_only`
+(whether every staged path is documentation-only — consumed by `## Doc-only [no ci]
+rule` below). Consume it with `printf '%s' "$PREFLIGHT" | jq …`, **never** `echo
+"$PREFLIGHT" | jq` — see
+[`shared/docs/shell-echo-vs-printf.md`](../../shared/docs/shell-echo-vs-printf.md) for
+the corruption hazard.
 
-**On no matches** → silent; continue to `## Doc-only [no ci] rule`.
+**On an empty `.staged` array** → abort and tell the user to `git add` first — there
+is nothing to commit.
 
-**On match**, print the file list verbatim to the user, then call
-`AskUserQuestion`:
+**On an empty `.suspicious` array** → silent; continue to `## Doc-only [no ci] rule`.
+
+**On a non-empty `.suspicious` array**, print the file list verbatim to the user, then
+call `AskUserQuestion`:
 
 ```json
 {
@@ -144,25 +154,12 @@ exclusion pass is not their gate.
 
 ## Doc-only `[no ci]` rule
 
-When ALL staged paths match doc-only patterns, append ` [no ci]` to the commit subject:
-
-```
-Doc-only patterns:
-  - *.md AND NOT under commands/, skills/, agents/      (e.g. README.md, root-level *.md)
-  - docs/**
-  - .github/*.md  (direct children of .github/ only — not subdirs like ISSUE_TEMPLATE/)
-```
+Append ` [no ci]` to the commit subject only when all three hold: `$PREFLIGHT`'s
+`.docs_only` is `true` (read from the same result the pre-commit gate above already
+computed — do not re-derive it), the host CI honours the marker (see below), and the
+user has not overridden.
 
 **Exclusion is load-bearing.** Markdown under `commands/`, `skills/`, `agents/` is plugin behaviour — changing those files changes the plugin's runtime, even though the file extension is `.md`. Never apply `[no ci]` to those.
-
-How to test the staged set:
-```bash
-TOTAL=$(git diff --staged --name-only | wc -l)
-MATCHED=$(git diff --staged --name-only | grep -Ev '^(commands|skills|agents)/' | grep -E '\.md$|^docs/|^\.github/[^/]*\.md$' | wc -l)
-[ "$MATCHED" -eq "$TOTAL" ] && echo "[no ci] applies" || echo "[no ci] does NOT apply"
-```
-
-If every staged path matches (`MATCHED == TOTAL`), append ` [no ci]`. Otherwise, do not.
 
 **Detect `[no ci]` behaviour.** Whether per-PR `[no ci]` is honoured depends on the host repo's CI configuration:
 
@@ -223,7 +220,6 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 
 | Failure | Signal | Action |
 |---|---|---|
-| No staged changes | `git diff --staged` empty | Abort. Tell user to `git add` first. |
 | Commit hook fails (bad subject) | Non-zero exit on `git commit` | Re-read `.githooks/commit-msg`, refine subject, re-attempt. **Do NOT use `--no-verify`.** |
 | Branch is `main`/`master` | `git rev-parse --abbrev-ref HEAD` | Abort. Pre-commit hook will block; tell user to checkout a feature branch. |
 | `gh auth status` fails | Non-zero exit | Abort. Print fix hint: `gh auth login`. |
@@ -231,7 +227,8 @@ If user replies `yes` → invoke `/swe-workbench:review <N>` with the new PR num
 | `git push` rejected (non-FF) | Non-zero exit | Abort. Tell user to `git pull --rebase`; do NOT force-push. |
 | Doc-only `[no ci]` rule mis-triggers (ambiguous case) | User disagrees | Skip `[no ci]` and warn. The doc-only rule is conservative — when in doubt, run CI. |
 | Duplicate PR (already exists) | `gh pr view` returns `state == "OPEN"` before `gh pr create` | Surface URL via `AskUserQuestion` (see Pre-check section). On `Update existing PR`, skip `gh pr create`. **Never** re-run `gh pr create` to recover. |
-| Staged files look like secrets | `grep` matches against curated pattern set | Print file list. `AskUserQuestion` → on `Cancel`, abort with no `git restore --staged` and no commit. Never auto-unstage. |
+| Staged files look like secrets | `swe-workbench-preflight-commit`'s `.suspicious` is non-empty | Print file list. `AskUserQuestion` → on `Cancel`, abort with no `git restore --staged` and no commit. Never auto-unstage. |
+| `swe-workbench-preflight-commit` exits non-zero | Non-zero exit, empty stdout | Abort — the gate could not run. Non-zero never means "clean". Print stderr to the user. |
 
 ## Common mistakes
 

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -31,6 +31,7 @@ SCRIPTS = {
     "swe-workbench-gh-timeout": "bash",
     "swe-workbench-lsp": "python3",
     "swe-workbench-new-run-dir": "bash",
+    "swe-workbench-preflight-commit": "python3",
     "swe-workbench-preflight-pr": "bash",
     "swe-workbench-pr-review-submit": "python3",
     "swe-workbench-reap-run-dir": "bash",

--- a/tests/test_preflight_commit_script.py
+++ b/tests/test_preflight_commit_script.py
@@ -1,0 +1,329 @@
+"""Tests for bin/swe-workbench-preflight-commit (issue #660).
+
+Replaces the two shell pipelines workflow-commit-and-pr/SKILL.md previously asked the
+agent to transcribe and run at runtime: the suspicious-filename secret scan and the
+docs-only `[no ci]` classification. One snapshot of the staged set covers both, avoiding
+a TOCTOU window between two separate `git diff --staged` calls.
+
+Unit tests import the pure functions directly (SourceFileLoader, mirroring
+test_pr_review_submit_script.py's `_load_module()` precedent) — they are the port's
+oracle against the old regex-in-Markdown behavior. Behavioral tests drive the script as
+a subprocess against a real throwaway git repo (test_diff_line_lookup_script.py's
+`_init_repo` precedent).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "bin" / "swe-workbench-preflight-commit"
+
+
+def _load_module():
+    loader = SourceFileLoader("preflight_commit", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("preflight_commit", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["preflight_commit"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pc = _load_module()
+
+
+# ── Behavioral test harness ─────────────────────────────────────────────────
+
+
+def _git(args, *, cwd: Path):
+    result = subprocess.run(["git", *args], capture_output=True, text=True, cwd=str(cwd), env=dict(_CLEAN_ENV))
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    _git(["init", "-b", "main", str(tmp_path)], cwd=tmp_path)
+    return tmp_path
+
+
+def _run(args=(), *, cwd: Path, stdin: str | None = None):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin,
+        capture_output=True, text=True,
+        cwd=str(cwd),
+        env=dict(_CLEAN_ENV),
+    )
+
+
+# ── Existence ────────────────────────────────────────────────────────────────
+
+
+def test_script_exists_and_executable():
+    assert SCRIPT.exists(), "bin/swe-workbench-preflight-commit must exist"
+    assert os.access(SCRIPT, os.X_OK), "bin/swe-workbench-preflight-commit must be executable (chmod +x)"
+
+
+# ── Unit: pure-function port fidelity — positive/negative matrix migrated from
+#    tests/test_workflow_commit_and_pr_secret_scan.py's old regex-in-Markdown test ──
+
+
+POSITIVE_FILENAMES = [
+    ".env",
+    ".env.local",
+    ".env.production",
+    "prod.env",
+    "path/to/.env",
+    "private.pem",
+    "tls.key",
+    "credentials.json",
+    "secrets.yaml",
+    "secrets.json",
+    "secret.yml",
+    "Secrets.yaml",
+    "config/credentials.json",
+    "certs/private.pem",
+    "path/to/secrets.yaml",
+    "my.sample.pem",
+]
+
+NEGATIVE_FILENAMES = [
+    ".env.example",
+    ".env.sample",
+    ".env.template",
+    ".env.dist",
+    ".env.EXAMPLE",
+    ".env.Sample",
+    "secrets.example.yaml",
+    "secrets.sample.json",
+    "README.md",
+    "src/main.py",
+    "package.json",
+    "Cargo.lock",
+    "Makefile",
+]
+
+
+def test_positive_matrix_flagged():
+    for fname in POSITIVE_FILENAMES:
+        assert pc.is_suspicious(fname), f"expected {fname!r} to be flagged suspicious"
+
+
+def test_negative_matrix_not_flagged():
+    for fname in NEGATIVE_FILENAMES:
+        assert not pc.is_suspicious(fname), f"expected {fname!r} NOT to be flagged suspicious"
+
+
+def test_filenames_with_spaces():
+    # Verified against real grep: the positive pattern is anchored on (^|/), so a
+    # bare "secrets.*" only matches at the very start of the path or right after a
+    # "/" — "my secrets.yaml" has neither, so it is NOT flagged (port-verified, not
+    # a bug in this port). "path with space/.env" and "a b.pem" both have a
+    # qualifying anchor and are flagged.
+    for fname in ["path with space/.env", "a b.pem"]:
+        assert pc.is_suspicious(fname), f"expected {fname!r} to be flagged suspicious"
+    assert not pc.is_suspicious("my secrets.yaml")
+    assert not pc.is_suspicious("docs/my notes.md")
+
+
+def test_port_fidelity_non_ascii_quote_and_newline():
+    """Regression lock for the -z decode fix: a plain grep|grep pipeline over
+    core.quotePath-quoted paths misses all three of these — verified against real git."""
+    assert pc.is_suspicious("Ünïcödé.env")
+    assert pc.is_suspicious('weird"quote.pem')
+    assert pc.is_suspicious("a.pem\nb")
+
+
+def test_exclusion_is_ascii_exact_not_unicode_folding():
+    """"secrets.ſample" (long s, U+017F) is positively matched by the detector — [a-z]
+    under re.IGNORECASE folds ſ to s, which is the deliberate widening. But the
+    exclusion pass is a literal str.lower().endswith() check, and str.lower() does
+    NOT fold ſ to s, so the file is correctly NOT excluded — still flagged. A
+    regex-based exclusion with re.IGNORECASE would have folded it and wrongly
+    suppressed a real positive (the fail-open regression this design avoids)."""
+    assert pc.is_suspicious("secrets.ſample")
+    assert not pc.is_suspicious("secrets.sample")
+
+
+# ── Unit: docs-only truth table ─────────────────────────────────────────────
+
+
+def test_docs_only_truth_table():
+    truthy = [
+        "README.md",
+        "docs/a.png",
+        "docs/guide.md",
+        ".github/CONTRIBUTING.md",
+        ".github/ISSUE_TEMPLATE/bug.md",  # pins preserved (not prose-described) behavior
+    ]
+    falsy = [
+        ".github/CODEOWNERS",  # proves the .github/ alternative isn't a blanket
+        "skills/x/SKILL.md",
+        "commands/y.md",
+        "agents/z.md",
+        "src/main.py",
+    ]
+    for path in truthy:
+        assert pc.is_docs(path), f"expected {path!r} to be docs"
+    for path in falsy:
+        assert not pc.is_docs(path), f"expected {path!r} NOT to be docs"
+    assert not pc.is_docs("a.md\nb")  # control-char path is never docs
+
+
+def test_is_docs_only_empty_set_is_false():
+    assert pc.is_docs_only([]) is False
+
+
+def test_is_docs_only_all_docs_true():
+    assert pc.is_docs_only(["README.md", "docs/guide.md"]) is True
+
+
+def test_is_docs_only_mixed_false():
+    assert pc.is_docs_only(["README.md", "src/main.py"]) is False
+
+
+# ── Behavioral: real git repo ────────────────────────────────────────────────
+
+
+def test_suspicious_file_reported_and_template_spared(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / ".env").write_text("SECRET=1\n")
+    (repo / ".env.example").write_text("SECRET=\n")
+    _git(["add", ".env", ".env.example"], cwd=repo)
+
+    result = _run(cwd=repo)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["suspicious"] == [".env"]
+    assert set(payload["staged"]) == {".env", ".env.example"}
+
+
+def test_quoted_path_fidelity_round_trips_through_json(tmp_path):
+    """Regression lock: real git quotes these under default core.quotePath. -z must
+    yield them raw, and they must appear verbatim in both staged and suspicious."""
+    repo = _init_repo(tmp_path)
+    names = ['weird"quote.pem', "back\\slash.key", "Ünïcödé.env"]
+    for name in names:
+        (repo / name).write_bytes(b"x")
+        _git(["add", "--", name], cwd=repo)
+
+    result = _run(cwd=repo)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert set(payload["staged"]) == set(names)
+    assert set(payload["suspicious"]) == set(names)
+
+
+def test_spaces_round_trip_verbatim(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "my secrets.yaml").write_text("x")
+    _git(["add", "my secrets.yaml"], cwd=repo)
+
+    result = _run(cwd=repo)
+    payload = json.loads(result.stdout)
+    assert payload["staged"] == ["my secrets.yaml"]
+
+
+def test_mixed_set_and_runtime_markdown_not_docs_only(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("x")
+    (repo / "main.py").write_text("x")
+    _git(["add", "README.md", "main.py"], cwd=repo)
+    result = _run(cwd=repo)
+    assert json.loads(result.stdout)["docs_only"] is False
+
+    repo3_dir = tmp_path / "repo3"
+    repo3_dir.mkdir()
+    repo3 = _init_repo(repo3_dir)
+    (repo3 / "skills").mkdir()
+    (repo3 / "skills" / "x.md").write_text("x")
+    _git(["add", "skills/x.md"], cwd=repo3)
+    result3 = _run(cwd=repo3)
+    assert json.loads(result3.stdout)["docs_only"] is False
+
+
+def test_unborn_head_no_commits_yet(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "a.txt").write_text("x")
+    _git(["add", "a.txt"], cwd=repo)
+
+    result = _run(cwd=repo)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["staged"] == ["a.txt"]
+
+
+def test_index_not_mutated(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "a.txt").write_text("x")
+    _git(["add", "a.txt"], cwd=repo)
+
+    before_status = _git(["status", "--porcelain"], cwd=repo).stdout
+    before_staged = _git(["diff", "--staged", "--name-only"], cwd=repo).stdout
+
+    _run(cwd=repo)
+
+    after_status = _git(["status", "--porcelain"], cwd=repo).stdout
+    after_staged = _git(["diff", "--staged", "--name-only"], cwd=repo).stdout
+    assert before_status == after_status
+    assert before_staged == after_staged
+
+
+def test_fails_closed_outside_git_repo(tmp_path):
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+    result = _run(cwd=non_repo)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr.strip() != ""
+
+
+def test_fails_closed_on_missing_git_binary(monkeypatch, capsys):
+    """OSError (e.g. FileNotFoundError from a missing git on PATH), not just a non-zero
+    git exit, must produce the module's own clean stderr message and exit 1 — not an
+    uncaught traceback."""
+    def _raise(*_args, **_kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "git")
+
+    monkeypatch.setattr(pc.subprocess, "run", _raise)
+    assert pc.main([]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "swe-workbench-preflight-commit:" in captured.err
+
+
+def test_bogus_flag_exits_2(tmp_path):
+    repo = _init_repo(tmp_path)
+    result = _run(["--bogus"], cwd=repo)
+    assert result.returncode == 2
+    assert result.stdout == ""
+
+
+def test_stray_positional_exits_2(tmp_path):
+    repo = _init_repo(tmp_path)
+    result = _run(["extra"], cwd=repo)
+    assert result.returncode == 2
+
+
+def test_help_exits_0_and_states_caveat(tmp_path):
+    repo = _init_repo(tmp_path)
+    result = _run(["--help"], cwd=repo)
+    assert result.returncode == 0
+    assert "no obvious filename red flags" in result.stdout
+
+
+def test_stdout_is_exactly_one_json_object_with_three_keys(tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "README.md").write_text("x")
+    _git(["add", "README.md"], cwd=repo)
+
+    result = _run(cwd=repo)
+    payload = json.loads(result.stdout)
+    assert set(payload.keys()) == {"staged", "suspicious", "docs_only"}

--- a/tests/test_workflow_commit_and_pr_secret_scan.py
+++ b/tests/test_workflow_commit_and_pr_secret_scan.py
@@ -5,7 +5,9 @@ before the commit preview runs. It is the commit-layer complement to #181's
 write-time hook: #181 catches secrets the agent introduces via Write/Edit;
 this gate catches secrets staged by anyone before commit.
 """
+import importlib.util
 import re
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -75,7 +77,7 @@ def test_secret_scan_section_present_with_askuserquestion():
 
     Asserts:
     1. Section heading exists.
-    2. Body contains the scan command (git diff --staged --name-only).
+    2. Body delegates the scan to swe-workbench-preflight-commit behind a command -v guard.
     3. Body contains a fenced JSON AskUserQuestion block with "Cancel" as the last option.
     4. Body encodes the "don't auto-unstage" invariant ("NOT touched" or "untouched").
     5. Body cross-references issue #181 (the write-time hook complement).
@@ -88,8 +90,9 @@ def test_secret_scan_section_present_with_askuserquestion():
 
     section = _section_body(body, SECTION_HEADING)
 
-    assert "git diff --staged --name-only" in section, (
-        "Pre-commit gate section must contain 'git diff --staged --name-only'"
+    assert "command -v swe-workbench-preflight-commit" in section, (
+        "Pre-commit gate section must guard swe-workbench-preflight-commit with a "
+        "command -v check before invoking it"
     )
 
     aq_block = _extract_fenced_block(section, "json")
@@ -116,48 +119,46 @@ def test_secret_scan_section_present_with_askuserquestion():
     )
 
 
+def _load_preflight_commit_module():
+    """Import bin/swe-workbench-preflight-commit as a module (issue #660), mirroring
+    test_pr_review_submit_script.py's `_load_module()` precedent. This is a strict
+    upgrade over the prior version of this test, which extracted the grep -iE / -vE
+    patterns as strings out of the Markdown and re-ran them through Python `re` — not
+    POSIX ERE, and not `grep | grep` pipeline semantics. This tests the real code."""
+    script = ROOT / "bin" / "swe-workbench-preflight-commit"
+    loader = SourceFileLoader("preflight_commit", str(script))
+    spec = importlib.util.spec_from_file_location("preflight_commit", script, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_secret_scan_regex_matches_expected_positives_and_negatives():
-    """The regex embedded in the skill must flag expected positives and spare negatives.
-
-    Extracts the grep -iE (positive) and grep -vE (exclusion) patterns from
-    the fenced bash block in the pre-commit gate section, then applies them to
-    a hand-picked filename matrix.
-    """
-    body = SKILL_PATH.read_text()
-    section = _section_body(body, SECTION_HEADING)
-
-    assert section, f"Section '{SECTION_HEADING}' not found in SKILL.md"
-
-    bash_block = _extract_fenced_block(section, "bash")
-    assert bash_block is not None, (
-        "Pre-commit gate section must contain a fenced bash block with the scan command"
-    )
-
-    pos_match = re.search(r"grep\s+-iE\s+'([^']+)'", bash_block)
-    assert pos_match, "Could not extract grep -iE pattern from bash block"
-    pos_pattern = pos_match.group(1)
-
-    excl_match = re.search(r"grep\s+-i?vE\s+'([^']+)'", bash_block)
-    assert excl_match, "Could not extract grep -vE pattern from bash block"
-    excl_pattern = excl_match.group(1)
-
-    def should_flag(filename: str) -> bool:
-        if not re.search(pos_pattern, filename, re.IGNORECASE):
-            return False
-        if re.search(excl_pattern, filename, re.IGNORECASE):
-            return False
-        return True
+    """bin/swe-workbench-preflight-commit's is_suspicious() must flag expected
+    positives and spare expected negatives — the same filename matrix the old
+    Markdown-regex-extraction version of this test used, now run against the real
+    ported function instead of a string that resembles code."""
+    pc = _load_preflight_commit_module()
 
     for fname in POSITIVE_FILENAMES:
-        assert should_flag(fname), (
-            f"Expected '{fname}' to be flagged as suspicious, but it was not.\n"
-            f"  pos_pattern:  {pos_pattern!r}\n"
-            f"  excl_pattern: {excl_pattern!r}"
-        )
+        assert pc.is_suspicious(fname), f"Expected '{fname}' to be flagged as suspicious, but it was not."
 
     for fname in NEGATIVE_FILENAMES:
-        assert not should_flag(fname), (
-            f"Expected '{fname}' NOT to be flagged, but it was.\n"
-            f"  pos_pattern:  {pos_pattern!r}\n"
-            f"  excl_pattern: {excl_pattern!r}"
-        )
+        assert not pc.is_suspicious(fname), f"Expected '{fname}' NOT to be flagged, but it was."
+
+
+def test_skill_does_not_reimplement_the_scan_inline():
+    """The inlined grep|grep pipeline and MATCHED/TOTAL wc -l classification must not
+    creep back into the skill now that both live in swe-workbench-preflight-commit —
+    one snapshot of the staged set, not two independently-drifting shell pipelines."""
+    body = SKILL_PATH.read_text()
+    assert "grep -iE" not in body, "SKILL.md must not reimplement the secret scan's grep -iE pipeline inline"
+    assert "wc -l" not in body, "SKILL.md must not reimplement the docs-only MATCHED/TOTAL count inline"
+    assert "MATCHED" not in body, "SKILL.md must not reimplement the docs-only MATCHED/TOTAL count inline"
+
+    no_ci_section = _section_body(body, "## Doc-only `[no ci]` rule")
+    assert no_ci_section, "Missing '## Doc-only `[no ci]` rule' section in SKILL.md"
+    assert ".docs_only" in no_ci_section, (
+        "'## Doc-only [no ci] rule' must read `.docs_only` from the preflight result "
+        "computed by the pre-commit gate above, not re-derive the classification"
+    )


### PR DESCRIPTION
## Summary
- Extracts the two deterministic staged-file classifications (suspicious-secret-filename scan, docs-only `[no ci]` rule) out of `skills/workflow-commit-and-pr/SKILL.md`'s fenced shell — which the agent was previously expected to transcribe and run at runtime — into a new packaged, directly-testable `bin/swe-workbench-preflight-commit` (python3).
- Both classifications now come from **one** JSON snapshot of the staged set (`{"staged": [...], "suspicious": [...], "docs_only": bool}`), avoiding a TOCTOU window between two separate `git diff --staged` calls the old two-pass shell had.
- Regex patterns are a verbatim port of the old `grep -iE`/`-vE` pipeline (every trailing `$` → `\Z`) — executable behavior is preserved exactly, including one documented prose/behavior divergence found during investigation and deliberately left as-is (a follow-up to file post-merge, see below), since this PR is scoped as an extraction, not a behavior change.
- Retargeted the old regex-extracted-from-Markdown test to exercise the real ported functions directly (`tests/test_workflow_commit_and_pr_secret_scan.py`), and added a ratchet test asserting the inlined shell can't creep back into the skill.
- New `tests/test_preflight_commit_script.py`: pure-function unit tests plus behavioral tests against real throwaway git repos (quoting/`-z` fidelity, unborn HEAD, index-not-mutated, fail-closed paths).

### Two deliberate, documented behavior changes (both fail-safe only)
- **`-z` decode fix**: switched from `git diff --staged --name-only` to `... -z`. Under default `core.quotePath`, git quotes paths containing `"`, `\`, or non-ASCII — those paths were silently missed by the old secret scan. `-z` yields raw, unquoted paths, so the scan now flags strictly more than before (never fewer).
- **Fails closed on git error**: the old shell ended in `|| true`, silently reporting "clean" on any git failure. The new script exits 1 with nothing on stdout on any git error — a non-zero exit never means "clean".

### Follow-ups to file after merge (per the implementation plan, not done here)
1. Docs-only classification is repo-layout-coupled (`\.md$` matches at any depth; the `commands|skills|agents` exclusion describes this plugin's own layout, not an arbitrary host repo's).
2. Staged deletions are false positives (`git diff --staged --name-only` includes deletions, so staging a `.env` *removal* still warns).

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually (`python3 bin/swe-workbench-preflight-commit --help`, normal run, `--bogus` → exit 2, run outside a git repo → exit 1 with empty stdout, simulated missing-`git` binary → clean stderr message + exit 1)
- [x] `pytest tests/` — 3099 passed, 3 skipped; `bash scripts/validate.sh` — all checks passed; `bash scripts/bump-version.sh --audit` — clean
- [x] Both `superpowers:requesting-code-review` and `swe-workbench:reviewer` dispatched in parallel; findings (exception-handling breadth, one prose/flow nit) applied and re-verified

Closes #660
