### PR TITLE
[chore] Replace the bin/README.md table spliced into every Pi system prompt

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -13,56 +13,28 @@ full implementation, invocable directly by its bare `swe-workbench-<name>` comma
 | `bin/` | Plugin-runtime scripts executed on end-user machines | Skills / commands / agents at runtime |
 | `scripts/` | Repo-dev / CI tooling: release, setup, validation | Developers from a checkout; CI pipelines |
 
-## Current scripts
-
-| Script | Purpose |
-|--------|---------|
-| `swe-workbench-address-feedback-fetch` | Fetch + eligibility projection for `swe-workbench:workflow-address-feedback` Phase 1 (`--pr <N>`) — wraps `swe-workbench-preflight-pr`, short-circuits on a non-OPEN PR before any paginated fetch, otherwise paginates `reviewThreads` (per-thread `eligible`/`skip_reason` projection) and REST PR comments (bot/owner-exclusion + handled-marker/manual-reply eligibility) and atomically writes the three snapshot files `swe-workbench-sweep-residuals` hardcodes. Manifest of paths/counts only — thread and comment records stay in the snapshot files. Envelope schema `swb.address-feedback-fetch/1` |
-| `swe-workbench-address-feedback-worktree` | Worktree acquire/reconcile/release lifecycle for `swe-workbench:workflow-address-feedback` Phase 2/Phase 7 (`acquire --pr <N> --branch <PR_BRANCH>`, `release --pr <N> --path <abs-path> --branch <PR_BRANCH> --created <true\|false>`) — reuse-current/reuse-existing/create-via-rimba/create-via-git, fast-forward or diverged-warn reconcile, deps install; release is path-keyed only (never branch-keyed) and gated by an ownership receipt so it can never remove a worktree it did not itself create, or delete the PR's real head branch. Two envelopes: `swb.address-feedback-worktree-acquire/1`, `swb.address-feedback-worktree-release/1` |
-| `swe-workbench-apply-conflict-resolution` | Apply a keep-mine/keep-main conflict resolution to one file — validates a merge/rebase is in progress, the declared `--operation` matches it, and the path is unmerged, then translates intent to git's `--ours`/`--theirs` (inverted under rebase vs merge) and stages the result |
-| `swe-workbench-clean-ephemeral` | Safe `rm -rf` for ephemeral git worktrees (sanity-checked before removal) |
-| `swe-workbench-clean-state-files` | Safe `rm -f` for per-invocation `/tmp` state files |
-| `swe-workbench-comment-scan` | Advisory comment-quality scanner — reads a unified diff on stdin, prints findings + a footer; never exits non-zero |
-| `swe-workbench-diff-line-lookup` | Resolve the post-diff line number for a literal code snippet (`path:line`) from a git diff or piped unified diff; refuses to guess on ambiguous matches. Default (no flag) mode is invisible to brand-new untracked files — `git add` (or pass `--staged`) first |
-| `swe-workbench-doctor` | Read-only preflight check of runtime dependencies (gh, git, jq, rimba, claude, python3) |
-| `swe-workbench-fetch-pr` | Fetch a PR's metadata JSON via `gh pr view`; exits 1 if the PR is inaccessible |
-| `swe-workbench-gh-timeout` | Run a `gh` call under a per-call deadline (default 60s, override via `GH_TIMEOUT_SECS`); degrades to unbounded `gh` when neither `timeout` nor `gtimeout` is on PATH |
-| `swe-workbench-lsp` | Stdlib-only LSP JSON-RPC client — semantic code navigation (`refs`/`def`/`impl`/`callers`/`callees`/`hover`/`symbols`/`wsymbols`/`check`) reachable via `Bash` regardless of whether the harness's own `LSP` tool is wired up for subagents |
-| `swe-workbench-new-run-dir` | Allocate a mode-0700 run-scoped scratch dir under `/tmp/swe-workbench-run/` (`mktemp -d`, explicit template); also runs the age-gated (24h) orphan sweep at allocation time |
-| `swe-workbench-pr-review-submit` | Posting mechanism for workflow-pr-review-post's `## Post` section: fetch review threads (paginated), Jaccard dedup + 👍 reactions, diff-line pre-validate, pr-level batching, self-review/diff-scoping decision flip, atomic Reviews-API submit with a bounded 422 retry and a per-comment fallback. `--findings-json <path\|->` in; one JSON envelope out (schema `swb.pr-review-submit/1` — see [Result contract](#result-contract)) |
-| `swe-workbench-pr-review-worktree` | Single source of the ephemeral PR-review worktree acquire/release/naming contract shared by `swe-workbench:workflow-pr-review` (first-pass + followup) and the PR-mode specialist sub-flow in `commands/review.md`: `acquire --mode <MODE> --pr <N>`, `release --mode <MODE> --pr <N> --intent <completed\|declined\|failed>`, `names --pr <N>`; rimba-first with a direct-git fallback, self-heals a stale/collided worktree at the same label (refusing when dirty), and never force-removes a dirty worktree on release |
-| `swe-workbench-preflight-commit` | Read-only preflight over the staged file set for `swe-workbench:workflow-commit-and-pr`: one JSON envelope (schema `swb.preflight-commit/1`) classifying secret-shaped filenames (`suspicious`) and whether every staged path is documentation-only (`docs_only`); fails closed — a non-zero exit never means "clean" |
-| `swe-workbench-reap-run-dir` | Safe `rm -rf` for a single run-scoped scratch dir allocated by `swe-workbench-new-run-dir` (depth-exactly-one, name-shape, ownership, and `.git`-absence checks) |
-| `swe-workbench-reap-session-scratch` | Platform-neutral content-clear (directory preserved) for a verified current-session scratch target, authorized by exactly one packaged session scratch adapter; ambiguous or unsafe resolution is a zero-count no-op |
-| `swe-workbench-session-scratch-adapter-claude` | Claude Code session scratch adapter |
-| `swe-workbench-session-scratch-adapter-pi` | Pi Coding Agent session scratch adapter |
-| `swe-workbench-reply-and-resolve` | Post a PR review thread reply (REST) and optionally resolve it (GraphQL) |
-| `swe-workbench-result-check` | Validate a producer's JSON result envelope against a schema registry and pass it through unchanged (`swe-workbench-result-check <schema>`) — the standard consumption mechanism for the envelope contract, replacing `eval` for a migrated producer; see [Result contract](#result-contract) |
-| `swe-workbench-skill-script` | Invoke a skill-local `scripts/<name>.sh` helper (`swe-workbench-skill-script <skill> <script> [args...]`) — rejects traversal, resolves the plugin root itself so no skill has to |
-| `swe-workbench-sweep-residuals` | PR-scoped residual-artifact backstop for `swe-workbench:workflow-cleanup-merged` Step 5 — force-removes leftover worktrees, state files, run dirs, and session-scratch entries for a merged PR number; emits one JSON envelope (schema `swb.sweep-residuals/1`) with retained/failed worktrees as `[{path, reason}]`, not just a count |
-| `swe-workbench-sync-pr-metadata` | Apply a revised title and/or body to an existing PR (address-feedback Phase 6 drift sync) |
-
-`swe-workbench-address-feedback-fetch`, `swe-workbench-comment-scan`, `swe-workbench-lsp`,
-`swe-workbench-pr-review-submit`, `swe-workbench-preflight-commit`, and `swe-workbench-result-check`
-are the six scripts in this directory with a `#!/usr/bin/env python3` shebang instead of
-`#!/usr/bin/env bash`. `comment-scan`
-is a pure diff-in/findings-out function (no git calls of its own; see
-`shared/agents/comment-scan.md` for the canonical diff command); `pr-review-submit` does call
-`git`/`gh` but needed Python's JSON and multi-call state-machine handling (422 retry,
-read-your-write confirmation) more than bash's process-spawning idioms; `lsp` speaks JSON-RPC
-framing to a spawned language server subprocess, which needs a real threaded reader loop bash
-can't give it; `preflight-commit` classifies NUL-delimited raw staged paths and emits JSON — bash
-would need `jq` for escaping arbitrary path bytes and a second regex dialect (Oniguruma) for
-matching, a second engine to audit in a security gate that should have exactly one;
-`result-check` needs the same JSON-object type/shape validation `preflight-commit` does, for the
-same reason; `address-feedback-fetch` needed the same paginated-cursor state machine as
+Every script documents itself: run `swe-workbench-<name> --help` for usage, arguments, and
+behavior — there is no separate script-by-script table here to keep in sync with the code as
+scripts change. `swe-workbench-address-feedback-fetch`, `swe-workbench-comment-scan`,
+`swe-workbench-lsp`, `swe-workbench-pr-review-submit`, `swe-workbench-preflight-commit`, and
+`swe-workbench-result-check` are the six scripts in this directory with a `#!/usr/bin/env python3`
+shebang instead of `#!/usr/bin/env bash`. `comment-scan` is a pure diff-in/findings-out function
+(no git calls of its own; see `shared/agents/comment-scan.md` for the canonical diff command);
+`pr-review-submit` does call `git`/`gh` but needed Python's JSON and multi-call state-machine
+handling (422 retry, read-your-write confirmation) more than bash's process-spawning idioms; `lsp`
+speaks JSON-RPC framing to a spawned language server subprocess, which needs a real threaded
+reader loop bash can't give it; `preflight-commit` classifies NUL-delimited raw staged paths and
+emits JSON — bash would need `jq` for escaping arbitrary path bytes and a second regex dialect
+(Oniguruma) for matching, a second engine to audit in a security gate that should have exactly
+one; `result-check` needs the same JSON-object type/shape validation `preflight-commit` does, for
+the same reason; `address-feedback-fetch` needed the same paginated-cursor state machine as
 `pr-review-submit` (a `reviewThreads(first:100, after:$after)` / `pageInfo{endCursor hasNextPage}`
 loop) plus JSON emission over arbitrary-byte review-comment text, where bash would again mean a
 second escaping engine (`jq`) layered under the same shell process-spawning idioms `pr-review-submit`
-already rejected for the identical reason. Unlike `comment-scan` (advisory, correctly fails open), `preflight-commit`,
-`result-check`, and `address-feedback-fetch` fail closed: an error is a hard non-zero exit with
-nothing on stdout, never a silent "clean". Same bare-command convention applies; only the
-interpreter differs.
+already rejected for the identical reason. Unlike `comment-scan` (advisory, correctly fails open),
+`preflight-commit`, `result-check`, and `address-feedback-fetch` fail closed: an error is a hard
+non-zero exit with nothing on stdout, never a silent "clean". Same bare-command convention
+applies; only the interpreter differs.
 
 ## Result contract
 

--- a/bin/swe-workbench-address-feedback-worktree
+++ b/bin/swe-workbench-address-feedback-worktree
@@ -72,6 +72,11 @@
 
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 STATE_DIR="/tmp/swe-workbench-address-feedback"
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 

--- a/bin/swe-workbench-apply-conflict-resolution
+++ b/bin/swe-workbench-apply-conflict-resolution
@@ -28,6 +28,11 @@
 # an unmerged path, or a checkout failure unrelated to a missing blob.
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 usage() {
   echo "Usage: swe-workbench-apply-conflict-resolution --file <path> --intent <mine|main> --operation <merge|rebase>" >&2
   exit 1

--- a/bin/swe-workbench-clean-ephemeral
+++ b/bin/swe-workbench-clean-ephemeral
@@ -22,6 +22,11 @@
 
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 # ── Argument validation ────────────────────────────────────────────────────
 
 TARGET="${1:-}"

--- a/bin/swe-workbench-clean-state-files
+++ b/bin/swe-workbench-clean-state-files
@@ -25,6 +25,11 @@
 
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 reject() {
   printf 'clean-state-files: %s\n' "$*" >&2
   exit 1

--- a/bin/swe-workbench-comment-scan
+++ b/bin/swe-workbench-comment-scan
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Advisory comment-quality scanner backing the comment-reduction verified gate.
 
+Usage: git diff -M | swe-workbench-comment-scan [--help]
+
 Pure function: unified diff text in on stdin, findings + a footer out on
 stdout. No git access inside this module — callers resolve the diff by
 whatever means their context already established (see shared/agents/
@@ -817,7 +819,13 @@ def format_output(findings: list[Finding], coverage: dict) -> str:
     return "\n".join(lines)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+
+    if len(argv) == 1 and argv[0] in ("--help", "-h"):
+        print(__doc__)
+        return 0
+
     try:
         diff_text = sys.stdin.read()
     except Exception as exc:  # fail-open: unreadable stdin

--- a/bin/swe-workbench-diff-line-lookup
+++ b/bin/swe-workbench-diff-line-lookup
@@ -4,6 +4,11 @@
 # Usage: swe-workbench-diff-line-lookup <path> <pattern> [--range=<rev-range> | --staged | --stdin]
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 usage() {
   if [ $# -gt 0 ]; then
     echo "swe-workbench-diff-line-lookup: $1" >&2

--- a/bin/swe-workbench-doctor
+++ b/bin/swe-workbench-doctor
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Read-only preflight probe for swe-workbench runtime dependencies.
 # Prints a green/red table to stdout. Writes no files. Exits 0 always.
+# Usage: swe-workbench-doctor
 set -uo pipefail  # -e omitted: exit 0 required even when probes fail
                   # -u active: all variables must be initialized before use
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 
 MISSING=0
 

--- a/bin/swe-workbench-fetch-pr
+++ b/bin/swe-workbench-fetch-pr
@@ -2,6 +2,12 @@
 # Fetch a PR's metadata JSON; exit 1 if the PR is missing or unreadable.
 # Usage: swe-workbench-fetch-pr <PR> <out_path> <json_fields>
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 PR="${1:?Usage: swe-workbench-fetch-pr <PR> <out_path> <json_fields>}"
 OUT="${2:?Usage: swe-workbench-fetch-pr <PR> <out_path> <json_fields>}"
 FIELDS="${3:?Usage: swe-workbench-fetch-pr <PR> <out_path> <json_fields>}"

--- a/bin/swe-workbench-gh-timeout
+++ b/bin/swe-workbench-gh-timeout
@@ -5,6 +5,8 @@
 # On timeout, exits 124 and prints a diagnostic to stderr so a stall is not misreported
 # by a caller (e.g. swe-workbench-fetch-pr's "PR not found" branch).
 # Usage: swe-workbench-gh-timeout <gh-subcommand> [args...]
+# A sole --help/-h argument prints this header instead of running gh — pass a subcommand first
+# (e.g. `swe-workbench-gh-timeout api --help`) to reach gh's own --help for that subcommand.
 set -euo pipefail
 
 if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then

--- a/bin/swe-workbench-gh-timeout
+++ b/bin/swe-workbench-gh-timeout
@@ -4,7 +4,13 @@
 # Degrades to plain `gh` when neither `timeout` nor `gtimeout` (macOS/coreutils) is present.
 # On timeout, exits 124 and prints a diagnostic to stderr so a stall is not misreported
 # by a caller (e.g. swe-workbench-fetch-pr's "PR not found" branch).
+# Usage: swe-workbench-gh-timeout <gh-subcommand> [args...]
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 
 secs="${GH_TIMEOUT_SECS:-60}"
 # Require >=1: a 0 duration means "disable the timer" to GNU timeout/gtimeout, which would

--- a/bin/swe-workbench-new-run-dir
+++ b/bin/swe-workbench-new-run-dir
@@ -36,6 +36,11 @@
 
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 reject() {
   printf 'new-run-dir: %s\n' "$*" >&2
   exit 1

--- a/bin/swe-workbench-pr-review-worktree
+++ b/bin/swe-workbench-pr-review-worktree
@@ -47,6 +47,11 @@
 # relative-path anchor logic.
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 FALLBACK_ROOT="/tmp/swe-workbench-pr-review"
 SPECIALIST_MODES=(security accessibility dependency performance tests ux)

--- a/bin/swe-workbench-preflight-pr
+++ b/bin/swe-workbench-preflight-pr
@@ -12,6 +12,11 @@
 # from any cwd, including an ephemeral PR worktree.
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 PR="${1:?Usage: swe-workbench-preflight-pr <PR> <out_json> [fields]}"
 OUT_JSON="${2:?Usage: swe-workbench-preflight-pr <PR> <out_json> [fields]}"
 FIELDS="${3:-state,number,headRefName,baseRefName,headRefOid,title,body,author,reviewDecision}"

--- a/bin/swe-workbench-reap-run-dir
+++ b/bin/swe-workbench-reap-run-dir
@@ -37,6 +37,11 @@
 
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 reject() {
   printf 'reap-run-dir: %s\n' "$*" >&2
   exit 1

--- a/bin/swe-workbench-reap-session-scratch
+++ b/bin/swe-workbench-reap-session-scratch
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # swe-workbench-reap-session-scratch
 # Clear a verified current-session scratch target without removing the target directory.
+# Usage: swe-workbench-reap-session-scratch
 
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 
 note() {
   printf 'reap-session-scratch: %s\n' "$*" >&2

--- a/bin/swe-workbench-reply-and-resolve
+++ b/bin/swe-workbench-reply-and-resolve
@@ -8,6 +8,10 @@
 # "issue" posts REPLY_BODY to the PR's top-level conversation (issues/{pr}/comments) instead — used
 # for PR-level comments, which have no thread to resolve. COMMENT_DATABASEID/THREAD_ID are ignored.
 set -euo pipefail
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 # Fast-exit when both reply and resolve are suppressed (both args empty) — nothing to do.
 if [ -z "${6:-}" ] && [ -z "${5:-}" ]; then exit 0; fi
 OWNER="${1:?}"; REPO="${2:?}"; PR="${3:?}"

--- a/bin/swe-workbench-result-check
+++ b/bin/swe-workbench-result-check
@@ -159,6 +159,10 @@ def validate_envelope(schema: str, envelope: object) -> list[str]:
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
 
+    if len(argv) == 1 and argv[0] in ("--help", "-h"):
+        print(__doc__)
+        return 0
+
     if len(argv) != 1:
         print("Usage: swe-workbench-result-check <schema>", file=sys.stderr)
         return 1

--- a/bin/swe-workbench-session-scratch-adapter-claude
+++ b/bin/swe-workbench-session-scratch-adapter-claude
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Claude authorizes only /tmp/claude-<uid>/<project>/<session>/scratchpad;
 # the core owns deletion after independently validating this descriptor.
+# Usage: swe-workbench-session-scratch-adapter-claude
 
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 
 note() {
   printf 'session-scratch-adapter-claude: %s\n' "$*" >&2

--- a/bin/swe-workbench-session-scratch-adapter-pi
+++ b/bin/swe-workbench-session-scratch-adapter-pi
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Pi authorizes no scratch target until a sanctioned contract exists; never derive one
 # from session JSONL.
+# Usage: swe-workbench-session-scratch-adapter-pi
 
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
 
 note() {
   printf 'session-scratch-adapter-pi: %s\n' "$*" >&2

--- a/bin/swe-workbench-skill-script
+++ b/bin/swe-workbench-skill-script
@@ -2,6 +2,12 @@
 # Invoke a skill-local scripts/ helper without any skill-prose path construction.
 # Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 SKILL="${1:?Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]}"
 SCRIPT="${2:?Usage: swe-workbench-skill-script <skill-name> <script-name> [args...]}"
 shift 2

--- a/bin/swe-workbench-sweep-residuals
+++ b/bin/swe-workbench-sweep-residuals
@@ -40,6 +40,11 @@
 # genuine partial failure is expressed through status/data, not the exit code.
 set -euo pipefail
 
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 SWEPT_WORKTREES=0
 SWEPT_STATE_FILES=0
 SWEPT_RUN_DIRS=0

--- a/bin/swe-workbench-sync-pr-metadata
+++ b/bin/swe-workbench-sync-pr-metadata
@@ -3,6 +3,12 @@
 # Usage: swe-workbench-sync-pr-metadata <pr> <new_title> <body_file>
 # Empty new_title skips --title; empty body_file skips --body-file.
 set -euo pipefail
+
+if [ $# -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  awk 'NR>1 && /^#/ { sub(/^# ?/, ""); print; next } NR>1 { exit }' "$0"
+  exit 0
+fi
+
 PR="${1:?sync-pr-metadata: PR number required}"
 NEW_TITLE="${2:-}"; BODY_FILE="${3:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -172,8 +172,9 @@ dependency on a harness-provided `LSP` tool ever being wired up.
 
 Phase 1 already did the only port work this capability needs: `pi/extensions/index.ts`
 appends `<root>/bin` to `process.env.PATH`, so `swe-workbench-lsp` is already a bare command in a
-Pi session, and it splices `bin/README.md`'s `## Current scripts` body into the Tier-1 preamble,
-so a Pi session is already told the capability exists. A Pi-registered `LSP` tool would fork the
+Pi session, and `pi/extensions/bin-scripts.ts` generates a bare-id inventory of `bin/` (plus a
+one-entry capability row naming `swe-workbench-lsp`'s subcommands) into the Tier-1 preamble, so a
+Pi session is already told the capability exists. A Pi-registered `LSP` tool would fork the
 886-line script plus `tests/test_lsp_script.py`'s suite into a second implementation, teach the
 two harnesses different vocabularies for one capability — the opposite of what
 `pi/extensions/tool-vocab.ts` exists to do — and gain zero callers, since the four consumers

--- a/pi/extensions/bin-scripts.ts
+++ b/pi/extensions/bin-scripts.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure text for the swe-workbench bin/ scripts preamble section.
+ *
+ * Layer: domain. This file must import NOTHING from the Pi SDK, not even as a type — only
+ * node:fs/node:path. Composing it into the system prompt (composePreamble) is index.ts's job.
+ *
+ * Replaces the old bin/README.md "## Current scripts" splice: that table was human
+ * documentation prose re-purposed as a machine-parseable section, so it grew every time a row
+ * was edited for readability. This module generates a bare-id list from the real bin/ directory
+ * instead — it cannot drift from what actually ships — plus a one-entry CAPABILITY_ROWS
+ * allowlist for the one script (`swe-workbench-lsp`) that needs more than its own name to be
+ * usable, and a pointer at each script's own `--help` output for everything else.
+ */
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Scripts whose usage is not obvious from the bare id alone — kept deliberately small: expand
+ *  one entry at a time, with a recorded reason, only if a Pi session is observed reimplementing
+ *  a script inline instead of discovering it. Do not add a second entry casually — it names
+ *  exactly this one. */
+export const CAPABILITY_ROWS: ReadonlyArray<{ id: string; body: string }> = [
+  {
+    id: "swe-workbench-lsp",
+    body:
+      "swe-workbench-lsp — semantic code navigation " +
+      "(refs/def/impl/callers/callees/hover/symbols/wsymbols/check)",
+  },
+];
+
+/** By construction the exact set of bare commands `<root>/bin` on PATH exposes — mirrors
+ *  tool-vocab.ts's readSkillIds shape exactly (try/catch -> null) so a missing/unreadable bin/
+ *  degrades only this section, never the rest of the preamble. */
+function readBinScriptIds(binDir: string): string[] | null {
+  try {
+    return readdirSync(binDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.startsWith("swe-workbench-"))
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return null;
+  }
+}
+
+/** Returns the {title, body}-shaped section composePreamble expects for the bin/ script
+ *  inventory, or null when bin/ is unreadable or (degenerately) empty of swe-workbench-*
+ *  entries — present-or-wholly-absent, never "present but empty", matching the old
+ *  missing-README fail-soft posture this replaces. */
+export function binScriptsSection(root: string): { title: string; body: string } | null {
+  const ids = readBinScriptIds(join(root, "bin"));
+  if (ids === null || ids.length === 0) return null;
+
+  const idList = ids.map((id) => `\`${id}\``).join(", ");
+  const capabilityLines = CAPABILITY_ROWS.map((row) => `- ${row.body}`).join("\n");
+  const pointer =
+    "Each bare command supports its own `--help` — e.g. `swe-workbench-lsp --help` — for " +
+    "usage and argument shape; check before reimplementing a script's behavior inline.";
+
+  const body = [
+    `Bare commands on PATH (see "Reference pattern" in bin/README.md for the calling ` +
+      `convention): ${idList}.`,
+    capabilityLines,
+    pointer,
+  ].join("\n\n");
+
+  return { title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body };
+}

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -27,7 +27,7 @@
  *     `_ctx` argument, which kills the `PI_SESSION_ID`/`PI_MODEL`/`PI_PROVIDER` env vars the bash
  *     tool's own guidelines tell the model to read. Do not copy that pattern verbatim.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -64,34 +64,6 @@ function composePreamble(sections: { title: string; body: string }[]): string {
   );
 }
 
-/** Extracts the body of bin/README.md's "## Current scripts" section, up to the next "## " heading. */
-function extractCurrentScripts(readmeText: string): string | null {
-  const heading = "## Current scripts";
-  const start = readmeText.indexOf(heading);
-  if (start === -1) return null;
-  const rest = readmeText.slice(start + heading.length);
-  const nextHeadingOffset = rest.indexOf("\n## ");
-  const body = nextHeadingOffset === -1 ? rest : rest.slice(0, nextHeadingOffset);
-  return body.trim();
-}
-
-/**
- * Reads bin/README.md and extracts the "## Current scripts" section. Returns null on any
- * failure (file missing/unreadable, or heading missing) — this is a doc file, not load-bearing
- * for PATH exposure or skill discovery, so its absence must degrade only the bin-scripts row of
- * the preamble, never take down the whole extension or the rest of the preamble (in particular,
- * toolVocabSection's content — including the anti-hallucination rule — must still be injected).
- */
-function readCurrentScripts(binDir: string): string | null {
-  let readmeText: string;
-  try {
-    readmeText = readFileSync(join(binDir, "README.md"), "utf8");
-  } catch {
-    return null;
-  }
-  return extractCurrentScripts(readmeText);
-}
-
 export default function (pi: ExtensionAPI): void {
   const here = dirname(fileURLToPath(import.meta.url));
   const root = findPluginRoot(here);
@@ -102,21 +74,11 @@ export default function (pi: ExtensionAPI): void {
     process.env.PATH = [...pathEntries, binDir].join(delimiter);
   }
 
-  // Only the bin-scripts section depends on bin/README.md; toolVocabSection is pure and never
-  // fails, so it must NOT be dragged down by a missing/unreadable README — Tier-1 vocabulary
-  // prose (including the anti-hallucination rule) stays on unconditionally, same posture as
-  // ask-user.ts's kill switch. composePreamble (via getPreamble() below) is still computed
-  // exactly once per session (cached after first call), so the single PREAMBLE_MARKER dedup
-  // check keeps proving something real.
-  const currentScripts = readCurrentScripts(binDir);
-  const binSection =
-    currentScripts === null
-      ? []
-      : [{ title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts }];
-
-  // Expand step: the generated section coexists with the bin/README.md splice above. A later
-  // commit removes binSection/readCurrentScripts/extractCurrentScripts once pi-extensions/tests
-  // have been retargeted onto this one — see docs/plugin-platform-decisions.md.
+  // toolVocabSection is pure and never fails, so it must NOT be dragged down by an
+  // unreadable/empty bin/ — Tier-1 vocabulary prose (including the anti-hallucination rule)
+  // stays on unconditionally, same posture as ask-user.ts's kill switch. composePreamble (via
+  // getPreamble() below) is still computed exactly once per session (cached after first call),
+  // so the single PREAMBLE_MARKER dedup check keeps proving something real.
   const generatedBinSection = binScriptsSection(root);
   const generatedSection = generatedBinSection === null ? [] : [generatedBinSection];
 
@@ -132,11 +94,7 @@ export default function (pi: ExtensionAPI): void {
   function getPreamble(): string {
     if (cachedPreamble === undefined) {
       const taskToolRegistered = pi.getActiveTools().includes(TASK_TOOL_NAME);
-      cachedPreamble = composePreamble([
-        ...binSection,
-        ...generatedSection,
-        toolVocabSection(root, taskToolRegistered),
-      ]);
+      cachedPreamble = composePreamble([...generatedSection, toolVocabSection(root, taskToolRegistered)]);
     }
     return cachedPreamble;
   }
@@ -147,10 +105,10 @@ export default function (pi: ExtensionAPI): void {
   }));
 
   pi.on("session_start", (_event, ctx: ExtensionContext) => {
-    if (currentScripts === null && !warnedMissingAnchor && ctx.hasUI) {
+    if (generatedBinSection === null && !warnedMissingAnchor && ctx.hasUI) {
       warnedMissingAnchor = true;
       ctx.ui.notify(
-        "swe-workbench: bin/README.md's '## Current scripts' section could not be read — the " +
+        "swe-workbench: bin/ could not be read (or has no swe-workbench-* scripts) — the " +
           "bin/ script inventory will not be injected into the system prompt this session.",
         "warning",
       );

--- a/pi/extensions/index.ts
+++ b/pi/extensions/index.ts
@@ -32,6 +32,7 @@ import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerAskUser } from "./ask-user.ts";
+import { binScriptsSection } from "./bin-scripts.ts";
 import { registerGuards } from "./guards.ts";
 import { registerSubagent, TASK_TOOL_NAME } from "./subagent.ts";
 import { toolVocabSection } from "./tool-vocab.ts";
@@ -113,6 +114,12 @@ export default function (pi: ExtensionAPI): void {
       ? []
       : [{ title: "swe-workbench bin/ scripts (bare commands, already on PATH)", body: currentScripts }];
 
+  // Expand step: the generated section coexists with the bin/README.md splice above. A later
+  // commit removes binSection/readCurrentScripts/extractCurrentScripts once pi-extensions/tests
+  // have been retargeted onto this one — see docs/plugin-platform-decisions.md.
+  const generatedBinSection = binScriptsSection(root);
+  const generatedSection = generatedBinSection === null ? [] : [generatedBinSection];
+
   let warnedMissingAnchor = false;
   let cachedPreamble: string | undefined;
 
@@ -125,7 +132,11 @@ export default function (pi: ExtensionAPI): void {
   function getPreamble(): string {
     if (cachedPreamble === undefined) {
       const taskToolRegistered = pi.getActiveTools().includes(TASK_TOOL_NAME);
-      cachedPreamble = composePreamble([...binSection, toolVocabSection(root, taskToolRegistered)]);
+      cachedPreamble = composePreamble([
+        ...binSection,
+        ...generatedSection,
+        toolVocabSection(root, taskToolRegistered),
+      ]);
     }
     return cachedPreamble;
   }

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1780,6 +1780,49 @@ def check_bin_wrappers():
         )
 
 
+_BASH_HELP_MARKER = "awk 'NR>1 && /^#/"
+_PY_HELP_MARKER_RE = re.compile(r'\(\s*"--help",\s*"-h"\s*\)')
+
+
+def check_bin_help_flags():
+    """Every bin/swe-workbench-* script must intercept a sole --help/-h
+    argument — this ratchet is what keeps the duplicated bash awk-header
+    blocks (inline by design, not extracted to a shared bin/lib/ file) and
+    the python docstring-print idiom from drifting apart. argparse-based
+    python scripts are exempt: their -h/--help comes free from argparse
+    itself and carries no literal marker to check."""
+    bin_dir = ROOT / "bin"
+    if not bin_dir.is_dir():
+        return
+    for wrapper in sorted(bin_dir.iterdir()):
+        if not wrapper.is_file() or wrapper.name == "README.md":
+            continue
+        if not wrapper.name.startswith("swe-workbench-"):
+            continue  # already flagged by check_bin_wrappers()
+        rel = wrapper.relative_to(ROOT)
+        try:
+            text = wrapper.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if text.startswith("#!/usr/bin/env python3"):
+            if "argparse" in text:
+                continue
+            if not (_PY_HELP_MARKER_RE.search(text) and "__doc__" in text):
+                fail(
+                    rel,
+                    'must intercept a sole --help/-h argument via '
+                    '`if len(argv) == 1 and argv[0] in ("--help", "-h"): print(__doc__)`',
+                )
+        elif text.startswith("#!/usr/bin/env bash"):
+            if _BASH_HELP_MARKER not in text:
+                fail(
+                    rel,
+                    "must intercept a sole --help/-h argument via the canonical awk-header "
+                    "block placed immediately after `set` and before any argument-consuming "
+                    "line",
+                )
+
+
 # ──────────────────────────────────────────────
 # Dependency-flow cycle checker
 # ──────────────────────────────────────────────
@@ -2497,6 +2540,7 @@ def main():
     check_hook_scripts()
     check_hook_script_permissions()
     check_bin_wrappers()
+    check_bin_help_flags()
     check_test_subprocess_env()
     check_no_cycles(cache=cache)
     check_browser_tool_gate(cache=cache)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1782,6 +1782,7 @@ def check_bin_wrappers():
 
 _BASH_HELP_MARKER = "awk 'NR>1 && /^#/"
 _PY_HELP_MARKER_RE = re.compile(r'\(\s*"--help",\s*"-h"\s*\)')
+_PY_ARGPARSE_RE = re.compile(r'\bimport argparse\b|\bargparse\.ArgumentParser\(')
 
 
 def check_bin_help_flags():
@@ -1805,7 +1806,7 @@ def check_bin_help_flags():
         except OSError:
             continue
         if text.startswith("#!/usr/bin/env python3"):
-            if "argparse" in text:
+            if _PY_ARGPARSE_RE.search(text):
                 continue
             if not (_PY_HELP_MARKER_RE.search(text) and "__doc__" in text):
                 fail(

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -14,6 +14,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from conftest import _CLEAN_ENV
 
 ROOT = Path(__file__).parent.parent
@@ -264,6 +266,32 @@ def test_e2e_skill_script_rejects_traversal():
         assert result.returncode == 1, f"expected rejection for skill={skill!r} script={script!r}"
         assert result.stdout == ""
         assert result.stderr.strip(), f"expected a stderr message for skill={skill!r} script={script!r}"
+
+
+# ──────────────────────────────────────────────
+# --help / -h conformance: every script must respond to a sole --help/-h
+# argument with exit 0 and non-empty, script-identifying stdout — not just
+# rc == 0, which both swe-workbench-doctor's old "always exits 0" behavior
+# and swe-workbench-gh-timeout's unhandled-passthrough behavior would
+# satisfy vacuously.
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(SCRIPTS))
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_help_flag_exits_zero_with_identifying_stdout(name, flag):
+    result = subprocess.run(
+        [str(BIN / name), flag],
+        capture_output=True, text=True,
+        env=dict(_CLEAN_ENV),
+    )
+    assert result.returncode == 0, (
+        f"bin/{name} {flag} must exit 0, got {result.returncode} (stderr: {result.stderr!r})"
+    )
+    assert result.stdout.strip(), f"bin/{name} {flag} must print non-empty stdout"
+    assert name in result.stdout, (
+        f"bin/{name} {flag} stdout must name the script itself, got: {result.stdout!r}"
+    )
 
 
 def test_e2e_skill_script_requires_both_args():

--- a/tests/test_diff_line_lookup_script.py
+++ b/tests/test_diff_line_lookup_script.py
@@ -11,7 +11,7 @@ Behavioral paths under test:
   - Not-found paths (exit 1): absent entirely, found on a context line, found on a removed line
   - Ambiguity (exit 2): multiple matching `+` lines, stdout empty, all candidates on stderr
   - Git-internal modes: default (git diff HEAD), --staged, --range=<rev>
-  - Wiring: SCRIPTS dict, shellcheck auto-discovery contract, bin/README.md,
+  - Wiring: SCRIPTS dict, shellcheck auto-discovery contract, --help output,
     agents/reviewer.md, workflow-pr-review-post/SKILL.md
 """
 
@@ -409,11 +409,12 @@ def test_shellcheck_coverage_contract_contains_wrapper():
     )
 
 
-def test_bin_readme_has_row():
-    text = (ROOT / "bin" / "README.md").read_text()
-    assert "swe-workbench-diff-line-lookup" in text, (
-        "bin/README.md must document swe-workbench-diff-line-lookup in the current scripts table"
+def test_help_flag_names_the_script():
+    result = subprocess.run(
+        [str(SCRIPT), "--help"], capture_output=True, text=True, env=dict(_CLEAN_ENV)
     )
+    assert result.returncode == 0
+    assert "swe-workbench-diff-line-lookup" in result.stdout
 
 
 def test_reviewer_agent_references_helper():

--- a/tests/test_lsp_literacy.py
+++ b/tests/test_lsp_literacy.py
@@ -8,7 +8,10 @@ the dependency on it was replaced with `bin/swe-workbench-lsp`, a stdlib-only
 script reachable via `Bash` from any harness. This file now pins that
 script-based contract: the four agents' shared prose still references it,
 the doc names its subcommands, the three orchestrator skills still carry the
-fallback sentence, and docs/dependencies.md still documents it.
+fallback sentence, docs/dependencies.md still documents it, and
+`pi/extensions/bin-scripts.ts`'s generated inventory section — the sole
+channel by which a Pi session learns `swe-workbench-lsp` exists — still
+names it and every one of its subcommands.
 
 Agent tools:/body content for these four agents is otherwise covered by
 `scripts/validate.py`'s check_lsp_tool_gate() (self-disarms once no agent
@@ -31,6 +34,7 @@ AGENTS_DIR = ROOT / "agents"
 SKILLS_DIR = ROOT / "skills"
 SHARED_DIR = ROOT / "shared"
 LSP_SRC = SHARED_DIR / "agents" / "lsp.md"
+BIN_SCRIPTS_TS = ROOT / "pi" / "extensions" / "bin-scripts.ts"
 
 # The four agents this feature's shared doc still targets.
 LSP_AGENTS = ["reviewer", "auditor", "debugger", "refactorer"]
@@ -155,36 +159,27 @@ def test_dependencies_doc_has_language_servers_section():
 
 
 # ──────────────────────────────────────────────────────────────
-# bin/README.md's Current scripts section is the sole channel by which a
-# Pi session learns swe-workbench-lsp exists (pi/extensions/index.ts
-# splices that section into the Tier-1 preamble)
+# pi/extensions/bin-scripts.ts's generated inventory section is the sole
+# channel by which a Pi session learns swe-workbench-lsp exists
+# (pi/extensions/index.ts composes binScriptsSection() into the Tier-1
+# preamble). No Node required — this is a structural read of the source
+# text, not a behavioural drive of the compiled module, so it cannot
+# silently skip the way a requires_node test could.
 # ──────────────────────────────────────────────────────────────
 
 
-def test_bin_readme_lsp_row_is_the_pi_discovery_surface():
-    """bin/README.md's Current scripts section names swe-workbench-lsp and
-    every one of its subcommands. pi/extensions/index.ts makes this section
-    the sole channel by which a Pi session learns the script exists, and
-    test_pi_extension.py only pins the section's first row
-    (swe-workbench-clean-ephemeral) — so deleting or renaming this row would
-    silently drop LSP from every Pi session with a fully green suite."""
-    path = ROOT / "bin" / "README.md"
-    assert path.exists(), "bin/README.md does not exist"
-    text = path.read_text(encoding="utf-8")
-    start = text.find("## Current scripts")
-    assert start != -1, "bin/README.md is missing the '## Current scripts' heading"
-    end = text.find("\n## ", start + len("## Current scripts"))
-    assert end != -1, "bin/README.md's Current scripts section has no terminating heading"
-    section = text[start:end]
-
-    lsp_row = next(
-        (line for line in section.splitlines() if "swe-workbench-lsp" in line),
-        None,
-    )
-    assert lsp_row is not None, (
-        "bin/README.md's Current scripts section is missing the swe-workbench-lsp row"
+def test_bin_scripts_ts_names_lsp_and_every_subcommand():
+    """bin-scripts.ts's CAPABILITY_ROWS entry for swe-workbench-lsp must name the script and
+    every one of its subcommands as source-text literals. This is the load-bearing "sole
+    discovery channel" guarantee for a Pi session — test_pi_extension.py's behavioural driver
+    test pins the same content reaching the composed system prompt, but that test is
+    requires_node-gated and can skip; this structural half cannot."""
+    assert BIN_SCRIPTS_TS.exists(), "pi/extensions/bin-scripts.ts does not exist"
+    text = BIN_SCRIPTS_TS.read_text(encoding="utf-8")
+    assert "swe-workbench-lsp" in text, (
+        "pi/extensions/bin-scripts.ts is missing a reference to swe-workbench-lsp"
     )
     for subcommand in [*SCRIPT_SUBCOMMANDS, "check"]:
-        assert subcommand in lsp_row, (
-            f"bin/README.md's swe-workbench-lsp row is missing the subcommand '{subcommand}'"
+        assert subcommand in text, (
+            f"pi/extensions/bin-scripts.ts is missing the LSP subcommand '{subcommand}'"
         )

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -796,6 +796,7 @@ def test_ask_user_ts_has_no_typebox_import():
 AGENT_SPEC_TS = EXTENSIONS_DIR / "agent-spec.ts"
 MODEL_POLICY_TS = EXTENSIONS_DIR / "model-policy.ts"
 SUBAGENT_TS = EXTENSIONS_DIR / "subagent.ts"
+BIN_SCRIPTS_TS = EXTENSIONS_DIR / "bin-scripts.ts"
 
 
 def test_agent_spec_ts_never_references_pi():
@@ -817,6 +818,16 @@ def test_model_policy_ts_never_references_pi():
     text = MODEL_POLICY_TS.read_text(encoding="utf-8")
     assert "pi-coding-agent" not in text, "model-policy.ts must not reference the Pi SDK at all"
     assert "node:child_process" not in text, "model-policy.ts must not spawn processes — that is subagent.ts's job"
+
+
+def test_bin_scripts_ts_never_references_pi():
+    """bin-scripts.ts is the domain layer for the generated bin/ inventory preamble section:
+    pure text generation from node:fs/node:path only, no Pi SDK reference and no process
+    spawning — index.ts owns composing it into the system prompt. Same posture, same test
+    shape, as test_agent_spec_ts_never_references_pi above."""
+    text = BIN_SCRIPTS_TS.read_text(encoding="utf-8")
+    assert "pi-coding-agent" not in text, "bin-scripts.ts must not reference the Pi SDK at all"
+    assert "node:child_process" not in text, "bin-scripts.ts must not spawn processes — that is index.ts's job"
 
 
 _TRANSLATION_TABLE_DRIVER = """

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -26,6 +26,8 @@ INDEX_TS = ROOT / "pi" / "extensions" / "index.ts"
 GUARDS_TS = ROOT / "pi" / "extensions" / "guards.ts"
 GUARD_RUNNER_TS = ROOT / "pi" / "extensions" / "guard-runner.ts"
 TOOL_VOCAB_TS = ROOT / "pi" / "extensions" / "tool-vocab.ts"
+BIN_SCRIPTS_TS = ROOT / "pi" / "extensions" / "bin-scripts.ts"
+BIN_DIR = ROOT / "bin"
 ASK_USER_TS = ROOT / "pi" / "extensions" / "ask-user.ts"
 BIN_README = ROOT / "bin" / "README.md"
 SKILLS_DIR = ROOT / "skills"
@@ -377,6 +379,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
         "cc-payload.ts",
         "guard-runner.ts",
         "tool-vocab.ts",
+        "bin-scripts.ts",
         "ask-user.ts",
         "agent-spec.ts",
         "model-policy.ts",
@@ -975,6 +978,67 @@ def test_tool_vocab_generated_skill_id_list_matches_disk(tmp_path_factory):
     on_disk = sorted(p.parent.name for p in SKILLS_DIR.glob("*/SKILL.md"))
     for skill_id in on_disk:
         assert skill_id in section["body"], f"{skill_id} missing from the generated skill legend"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural: bin-scripts.ts. Pure text generation from the real bin/ directory — no stub
+# `pi`/`ctx` needed, but still imported through Node under --experimental-strip-types since it
+# is a .ts module. Same driver shape as _TOOL_VOCAB_DRIVER above.
+# ---------------------------------------------------------------------------
+
+_BIN_SCRIPTS_DRIVER = """
+import { pathToFileURL } from "node:url";
+
+const [, , modPath, root] = process.argv;
+const mod = await import(pathToFileURL(modPath).href);
+const section = mod.binScriptsSection(root);
+console.log(JSON.stringify(section));
+"""
+
+
+def _bin_scripts_section(root, tmp_path_factory):
+    return _run_node(
+        _BIN_SCRIPTS_DRIVER, [str(BIN_SCRIPTS_TS), str(root)], tmp_path_factory, label="pi-bin-scripts-driver"
+    )
+
+
+@requires_node
+def test_bin_scripts_section_lists_every_script_on_disk(tmp_path_factory):
+    section = _bin_scripts_section(ROOT, tmp_path_factory)
+    assert section["title"] == "swe-workbench bin/ scripts (bare commands, already on PATH)"
+    on_disk = sorted(
+        p.name for p in BIN_DIR.iterdir() if p.is_file() and p.name.startswith("swe-workbench-")
+    )
+    for script_id in on_disk:
+        assert script_id in section["body"], f"{script_id} missing from the generated bin-scripts section"
+
+
+@requires_node
+def test_bin_scripts_section_names_lsp_and_its_subcommands(tmp_path_factory):
+    """swe-workbench-lsp is the sole CAPABILITY_ROWS entry — its subcommands must reach the
+    generated section verbatim, since this is the sole channel by which a Pi session learns the
+    script (and what it can do) exists."""
+    section = _bin_scripts_section(ROOT, tmp_path_factory)
+    assert "swe-workbench-lsp" in section["body"]
+    for subcommand in ["refs", "def", "impl", "callers", "callees", "hover", "symbols", "wsymbols", "check"]:
+        assert subcommand in section["body"], f"missing LSP subcommand {subcommand!r}"
+
+
+@requires_node
+def test_bin_scripts_section_is_null_when_bin_dir_has_no_scripts(tmp_path_factory):
+    empty_bin = tmp_path_factory.mktemp("pi-bin-scripts-empty")
+    section = _bin_scripts_section(empty_bin, tmp_path_factory)
+    assert section is None
+
+
+@requires_node
+def test_before_agent_start_injects_generated_bin_scripts_section(extension_result):
+    """Wiring assertion: the generated section's content (not just the old splice's) actually
+    reaches firstInjection.systemPrompt via the real index.ts composition."""
+    injected = extension_result["firstInjection"]["systemPrompt"]
+    assert "swe-workbench-lsp" in injected
+    for subcommand in ["refs", "def", "impl", "callers", "callees", "hover", "symbols", "wsymbols", "check"]:
+        assert subcommand in injected, f"missing LSP subcommand {subcommand!r} in injected preamble"
 
 
 @requires_node

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -29,7 +29,6 @@ TOOL_VOCAB_TS = ROOT / "pi" / "extensions" / "tool-vocab.ts"
 BIN_SCRIPTS_TS = ROOT / "pi" / "extensions" / "bin-scripts.ts"
 BIN_DIR = ROOT / "bin"
 ASK_USER_TS = ROOT / "pi" / "extensions" / "ask-user.ts"
-BIN_README = ROOT / "bin" / "README.md"
 SKILLS_DIR = ROOT / "skills"
 
 # Concatenated (not a single literal) so this fixture's shape never appears contiguous in this
@@ -220,17 +219,6 @@ def test_package_json_has_no_forbidden_pi_keys():
 def test_package_json_has_no_dependencies_key():
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
     assert "dependencies" not in data
-
-
-def test_bin_readme_current_scripts_section_has_a_terminating_heading():
-    text = BIN_README.read_text(encoding="utf-8")
-    start = text.find("## Current scripts")
-    assert start != -1, "bin/README.md must contain the literal '## Current scripts' heading"
-    next_heading = text.find("\n## ", start + len("## Current scripts"))
-    assert next_heading != -1, (
-        "a later '## ' heading must terminate the Current scripts section so extraction "
-        "in pi/extensions/index.ts has a well-defined end"
-    )
 
 
 def test_index_ts_has_no_hardcoded_root_hop():

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -280,10 +280,10 @@ def test_path_gains_bin_dir_exactly_once_after_two_factory_invocations(extension
 
 
 @requires_node
-def test_before_agent_start_injects_marker_and_first_script_row(extension_result):
+def test_before_agent_start_injects_marker_and_a_bin_script_id(extension_result):
     injected = extension_result["firstInjection"]["systemPrompt"]
     assert "<!-- swe-workbench:pi-bin-preamble -->" in injected
-    assert "swe-workbench-clean-ephemeral" in injected
+    assert "swe-workbench-doctor" in injected
 
 
 @requires_node
@@ -357,19 +357,20 @@ def test_before_agent_start_does_not_duplicate_on_already_injected_prompt(extens
 
 
 @requires_node
-def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
-    """A missing bin/README.md must not take down PATH exposure or skill discovery.
+def test_empty_bin_dir_degrades_gracefully(tmp_path_factory):
+    """A bin/ directory with zero swe-workbench-* entries must not take down PATH exposure or
+    skill discovery — binScriptsSection() returns null in this case (same fail-soft posture as
+    an unreadable bin/), so only the bin-scripts row of the preamble disappears.
 
-    Regression test: the extension used to read bin/README.md unguarded, so a missing file
-    threw synchronously inside the factory — which fails the whole extension, not just the
-    bin-scripts row of the preamble (the one failure mode the code already degrades for). The
-    rest of the preamble — tool-vocab.ts's content, including the anti-hallucination rule —
-    must still be injected; only the bin-scripts row disappears.
+    Regression test: the extension used to read bin/README.md unguarded for this same row, so a
+    missing file threw synchronously inside the factory — which failed the whole extension, not
+    just this one row. The rest of the preamble — tool-vocab.ts's content, including the
+    anti-hallucination rule — must still be injected regardless.
     """
     synthetic_root = tmp_path_factory.mktemp("pi-synthetic-root")
     (synthetic_root / ".claude-plugin").mkdir()
     (synthetic_root / ".claude-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
-    (synthetic_root / "bin").mkdir()  # deliberately no README.md
+    (synthetic_root / "bin").mkdir()  # deliberately empty — zero swe-workbench-* entries
     (synthetic_root / "skills").mkdir()
     synthetic_index = synthetic_root / "pi" / "extensions" / "index.ts"
     synthetic_index.parent.mkdir(parents=True)
@@ -391,7 +392,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
             (ROOT / "pi" / "extensions" / helper).read_text(encoding="utf-8"), encoding="utf-8"
         )
 
-    driver = tmp_path_factory.mktemp("pi-extension-driver-missing-readme") / "driver.mjs"
+    driver = tmp_path_factory.mktemp("pi-extension-driver-empty-bin") / "driver.mjs"
     driver.write_text(_DRIVER, encoding="utf-8")
     node = shutil.which("node")
     assert node is not None
@@ -411,7 +412,7 @@ def test_missing_bin_readme_degrades_gracefully(tmp_path_factory):
     assert str(synthetic_root / "bin") in parsed["pathEntries"]
     injected = parsed["firstInjection"]["systemPrompt"]
     assert "<!-- swe-workbench:pi-bin-preamble -->" in injected
-    assert "swe-workbench-clean-ephemeral" not in injected, "bin-scripts row must be absent"
+    assert "swe-workbench-doctor" not in injected, "bin-scripts row must be absent"
     assert "Claude Code -> Pi tool vocabulary" in injected, "tool-vocab section must still inject"
 
 


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Replaces `bin/README.md`'s "## Current scripts" table (8,210 chars ≈ 2,052 tokens, spliced verbatim into every Pi Coding Agent system prompt) with a generated, bare-id inventory computed from `readdirSync(bin/)` in a new SDK-free `pi/extensions/bin-scripts.ts` module, plus a one-entry `CAPABILITY_ROWS` allowlist for `swe-workbench-lsp` (the only script needing more than its own name to be usable) and a `<name> --help` discovery pointer.
- Ships as four internal commits in expand → retarget → contract order (per issue #682's rollout plan, since the old table was the sole channel by which a Pi session learned `swe-workbench-lsp` exists):
  1. Add `--help`/`-h` handlers to the 21 of 25 `bin/` scripts that lacked one, so the generated section's `--help` pointer is truthful from the start.
  2. Add `pi/extensions/bin-scripts.ts` and wire it into `index.ts` alongside the still-live old splice.
  3. Retarget the LSP-discovery and splice-presence/absence tests onto the new generated section.
  4. Remove the old `bin/README.md`-splice mechanism from `index.ts` and the table itself from `bin/README.md`.
  5. A small follow-up commit addressing two Low-severity findings from review (tighten the `argparse` exemption in the new `scripts/validate.py` ratchet; document `swe-workbench-gh-timeout`'s `--help` shadowing).
- Measured token delta: the generated section is ~302.5 tokens (`len(body)/4.0`), within the ticket's ~325±10% target — an ~85% reduction from the original splice.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` — clean (includes the new `--help` ratchet)

### Type-tailored checks (chore)
- [x] `npm run typecheck` — clean
- [x] `shellcheck bin/swe-workbench-*` (all touched bash scripts) — 0 issues
- [x] `python3 -m pytest tests/ -q` — 3500 passed, 3 skipped
- [x] Both required reviewers (plan-alignment + `swe-workbench:reviewer` diff review) dispatched in parallel — both returned "Ready to merge: Yes", no Critical/Important findings; two Low findings addressed in a follow-up commit

Closes #682
