### PR TITLE
[fix] Update Z.AI clamp docs/test for real glm-5.3 thinkingLevelMap

### DIFF
--- a/docs/cost-tiers.md
+++ b/docs/cost-tiers.md
@@ -122,18 +122,20 @@ this translation is the identity (portable effort passes straight through). For 
 `opus` dispatch strictly deeper than `sonnet` dispatch for the same nominal effort — `opus`'s table
 shifts effort up toward `max`, `sonnet`'s shifts it down toward `low`, both clamped at their end.
 
-**Z.AI clamp caveat.** The effective thinking level `MODEL_POLICY` emits is *nominal* — the
-installed Pi SDK clamps it further per what its own bundled catalog *declares* the target model
-supports, which is not the same thing as what the model actually supports. Per Z.AI's own spec,
-`glm-5.3` always reasons and genuinely supports `max` as one of its three real effort levels
-(`low`/`high`/`max`) — but the catalog pin as of `@earendil-works/pi-coding-agent` 0.84.2 carries
-no `thinkingLevelMap` for it at all, so *that dependency's* clamp logic reduces the nominal
-`zai.opus` value of `max` down to `high` at dispatch time — identical, today, to `zai.sonnet`'s
-nominal (and already-recognized) `high`. This is a limitation of the pinned catalog data, not of
-`glm-5.3` itself, and it's expected, not a bug: `MODEL_POLICY` encodes the forward-looking policy,
-and `tests/test_pi_contract.py` pins the current clamp directly against the bundled catalog data,
-so a future catalog bump that adds a proper `thinkingLevelMap` for `glm-5.3` fails that test
-loudly — the signal to revisit, not silently drift past.
+**Z.AI clamp caveat (resolved).** The effective thinking level `MODEL_POLICY` emits used to be
+*nominal only* — the installed Pi SDK clamped it further per what its own bundled catalog
+*declared* the target model supports, which didn't match what the model actually supports. Per
+Z.AI's own spec, `glm-5.3` always reasons and genuinely supports `max` as one of its three real
+effort levels (`low`/`high`/`max`); through `@earendil-works/pi-coding-agent` 0.84.2 the catalog
+pin carried no `thinkingLevelMap` for it at all, so *that dependency's* clamp logic reduced the
+nominal `zai.opus` value of `max` down to `high` at dispatch time — identical, then, to
+`zai.sonnet`'s nominal (and already-recognized) `high`. As of the 0.84.3 bump, the pinned catalog
+now ships a real `thinkingLevelMap` for `glm-5.3` (`low`/`high`/`max`), so `zai.opus`'s nominal
+`max` dispatches as genuine `max` — strictly deeper than `zai.sonnet`'s `high`, no longer clamped
+down to it. The opus/sonnet split on Z.AI is therefore real, dispatch-visible behavior now, not
+purely nominal. `tests/test_pi_contract.py` pins this directly against the bundled catalog data,
+so a future catalog change that drops `glm-5.3`'s `thinkingLevelMap` again fails that test
+loudly — the signal to revisit this caveat once more, not silently drift past.
 
 **Fallback.** For any provider outside the three above, an unrecognized/missing `model:` tier, an
 unrecognized/missing `effort:` value, or a tier/provider combination whose exact model id isn't in

--- a/docs/plugin-platform-decisions.md
+++ b/docs/plugin-platform-decisions.md
@@ -285,11 +285,11 @@ of model-dispatch mapping itself, and the actual implementation avoids it entire
   so the map shifts effort toward `max` for `opus` and toward `low` for `sonnet`, clamped at each
   end, to keep the two tiers distinguishable on the one axis left once the model id itself can't
   disambiguate them. See `docs/cost-tiers.md`'s "On the Pi Coding Agent" section for the full
-  matrix, the Z.AI clamp caveat (the installed SDK further clamps a nominal thinking level per
-  what its own bundled catalog *declares* the target model supports — a limitation of that
-  pinned catalog data today, not of `glm-5.3` itself, which per Z.AI's own spec genuinely
-  supports `max` — verified, not reimplemented, in `tests/test_pi_contract.py`'s pinned-catalog
-  test), and the four fallback reasons.
+  matrix, the Z.AI clamp caveat (as of the `@earendil-works/pi-coding-agent` 0.84.3 bump, the
+  installed SDK's bundled catalog ships a real `thinkingLevelMap` for `glm-5.3`, so the opus/sonnet
+  split is real, dispatch-visible behavior — not merely nominal; verified, not reimplemented, in
+  `tests/test_pi_contract.py`'s pinned-catalog test, which fails loudly if a future catalog bump
+  drops that map again), and the four fallback reasons.
 
 `tests/test_pi_contract.py::test_model_tiers_are_inventoried`, its `EFFORTS` counterpart, and an
 exhaustiveness check over `MODEL_POLICY`'s 3 providers x 3 tiers x 5 efforts ratchet the tier and

--- a/docs/session-scratch-adapters.md
+++ b/docs/session-scratch-adapters.md
@@ -166,7 +166,7 @@ nothing:
 
 - Active marker: non-empty `PI_SESSION_ID`; the marker is rejected if it contains control
   characters.
-- Pi (through 0.84.2) documents session metadata (`PI_SESSION_ID`, optional
+- Pi (through 0.84.3) documents session metadata (`PI_SESSION_ID`, optional
   `PI_SESSION_FILE`, configurable session storage) and JSONL session files — but no
   sanctioned session scratch directory. The adapter therefore returns its
   active-but-unsupported status and cleanup reports `SWEPT_SESSION_FILES=0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "typescript": "^7.0.2"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.84.2 <1",
-        "@earendil-works/pi-tui": ">=0.84.2 <1"
+        "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
+        "@earendil-works/pi-tui": ">=0.84.3 <1"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-coding-agent": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "typescript": "^7.0.2"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.84.2 <1",
-    "@earendil-works/pi-tui": ">=0.84.2 <1"
+    "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
+    "@earendil-works/pi-tui": ">=0.84.3 <1"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {

--- a/pi/extensions/model-policy.ts
+++ b/pi/extensions/model-policy.ts
@@ -78,12 +78,13 @@ const IDENTITY: Readonly<Record<Effort, ThinkingLevel>> = {
  *  clamped at `max` — reproducing the ticket-pinned `high -> max` translation (opus's default
  *  effort per DEFAULT_TIER_EFFORT is "high") while staying monotone and gapless over all five
  *  efforts. Per Z.AI's own spec, `glm-5.3` always reasons and genuinely supports `max` as one of
- *  its three real effort levels (`low`/`high`/`max`) — the currently-pinned Pi SDK's bundled
- *  catalog entry for it just has no `thinkingLevelMap` yet, so *that dependency's* clamp logic
- *  (not a limitation of the model itself) reduces `high`/`xhigh`/`max` all down to `high` at
- *  dispatch time today (see the pinned-catalog test in tests/test_pi_contract.py) —
- *  nominal-vs-effective divergence is expected and doesn't need runtime handling here (see this
- *  file's header). */
+ *  its three real effort levels (`low`/`high`/`max`) — the pinned Pi SDK's bundled catalog entry
+ *  for it now ships a real `thinkingLevelMap` for those three levels (see the pinned-catalog test
+ *  in tests/test_pi_contract.py), so this nominal `high -> max` shift dispatches as genuine `max`
+ *  thinking, no longer clamped down to `high` the way it was before that catalog bump.
+ *  `medium`/`xhigh` aren't directly supported and still round up to the nearest real level
+ *  (`high`/`max`) — that narrower nominal-vs-effective divergence is expected and doesn't need
+ *  runtime handling here (see this file's header). */
 const ZAI_OPUS_THINKING: Readonly<Record<Effort, ThinkingLevel>> = {
   low: "high",
   medium: "xhigh",

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -1139,18 +1139,23 @@ console.log(JSON.stringify({
 
 @requires_node
 @requires_pi_ai_catalog
-def test_zai_glm_5_3_clamps_nominal_max_to_high_in_pinned_catalog():
-    """Pins the Z.AI clamp this repo's MODEL_POLICY deliberately ships ahead of: the pinned Pi
-    SDK's bundled catalog *entry* for `glm-5.3` declares no `thinkingLevelMap` today (a gap in
-    that dependency's data, not in glm-5.3 itself — per Z.AI's own spec the model always reasons
-    and genuinely supports "max" as one of its three real effort levels: low/high/max), so the
-    installed SDK's own `clampThinkingLevel` (dist/models.js, @earendil-works/pi-coding-agent@
-    0.84.2's bundled pi-ai) reduces MODEL_POLICY.zai.opus's nominal "max" down to "high" at
-    dispatch time — identical to zai.sonnet's nominal "high". This drives the REAL SDK clamp
-    function against the REAL pinned catalog data, not a reimplementation of its logic. When a
-    future catalog bump adds a proper thinkingLevelMap for glm-5.3, this test fails loudly — the
-    signal that the opus/sonnet thinking-level split on Z.AI has become real and worth revisiting
-    docs/cost-tiers.md's Z.AI clamp caveat over, not a silent behavior change to discover later."""
+def test_zai_glm_5_3_dispatches_real_max_thinking_in_pinned_catalog():
+    """Successor to the signal test this replaces (`..._clamps_nominal_max_to_high_...`), which
+    pinned the Z.AI clamp this repo's MODEL_POLICY deliberately shipped ahead of: through
+    @earendil-works/pi-coding-agent@0.84.2, the pinned Pi SDK's bundled catalog *entry* for
+    `glm-5.3` declared no `thinkingLevelMap` at all (a gap in that dependency's data, not in
+    glm-5.3 itself — per Z.AI's own spec the model always reasons and genuinely supports "max" as
+    one of its three real effort levels: low/high/max), so the installed SDK's own
+    `clampThinkingLevel` (dist/models.js) reduced MODEL_POLICY.zai.opus's nominal "max" down to
+    "high" at dispatch time — identical to zai.sonnet's nominal "high". As of the 0.84.3 bump, the
+    pinned catalog now ships a real `thinkingLevelMap` for `glm-5.3` (low/high/max), so that clamp
+    no longer applies: zai.opus's nominal "max" dispatches as genuine "max", strictly deeper than
+    zai.sonnet's "high" — the opus/sonnet split documented in docs/cost-tiers.md's Z.AI clamp
+    caveat is now real, dispatch-visible behavior, not purely nominal. This drives the REAL SDK
+    clamp function against the REAL pinned catalog data, not a reimplementation of its logic. If a
+    future catalog change drops glm-5.3's thinkingLevelMap again, this test fails loudly — the
+    signal to revisit docs/cost-tiers.md's Z.AI clamp caveat once more, not a silent behavior
+    change to discover later."""
     node = shutil.which("node")
     assert node is not None
     assert _PI_AI_DATA_DIR is not None  # narrows for the type checker; requires_pi_ai_catalog already gates this
@@ -1168,12 +1173,12 @@ def test_zai_glm_5_3_clamps_nominal_max_to_high_in_pinned_catalog():
         )
     assert result.returncode == 0, f"driver failed: {result.stderr}"
     dumped = json.loads(result.stdout)
-    assert "xhigh" not in dumped["supported"] and "max" not in dumped["supported"], (
-        f"glm-5.3 now declares xhigh/max support ({dumped['supported']}) in the pinned catalog — "
-        "the zai opus/sonnet thinking-level split in MODEL_POLICY is no longer purely nominal; "
-        "revisit docs/cost-tiers.md's Z.AI clamp caveat and this test"
+    assert {"low", "high", "max"} <= set(dumped["supported"]), (
+        f"glm-5.3 no longer declares low/high/max support ({dumped['supported']}) in the pinned "
+        "catalog — the zai opus/sonnet thinking-level split in MODEL_POLICY may have reverted to "
+        "purely nominal; revisit docs/cost-tiers.md's Z.AI clamp caveat and this test"
     )
-    assert dumped["clampedMax"] == "high"
+    assert dumped["clampedMax"] == "max", "zai.opus's nominal max should dispatch as real max now"
     assert dumped["clampedHigh"] == "high"
 
 

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -81,7 +81,7 @@ PiCompatibleYamlLoader.add_implicit_resolver(
 )
 
 # Transcribed byte-for-byte from `substituteArgs`'s replacement regex in
-# @earendil-works/pi-coding-agent@0.84.2's dist/core/prompt-templates.js (also present,
+# @earendil-works/pi-coding-agent@0.84.3's dist/core/prompt-templates.js (also present,
 # unchanged, on that package's `src/core/prompt-templates.ts` at the same pin). Re-diff this
 # against the installed package (`grep -n substituteArgs node_modules/@earendil-works/
 # pi-coding-agent/dist/core/prompt-templates.js`) whenever the root `package.json`'s
@@ -190,7 +190,7 @@ def _body_after_frontmatter(path):
     and so cannot be offset from directly by counting its own newlines alone.
 
     Mirrors dist/utils/frontmatter.js's extractFrontmatter exactly (source at
-    @earendil-works/pi-coding-agent@0.84.2): normalize newlines ('\\r\\n' then '\\r' -> '\\n',
+    @earendil-works/pi-coding-agent@0.84.3): normalize newlines ('\\r\\n' then '\\r' -> '\\n',
     same as Pi's normalizeNewlines) before any offset math, find the closing '---' via
     indexOf from index 3, slice from 4 chars past that match, then strip(). Do NOT reuse
     _frontmatter_block's delimiter logic here — it requires an exact '\\n---\\n' match and
@@ -718,7 +718,7 @@ def test_no_pi_argument_substitution_hazard_in_commands():
                 violations.append(f"{path.relative_to(ROOT)}:{line_no}: {match.group(0)!r}")
     assert not violations, (
         "Pi's substituteArgs (dist/core/prompt-templates.js, "
-        "@earendil-works/pi-coding-agent@0.84.2) would rewrite these tokens — every "
+        "@earendil-works/pi-coding-agent@0.84.3) would rewrite these tokens — every "
         "alternative it matches other than literal `$ARGUMENTS` is replaced with the "
         "matched positional arg or, if unset, the empty string, silently corrupting the "
         "command body when swe-workbench's own commands are loaded as Pi prompt templates. "
@@ -747,8 +747,8 @@ def test_pi_extension_wires_commands_as_prompt_paths():
 # ---------------------------------------------------------------------------
 # ask_user_question schema-as-data ratchet. Pins pi/extensions/ask-user.ts's parameters to a
 # plain JSON-Schema object literal — never a TypeBox value import — since
-# @earendil-works/pi-ai's constrained-sampling.js (getJsonSchemaToolParameters, ~line 112 as of
-# pi-coding-agent@0.84.2) returns `tool.parameters` verbatim to the provider and nothing on the
+# @earendil-works/pi-ai's constrained-sampling.js (getJsonSchemaToolParameters, ~line 111 as of
+# pi-coding-agent@0.84.3) returns `tool.parameters` verbatim to the provider and nothing on the
 # registration path (dist/core/tools/tool-definition-wrapper.js) runs TypeBox's
 # Value.Check/Compile against it. Re-diff that citation directly if this test ever needs to
 # change: `grep -n getJsonSchemaToolParameters` against the installed pi-ai package.

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -166,7 +166,7 @@ def test_package_json_values():
         f"peerDependencies range must have an explicit floor and ceiling, got {peer_range!r}"
     )
     floor, ceiling = parts
-    assert floor == ">=0.84.2", (
+    assert floor == f">={dev_pin}", (
         f"peerDependencies floor must equal the devDependencies pin ({dev_pin!r}), got {floor!r}"
     )
     assert ceiling == "<1", (


### PR DESCRIPTION
## Summary
- The pinned `@earendil-works/pi-coding-agent` bump to 0.84.3 (merged separately in #685) now ships a real `thinkingLevelMap` for Z.AI's `glm-5.3` model, which broke a deliberate canary test (`tests/test_pi_contract.py::test_zai_glm_5_3_clamps_nominal_max_to_high_in_pinned_catalog`) whose own docstring predicted exactly this and instructed what to do about it.
- `zai.opus`'s nominal `max` effort no longer gets clamped down to `high` at dispatch time — it now dispatches as genuine `max`, making the `zai.opus`/`zai.sonnet` thinking-level split real and dispatch-visible instead of purely nominal.
- Renamed/updated the canary test to pin the new (correct) behavior, updated `pi/extensions/model-policy.ts`'s `ZAI_OPUS_THINKING` comment, and updated the "Z.AI clamp caveat" description in both `docs/cost-tiers.md` and `docs/plugin-platform-decisions.md` (the latter caught by review — it still described the old, now-stale state).
- No runtime dispatch logic changed; `MODEL_POLICY` was already correctly forward-looking for this.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [ ] Changed skills/commands/agents load without errors
- [ ] Examples in the diff were exercised manually

### Type-tailored checks (fix)
- [x] Reproduced the original failure (`python3 -m pytest tests/ -q` showed 1 failed, 3628 passed)
- [x] Verified the root cause empirically via node against the real pinned SDK/catalog (`getSupportedThinkingLevels` now returns `["low","high","max"]`; `clampThinkingLevel(model, "max")` now returns `"max"`)
- [x] Full suite green after the fix: `python3 -m pytest tests/ -q` → 3629 passed, 3 skipped
- [x] `npm run typecheck` passes
- [x] Reviewed via `swe-workbench:reviewer` — one real finding (stale doc in `docs/plugin-platform-decisions.md`) found and fixed

Issue: N/A — dependency-drift test fix, no tracking issue
