### PR TITLE
[fix] Reap workflow state on rejected PR paths

### DIFF
--- a/bin/swe-workbench-preflight-pr
+++ b/bin/swe-workbench-preflight-pr
@@ -23,6 +23,20 @@ bash "$SCRIPT_DIR/swe-workbench-gh-timeout" auth status >/dev/null || {
   exit 1
 }
 
+# The fetch below creates $OUT_JSON. Every abort past this point is this
+# script's own failure, so it owns removing the artifact it created --
+# callers structurally cannot, because eval "$(...)" discards this script's
+# exit status. Cleanup errors are suppressed: on an error path the original
+# failure is the news, and a reap complaint must not mask it. A function
+# (rather than an inline trap string) so shellcheck can track `rc`'s
+# assignment within its own scope.
+_preflight_pr_cleanup() {
+  local rc=$?
+  [ "$rc" -eq 0 ] || bash "$SCRIPT_DIR/swe-workbench-clean-state-files" "$OUT_JSON" >/dev/null 2>&1 || true
+  exit "$rc"
+}
+trap _preflight_pr_cleanup EXIT
+
 bash "$SCRIPT_DIR/swe-workbench-fetch-pr" "$PR" "$OUT_JSON" "$FIELDS"
 
 BASE=$(jq -r .baseRefName     "$OUT_JSON")

--- a/skills/workflow-address-feedback/SKILL.md
+++ b/skills/workflow-address-feedback/SKILL.md
@@ -35,19 +35,16 @@ command -v swe-workbench-preflight-pr >/dev/null 2>&1 || {
 }
 JSON="/tmp/swe-workbench-address-feedback/${PR}.json"
 eval "$(swe-workbench-preflight-pr "$PR" "$JSON")"
+[ "$STATE" = "OPEN" ] || { swe-workbench-clean-state-files "$JSON"; echo "PR #$PR is $STATE — address-feedback only applies to open PRs."; exit 1; }
 CURRENT_USER=$(gh api /user -q .login)
 PR_BRANCH=$(jq -r .headRefName "$JSON"); eval "$(swe-workbench-new-run-dir address-feedback "$PR")"
 ```
-`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `PR_BRANCH` is derived from `headRefName` in `$JSON` (address-feedback uses it for worktree setup in Phase 2). `new-run-dir.sh` allocates `$RUN_DIR` — a mode-0700 scratch directory under `/tmp/swe-workbench-run/` for this run's own ad-hoc bash artifacts, distinct from the deliberate PR-keyed state files below (including `${PR}-triage.json`, which is a cross-invocation resume point and must never move here).
+`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. The `[ "$STATE" = "OPEN" ]` gate runs immediately after the preflight fetch and before `$RUN_DIR` is allocated, so a rejected PR reaps `$JSON` inline via `swe-workbench-clean-state-files` rather than leaking it — `$RUN_DIR` never exists on this path, so there is nothing else to reap. `PR_BRANCH` is derived from `headRefName` in `$JSON` (address-feedback uses it for worktree setup in Phase 2). `new-run-dir.sh` allocates `$RUN_DIR` — a mode-0700 scratch directory under `/tmp/swe-workbench-run/` for this run's own ad-hoc bash artifacts, distinct from the deliberate PR-keyed state files below (including `${PR}-triage.json`, which is a cross-invocation resume point and must never move here).
 
-Check that the PR is open before proceeding:
-```bash
-[ "$STATE" = "OPEN" ] || { echo "PR #$PR is $STATE — address-feedback only applies to open PRs."; exit 1; }
-```
 If `CURRENT_USER != AUTHOR_LOGIN`, warn:
 > "You are not the PR author (PR author: @AUTHOR_LOGIN, you: @CURRENT_USER). Address-feedback flows are typically owner-side. Continue anyway? Reply `yes` to proceed."
 
-Wait for confirmation before continuing.
+Wait for confirmation before continuing. If the user declines, run **Phase 7 — Cleanup** and exit.
 
 Fetch outstanding review threads via GraphQL:
 ```bash
@@ -86,7 +83,7 @@ SKIPPED_PR_COMMENTS=$(jq '[.[] | select(.eligible | not)] | length' "/tmp/swe-wo
 ```
 If all threads are resolved (or no threads exist) **and** `$ELIGIBLE_PR_COMMENTS` is zero, print:
 > "No open threads — nothing to address."
-Then exit cleanly.
+Then run **Phase 7 — Cleanup** and exit.
 
 If a prior triage save exists at `/tmp/swe-workbench-address-feedback/${PR}-triage.json`, offer to resume from it.
 
@@ -226,19 +223,12 @@ After all replies and resolutions land, emit the follow-up CTA:
 
 > "Want me to ping the reviewer to re-check? Reply `yes` to run `/swe-workbench:review --check-followup <N>`."
 
-On the Phase 5 success path, delete the address-feedback state files. The reap runs foreground; failures surface (no `2>/dev/null`):
+On the Phase 5 success path, delete the triage resume-point file. The three run-scoped state files (`${PR}.json`, `${PR}-threads.json`, `${PR}-pr-comments.json`) are reaped by **Phase 7** on every exit instead — `${PR}-triage.json` is reaped here specifically, because completion is what makes the resume point spent, and Phase 7 must never touch it (see Phase 7). The reap runs foreground; failures surface (no `2>/dev/null`):
 ```bash
-swe-workbench-clean-state-files \
-  "/tmp/swe-workbench-address-feedback/${PR}.json" \
-  "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
-  "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json" \
-  "/tmp/swe-workbench-address-feedback/${PR}-triage.json"
-for f in "/tmp/swe-workbench-address-feedback/${PR}.json" \
-         "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
-         "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json" \
-         "/tmp/swe-workbench-address-feedback/${PR}-triage.json"; do
-  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
-done
+swe-workbench-clean-state-files "/tmp/swe-workbench-address-feedback/${PR}-triage.json"
+[ -e "/tmp/swe-workbench-address-feedback/${PR}-triage.json" ] \
+  && echo "⚠ state file NOT reaped: /tmp/swe-workbench-address-feedback/${PR}-triage.json" >&2 \
+  || echo "✓ state file reaped: /tmp/swe-workbench-address-feedback/${PR}-triage.json"
 ```
 Then run **Phase 6 — Sync PR metadata**.
 
@@ -248,9 +238,11 @@ Skipped when `$FIX_SHA` is unset (no fixes committed in Phase 4). Otherwise fetc
 
 ### Phase 7 — Cleanup (always)
 
-Run on every exit that occurs after a worktree was **created** in Phase 2 (success, Q-quit, or error). Skip the worktree-removal block on Phase 1 early-exits (before any worktree exists) and when the reuse-guard fired (`REUSED_WT=1`) — the reuse path sets `$WT` to an existing checkout, never creates a worktree, so there is nothing to remove.
+Run on every exit after the Phase 1 preflight line. Skip the worktree-removal block on Phase 1 early-exits (before any worktree exists) and when the reuse-guard fired (`REUSED_WT=1`) — the reuse path sets `$WT` to an existing checkout, never creates a worktree, so there is nothing to remove. The `${WT:-}` check specifically guards against a Phase-1-only exit falling into the `rimba remove "$PR_BRANCH"` branch below: that command is keyed by branch name alone, not by this run's own `$WT`, so without the guard it could force-remove a different, concurrently-active session's live worktree on the same PR branch.
 ```bash
-if [ "${REUSED_WT:-0}" = "1" ]; then
+if [ -z "${WT:-}" ]; then
+  echo "No worktree was created this run — skipping worktree cleanup."
+elif [ "${REUSED_WT:-0}" = "1" ]; then
   echo "Reused existing worktree at $WT — skipping cleanup (nothing was created)."
 else
   # task = the PR branch (Phase 2 creates the worktree on $PR_BRANCH); --keep-branch
@@ -263,9 +255,18 @@ else
     echo "⚠ rimba remove failed (rimba absent or worktree busy); attempted git-worktree fallback on $WT."
   fi
 fi
-swe-workbench-reap-run-dir "$RUN_DIR"; [ -e "$RUN_DIR" ] && echo "⚠ run dir NOT reaped: $RUN_DIR" >&2 || echo "✓ run dir reaped: $RUN_DIR"
+[ -n "${RUN_DIR:-}" ] && { swe-workbench-reap-run-dir "$RUN_DIR"; [ -e "$RUN_DIR" ] && echo "⚠ run dir NOT reaped: $RUN_DIR" >&2 || echo "✓ run dir reaped: $RUN_DIR"; }
+swe-workbench-clean-state-files \
+  "/tmp/swe-workbench-address-feedback/${PR}.json" \
+  "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+  "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json"
+for f in "/tmp/swe-workbench-address-feedback/${PR}.json" \
+         "/tmp/swe-workbench-address-feedback/${PR}-threads.json" \
+         "/tmp/swe-workbench-address-feedback/${PR}-pr-comments.json"; do
+  [ -e "$f" ] && echo "⚠ state file NOT reaped: $f" >&2 || echo "✓ state file reaped: $f"
+done
 ```
-Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a warning and do not block completion. The fallback removes only the worktree directory — never delete `$PR_BRANCH` directly (e.g. via `git branch -D`), which would destroy the owner's actual PR head branch. `$RUN_DIR` is reaped unconditionally in this phase, independent of the `REUSED_WT` branch above — it was allocated in Phase 1 regardless of whether Phase 2 later reused an existing worktree. A Phase 1 early-exit (before Phase 7 runs at all) leaves `$RUN_DIR` for the age-gated orphan sweep in `new-run-dir.sh` to reap on a later invocation — bounded to 24h, not indefinite.
+Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a warning and do not block completion. The fallback removes only the worktree directory — never delete `$PR_BRANCH` directly (e.g. via `git branch -D`), which would destroy the owner's actual PR head branch. `$RUN_DIR` is reaped unconditionally whenever it exists, independent of the `REUSED_WT` branch above — it was allocated in Phase 1 regardless of whether Phase 2 later reused an existing worktree. It is guarded with `${RUN_DIR:-}` because the Phase 1 `STATE`-gate rejection is the one exit that precedes `$RUN_DIR`'s allocation entirely — that path reaps `$JSON` inline instead of routing through this phase (see Phase 1) and never reaches this guard. The three run-scoped state files reaped above (`${PR}.json`, `${PR}-threads.json`, `${PR}-pr-comments.json`) are the ones whose lifetime ends with the run itself; the resume-point file created on Q-quit is reaped separately, on completion, in Phase 5 — never here, since a Q-quit into this phase must leave it intact for the next invocation to resume from.
 
 ## Failure modes
 
@@ -289,7 +290,7 @@ Cleanup is **failure-tolerant**: if both rimba and the git fallback fail, log a 
 | Create a new worktree when already on the PR branch or when one already exists | Phase 2 runs two guards before `rimba add`: (1) compares `git rev-parse --abbrev-ref HEAD` against `$PR_BRANCH` — match reuses `$(pwd)`; (2) scans `git worktree list --porcelain` for a registered worktree on `$PR_BRANCH` — match reuses that path. Only fall through to creation when both checks find nothing. |
 | Pass `--skip-deps --skip-hooks` on the Phase 2 create | Never pass either flag — rimba must install deps and run hooks so the worktree is fully initialized with no separate bootstrap step. |
 | Create the worktree on a throwaway task branch (`rimba add pr:$PR --task …`) | Use `rimba add "$PR_BRANCH" --source "origin/$PR_BRANCH"` so the worktree is on the PR branch itself — Phase 4 pushes update the PR directly. |
-| Leave the worktree behind after skill exits | Phase 7 always removes it — skip Phase 7 only when exiting before Phase 2 (no worktree created yet) or when the reuse-guard fired (`REUSED_WT=1`, nothing was created). |
+| Leave the worktree behind after skill exits | Phase 7 runs on every exit past the Phase 1 preflight line — including exits before Phase 2 ever ran — but its worktree-removal block only fires when `$WT` is actually set; a Phase 1 early exit (`$WT` unset) or the reuse-guard (`REUSED_WT=1`) both skip removal since there is nothing this run created. |
 | Deleting `$PR_BRANCH` directly in Phase 7 fallback cleanup | Only remove the worktree directory — `$PR_BRANCH` is the real PR head branch; deleting it via `git branch -D` would destroy the owner's PR. |
 | Post the reply before the commit | Always commit first (Phase 4) so `$FIX_SHA` is available for the ADDRESSED reply template. |
 | Leave a CLARIFIED/DEFERRED **thread** open after reply | All three review-thread dispositions now resolve — an open thread blocks `/swe-workbench:review`'s approval gate. PR comments are unaffected (no thread to resolve). |

--- a/skills/workflow-pr-review/SKILL.md
+++ b/skills/workflow-pr-review/SKILL.md
@@ -72,15 +72,16 @@ esac
 echo "Mode: $MODE"
 JSON="/tmp/swe-workbench-pr-review/${PR}${STATE_SUFFIX}.json"
 eval "$(swe-workbench-preflight-pr "$PR" "$JSON")"
-CURRENT_USER=$(gh api /user -q .login)
-eval "$(swe-workbench-new-run-dir "$MODE_TAG" "$PR")"
 if [ "$MODE" = followup ] && [ "$STATE" != "OPEN" ]; then
+  swe-workbench-clean-state-files "$JSON"
   echo "PR #$PR is $STATE — follow-up review only applies to open PRs." >&2
   exit 1
 fi
+CURRENT_USER=$(gh api /user -q .login)
+eval "$(swe-workbench-new-run-dir "$MODE_TAG" "$PR")"
 ```
 
-`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `title`/`body` stay in `$JSON` — read them with `jq` when needed (Step 3 ticket-context). The JSON path is `${PR}${STATE_SUFFIX}.json`: first-pass leaves `STATE_SUFFIX` empty (`${PR}.json`); followup sets it to `-followup` (`${PR}-followup.json`), so both can coexist for the same PR. `new-run-dir.sh` allocates `$RUN_DIR` — a mode-0700 scratch directory under `/tmp/swe-workbench-run/` for this run's own ad-hoc bash artifacts (assembled JSON payloads, submit-response captures) that this flow's bash produces but never enumerates ahead of time. Distinct from `$JSON` above, which is a deliberate PR-keyed state file reaped by name in Step 7. The trailing `if [ "$MODE" = followup ] …` guard is followup-only: a first-pass review proceeds regardless of PR state, while a followup re-check only makes sense while the PR is still open for further pushes.
+`preflight-pr.sh` handles `gh auth status`, fetches the PR JSON to `$JSON`, and emits `BASE`, `HEAD_SHA`, `AUTHOR_LOGIN`, `OWNER`, `REPO`, `STATE` as shell assignments. `title`/`body` stay in `$JSON` — read them with `jq` when needed (Step 3 ticket-context). The JSON path is `${PR}${STATE_SUFFIX}.json`: first-pass leaves `STATE_SUFFIX` empty (`${PR}.json`); followup sets it to `-followup` (`${PR}-followup.json`), so both can coexist for the same PR. `new-run-dir.sh` allocates `$RUN_DIR` — a mode-0700 scratch directory under `/tmp/swe-workbench-run/` for this run's own ad-hoc bash artifacts (assembled JSON payloads, submit-response captures) that this flow's bash produces but never enumerates ahead of time. Distinct from `$JSON` above, which is a deliberate PR-keyed state file reaped by name in Step 7. The `if [ "$MODE" = followup ] …` guard is followup-only: a first-pass review proceeds regardless of PR state, while a followup re-check only makes sense while the PR is still open for further pushes. This gate runs immediately after the preflight fetch and before `$RUN_DIR` is allocated, so a rejected followup reaps `$JSON` inline via `swe-workbench-clean-state-files` rather than leaking it — `$RUN_DIR` never exists on this path, so there is nothing else to reap.
 
 ### Step 2 — Ephemeral worktree
 

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -48,7 +48,11 @@ SCRIPTS = {
 SIBLING_CALLERS = {
     "swe-workbench-fetch-pr": ["swe-workbench-gh-timeout"],
     "swe-workbench-new-run-dir": ["swe-workbench-reap-run-dir"],
-    "swe-workbench-preflight-pr": ["swe-workbench-gh-timeout", "swe-workbench-fetch-pr"],
+    "swe-workbench-preflight-pr": [
+        "swe-workbench-gh-timeout",
+        "swe-workbench-fetch-pr",
+        "swe-workbench-clean-state-files",
+    ],
     "swe-workbench-pr-review-submit": ["swe-workbench-gh-timeout", "swe-workbench-diff-line-lookup"],
     "swe-workbench-reply-and-resolve": ["swe-workbench-gh-timeout"],
     "swe-workbench-sweep-residuals": [

--- a/tests/test_preflight_pr_script.py
+++ b/tests/test_preflight_pr_script.py
@@ -1,4 +1,4 @@
-"""Structural assertions for bin/swe-workbench-preflight-pr (Fix A).
+"""Structural + behavioural assertions for bin/swe-workbench-preflight-pr.
 
 Mirrors tests/test_fetch_pr_script.py conventions.
 Verifies that preflight-pr.sh:
@@ -7,10 +7,16 @@ Verifies that preflight-pr.sh:
   - emits only safe scalars via printf %q (BASE, HEAD_SHA, AUTHOR_LOGIN, OWNER, REPO, STATE)
   - NEVER echoes title or body (free-text → eval-injection risk)
   - uses set -euo pipefail
+  - owns cleanup of $OUT_JSON on its own failure (an EXIT trap), and leaves
+    $OUT_JSON in place on success — a caller invokes it as eval "$(...)", which
+    structurally discards the script's own exit status, so the script must
+    reap its own artifact rather than relying on the caller to do so.
 """
 
 import re
 import subprocess
+import tempfile
+import uuid
 from pathlib import Path
 
 from conftest import _CLEAN_ENV
@@ -123,4 +129,127 @@ def test_preflight_bash_syntax():
     assert result.returncode == 0, (
         f"bash -n bin/swe-workbench-preflight-pr failed:\n{result.stderr}"
     )
+
+
+# ── Behavioural: own-artifact cleanup ────────────────────────────────────────
+#
+# Extends the _make_gh_stub / PATH-prepend pattern from test_fetch_pr_script.py
+# to an argument-dispatching stub, since preflight-pr drives three distinct
+# `gh` subcommands (auth status, pr view, repo view) through the real sibling
+# scripts (swe-workbench-gh-timeout, swe-workbench-fetch-pr) rather than a
+# single call.
+
+def _make_gh_dispatch_stub(stub_dir: Path, *, pr_json: str, pr_exit: int = 0,
+                            owner: str = "test-owner", repo: str = "test-repo") -> None:
+    """Write a fake gh binary that dispatches on subcommand.
+
+    - `auth status`            -> exit 0
+    - `pr view ...`            -> emit `pr_json`, exit `pr_exit`
+    - `repo view --json owner` -> emit `owner`, exit 0
+    - `repo view --json name`  -> emit `repo`, exit 0
+    """
+    stub_dir.mkdir(exist_ok=True)
+    pr_json_file = stub_dir / "_pr_view_output"
+    pr_json_file.write_text(pr_json)
+    stub = stub_dir / "gh"
+    stub.write_text(f"""#!/bin/sh
+case "$1" in
+  auth)
+    [ "$2" = "status" ] && exit 0
+    exit 1
+    ;;
+  pr)
+    if [ "$2" = "view" ]; then
+      cat '{pr_json_file}'
+      exit {pr_exit}
+    fi
+    exit 1
+    ;;
+  repo)
+    if [ "$2" = "view" ]; then
+      for a in "$@"; do
+        case "$a" in
+          *owner*) echo '{owner}'; exit 0 ;;
+          *name*) echo '{repo}'; exit 0 ;;
+        esac
+      done
+    fi
+    exit 1
+    ;;
+esac
+exit 1
+""")
+    stub.chmod(0o755)
+
+
+def _run_preflight(pr: str, out_json: Path, *, stub_dir: Path):
+    env = dict(_CLEAN_ENV)
+    env["PATH"] = f"{stub_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+    return subprocess.run(
+        ["bash", str(SCRIPT), pr, str(out_json)],
+        capture_output=True, text=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+
+
+# $OUT_JSON must be a sanctioned path — swe-workbench-clean-state-files (invoked
+# by the trap) rejects anything outside /tmp/swe-workbench-{pr-review,
+# address-feedback}/ or the bare-/tmp basename allowlist, so a tmp_path fixture
+# path would make the trap a silent no-op and the assertions below would pass
+# for the wrong reason. A unique basename avoids the shared-/tmp race with a
+# concurrent session.
+def _sanctioned_out_json() -> Path:
+    return Path(f"/tmp/swe-workbench-pr-review/{uuid.uuid4().hex}.json")
+
+
+def test_preflight_trap_removes_out_json_on_null_field_abort():
+    """author.login == null trips the L33-39 field-emptiness loop -> exit 1 ->
+    the EXIT trap must remove $OUT_JSON (the script's own failed artifact)."""
+    with tempfile.TemporaryDirectory() as stub_dir_str:
+        stub_dir = Path(stub_dir_str)
+        pr_json = (
+            '{"state":"OPEN","number":1,"headRefName":"feature-x",'
+            '"baseRefName":"main","headRefOid":"abc123","title":"t","body":"b",'
+            '"author":{"login":null},"reviewDecision":null}'
+        )
+        _make_gh_dispatch_stub(stub_dir, pr_json=pr_json)
+        out_json = _sanctioned_out_json()
+        try:
+            result = _run_preflight("1", out_json, stub_dir=stub_dir)
+            assert result.returncode != 0, (
+                f"Expected non-zero exit on null author.login\nstderr: {result.stderr!r}"
+            )
+            assert not out_json.exists(), (
+                "the trap must remove $OUT_JSON when the script aborts after creating it — "
+                "a caller invoking this via eval \"$(...)\" cannot do this cleanup itself, "
+                "since eval discards the script's exit status"
+            )
+        finally:
+            out_json.unlink(missing_ok=True)
+
+
+def test_preflight_trap_leaves_out_json_on_success():
+    """Fully valid PR JSON -> script exits 0 -> $OUT_JSON must remain (it is the
+    deliverable callers read title/body/headRefName from)."""
+    with tempfile.TemporaryDirectory() as stub_dir_str:
+        stub_dir = Path(stub_dir_str)
+        pr_json = (
+            '{"state":"OPEN","number":1,"headRefName":"feature-x",'
+            '"baseRefName":"main","headRefOid":"abc123","title":"t","body":"b",'
+            '"author":{"login":"octocat"},"reviewDecision":null}'
+        )
+        _make_gh_dispatch_stub(stub_dir, pr_json=pr_json)
+        out_json = _sanctioned_out_json()
+        try:
+            result = _run_preflight("1", out_json, stub_dir=stub_dir)
+            assert result.returncode == 0, (
+                f"Expected exit 0 on valid PR JSON\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+            )
+            assert out_json.exists(), (
+                "the trap must NOT remove $OUT_JSON on a successful run — over-broad "
+                "trap logic would delete the file callers rely on for title/body/headRefName"
+            )
+        finally:
+            out_json.unlink(missing_ok=True)
 

--- a/tests/test_workflow_address_feedback_skill.py
+++ b/tests/test_workflow_address_feedback_skill.py
@@ -870,6 +870,102 @@ def test_pr_comments_jq_filter_manual_reply_dedup():
     )
 
 
+# --- Reap-on-reject ordering + Phase 7 run-scoped reap ---
+
+def test_address_feedback_skill_state_gate_precedes_run_dir_allocation():
+    """Phase 1's OPEN-state gate must be hoisted above swe-workbench-new-run-dir
+    allocation — a rejected PR must never allocate $RUN_DIR at all, rather than
+    allocating and then leaking it."""
+    text = SKILL_MD.read_text()
+    gate_idx = text.find('[ "$STATE" = "OPEN" ] ||')
+    run_dir_idx = text.find('swe-workbench-new-run-dir address-feedback "$PR"')
+    assert gate_idx != -1, "SKILL.md Phase 1 must contain the OPEN-state gate"
+    assert run_dir_idx != -1, "SKILL.md Phase 1 must contain the swe-workbench-new-run-dir call"
+    assert gate_idx < run_dir_idx, (
+        "the OPEN-state gate must precede swe-workbench-new-run-dir allocation — "
+        "otherwise a rejected PR leaks $RUN_DIR"
+    )
+
+
+def test_address_feedback_skill_state_gate_reject_reaps_json():
+    """The OPEN-state gate's reject branch must reap $JSON before exiting."""
+    text = SKILL_MD.read_text()
+    line = next(
+        (ln for ln in text.splitlines() if ln.strip().startswith('[ "$STATE" = "OPEN" ] ||')),
+        None,
+    )
+    assert line is not None, "SKILL.md Phase 1 must contain the OPEN-state gate line"
+    assert 'swe-workbench-clean-state-files "$JSON"' in line, (
+        'the OPEN-state gate reject branch must call swe-workbench-clean-state-files "$JSON" '
+        "before exiting, to avoid leaking the PR-keyed state file"
+    )
+
+
+def test_address_feedback_skill_phase7_reaps_run_scoped_files():
+    """Phase 7 must reap all three run-scoped state files and guard the run-dir
+    reap — the ownership-decline and no-open-threads early exits now route
+    through Phase 7 before ever creating a worktree, so $RUN_DIR is guarded
+    for the one exit (the OPEN-state gate) that precedes its allocation."""
+    text = SKILL_MD.read_text()
+    phase7_idx = text.find("### Phase 7")
+    assert phase7_idx != -1, "SKILL.md must have a ### Phase 7 section"
+    next_section = re.search(r'\n## ', text[phase7_idx:])
+    phase7_text = text[phase7_idx: phase7_idx + next_section.start()] if next_section else text[phase7_idx:]
+    for suffix in ["", "-threads", "-pr-comments"]:
+        path = f"/tmp/swe-workbench-address-feedback/${{PR}}{suffix}.json"
+        assert path in phase7_text, (
+            f"Phase 7 must reap {path} — run-scoped state files are reaped on every exit"
+        )
+    assert "${RUN_DIR:-}" in phase7_text, (
+        "Phase 7 must guard the run-dir reap with ${RUN_DIR:-} — $RUN_DIR is unset on "
+        "the Phase 1 OPEN-state gate reject path, which never reaches Phase 7"
+    )
+
+
+def test_address_feedback_skill_phase7_worktree_removal_guards_on_wt_unset():
+    """Phase 7's worktree-removal block must skip entirely when $WT was never set.
+
+    A Phase-1-only exit (ownership decline, no-open-threads) leaves $WT unset since
+    Phase 2 never ran. Without a guard, the block falls into its else branch and
+    unconditionally runs `rimba remove "$PR_BRANCH"` — keyed by branch name alone,
+    not by this run's own $WT — which could force-remove a different, concurrently
+    active session's live worktree on the same PR branch.
+    """
+    text = SKILL_MD.read_text()
+    phase7_idx = text.find("### Phase 7")
+    assert phase7_idx != -1, "SKILL.md must have a ### Phase 7 section"
+    next_section = re.search(r'\n## ', text[phase7_idx:])
+    phase7_text = text[phase7_idx: phase7_idx + next_section.start()] if next_section else text[phase7_idx:]
+    match = re.search(
+        r'if \[ -z "\$\{WT:-\}" \]; then\n.*?\nelif \[ "\$\{REUSED_WT:-0\}" = "1" \]; then',
+        phase7_text, re.DOTALL,
+    )
+    assert match, (
+        'Phase 7\'s worktree-removal block must open with `if [ -z "${WT:-}" ]; then` '
+        "before the REUSED_WT branch — otherwise a Phase-1-only exit falls into the "
+        'else branch and unconditionally runs rimba remove "$PR_BRANCH"'
+    )
+
+
+def test_address_feedback_skill_early_exits_name_phase7():
+    """Both the ownership-decline and no-open-threads Phase 1 exits must route
+    through Phase 7 — otherwise they leak $JSON, the threads/pr-comments state
+    files, and $RUN_DIR."""
+    text = SKILL_MD.read_text()
+    decline_idx = text.find("Wait for confirmation before continuing.")
+    assert decline_idx != -1, "SKILL.md must contain the ownership-decline confirmation prose"
+    decline_window = text[decline_idx: decline_idx + 200]
+    assert "Phase 7" in decline_window, (
+        "the ownership-decline path must state that it runs Phase 7 — Cleanup before exiting"
+    )
+    no_threads_idx = text.find("No open threads — nothing to address")
+    assert no_threads_idx != -1, "SKILL.md must contain the no-open-threads exit message"
+    no_threads_window = text[no_threads_idx: no_threads_idx + 200]
+    assert "Phase 7" in no_threads_window, (
+        "the no-open-threads exit must state that it runs Phase 7 — Cleanup before exiting"
+    )
+
+
 @pytest.mark.skipif(not _JQ_AVAILABLE, reason="jq binary not available")
 def test_pr_comments_jq_filter_own_marker_replies_excluded_from_manual_heuristic():
     """A prior marker-bearing tool reply must not itself count as a 'manual reply' that

--- a/tests/test_workflow_pr_review_skill.py
+++ b/tests/test_workflow_pr_review_skill.py
@@ -173,3 +173,35 @@ def test_pr_review_skill_state_cleanup_has_post_check():
         "SKILL.md Step 7 must include a post-reap report line '✓ state file reaped: ...' "
         "so operators can verify cleanup completed without inspecting /tmp by hand"
     )
+
+
+# --- Reap-on-reject ordering ---
+
+def test_pr_review_skill_followup_gate_precedes_run_dir_allocation():
+    """The followup STATE gate must be hoisted above swe-workbench-new-run-dir
+    allocation — a rejected followup PR must never allocate $RUN_DIR at all,
+    rather than allocating and then leaking it."""
+    text = SKILL_MD.read_text()
+    gate_idx = text.find('[ "$MODE" = followup ] && [ "$STATE" != "OPEN" ]')
+    run_dir_idx = text.find('swe-workbench-new-run-dir "$MODE_TAG" "$PR"')
+    assert gate_idx != -1, "SKILL.md Step 1 must contain the followup STATE gate"
+    assert run_dir_idx != -1, "SKILL.md Step 1 must contain the swe-workbench-new-run-dir call"
+    assert gate_idx < run_dir_idx, (
+        "the followup STATE gate must precede swe-workbench-new-run-dir allocation — "
+        "otherwise a rejected followup PR leaks $RUN_DIR"
+    )
+
+
+def test_pr_review_skill_followup_reject_reaps_json():
+    """The followup-reject branch must reap $JSON before exiting — the PR-keyed
+    state file is otherwise abandoned when the PR turns out to be closed/merged."""
+    text = SKILL_MD.read_text()
+    match = re.search(
+        r'if \[ "\$MODE" = followup \] && \[ "\$STATE" != "OPEN" \]; then\n(.*?)\nfi',
+        text, re.DOTALL,
+    )
+    assert match, "SKILL.md Step 1 must contain the followup-reject if-block"
+    assert 'swe-workbench-clean-state-files "$JSON"' in match.group(1), (
+        'the followup-reject branch must call swe-workbench-clean-state-files "$JSON" '
+        "before exiting, to avoid leaking the PR-keyed state file"
+    )


### PR DESCRIPTION
## Summary
- Hoist the OPEN-state gate above `$RUN_DIR` allocation in `workflow-pr-review` (followup mode) and `workflow-address-feedback`, so a rejected PR reaps its state file inline instead of leaking it
- Give `bin/swe-workbench-preflight-pr` an EXIT trap that owns cleanup of its own output artifact on internal failure, since `eval "$(...)"` callers structurally can't observe its exit status
- Route two previously-silent `workflow-address-feedback` Phase 1 early exits (ownership decline, no open threads) through Phase 7 cleanup, which now reaps the three run-scoped state files and guards its worktree-removal block against tearing down a different session's live worktree

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — 0 issues
- [x] `shellcheck bin/swe-workbench-preflight-pr` — 0 issues
- [x] `pytest tests/ -v` — 3162 passed, 5 skipped

### Type-tailored checks (fix)
- [x] Two independent reviewers (a dedicated diff reviewer and a plan-alignment reviewer) converged on the same real bug in the initial implementation — Phase 7's worktree-removal block could force-remove a *different*, concurrently-active session's live worktree on the same PR branch; fixed with a `${WT:-}` guard and covered by a new regression test
- [x] New behavioural tests exercise `bin/swe-workbench-preflight-pr`'s EXIT trap against a real subprocess with a stubbed `gh`, asserting both the negative (trap removes `$OUT_JSON` on internal abort) and positive (trap leaves it alone on success) cases against a sanctioned `/tmp` path so `swe-workbench-clean-state-files`'s own allow-listing is genuinely exercised

Closes #663
