### PR TITLE
[fix] Show Pi task dispatch metadata while running

### DIFF
--- a/pi/extensions/subagent.ts
+++ b/pi/extensions/subagent.ts
@@ -15,10 +15,10 @@
  * registration, model-registry queries) lives here or in dispatch-resolver.ts (split off at the
  * line cap). agent-spec.ts and model-policy.ts stay SDK-free — see their own file headers.
  */
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import {
   composeSystemPrompt,
   listAgentNames,
@@ -34,10 +34,10 @@ import { sanitizeAgentId, TASK_TOOL_NAME, taskRenderCall, taskRenderResult } fro
 // module) keep a single import surface for the task tool — rendering and tool name included.
 export {
   composeTaskCallLine,
-  composeTaskResultHeader,
+  composeTaskDispatchLine,
   renderTaskCall,
   renderTaskResult,
-  TASK_TOOL_NAME,
+  TASK_TOOL_NAME
 } from "./task-call-line.ts";
 
 /** pi-subagents' own tool name (verified against its published source), excluded defensively
@@ -104,7 +104,7 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
     parameters: TASK_PARAMS_SCHEMA,
     renderCall: taskRenderCall,
     renderResult: taskRenderResult,
-    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const { agent, prompt } = params as unknown as TaskParams;
 
       const available = listAgentNames(root);
@@ -142,6 +142,7 @@ export function registerSubagent(pi: ExtensionAPI, root: string): void {
           "--no-session",
         ];
         const dispatch = resolveTargetDispatch(ctx, agent, spec);
+        onUpdate?.({ content: [], details: dispatch.details });
         if (dispatch.model) {
           args.push("--model", `${dispatch.model.provider}/${dispatch.model.id}`);
         }

--- a/pi/extensions/task-call-line.ts
+++ b/pi/extensions/task-call-line.ts
@@ -38,7 +38,7 @@ void import("@earendil-works/pi-tui")
 
 const UNSAFE_ID_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069]/g;
 
-/** Strips terminal and bidirectional controls before an agent id reaches the terminal. */
+/** Strips terminal and bidirectional controls before an identifier reaches the terminal. */
 export function sanitizeAgentId(agent: string): string {
   return agent.replace(UNSAFE_ID_CHARS, "");
 }
@@ -69,7 +69,8 @@ function dispatchMetadataFromDetails(details: unknown): TaskDispatchRenderMetada
   if (!("thinking" in details) || !isParentThinkingLevel(details.thinking)) return undefined;
 
   const separator = details.model.indexOf("/");
-  const modelId = separator === -1 ? details.model : details.model.slice(separator + 1);
+  const rawModelId = separator === -1 ? details.model : details.model.slice(separator + 1);
+  const modelId = sanitizeAgentId(rawModelId);
   return modelId === "" ? undefined : { modelId, thinking: details.thinking };
 }
 

--- a/pi/extensions/task-call-line.ts
+++ b/pi/extensions/task-call-line.ts
@@ -1,88 +1,52 @@
-/**
- * The `task` tool's custom renderers: a call-line renderer (`task · <agent>`, so concurrent
- * dispatched agents are distinguishable at a glance) and a result renderer (adds the resolved
- * thinking level, colored via Pi's own `thinking<Level>` theme tokens — the same tokens Pi's own
- * UI uses elsewhere, so a dispatch's reasoning depth reads in the same color language as the
- * rest of the session). Split from subagent.ts (at the line cap).
- *
- * The thinking level is never known at call-render time — it depends on `ctx.model`/
- * `ctx.thinkingLevel`, only available once `execute()` runs — so it's surfaced on the RESULT
- * render instead, which does receive the resolved `details`. `renderResult` only takes over
- * when a thinking level was actually resolved; otherwise it throws, deferring to Pi's own
- * default result rendering exactly as before this file added it.
- *
- * Stripper invariant: every `@earendil-works/*` import is type-only, so pytest runs under
- * `node --experimental-strip-types` with no node_modules; the one runtime specifier
- * (pi-tui below) resolves via Pi's jiti alias map in real sessions.
- */
+/** Renders Pi task rows with dispatch metadata as it becomes available. */
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
-import type { Text } from "@earendil-works/pi-tui";
+import type { Component, Text } from "@earendil-works/pi-tui";
 import type { ParentThinkingLevel } from "./model-policy.ts";
 
-/** Single source of truth for the registered tool name — consumed by pi.registerTool(),
- *  the `--exclude-tools` argv builder, and the call line below, so a rename can't desync
- *  them. */
+/** Single source of truth for the registered tool name. */
 export const TASK_TOOL_NAME = "task";
 
-/** Just the two members the renderer needs, so the pure formatter stays testable against
- *  a two-method stub theme. */
+/** Just the two members the renderer needs, so pure formatters accept stub themes. */
 export type CallLineTheme = Pick<Theme, "fg" | "bold">;
 
-/** pi-tui's Text constructor type — type-only, never resolved at module scope. */
+interface TaskDispatchRenderMetadata {
+  readonly modelId: string;
+  readonly thinking: ParentThinkingLevel;
+}
+
+export interface TaskRenderState {
+  dispatch?: TaskDispatchRenderMetadata;
+}
+
+interface TaskRenderContext {
+  args: unknown;
+  state: TaskRenderState;
+  invalidate: () => void;
+}
+
+/** pi-tui's Text constructor type, which is never resolved at module scope. */
 type TextCtor = typeof Text;
 
-/** Resolved once per process by the dynamic import below — dynamic because a static import
- *  would break the stripper invariant above. Undefined (unresolvable here) keeps every
- *  renderCall on the framework-fallback path; never re-attempted on failure. */
 let textCtor: TextCtor | undefined;
 void import("@earendil-works/pi-tui")
   .then((mod) => {
     textCtor = mod.Text;
   })
   .catch(() => {
-    /* unresolvable in this environment — plain-heading fallback, by design */
+    /* The framework fallback handles environments without pi-tui. */
   });
 
-/** Terminal/bidi-spoofing chars (controls, RLO/ALM/ZWSP, isolates, separators) with no
- *  place in a rendered id — legitimate ids are [a-z0-9-], so nothing valid is lost. */
 const UNSAFE_ID_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069]/g;
 
-/** Shared by this render path and subagent.ts's unknown-agent error — both surface the id
- *  to the terminal before validation sanitizes it. */
+/** Strips terminal and bidirectional controls before an agent id reaches the terminal. */
 export function sanitizeAgentId(agent: string): string {
   return agent.replace(UNSAFE_ID_CHARS, "");
 }
 
-/** Composes the call line: the toolTitle segment is byte-identical to Pi's own
- *  createCallFallback() formula, so the enriched line is the fallback heading plus a muted
- *  agent suffix. Exported pure so the nodeless pytest driver can exercise it directly. */
+/** Composes the call line from Pi's fallback heading plus a muted agent suffix. */
 export function composeTaskCallLine(agent: string, theme: CallLineTheme): string {
   const safe = sanitizeAgentId(agent);
   return theme.fg("toolTitle", theme.bold(TASK_TOOL_NAME)) + theme.fg("muted", ` · ${safe}`);
-}
-
-/** Renders the task call line. Throws — deliberately — when no agent name is present
- *  (partial mid-stream args, blank, or strips-to-empty) or Text is unresolved: Pi's
- *  ToolExecutionComponent catches renderer throws and swaps in its createCallFallback()
- *  heading, byte-identical to the pre-change display. Injectable ctor so the resolved path
- *  is testable without pi-tui. */
-export function renderTaskCall(args: unknown, theme: CallLineTheme, ctor: TextCtor | undefined): Text {
-  // Narrowing (not casting) args from unknown — casts are forbidden here.
-  const agent =
-    typeof args === "object" && args !== null && "agent" in args && typeof args.agent === "string"
-      ? args.agent.trim()
-      : "";
-  // A control-only id strips to empty — fall back rather than render a dangling "task · ".
-  if (agent === "" || sanitizeAgentId(agent) === "") {
-    throw new Error("task renderCall: no agent name available — framework fallback applies");
-  }
-  if (ctor === undefined) throw new Error("task renderCall: pi-tui unavailable — framework fallback applies");
-  return new ctor(composeTaskCallLine(agent, theme), 0, 0);
-}
-
-/** The renderCall subagent.ts registers — renderTaskCall bound to the memoized ctor. */
-export function taskRenderCall(args: unknown, theme: CallLineTheme): Text {
-  return renderTaskCall(args, theme, textCtor);
 }
 
 const THINKING_COLOR_TOKEN: Readonly<Record<ParentThinkingLevel, ThemeColor>> = {
@@ -99,49 +63,109 @@ function isParentThinkingLevel(value: unknown): value is ParentThinkingLevel {
   return typeof value === "string" && Object.hasOwn(THINKING_COLOR_TOKEN, value);
 }
 
-/** Same call-line format, plus the resolved thinking level in its own semantic color. */
-export function composeTaskResultHeader(agent: string, theme: CallLineTheme, thinking: ParentThinkingLevel): string {
-  return `${composeTaskCallLine(agent, theme)} ${theme.fg(THINKING_COLOR_TOKEN[thinking], `(${thinking})`)}`;
+function dispatchMetadataFromDetails(details: unknown): TaskDispatchRenderMetadata | undefined {
+  if (typeof details !== "object" || details === null) return undefined;
+  if (!("model" in details) || typeof details.model !== "string") return undefined;
+  if (!("thinking" in details) || !isParentThinkingLevel(details.thinking)) return undefined;
+
+  const separator = details.model.indexOf("/");
+  const modelId = separator === -1 ? details.model : details.model.slice(separator + 1);
+  return modelId === "" ? undefined : { modelId, thinking: details.thinking };
 }
 
-/** Same line-count Pi's own createResultFallback() collapses to when a result isn't expanded
- *  (tool-execution.js's FALLBACK_PREVIEW_LINES) — kept in sync by inspection, not import, since
- *  that constant isn't part of the SDK's public surface. */
+/** Adds resolved model metadata to a task call line. */
+export function composeTaskDispatchLine(
+  agent: string,
+  theme: CallLineTheme,
+  dispatch: TaskDispatchRenderMetadata,
+): string {
+  return (
+    composeTaskCallLine(agent, theme) +
+    theme.fg("muted", ` (${dispatch.modelId} `) +
+    theme.fg(THINKING_COLOR_TOKEN[dispatch.thinking], dispatch.thinking) +
+    theme.fg("muted", ")")
+  );
+}
+
+/** Renders a task call line, adding metadata synchronized from partial updates. */
+export function renderTaskCall(
+  args: unknown,
+  theme: CallLineTheme,
+  ctor: TextCtor | undefined,
+  state?: TaskRenderState,
+): Text {
+  const agent =
+    typeof args === "object" && args !== null && "agent" in args && typeof args.agent === "string"
+      ? args.agent.trim()
+      : "";
+  if (agent === "" || sanitizeAgentId(agent) === "") {
+    throw new Error("task renderCall: no agent name available — framework fallback applies");
+  }
+  if (ctor === undefined) throw new Error("task renderCall: pi-tui unavailable — framework fallback applies");
+
+  const line = state?.dispatch === undefined
+    ? composeTaskCallLine(agent, theme)
+    : composeTaskDispatchLine(agent, theme, state.dispatch);
+  return new ctor(line, 0, 0);
+}
+
+/** Renders a task call line with state shared by Pi's call and result slots. */
+export function taskRenderCall(
+  args: unknown,
+  theme: CallLineTheme,
+  context?: Pick<TaskRenderContext, "state">,
+): Text {
+  return renderTaskCall(args, theme, textCtor, context?.state);
+}
+
 const RESULT_PREVIEW_LINES = 10;
 
-/** Narrowing (not casting) `details` from unknown, mirroring this file's other args-narrowing
- *  call sites. */
-function thinkingFromDetails(details: unknown): unknown {
-  return typeof details === "object" && details !== null && "thinking" in details ? details.thinking : undefined;
+function emptyComponent(): Component {
+  return { render: () => [], invalidate: () => {} };
 }
 
-/** Renders the task result line: the same call-line format plus a colored thinking-level
- *  suffix, followed by the agent's own output text — collapsed to RESULT_PREVIEW_LINES with a
- *  "more lines" marker when not expanded, mirroring Pi's own createResultFallback() truncation
- *  contract (every other tool row collapses by default; this one must too, not dump the full,
- *  possibly-50000-char capped output unconditionally). Throws — deliberately — when no thinking
- *  level was resolved (nothing extra to show) or Text is unresolved, so Pi's own default result
- *  rendering takes over unchanged; see this file's header for why the thinking level can only
- *  ever be known here, not at call-render time. Injectable ctor so the resolved path is testable
- *  without pi-tui. */
+function synchronizeDispatchState(
+  details: unknown,
+  context: Pick<TaskRenderContext, "state" | "invalidate">,
+): TaskDispatchRenderMetadata {
+  const dispatch = dispatchMetadataFromDetails(details);
+  if (dispatch === undefined) {
+    throw new Error("task renderResult: no dispatch metadata resolved — framework fallback applies");
+  }
+
+  const current = context.state.dispatch;
+  if (current?.modelId !== dispatch.modelId || current.thinking !== dispatch.thinking) {
+    context.state.dispatch = dispatch;
+    context.invalidate();
+  }
+  return dispatch;
+}
+
+/** Renders only task output; the call renderer owns the stable task header. */
 export function renderTaskResult(
   result: { content: readonly { type: string; text?: string }[]; details?: unknown },
   theme: CallLineTheme,
   ctor: TextCtor | undefined,
-  agent: string,
+  _agent: string,
   expanded: boolean,
-): Text {
-  const thinking = thinkingFromDetails(result.details);
-  if (!isParentThinkingLevel(thinking)) {
-    throw new Error("task renderResult: no thinking level resolved — framework fallback applies");
+  context?: Pick<TaskRenderContext, "state" | "invalidate">,
+  isPartial = false,
+): Component {
+  if (context === undefined) {
+    if (dispatchMetadataFromDetails(result.details) === undefined) {
+      throw new Error("task renderResult: no dispatch metadata resolved — framework fallback applies");
+    }
+  } else {
+    synchronizeDispatchState(result.details, context);
   }
   if (ctor === undefined) throw new Error("task renderResult: pi-tui unavailable — framework fallback applies");
-  const header = composeTaskResultHeader(agent, theme, thinking);
+  if (isPartial) return emptyComponent();
+
   const rawBody = result.content
-    .filter((c) => c.type === "text" && typeof c.text === "string")
-    .map((c) => c.text as string)
+    .filter((content) => content.type === "text" && typeof content.text === "string")
+    .map((content) => content.text)
     .join("\n\n");
-  if (!rawBody) return new ctor(header, 0, 0);
+  if (rawBody === "") return emptyComponent();
 
   const lines = rawBody.split("\n");
   const displayLines = expanded ? lines : lines.slice(0, RESULT_PREVIEW_LINES);
@@ -150,32 +174,32 @@ export function renderTaskResult(
   if (remaining > 0) {
     body += theme.fg("muted", `\n... (${remaining} more line${remaining === 1 ? "" : "s"} — expand to see all)`);
   }
-  return new ctor(`${header}\n\n${body}`, 0, 0);
+  return new ctor(body, 0, 0);
 }
 
-/** The renderResult subagent.ts registers — renderTaskResult bound to the memoized ctor, agent
- *  id and expanded state read from the shared render context/options. */
+/** Renders a task result with state shared by Pi's call and result slots. */
 export function taskRenderResult(
   result: unknown,
   options: unknown,
   theme: CallLineTheme,
-  context: { args: unknown },
-): Text {
-  // Narrowing (not casting) context.args from unknown — same posture as renderTaskCall's args.
+  context: TaskRenderContext,
+): Component {
   const args = context.args;
   const agent =
     typeof args === "object" && args !== null && "agent" in args && typeof args.agent === "string"
       ? args.agent.trim()
       : "";
   const expanded =
-    typeof options === "object" && options !== null && "expanded" in options && typeof options.expanded === "boolean"
-      ? options.expanded
-      : false;
+    typeof options === "object" && options !== null && "expanded" in options && options.expanded === true;
+  const isPartial =
+    typeof options === "object" && options !== null && "isPartial" in options && options.isPartial === true;
   return renderTaskResult(
     result as { content: readonly { type: string; text?: string }[]; details?: unknown },
     theme,
     textCtor,
     agent,
     expanded,
+    context,
+    isPartial,
   );
 }

--- a/tests/build-requirements.lock
+++ b/tests/build-requirements.lock
@@ -8,9 +8,9 @@ build==1.5.0 \
     --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
     --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
     # via pip-tools
-click==8.4.2 \
-    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
-    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
+click==8.5.0 \
+    --hash=sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360 \
+    --hash=sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34
     # via pip-tools
 packaging==26.3 \
     --hash=sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79 \

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1239,6 +1239,32 @@ if (registered) {
   out.composedDispatchLine = typeof mod.composeTaskDispatchLine === "function"
     ? mod.composeTaskDispatchLine("reviewer", stubTheme, { modelId: "claude-sonnet-5", thinking: "high" })
     : null;
+  const hostileModelState = {};
+  const hostileModelContext = { state: hostileModelState, invalidate() {} };
+  out.renderHostileModelId = probe(() => {
+    const result = mod.renderTaskResult(
+      {
+        content: [],
+        details: { model: "anthropic/claude-\\x1bsonnet-\\u202e5\\n", thinking: "high" },
+      },
+      stubTheme,
+      FakeText,
+      "reviewer",
+      false,
+      hostileModelContext,
+      true,
+    );
+    const call = mod.renderTaskCall({ agent: "reviewer" }, stubTheme, FakeText, hostileModelState);
+    return { partialLines: result.render(80), line: call.text };
+  });
+  out.renderControlOnlyModel = probe(() =>
+    mod.renderTaskResult(
+      { content: [], details: { model: "anthropic/\\x1b\\u202e\\n", thinking: "high" } },
+      stubTheme,
+      FakeText,
+      "reviewer",
+      false,
+    ));
   out.renderResultNoThinking = probe(() =>
     mod.renderTaskResult({ content: [{ type: "text", text: "hi" }], details: {} }, stubTheme, FakeText, "reviewer", false));
   out.renderResultUnknownThinking = probe(() =>
@@ -1639,6 +1665,31 @@ def test_compose_task_dispatch_line_appends_model_and_colored_thinking_level(sub
         "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
         "<muted> (claude-sonnet-5 </muted><thinkingHigh>high</thinkingHigh><muted>)</muted>"
     )
+
+
+@requires_node
+def test_task_row_strips_terminal_and_bidi_controls_from_model_id(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    outcome = result["renderHostileModelId"]
+
+    assert outcome["threw"] is False
+    assert outcome["value"] == {
+        "partialLines": [],
+        "line": (
+            "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
+            "<muted> (claude-sonnet-5 </muted>"
+            "<thinkingHigh>high</thinkingHigh><muted>)</muted>"
+        ),
+    }
+
+
+@requires_node
+def test_task_result_falls_back_when_model_id_strips_to_empty(subagent_root, tmp_path_factory):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    outcome = result["renderControlOnlyModel"]
+
+    assert outcome["threw"] is True
+    assert "task" in outcome["message"]
 
 
 @requires_node

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1132,6 +1132,7 @@ const mod = await import(pathToFileURL(modPath).href);
 const execCalls = [];
 const modelRegistryCalls = [];
 const notifyCalls = [];
+let activeUpdateCalls = [];
 const stubPi = {
   registerTool(tool) { this._registered = tool; },
   async exec(command, args, options) {
@@ -1143,6 +1144,7 @@ const stubPi = {
     execCalls.push({
       command, args, promptFileContent,
       cwd: options && options.cwd, timeout: options && options.timeout,
+      updatesBeforeExec: activeUpdateCalls.length,
     });
     if (config.execBehavior === "throw") throw new Error("forced exec throw (test)");
     if (config.execBehavior === "failure") return { stdout: "", stderr: "boom", code: 1, killed: false };
@@ -1175,11 +1177,13 @@ async function run(agent, prompt, model, availableModels, scopedModels, thinking
       },
     },
   };
+  activeUpdateCalls = [];
+  const onUpdate = (update) => activeUpdateCalls.push(update);
   try {
-    const result = await registered.execute("tc1", { agent, prompt }, undefined, undefined, ctx);
-    return { ok: true, result };
+    const result = await registered.execute("tc1", { agent, prompt }, undefined, onUpdate, ctx);
+    return { ok: true, result, updates: activeUpdateCalls.slice() };
   } catch (err) {
-    return { ok: false, message: String(err && err.message) };
+    return { ok: false, message: String(err && err.message), updates: activeUpdateCalls.slice() };
   }
 }
 
@@ -1210,6 +1214,9 @@ if (registered) {
     : null;
   class FakeText {
     constructor(text, paddingX, paddingY) { this.text = text; this.px = paddingX; this.py = paddingY; }
+    setText(text) { this.text = text; }
+    render() { return this.text === "" ? [] : this.text.split("\\n"); }
+    invalidate() {}
   }
   out.hasRenderCall = typeof registered.renderCall === "function";
   const probe = (fn) => {
@@ -1229,18 +1236,27 @@ if (registered) {
 
   // renderResult probes — same nodeless-throws-to-fallback posture as renderCall above.
   out.hasRenderResult = typeof registered.renderResult === "function";
-  out.composedResultHeader = typeof mod.composeTaskResultHeader === "function"
-    ? mod.composeTaskResultHeader("reviewer", stubTheme, "high")
+  out.composedDispatchLine = typeof mod.composeTaskDispatchLine === "function"
+    ? mod.composeTaskDispatchLine("reviewer", stubTheme, { modelId: "claude-sonnet-5", thinking: "high" })
     : null;
   out.renderResultNoThinking = probe(() =>
     mod.renderTaskResult({ content: [{ type: "text", text: "hi" }], details: {} }, stubTheme, FakeText, "reviewer", false));
   out.renderResultUnknownThinking = probe(() =>
-    mod.renderTaskResult({ content: [], details: { thinking: "bogus" } }, stubTheme, FakeText, "reviewer", false));
+    mod.renderTaskResult(
+      { content: [], details: { model: "anthropic/claude-sonnet-5", thinking: "bogus" } },
+      stubTheme, FakeText, "reviewer", false,
+    ));
   out.renderResultMissingCtor = probe(() =>
-    mod.renderTaskResult({ content: [], details: { thinking: "high" } }, stubTheme, undefined, "reviewer", false));
+    mod.renderTaskResult(
+      { content: [], details: { model: "anthropic/claude-sonnet-5", thinking: "high" } },
+      stubTheme, undefined, "reviewer", false,
+    ));
   out.renderResultResolved = probe(() => {
     const c = mod.renderTaskResult(
-      { content: [{ type: "text", text: "agent output" }], details: { thinking: "xhigh" } },
+      {
+        content: [{ type: "text", text: "agent output" }],
+        details: { model: "anthropic/claude-sonnet-5", thinking: "xhigh" },
+      },
       stubTheme, FakeText, "reviewer", false,
     );
     return { text: c.text, px: c.px, py: c.py };
@@ -1248,32 +1264,94 @@ if (registered) {
   const longBody = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`).join("\\n");
   out.renderResultLongBodyCollapsed = probe(() => {
     const c = mod.renderTaskResult(
-      { content: [{ type: "text", text: longBody }], details: { thinking: "high" } },
+      { content: [{ type: "text", text: longBody }], details: { model: "anthropic/claude-sonnet-5", thinking: "high" } },
       stubTheme, FakeText, "reviewer", false,
     );
     return { text: c.text };
   });
   out.renderResultLongBodyExpanded = probe(() => {
     const c = mod.renderTaskResult(
-      { content: [{ type: "text", text: longBody }], details: { thinking: "high" } },
+      { content: [{ type: "text", text: longBody }], details: { model: "anthropic/claude-sonnet-5", thinking: "high" } },
       stubTheme, FakeText, "reviewer", true,
     );
     return { text: c.text };
   });
   out.renderResultNoBody = probe(() => {
     const c = mod.renderTaskResult(
-      { content: [], details: { thinking: "high" } },
+      { content: [], details: { model: "anthropic/claude-sonnet-5", thinking: "high" } },
       stubTheme, FakeText, "reviewer", false,
     );
-    return { text: c.text };
+    return { lines: c.render(80) };
   });
   out.registeredRenderResultViaContext = probe(() =>
     registered.renderResult(
-      { content: [{ type: "text", text: "agent output" }], details: { thinking: "max" } },
+      { content: [{ type: "text", text: "agent output" }], details: { model: "anthropic/claude-sonnet-5", thinking: "max" } },
       { expanded: false, isPartial: false },
       stubTheme,
-      { args: { agent: "reviewer", prompt: "hi" } },
+      { args: { agent: "reviewer", prompt: "hi" }, state: {}, invalidate() {} },
     ));
+
+  const lifecycleState = {};
+  let lifecycleInvalidations = 0;
+  const lifecycleContext = {
+    args: { agent: "reviewer", prompt: "review" },
+    state: lifecycleState,
+    lastComponent: undefined,
+    invalidate() { lifecycleInvalidations += 1; },
+  };
+  const lifecycleDetails = {
+    agent: "reviewer",
+    tier: "sonnet",
+    portableEffort: "xhigh",
+    model: "anthropic/claude-sonnet-5",
+    thinking: "xhigh",
+    policySource: "model-policy",
+    poolSource: "available",
+  };
+  const callBefore = mod.renderTaskCall(
+    lifecycleContext.args,
+    stubTheme,
+    FakeText,
+    lifecycleState,
+  );
+  const partialResult = mod.renderTaskResult(
+    { content: [], details: lifecycleDetails },
+    stubTheme,
+    FakeText,
+    "reviewer",
+    false,
+    lifecycleContext,
+    true,
+  );
+  const callDuring = mod.renderTaskCall(
+    lifecycleContext.args,
+    stubTheme,
+    FakeText,
+    lifecycleState,
+  );
+  const finalResult = mod.renderTaskResult(
+    { content: [{ type: "text", text: "agent output" }], details: lifecycleDetails },
+    stubTheme,
+    FakeText,
+    "reviewer",
+    false,
+    lifecycleContext,
+    false,
+  );
+  const callAfter = mod.renderTaskCall(
+    lifecycleContext.args,
+    stubTheme,
+    FakeText,
+    lifecycleState,
+  );
+  out.renderLifecycle = {
+    before: callBefore.text,
+    partialLines: partialResult.render(80),
+    during: callDuring.text,
+    finalLines: finalResult.render(80),
+    after: callAfter.text,
+    invalidations: lifecycleInvalidations,
+  };
 
   out.emptyTools = await run("empty-tools-agent", "hi");
 
@@ -1555,12 +1633,11 @@ def test_task_registers_a_render_result_override(subagent_root, tmp_path_factory
 
 
 @requires_node
-def test_compose_task_result_header_appends_colored_thinking_level(subagent_root, tmp_path_factory):
-    """The result header is the call line plus the thinking level in its own semantic
-    `thinking<Level>` theme token — the same token family Pi's own UI uses elsewhere."""
+def test_compose_task_dispatch_line_appends_model_and_colored_thinking_level(subagent_root, tmp_path_factory):
     result = _subagent_result(subagent_root, tmp_path_factory)
-    assert result["composedResultHeader"] == (
-        "<toolTitle>**task**</toolTitle><muted> · reviewer</muted> <thinkingHigh>(high)</thinkingHigh>"
+    assert result["composedDispatchLine"] == (
+        "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
+        "<muted> (claude-sonnet-5 </muted><thinkingHigh>high</thinkingHigh><muted>)</muted>"
     )
 
 
@@ -1598,17 +1675,12 @@ def test_render_task_result_throws_to_framework_fallback_without_pi_tui(subagent
 
 
 @requires_node
-def test_render_task_result_builds_header_plus_body_text(subagent_root, tmp_path_factory):
-    """Assert the resolved path builds a single Text combining the colored header and the
-    agent's own output text, with (0, 0) padding matching the call-line renderer."""
+def test_render_task_result_builds_only_body_text(subagent_root, tmp_path_factory):
     result = _subagent_result(subagent_root, tmp_path_factory)
     outcome = result["renderResultResolved"]
     assert outcome["threw"] is False
     resolved = outcome["value"]
-    assert resolved["text"] == (
-        "<toolTitle>**task**</toolTitle><muted> · reviewer</muted> <thinkingXhigh>(xhigh)</thinkingXhigh>"
-        "\n\n<toolOutput>agent output</toolOutput>"
-    )
+    assert resolved["text"] == "<toolOutput>agent output</toolOutput>"
     assert [resolved["px"], resolved["py"]] == [0, 0]
 
 
@@ -1623,7 +1695,7 @@ def test_render_task_result_collapses_long_body_to_preview_lines_by_default(suba
     assert outcome["threw"] is False
     text = outcome["value"]["text"]
     shown_lines = [f"<toolOutput>line {i}</toolOutput>" for i in range(1, 11)]
-    assert text.endswith("\n\n" + "\n".join(shown_lines) + "<muted>\n... (5 more lines — expand to see all)</muted>")
+    assert text == "\n".join(shown_lines) + "<muted>\n... (5 more lines — expand to see all)</muted>"
     assert "line 11" not in text
 
 
@@ -1638,15 +1710,33 @@ def test_render_task_result_shows_full_body_when_expanded(subagent_root, tmp_pat
 
 
 @requires_node
-def test_render_task_result_with_no_body_shows_only_the_header(subagent_root, tmp_path_factory):
-    """No content text (an edge case, not a real dispatch shape today) must render just the
-    header, not a dangling separator or an empty truncation marker."""
+def test_render_task_result_with_no_body_returns_no_lines(subagent_root, tmp_path_factory):
     result = _subagent_result(subagent_root, tmp_path_factory)
     outcome = result["renderResultNoBody"]
     assert outcome["threw"] is False
-    assert outcome["value"]["text"] == (
-        "<toolTitle>**task**</toolTitle><muted> · reviewer</muted> <thinkingHigh>(high)</thinkingHigh>"
+    assert outcome["value"]["lines"] == []
+
+
+@requires_node
+def test_task_row_adds_model_and_thinking_without_duplicate_result_header(
+    subagent_root, tmp_path_factory
+):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    lifecycle = result["renderLifecycle"]
+    base = "<toolTitle>**task**</toolTitle><muted> · reviewer</muted>"
+    resolved = (
+        base
+        + "<muted> (claude-sonnet-5 </muted>"
+        + "<thinkingXhigh>xhigh</thinkingXhigh>"
+        + "<muted>)</muted>"
     )
+
+    assert lifecycle["before"] == base
+    assert lifecycle["partialLines"] == []
+    assert lifecycle["during"] == resolved
+    assert lifecycle["finalLines"] == ["<toolOutput>agent output</toolOutput>"]
+    assert lifecycle["after"] == resolved
+    assert lifecycle["invalidations"] == 1
 
 
 @requires_node
@@ -1844,6 +1934,30 @@ def test_subagent_tiered_agent_resolves_model_via_tier_table(subagent_root, tmp_
     assert run["result"]["content"] == [{"type": "text", "text": "agent output"}], (
         "no fallback warning line on the success path"
     )
+
+
+@requires_node
+def test_task_emits_resolved_dispatch_details_before_child_process_starts(
+    subagent_root, tmp_path_factory
+):
+    result = _subagent_result(subagent_root, tmp_path_factory)
+    run = result["tieredAgentResolvesHaiku"]
+
+    assert run["updates"] == [
+        {
+            "content": [],
+            "details": {
+                "agent": "tiered-agent",
+                "tier": "haiku",
+                "portableEffort": "high",
+                "model": "anthropic/claude-haiku-4-5",
+                "thinking": "high",
+                "policySource": "model-policy",
+                "poolSource": "available",
+            },
+        }
+    ]
+    assert result["tieredAgentExecCalls"][0]["updatesBeforeExec"] == 1
 
 
 @requires_node


### PR DESCRIPTION
## Summary
- Publish resolved Pi subagent model/thinking metadata before child execution so the running task row shows dispatch depth immediately.
- Keep one stable `task · <agent> (<model-id> <thinking>)` header, render final output without duplication, and sanitize model IDs against terminal/BiDi injection.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually — live TUI confirmation remains deferred; composed lifecycle behavior is covered automatically
- [x] Full repository validation, TypeScript typecheck, and pytest suite pass

### Type-tailored checks ([fix])
- [x] Reproduced missing running metadata and duplicate result header before the fix
- [x] Verified hostile control/BiDi model IDs fail before sanitization and pass after
- [x] `pytest tests/ -v` — 3287 passed, 3 skipped
- [x] `bash scripts/validate.sh && npm run typecheck`
- [x] `swe-workbench-comment-scan` — 0 must-triage

Issue: N/A — reported directly from Pi TUI behavior without a tracked issue
