### PR TITLE
[fix] Resume merged-but-untagged releases after transport failures

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,10 +3,21 @@ set -euo pipefail
 
 # ── Preflight ────────────────────────────────────────────────
 
-BUMP="${1:-}"
-if [[ ! "$BUMP" =~ ^(patch|minor|major)$ ]]; then
-  echo "Usage: $0 <patch|minor|major>" >&2
-  exit 1
+RESUME_TAG=""
+if [[ "${1:-}" == "--resume" ]]; then
+  RESUME_TAG="${2:-}"
+  if [[ ! "$RESUME_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Usage: $0 <patch|minor|major>" >&2
+    echo "       $0 --resume vX.Y.Z   (finish a merged-but-untagged release)" >&2
+    exit 1
+  fi
+else
+  BUMP="${1:-}"
+  if [[ ! "$BUMP" =~ ^(patch|minor|major)$ ]]; then
+    echo "Usage: $0 <patch|minor|major>" >&2
+    echo "       $0 --resume vX.Y.Z   (finish a merged-but-untagged release)" >&2
+    exit 1
+  fi
 fi
 
 if ! gh auth status &>/dev/null; then
@@ -89,6 +100,109 @@ retry_transport() {
 
 retry_transport 5 "git fetch origin" git fetch origin
 retry_transport 5 "git pull" git pull --ff-only origin main
+
+# ── Resume an unfinished release ─────────────────────────────
+# A bump PR can merge and then lose its tag publication to a transport
+# failure. GitHub is the single source of truth for reconstruction — no local
+# checkpoint: headRefName survives branch deletion, mergeCommit pins the SHA,
+# and remote tag presence decides what is left to do. Fails closed on any
+# unverifiable field; never tags a commit the remote state does not prove.
+resume_release() {
+  local tag=$1
+  local ver=${tag#v}
+  local branch="chore/bump-${tag}"
+
+  echo "Resuming release ${tag}..."
+
+  local pr_json
+  pr_json=$(retry_transport 5 "gh pr list (${branch})" \
+    gh pr list --state merged --limit 20 \
+      --json number,headRefName,mergeCommit \
+      --jq "[.[] | select(.headRefName == \"${branch}\")][0]") || return 1
+  if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+    echo "Error: no merged PR found for branch '${branch}' — cannot resume ${tag}." >&2
+    echo "  Inspect: https://github.com/${GH_REPO}/pulls?q=is%3Apr+is%3Amerged+head%3A${branch}" >&2
+    return 1
+  fi
+
+  local pr_num merge_sha
+  pr_num=$(printf '%s' "$pr_json" | jq -r '.number')
+  merge_sha=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
+  if [[ -z "$merge_sha" || "$merge_sha" == "null" ]]; then
+    echo "Error: GitHub returned no merge commit for the '${branch}' PR." >&2
+    return 1
+  fi
+
+  # The merge SHA must be reachable from origin/main — never tag an
+  # unmerged or reverted commit.
+  if ! git merge-base --is-ancestor "$merge_sha" origin/main; then
+    echo "Error: merge SHA ${merge_sha} of PR #${pr_num} is not reachable from origin/main." >&2
+    echo "  Was the release reverted? Inspect before resuming." >&2
+    return 1
+  fi
+
+  # Every declared manifest at the merge SHA must carry the release version
+  # (mirrors the publication gate in .github/workflows/release.yml).
+  while IFS=$'\t' read -r path field; do
+    local at_sha
+    at_sha=$(git show "${merge_sha}:${path}" | jq -r "$field")
+    if [[ "$at_sha" != "$ver" ]]; then
+      echo "Error: ${path} at ${merge_sha} reports '${at_sha}', expected '${ver}'." >&2
+      return 1
+    fi
+  done < <(jq -r '.files[] | [.path, .field] | @tsv' .version-bump.json)
+
+  local remote_tag remote_tag_commit
+  remote_tag=$(retry_transport 5 "tag lookup ${tag}" \
+    git ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}") || return 1
+  # || true: grep exits 1 on no-match; pipefail would otherwise abort here.
+  remote_tag_commit=$(printf '%s' "$remote_tag" | grep '\^{}' | awk '{print $1}' || true)
+  [[ -z "$remote_tag_commit" ]] && remote_tag_commit=$(printf '%s' "$remote_tag" | awk '{print $1}' | head -1)
+  if [[ -n "$remote_tag_commit" ]]; then
+    if [[ "$remote_tag_commit" != "$merge_sha" ]]; then
+      echo "Error: remote tag ${tag} points to ${remote_tag_commit}, not merge commit ${merge_sha}." >&2
+      echo "  Inspect and delete the stale tag before re-running: git push origin :refs/tags/${tag}" >&2
+      return 1
+    fi
+    echo "Tag ${tag} already published at ${merge_sha} — nothing to do."
+    echo ""
+    echo "Resumed release complete!"
+    echo "  PR:       https://github.com/${GH_REPO}/pull/${pr_num}"
+    echo "  Tag:      ${tag}"
+    echo "  Release:  https://github.com/${GH_REPO}/releases/tag/${tag}"
+    return 0
+  fi
+
+  # --no-verify is safe ONLY here: the tuple above was verified against
+  # GitHub, and the PR's CI ran green on exactly this tree (a squash merge
+  # preserves the branch-head tree), so the pre-push hook would re-run
+  # validation that already passed. Fresh releases never skip the hook.
+  if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+    git tag -a "$tag" -m "Release ${tag}" "$merge_sha"
+  elif [[ "$(git rev-parse "${tag}^{commit}")" == "$merge_sha" ]]; then
+    echo "Tag ${tag} exists locally at ${merge_sha} — pushing."
+  else
+    echo "Error: local tag ${tag} points to $(git rev-parse "${tag}^{commit}"), not ${merge_sha}." >&2
+    echo "  Delete it before re-running: git tag -d ${tag}" >&2
+    return 1
+  fi
+  retry_transport 5 "tag push" git push --no-verify origin "$tag"
+
+  git branch -D "$branch" 2>/dev/null || true
+
+  echo ""
+  echo "Resumed release complete!"
+  echo "  PR:       https://github.com/${GH_REPO}/pull/${pr_num}"
+  echo "  Tag:      ${tag}"
+  echo "  Release:  https://github.com/${GH_REPO}/releases/tag/${tag}"
+  echo "  Re-run:   $0 <patch|minor|major> to start the next release"
+  return 0
+}
+
+if [[ -n "$RESUME_TAG" ]]; then
+  resume_release "$RESUME_TAG"
+  exit 0
+fi
 
 # ── Compute next version ─────────────────────────────────────
 
@@ -376,7 +490,7 @@ fi
 if git ls-remote --tags --exit-code origin "$TAG" >/dev/null 2>&1; then
   # Verify the existing tag targets the expected merge commit
   REMOTE_TAG_INFO=$(git ls-remote --tags origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" 2>/dev/null || true)
-  REMOTE_TAG_COMMIT=$(echo "$REMOTE_TAG_INFO" | grep '\^{}' | awk '{print $1}')
+  REMOTE_TAG_COMMIT=$(printf '%s' "$REMOTE_TAG_INFO" | grep '\^{}' | awk '{print $1}' || true)
   [[ -z "$REMOTE_TAG_COMMIT" ]] && REMOTE_TAG_COMMIT=$(echo "$REMOTE_TAG_INFO" | awk '{print $1}' | head -1)
   if [[ -n "$REMOTE_TAG_COMMIT" && "$REMOTE_TAG_COMMIT" != "$MERGE_SHA" ]]; then
     echo "Error: remote tag ${TAG} exists but points to ${REMOTE_TAG_COMMIT}, not merge commit ${MERGE_SHA}." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -61,8 +61,34 @@ case "$CURRENT_BRANCH" in
     ;;
 esac
 
-git fetch origin
-git pull --ff-only origin main
+# ── Transport retry helper ─────────────────────────────
+# One-shot git transport calls abort the whole release on a transient SSH
+# reset. Wrap them with the same bounded-retry contract as the CI-wait loop
+# below: classify (any non-zero exit = retryable transient), cap attempts,
+# sleep between attempts. Every wrapped command is safe to re-run — fetch
+# and ff-only pulls are read-only syncs, and pushes are idempotent ref
+# updates the remote rejects on mismatch.
+retry_transport() {
+  local max_attempts=$1 desc=$2
+  shift 2
+  local attempt=0
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
+      echo "Error: ${desc} failed after ${attempt} attempts (transient failure cap reached)." >&2
+      echo "  Re-run this script — it resumes the unfinished release." >&2
+      return 1
+    fi
+    echo "[$(date '+%H:%M:%S')] ${desc} transient failure (attempt ${attempt}/${max_attempts}); retrying in 10s..." >&2
+    sleep 10
+  done
+}
+
+retry_transport 5 "git fetch origin" git fetch origin
+retry_transport 5 "git pull" git pull --ff-only origin main
 
 # ── Compute next version ─────────────────────────────────────
 
@@ -141,9 +167,9 @@ REMOTE_BRANCH_SHA=$(git ls-remote origin "refs/heads/${BRANCH}" | awk '{print $1
 LOCAL_BRANCH_SHA=$(git rev-parse "$BRANCH")
 
 if [[ "$REBASED" -eq 1 ]] || [[ "$COMMITTED" -eq 1 && -n "$REMOTE_BRANCH_SHA" ]]; then
-  git push --force-with-lease -u origin "$BRANCH"
+  retry_transport 5 "branch push" git push --force-with-lease -u origin "$BRANCH"
 elif [[ -z "$REMOTE_BRANCH_SHA" ]] || [[ "$LOCAL_BRANCH_SHA" != "$REMOTE_BRANCH_SHA" ]]; then
-  git push -u origin "$BRANCH"
+  retry_transport 5 "branch push" git push -u origin "$BRANCH"
 else
   echo "Remote branch already up to date — skipping push."
 fi
@@ -318,7 +344,7 @@ if ! git checkout main; then
   echo "  Remedy: cd to the main worktree, switch off main, then re-run this script." >&2
   exit 1
 fi
-git pull --ff-only origin main
+retry_transport 5 "git pull" git pull --ff-only origin main
 
 MERGE_SHA=""
 POLL_TIMEOUT=60
@@ -360,10 +386,10 @@ if git ls-remote --tags --exit-code origin "$TAG" >/dev/null 2>&1; then
   echo "Tag ${TAG} already exists on origin — skipping."
 elif git rev-parse -q --verify "${TAG}^{tag}" >/dev/null 2>&1; then
   echo "Tag ${TAG} exists locally — pushing to origin."
-  git push origin "$TAG"
+  retry_transport 5 "tag push" git push origin "$TAG"
 else
   git tag -a "$TAG" -m "Release ${TAG}"
-  git push origin "$TAG"
+  retry_transport 5 "tag push" git push origin "$TAG"
 fi
 
 # Clean up local release branch (remote already deleted by --delete-branch)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -158,7 +158,7 @@ resume_release() {
   local failed_checks
   failed_checks=$(retry_transport 5 "gh pr view (${pr_num})" \
     gh pr view "$pr_num" --json statusCheckRollup \
-      --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED" or .state == "FAILURE" or .state == "ERROR")] | length') || return 1
+      --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED" or .conclusion == "STARTUP_FAILURE" or .state == "FAILURE" or .state == "ERROR")] | length') || return 1
   if [[ "$failed_checks" != "0" ]]; then
     echo "Error: PR #${pr_num} has failed CI checks — refusing to resume ${tag}." >&2
     echo "  The tag-push shortcut assumes CI ran green on this tree; inspect ${GH_REPO}/pull/${pr_num}." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -204,6 +204,54 @@ if [[ -n "$RESUME_TAG" ]]; then
   exit 0
 fi
 
+# discover_untagged_releases: emit "<tag>\t<pr>\t<merge-sha>" per merged bump
+# PR whose tag is absent from origin. headRefName is the primary key — it is
+# machine-generated and survives branch deletion. A tag deleted manually is
+# indistinguishable from an unpublished one; deletion is not an unpublish
+# intent this script can honor.
+discover_untagged_releases() {
+  local merged_prs ver num sha tag_out
+  merged_prs=$(retry_transport 5 "gh pr list" \
+    gh pr list --state merged --limit 20 \
+      --json number,headRefName,mergeCommit \
+      --jq '.[] | select(.headRefName | test("^chore/bump-v[0-9]+[.][0-9]+[.][0-9]+$")) | select(.mergeCommit.oid != null and .mergeCommit.oid != "") | [(.headRefName | sub("^chore/bump-"; "")), (.number | tostring), .mergeCommit.oid] | @tsv') || return 1
+  while IFS=$'\t' read -r ver num sha; do
+    [[ -n "$ver" ]] || continue
+    tag_out=$(retry_transport 5 "tag lookup ${ver}" \
+      git ls-remote --tags origin "refs/tags/${ver}") || return 1
+    if [[ -z "$tag_out" ]]; then
+      printf '%s\t%s\t%s\n' "$ver" "$num" "$sha"
+    fi
+  done <<<"$merged_prs"
+}
+
+# ── Resume unfinished releases (before computing a new version) ─
+# A rerun must finish a stranded release before deriving the next version —
+# otherwise it would compute NEXT from the already-bumped manifest and fork
+# a new release on top of an unpublished one (issue #695).
+UNTAGGED=$(discover_untagged_releases) || {
+  echo "Error: could not query GitHub for unfinished releases." >&2
+  exit 1
+}
+UNTAGGED_COUNT=0
+if [[ -n "$UNTAGGED" ]]; then
+  UNTAGGED_COUNT=$(printf '%s\n' "$UNTAGGED" | grep -c .)
+fi
+if [[ "$UNTAGGED_COUNT" -ge 2 ]]; then
+  echo "Error: multiple merged-but-untagged releases found — refusing to guess." >&2
+  printf '%s\n' "$UNTAGGED" | while IFS=$'\t' read -r ver num sha; do
+    echo "  ${ver}  PR #${num}  ${sha}" >&2
+  done
+  echo "Finish one explicitly with: $0 --resume vX.Y.Z" >&2
+  exit 1
+elif [[ "$UNTAGGED_COUNT" -eq 1 ]]; then
+  RESUME_TAG=$(printf '%s\n' "$UNTAGGED" | head -1 | cut -f1)
+  echo "Found unfinished release ${RESUME_TAG} (merged PR, missing tag) — resuming before starting a new release."
+  resume_release "$RESUME_TAG"
+  exit 0
+fi
+# No unfinished releases — fall through to a fresh release.
+
 # ── Compute next version ─────────────────────────────────────
 
 CURRENT=$(jq -r .version .claude-plugin/plugin.json)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -390,9 +390,9 @@ else
     if [[ $ELAPSED -ge $TIMEOUT ]]; then
       echo "Error: timed out waiting for CI on PR #${PR_NUM} after $((TIMEOUT / 60)) minutes." >&2
       echo "Check status at: ${PR_URL}" >&2
-      echo "Once CI passes, manually merge and tag with:" >&2
+      echo "Once CI passes, recover with:" >&2
       echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
-      echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+      echo "  $0 --resume ${TAG}" >&2
       exit 1
     fi
 
@@ -406,9 +406,9 @@ else
       if [[ $TRANSIENT_COUNT -ge $MAX_TRANSIENT ]]; then
         echo "Error: gh pr checks failed ${TRANSIENT_COUNT} times in a row (transient failure cap reached)." >&2
         echo "Check status at: ${PR_URL}" >&2
-        echo "Once CI passes, manually merge and tag with:" >&2
+        echo "Once CI passes, recover with:" >&2
         echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
-        echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+        echo "  $0 --resume ${TAG}" >&2
         exit 1
       fi
       echo "[$(date '+%H:%M:%S')] gh pr checks transient failure (rc=${CHECKS_RC}, attempt ${TRANSIENT_COUNT}/${MAX_TRANSIENT}); retrying in 10s..."
@@ -422,9 +422,9 @@ else
       if [[ $TRANSIENT_COUNT -ge $MAX_TRANSIENT ]]; then
         echo "Error: gh pr checks failed ${TRANSIENT_COUNT} times in a row (transient failure cap reached)." >&2
         echo "Check status at: ${PR_URL}" >&2
-        echo "Once CI passes, manually merge and tag with:" >&2
+        echo "Once CI passes, recover with:" >&2
         echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
-        echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+        echo "  $0 --resume ${TAG}" >&2
         exit 1
       fi
       echo "[$(date '+%H:%M:%S')] gh pr checks rc=8 but no output (attempt ${TRANSIENT_COUNT}/${MAX_TRANSIENT}); retrying in 10s..."
@@ -445,9 +445,9 @@ else
       if [[ "$FAILED" -gt 0 ]]; then
         echo "Error: ${FAILED} CI check(s) failed on PR #${PR_NUM}." >&2
         echo "Fix the failures at: ${PR_URL}" >&2
-        echo "Once CI passes, manually merge and tag with:" >&2
+        echo "Once CI passes, recover with:" >&2
         echo "  gh pr merge --squash --delete-branch ${PR_NUM}" >&2
-        echo "  git checkout main && git pull --ff-only && git tag -a ${TAG} -m 'Release ${TAG}' && git push origin ${TAG}" >&2
+        echo "  $0 --resume ${TAG}" >&2
         exit 1
       fi
 
@@ -521,7 +521,7 @@ done
 
 if [[ -z "$MERGE_SHA" ]]; then
   echo "Error: GitHub did not return mergeCommit.oid for PR #${PR_NUM} within ${POLL_TIMEOUT}s." >&2
-  echo "PR is merged; tagging skipped. Re-run this script — it is safe and idempotent." >&2
+  echo "PR is merged; tagging skipped. Re-run this script — it discovers the merged release and finishes it." >&2
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -226,8 +226,7 @@ discover_untagged_releases() {
 }
 
 # ── Resume unfinished releases (before computing a new version) ─
-# A rerun must finish a stranded release before deriving NEXT, or it forks
-# a new release on top of an unpublished one (issue #695).
+# A rerun must finish a stranded release before deriving NEXT (issue #695).
 UNTAGGED=$(discover_untagged_releases) || {
   echo "Error: could not query GitHub for unfinished releases." >&2
   exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,14 +82,20 @@ esac
 retry_transport() {
   local max_attempts=$1 desc=$2
   shift 2
-  local attempt=0
+  local attempt=0 out rc
   while true; do
-    if "$@"; then
+    set +e
+    out=$("$@" 2>&1)
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+      [[ -n "$out" ]] && printf '%s\n' "$out"
       return 0
     fi
     attempt=$((attempt + 1))
     if [[ "$attempt" -ge "$max_attempts" ]]; then
       echo "Error: ${desc} failed after ${attempt} attempts (transient failure cap reached)." >&2
+      [[ -n "$out" ]] && printf '%s\n' "$out" >&2
       echo "  Re-run this script — it resumes the unfinished release." >&2
       return 1
     fi
@@ -116,7 +122,7 @@ resume_release() {
 
   local pr_json
   pr_json=$(retry_transport 5 "gh pr list (${branch})" \
-    gh pr list --state merged --limit 20 \
+    gh pr list --state merged --limit 100 \
       --json number,headRefName,mergeCommit \
       --jq "[.[] | select(.headRefName == \"${branch}\")][0]") || return 1
   if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
@@ -141,16 +147,40 @@ resume_release() {
     return 1
   fi
 
+  # The PR's CI must have been green: the --no-verify shortcut below skips
+  # the pre-push hook precisely because CI validated this exact tree. A PR
+  # merged over red checks (admin override) loses that justification.
+  local failed_checks
+  failed_checks=$(retry_transport 5 "gh pr view (${pr_num})" \
+    gh pr view "$pr_num" --json statusCheckRollup \
+      --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .state == "FAILURE")] | length') || return 1
+  if [[ "$failed_checks" != "0" ]]; then
+    echo "Error: PR #${pr_num} has failed CI checks — refusing to resume ${tag}." >&2
+    echo "  The tag-push shortcut assumes CI ran green on this tree; inspect ${GH_REPO}/pull/${pr_num}." >&2
+    return 1
+  fi
+
   # Every declared manifest at the merge SHA must carry the release version
-  # (mirrors the publication gate in .github/workflows/release.yml).
+  # (mirrors the publication gate in .github/workflows/release.yml). The
+  # manifest LIST is also read at the SHA: reading the working-tree copy
+  # would judge an old release against files declared after it merged.
+  local declared_rows
+  if ! declared_rows=$(git show "${merge_sha}:.version-bump.json" 2>/dev/null \
+    | jq -r '.files[] | [.path, .field] | @tsv'); then
+    echo "Error: cannot read .version-bump.json at ${merge_sha} — refusing to skip manifest verification." >&2
+    return 1
+  fi
   while IFS=$'\t' read -r path field; do
     local at_sha
-    at_sha=$(git show "${merge_sha}:${path}" | jq -r "$field")
+    if ! at_sha=$(git show "${merge_sha}:${path}" 2>/dev/null | jq -r "$field"); then
+      echo "Error: cannot read ${path} at ${merge_sha} (declared in .version-bump.json)." >&2
+      return 1
+    fi
     if [[ "$at_sha" != "$ver" ]]; then
       echo "Error: ${path} at ${merge_sha} reports '${at_sha}', expected '${ver}'." >&2
       return 1
     fi
-  done < <(jq -r '.files[] | [.path, .field] | @tsv' .version-bump.json)
+  done <<<"$declared_rows"
 
   local remote_tag remote_tag_commit
   remote_tag=$(retry_transport 5 "tag lookup ${tag}" \
@@ -210,17 +240,17 @@ fi
 # indistinguishable from an unpublished one; deletion is not an unpublish
 # intent this script can honor.
 discover_untagged_releases() {
-  local merged_prs ver num sha tag_out
+  local merged_prs tag num sha tag_out
   merged_prs=$(retry_transport 5 "gh pr list" \
-    gh pr list --state merged --limit 20 \
+    gh pr list --state merged --limit 100 \
       --json number,headRefName,mergeCommit \
       --jq '.[] | select(.headRefName | test("^chore/bump-v[0-9]+[.][0-9]+[.][0-9]+$")) | select(.mergeCommit.oid != null and .mergeCommit.oid != "") | [(.headRefName | sub("^chore/bump-"; "")), (.number | tostring), .mergeCommit.oid] | @tsv') || return 1
-  while IFS=$'\t' read -r ver num sha; do
-    [[ -n "$ver" ]] || continue
-    tag_out=$(retry_transport 5 "tag lookup ${ver}" \
-      git ls-remote --tags origin "refs/tags/${ver}") || return 1
+  while IFS=$'\t' read -r tag num sha; do
+    [[ -n "$tag" ]] || continue
+    tag_out=$(retry_transport 5 "tag lookup ${tag}" \
+      git ls-remote --tags origin "refs/tags/${tag}") || return 1
     if [[ -z "$tag_out" ]]; then
-      printf '%s\t%s\t%s\n' "$ver" "$num" "$sha"
+      printf '%s\t%s\t%s\n' "$tag" "$num" "$sha"
     fi
   done <<<"$merged_prs"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,20 +82,25 @@ esac
 retry_transport() {
   local max_attempts=$1 desc=$2
   shift 2
-  local attempt=0 out rc
+  local attempt=0 out rc errfile
+  errfile=$(mktemp)
   while true; do
     set +e
-    out=$("$@" 2>&1)
+    out=$("$@" 2>"$errfile")
     rc=$?
     set -e
     if [[ "$rc" -eq 0 ]]; then
+      # Replay stdout only — callers parse it. stderr (progress, ssh
+      # warnings) must never leak into parsed output.
       [[ -n "$out" ]] && printf '%s\n' "$out"
+      rm -f "$errfile"
       return 0
     fi
     attempt=$((attempt + 1))
     if [[ "$attempt" -ge "$max_attempts" ]]; then
       echo "Error: ${desc} failed after ${attempt} attempts (transient failure cap reached)." >&2
-      [[ -n "$out" ]] && printf '%s\n' "$out" >&2
+      [[ -s "$errfile" ]] && cat "$errfile" >&2
+      rm -f "$errfile"
       echo "  Re-run this script — it resumes the unfinished release." >&2
       return 1
     fi
@@ -153,7 +158,7 @@ resume_release() {
   local failed_checks
   failed_checks=$(retry_transport 5 "gh pr view (${pr_num})" \
     gh pr view "$pr_num" --json statusCheckRollup \
-      --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .state == "FAILURE")] | length') || return 1
+      --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED" or .conclusion == "ACTION_REQUIRED" or .state == "FAILURE" or .state == "ERROR")] | length') || return 1
   if [[ "$failed_checks" != "0" ]]; then
     echo "Error: PR #${pr_num} has failed CI checks — refusing to resume ${tag}." >&2
     echo "  The tag-push shortcut assumes CI ran green on this tree; inspect ${GH_REPO}/pull/${pr_num}." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -226,8 +226,7 @@ discover_untagged_releases() {
 }
 
 # ── Resume unfinished releases (before computing a new version) ─
-# A rerun must finish a stranded release before deriving the next version —
-# otherwise it would compute NEXT from the already-bumped manifest and fork
+# A rerun must finish a stranded release before deriving NEXT, or it forks
 # a new release on top of an unpublished one (issue #695).
 UNTAGGED=$(discover_untagged_releases) || {
   echo "Error: could not query GitHub for unfinished releases." >&2

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -267,17 +267,33 @@ class TestResumeDynamic:
         assert "failed CI checks" in result.stderr
         assert not (tmp_path / "push_log").exists()
 
+    def test_timed_out_ci_check_fails_closed(self, tmp_path):
+        """Non-FAILURE terminal conclusions (TIMED_OUT, CANCELLED) must not
+        pass the CI gate — the fresh path treats cancel as failing too."""
+        _resume_env(
+            tmp_path,
+            _gh_stub(
+                _PR_JSON_OK,
+                rollup='{"statusCheckRollup":[{"conclusion":"TIMED_OUT"}]}',
+            ),
+            _git_stub_ok(tmp_path),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "failed CI checks" in result.stderr
+
     def test_manifest_list_unreadable_at_sha_fails_closed(self, tmp_path):
         """.version-bump.json itself missing at the merge SHA must fail loudly,
         not silently skip the manifest verification (fail-open guard)."""
         git_body = _git_stub_ok(tmp_path).replace(
-            "*.version-bump.json)",
+            """*.version-bump.json) printf '%s' '{"files":[{"path":".claude-plugin/plugin.json","field":".version"}]}' ;;""",
             '*.version-bump.json) echo "fatal: not found" >&2; exit 128 ;;',
         )
+        assert "exit 128" in git_body, "stub arm replacement failed to apply"
         _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
-        assert ".version-bump.json" in result.stderr
+        assert "refusing to skip manifest verification" in result.stderr
 
     def test_manifest_mismatch_fails_closed(self, tmp_path):
         _resume_env(
@@ -301,6 +317,21 @@ class TestResumeDynamic:
         assert not (
             tmp_path / "push_log"
         ).exists(), "must not push when the tag is already published"
+
+    def test_stderr_noise_on_success_does_not_pollute_tag_lookup(self, tmp_path):
+        """A successful ls-remote that also writes an ssh warning to stderr
+        must not corrupt the parsed tag state (false refusal / phantom tag)."""
+        git_body = _git_stub_ok(tmp_path).replace(
+            "ls-remote) printf ''",
+            "ls-remote) printf 'ssh: Warning: Permanently added host\\n' >&2; printf ''",
+        )
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        push_log = (tmp_path / "push_log").read_text()
+        assert (
+            "--no-verify" in push_log
+        ), "stderr noise on a successful lookup must not be parsed as tag state"
 
     def test_remote_tag_wrong_sha_fails_closed(self, tmp_path):
         git_body = _git_stub_ok(tmp_path).replace(
@@ -492,6 +523,26 @@ class TestDiscoveryDynamic:
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert "Found unfinished release v0.1.36" in result.stdout
+        assert (tmp_path / "discovery_log").read_text() == "resume v0.1.36\n"
+
+    def test_stderr_noise_on_success_does_not_defeat_discovery(self, tmp_path):
+        """gh succeeding while printing a warning must still surface the
+        untagged candidate — merged stderr would read as a phantom tag."""
+        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35"])
+        gh = tmp_path / "gh"
+        gh.write_text(
+            gh.read_text().replace(
+                'jq -r "$prog"',
+                'jq -r "$prog" 2>/dev/null; printf "ssh: Warning\\n" >&2',
+            )
+        )
+        result = _run_snippet(
+            _DISCOVERY_SNIPPET,
+            tmp_path,
+            {"MERGED_PRS_JSON": _MERGED_PRS_JSON},
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
         assert (tmp_path / "discovery_log").read_text() == "resume v0.1.36\n"
 
     def test_two_stacked_refuse_and_list(self, tmp_path):

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -31,13 +31,27 @@ def _write_stub(stub_dir: Path, name: str, body: str) -> None:
 
 
 def _run_snippet(
-    snippet: str, stub_dir: Path, extra_env: dict | None = None
+    snippet: str,
+    stub_dir: Path,
+    extra_env: dict | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess:
+    """Run a bash snippet under stubbed PATH.
+
+    Snippets that read repo-relative files (.version-bump.json) or whose
+    stubs write relative artifacts (push_log) must pass cwd= explicitly —
+    bash -c otherwise inherits the pytest process cwd.
+    """
     env = {**_CLEAN_ENV, "PATH": f"{stub_dir}:{_CLEAN_ENV.get('PATH', '')}"}
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
-        ["bash", "-c", snippet], capture_output=True, text=True, env=env, timeout=30
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        cwd=cwd,
     )
 
 
@@ -101,6 +115,213 @@ class TestRetryTransportStatic:
             assert re.search(
                 r"retry_transport\s+\d+\s+\"git pull[^\"]*\"\s+git pull --ff-only", ln
             ), f"Bare 'git pull --ff-only' outside retry_transport: {ln.strip()!r}"
+
+
+_RESUME_SNIPPET = textwrap.dedent("""\
+    set -euo pipefail
+    GH_REPO="owner/repo"
+    RESUME_TAG="v0.1.36"
+    retry_transport() {
+      local max_attempts=$1 desc=$2
+      shift 2
+      local attempt=0
+      while true; do
+        if "$@"; then
+          return 0
+        fi
+        attempt=$((attempt + 1))
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+          echo "Error: ${desc} failed after ${attempt} attempts." >&2
+          return 1
+        fi
+        sleep 10
+      done
+    }
+    resume_release() {
+      local tag=$1
+      local ver=${tag#v}
+      local branch="chore/bump-${tag}"
+      echo "Resuming release ${tag}..."
+      local pr_json
+      pr_json=$(retry_transport 5 "gh pr list (${branch})" \\
+        gh pr list --state merged --limit 20 \\
+          --json number,headRefName,mergeCommit \\
+          --jq "[.[] | select(.headRefName == \\"${branch}\\")][0]") || return 1
+      if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+        echo "Error: no merged PR found for branch '${branch}'." >&2
+        return 1
+      fi
+      local pr_num merge_sha
+      pr_num=$(printf '%s' "$pr_json" | jq -r '.number')
+      merge_sha=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
+      if ! git merge-base --is-ancestor "$merge_sha" origin/main; then
+        echo "Error: merge SHA ${merge_sha} of PR #${pr_num} is not reachable from origin/main." >&2
+        return 1
+      fi
+      while IFS=$'\\t' read -r path field; do
+        local at_sha
+        at_sha=$(git show "${merge_sha}:${path}" | jq -r "$field")
+        if [[ "$at_sha" != "$ver" ]]; then
+          echo "Error: ${path} at ${merge_sha} reports '${at_sha}', expected '${ver}'." >&2
+          return 1
+        fi
+      done < <(jq -r '.files[] | [.path, .field] | @tsv' .version-bump.json)
+      local remote_tag remote_tag_commit
+      remote_tag=$(retry_transport 5 "tag lookup ${tag}" \\
+        git ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}") || return 1
+      remote_tag_commit=$(printf '%s' "$remote_tag" | grep '\\^{}' | awk '{print $1}' || true)
+      [[ -z "$remote_tag_commit" ]] && remote_tag_commit=$(printf '%s' "$remote_tag" | awk '{print $1}' | head -1)
+      if [[ -n "$remote_tag_commit" ]]; then
+        if [[ "$remote_tag_commit" != "$merge_sha" ]]; then
+          echo "Error: remote tag ${tag} points to ${remote_tag_commit}, not merge commit ${merge_sha}." >&2
+          return 1
+        fi
+        echo "Tag ${tag} already published at ${merge_sha} — nothing to do."
+        return 0
+      fi
+      if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+        git tag -a "$tag" -m "Release ${tag}" "$merge_sha"
+      elif [[ "$(git rev-parse "${tag}^{commit}")" == "$merge_sha" ]]; then
+        echo "Tag ${tag} exists locally at ${merge_sha} — pushing."
+      else
+        echo "Error: local tag ${tag} points elsewhere." >&2
+        return 1
+      fi
+      retry_transport 5 "tag push" git push --no-verify origin "$tag"
+      echo "Resumed release complete!"
+      return 0
+    }
+    resume_release "$RESUME_TAG"
+""")
+
+
+def _resume_env(tmp_path: Path, gh_body: str, git_body: str) -> None:
+    _write_stub(tmp_path, "gh", gh_body)
+    _write_stub(tmp_path, "git", git_body)
+    (tmp_path / ".version-bump.json").write_text(
+        '{"files":[{"path":".claude-plugin/plugin.json","field":".version"}]}'
+    )
+
+
+class TestResumeStatic:
+    def test_resume_flag_usage_documented(self):
+        assert any(
+            "--resume vX.Y.Z" in ln and not _is_comment(ln)
+            for ln in _script_lines()
+        ), "usage text does not document --resume"
+
+    def test_resume_flag_validated(self):
+        assert any(
+            re.search(r"RESUME_TAG.*=~.*\^v\[0-9\]", ln) and not _is_comment(ln)
+            for ln in _script_lines()
+        ), "--resume argument is not regex-validated against vX.Y.Z"
+
+    def test_no_verify_appears_exactly_once_on_resume_push(self):
+        hits = [
+            ln.strip()
+            for ln in _script_lines()
+            if "--no-verify" in ln and not _is_comment(ln)
+        ]
+        assert len(hits) == 1, f"expected exactly 1 --no-verify line, got {hits}"
+        assert re.search(r"git push --no-verify", hits[0]), (
+            "--no-verify must live on the resume-path tag push"
+        )
+
+
+class TestResumeDynamic:
+    def test_happy_path_pushes_with_no_verify(self, tmp_path):
+        """Verified tuple → tag pushed with --no-verify (CI already validated the tree)."""
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
+            textwrap.dedent("""\
+            case "$1" in
+              merge-base) exit 0 ;;
+              show) printf '{"version":"0.1.36"}' ;;
+              ls-remote) printf '' ;;
+              rev-parse) exit 1 ;;
+              tag|push) printf '%s\\n' "$*" >> push_log ;;
+            esac
+            exit 0
+        """),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        push_log = (tmp_path / "push_log").read_text()
+        assert "--no-verify" in push_log, f"push args: {push_log!r}"
+
+    def test_no_merged_pr_fails_closed(self, tmp_path):
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf "null"; fi',
+            "exit 0",
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "no merged PR found" in result.stderr
+
+    def test_merge_sha_not_on_main_fails_closed(self, tmp_path):
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
+            'case "$1" in merge-base) exit 1 ;; *) exit 0 ;; esac',
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "not reachable from origin/main" in result.stderr
+
+    def test_manifest_mismatch_fails_closed(self, tmp_path):
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
+            textwrap.dedent("""\
+            case "$1" in
+              merge-base) exit 0 ;;
+              show) printf '{"version":"0.1.35"}' ;;
+              *) exit 0 ;;
+            esac
+        """),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "expected '0.1.36'" in result.stderr
+
+    def test_tag_already_published_is_success_no_push(self, tmp_path):
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
+            textwrap.dedent("""\
+            case "$1" in
+              merge-base) exit 0 ;;
+              show) printf '{"version":"0.1.36"}' ;;
+              ls-remote) printf 'c9035a0\\trefs/tags/v0.1.36\\nc9035a0\\trefs/tags/v0.1.36^{}\\n' ;;
+              *) exit 0 ;;
+            esac
+        """),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "already published" in result.stdout
+        assert not (tmp_path / "push_log").exists(), (
+            "must not push when the tag is already published"
+        )
+
+    def test_remote_tag_wrong_sha_fails_closed(self, tmp_path):
+        _resume_env(
+            tmp_path,
+            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
+            textwrap.dedent("""\
+            case "$1" in
+              merge-base) exit 0 ;;
+              show) printf '{"version":"0.1.36"}' ;;
+              ls-remote) printf 'deadbeef\\trefs/tags/v0.1.36\\ndeadbeef\\trefs/tags/v0.1.36^{}\\n' ;;
+              *) exit 0 ;;
+            esac
+        """),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "not merge commit" in result.stderr
 
 
 class TestRetryTransportDynamic:

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -55,28 +55,37 @@ def _run_snippet(
     )
 
 
-_RETRY_SNIPPET = textwrap.dedent("""\
-    set -euo pipefail
-    retry_transport() {
-      local max_attempts=$1 desc=$2
-      shift 2
-      local attempt=0
-      while true; do
-        if "$@"; then
-          return 0
-        fi
-        attempt=$((attempt + 1))
-        if [[ "$attempt" -ge "$max_attempts" ]]; then
-          echo "Error: ${desc} failed after ${attempt} attempts (transient failure cap reached)." >&2
-          echo "  Re-run this script — it resumes the unfinished release." >&2
-          return 1
-        fi
-        echo "[$(date '+%H:%M:%S')] ${desc} transient failure (attempt ${attempt}/${max_attempts}); retrying in 10s..." >&2
-        sleep 10
-      done
-    }
-    retry_transport 3 "git fetch" git fetch origin
-""")
+def _extract_functions(*names: str) -> str:
+    """Extract named top-level bash functions from release.sh verbatim.
+
+    Dynamic snippets are assembled from the REAL shipped bodies — a copied
+    snippet would drift from the script while the tests stay green (a drift
+    both Phase-4 reviewers flagged on the original copy-paste seam).
+    """
+    lines = RELEASE_SH.read_text().splitlines()
+    blocks = []
+    for name in names:
+        start = next(i for i, ln in enumerate(lines) if ln.startswith(f"{name}()"))
+        end = next(i for i in range(start, len(lines)) if lines[i] == "}")
+        blocks.append("\n".join(lines[start : end + 1]))
+    return "\n".join(blocks)
+
+
+def _extract_resume_wiring() -> str:
+    """Extract the top-level discovery wiring between its section markers."""
+    text = RELEASE_SH.read_text()
+    start = text.index("# ── Resume unfinished releases")
+    end = text.index("# ── Compute next version")
+    return text[start:end].rstrip()
+
+
+_RETRY_SNIPPET = "\n".join(
+    [
+        "set -euo pipefail",
+        _extract_functions("retry_transport"),
+        'retry_transport 3 "git fetch" git fetch origin',
+    ]
+)
 
 
 class TestRetryTransportStatic:
@@ -101,105 +110,85 @@ class TestRetryTransportStatic:
             ), f"No line matches required wrapper pattern: {pattern}"
 
     def test_git_pull_always_wrapped(self):
-        """Every executable 'git pull --ff-only' runs via retry_transport.
-
-        Echo'd guidance strings may mention git pull — they are recipes the
-        operator runs by hand, not transport ops this script executes. Task 4
-        replaces that guidance with --resume and guards it separately.
-        """
+        """Every executable 'git pull --ff-only' runs via retry_transport, and
+        no echo'd guidance teaches a manual pull recipe."""
         for ln in _script_lines():
             if _is_comment(ln) or "git pull --ff-only" not in ln:
                 continue
             if "echo " in ln:
-                continue
+                raise AssertionError(
+                    f"Guidance teaches a manual pull recipe: {ln.strip()!r}"
+                )
             assert re.search(
                 r"retry_transport\s+\d+\s+\"git pull[^\"]*\"\s+git pull --ff-only", ln
             ), f"Bare 'git pull --ff-only' outside retry_transport: {ln.strip()!r}"
 
 
-_RESUME_SNIPPET = textwrap.dedent("""\
-    set -euo pipefail
-    GH_REPO="owner/repo"
-    RESUME_TAG="v0.1.36"
-    retry_transport() {
-      local max_attempts=$1 desc=$2
-      shift 2
-      local attempt=0
-      while true; do
-        if "$@"; then
-          return 0
-        fi
-        attempt=$((attempt + 1))
-        if [[ "$attempt" -ge "$max_attempts" ]]; then
-          echo "Error: ${desc} failed after ${attempt} attempts." >&2
-          return 1
-        fi
-        sleep 10
-      done
-    }
-    resume_release() {
-      local tag=$1
-      local ver=${tag#v}
-      local branch="chore/bump-${tag}"
-      echo "Resuming release ${tag}..."
-      local pr_json
-      pr_json=$(retry_transport 5 "gh pr list (${branch})" \\
-        gh pr list --state merged --limit 20 \\
-          --json number,headRefName,mergeCommit \\
-          --jq "[.[] | select(.headRefName == \\"${branch}\\")][0]") || return 1
-      if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
-        echo "Error: no merged PR found for branch '${branch}'." >&2
-        return 1
-      fi
-      local pr_num merge_sha
-      pr_num=$(printf '%s' "$pr_json" | jq -r '.number')
-      merge_sha=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
-      if ! git merge-base --is-ancestor "$merge_sha" origin/main; then
-        echo "Error: merge SHA ${merge_sha} of PR #${pr_num} is not reachable from origin/main." >&2
-        return 1
-      fi
-      while IFS=$'\\t' read -r path field; do
-        local at_sha
-        at_sha=$(git show "${merge_sha}:${path}" | jq -r "$field")
-        if [[ "$at_sha" != "$ver" ]]; then
-          echo "Error: ${path} at ${merge_sha} reports '${at_sha}', expected '${ver}'." >&2
-          return 1
-        fi
-      done < <(jq -r '.files[] | [.path, .field] | @tsv' .version-bump.json)
-      local remote_tag remote_tag_commit
-      remote_tag=$(retry_transport 5 "tag lookup ${tag}" \\
-        git ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}") || return 1
-      remote_tag_commit=$(printf '%s' "$remote_tag" | grep '\\^{}' | awk '{print $1}' || true)
-      [[ -z "$remote_tag_commit" ]] && remote_tag_commit=$(printf '%s' "$remote_tag" | awk '{print $1}' | head -1)
-      if [[ -n "$remote_tag_commit" ]]; then
-        if [[ "$remote_tag_commit" != "$merge_sha" ]]; then
-          echo "Error: remote tag ${tag} points to ${remote_tag_commit}, not merge commit ${merge_sha}." >&2
-          return 1
-        fi
-        echo "Tag ${tag} already published at ${merge_sha} — nothing to do."
-        return 0
-      fi
-      if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
-        git tag -a "$tag" -m "Release ${tag}" "$merge_sha"
-      elif [[ "$(git rev-parse "${tag}^{commit}")" == "$merge_sha" ]]; then
-        echo "Tag ${tag} exists locally at ${merge_sha} — pushing."
-      else
-        echo "Error: local tag ${tag} points elsewhere." >&2
-        return 1
-      fi
-      retry_transport 5 "tag push" git push --no-verify origin "$tag"
-      echo "Resumed release complete!"
-      return 0
-    }
-    resume_release "$RESUME_TAG"
-""")
+_RESUME_SNIPPET = "\n".join(
+    [
+        "set -euo pipefail",
+        'GH_REPO="owner/repo"',
+        'RESUME_TAG="v0.1.36"',
+        _extract_functions("retry_transport", "resume_release"),
+        'resume_release "$RESUME_TAG"',
+    ]
+)
 
 
-def _resume_env(tmp_path: Path, gh_body: str, git_body: str) -> None:
+_PR_JSON_OK = (
+    '{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}'
+)
+
+
+def _resume_env(
+    tmp_path: Path,
+    gh_body: str,
+    git_body: str,
+) -> None:
+    """Wire gh/git stubs for the extracted resume_release snippet.
+
+    The git stub must be path-aware: resume reads BOTH the manifest list
+    (.version-bump.json) and each declared manifest at the merge SHA via
+    `git show <sha>:<path>`.
+    """
     _write_stub(tmp_path, "gh", gh_body)
     _write_stub(tmp_path, "git", git_body)
-    (tmp_path / ".version-bump.json").write_text(
-        '{"files":[{"path":".claude-plugin/plugin.json","field":".version"}]}'
+
+
+def _gh_stub(pr_list_json: str, rollup: str = '{"statusCheckRollup":[]}') -> str:
+    # Honors --jq by piping through real jq — the snippet consumes the same
+    # filtered shape real gh emits.
+    return textwrap.dedent(
+        f"""\
+        prog=""
+        prev=""
+        for a in "$@"; do
+          if [ "$prev" = "--jq" ]; then prog=$a; fi
+          prev=$a
+        done
+        if [ "$1" = "pr" ] && [ "$2" = "list" ]; then printf '[%s]' '{pr_list_json}' | jq -r "$prog"; exit $?; fi
+        if [ "$1" = "pr" ] && [ "$2" = "view" ]; then printf '%s' '{rollup}' | jq -r "$prog"; exit $?; fi
+        exit 0
+    """
+    )
+
+
+def _git_stub_ok(tmp_path: Path, manifest_json: str = '{"version":"0.1.36"}') -> str:
+    return textwrap.dedent(
+        f"""\
+        case "$1" in
+          merge-base) exit 0 ;;
+          show)
+            case "$2" in
+              *.version-bump.json) printf '%s' '{{"files":[{{"path":".claude-plugin/plugin.json","field":".version"}}]}}' ;;
+              *) printf '%s' '{manifest_json}' ;;
+            esac ;;
+          ls-remote) printf '' ;;
+          rev-parse) exit 1 ;;
+          tag|push) printf '%s\\n' "$*" >> push_log ;;
+        esac
+        exit 0
+    """
     )
 
 
@@ -222,82 +211,90 @@ class TestResumeStatic:
             if "--no-verify" in ln and not _is_comment(ln)
         ]
         assert len(hits) == 1, f"expected exactly 1 --no-verify line, got {hits}"
-        assert re.search(
-            r"git push --no-verify", hits[0]
-        ), "--no-verify must live on the resume-path tag push"
+        assert (
+            '"tag push"' in hits[0] and "git push --no-verify" in hits[0]
+        ), "--no-verify must live on the resume-path tag push only"
 
 
 class TestResumeDynamic:
     def test_happy_path_pushes_with_no_verify(self, tmp_path):
-        """Verified tuple → tag pushed with --no-verify (CI already validated the tree)."""
-        _resume_env(
-            tmp_path,
-            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
-            textwrap.dedent("""\
-            case "$1" in
-              merge-base) exit 0 ;;
-              show) printf '{"version":"0.1.36"}' ;;
-              ls-remote) printf '' ;;
-              rev-parse) exit 1 ;;
-              tag|push) printf '%s\\n' "$*" >> push_log ;;
-            esac
-            exit 0
-        """),
-        )
+        """Verified tuple -> tag pushed with --no-verify (CI already validated the tree)."""
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), _git_stub_ok(tmp_path))
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 0, f"stderr: {result.stderr}"
         push_log = (tmp_path / "push_log").read_text()
         assert "--no-verify" in push_log, f"push args: {push_log!r}"
 
     def test_no_merged_pr_fails_closed(self, tmp_path):
-        _resume_env(
-            tmp_path,
-            'if [ "$1" = "pr" ]; then printf "null"; fi',
-            "exit 0",
-        )
+        _resume_env(tmp_path, _gh_stub("null"), _git_stub_ok(tmp_path))
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
         assert "no merged PR found" in result.stderr
 
-    def test_merge_sha_not_on_main_fails_closed(self, tmp_path):
+    def test_mergecommit_null_fails_closed(self, tmp_path):
+        """A merged PR without a merge commit oid must not be resumable."""
         _resume_env(
             tmp_path,
-            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
-            'case "$1" in merge-base) exit 1 ;; *) exit 0 ;; esac',
+            _gh_stub(
+                '{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":null}'
+            ),
+            _git_stub_ok(tmp_path),
         )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "no merge commit" in result.stderr
+
+    def test_merge_sha_not_on_main_fails_closed(self, tmp_path):
+        git_body = _git_stub_ok(tmp_path).replace(
+            "merge-base) exit 0", "merge-base) exit 1"
+        )
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
         assert "not reachable from origin/main" in result.stderr
 
+    def test_failed_ci_checks_fail_closed(self, tmp_path):
+        """A PR merged over red CI must not take the --no-verify shortcut."""
+        _resume_env(
+            tmp_path,
+            _gh_stub(
+                _PR_JSON_OK, rollup='{"statusCheckRollup":[{"conclusion":"FAILURE"}]}'
+            ),
+            _git_stub_ok(tmp_path),
+        )
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "failed CI checks" in result.stderr
+        assert not (tmp_path / "push_log").exists()
+
+    def test_manifest_list_unreadable_at_sha_fails_closed(self, tmp_path):
+        """.version-bump.json itself missing at the merge SHA must fail loudly,
+        not silently skip the manifest verification (fail-open guard)."""
+        git_body = _git_stub_ok(tmp_path).replace(
+            "*.version-bump.json)",
+            '*.version-bump.json) echo "fatal: not found" >&2; exit 128 ;;',
+        )
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
+        result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
+        assert result.returncode == 1
+        assert ".version-bump.json" in result.stderr
+
     def test_manifest_mismatch_fails_closed(self, tmp_path):
         _resume_env(
             tmp_path,
-            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
-            textwrap.dedent("""\
-            case "$1" in
-              merge-base) exit 0 ;;
-              show) printf '{"version":"0.1.35"}' ;;
-              *) exit 0 ;;
-            esac
-        """),
+            _gh_stub(_PR_JSON_OK),
+            _git_stub_ok(tmp_path, manifest_json='{"version":"0.1.35"}'),
         )
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
         assert "expected '0.1.36'" in result.stderr
 
     def test_tag_already_published_is_success_no_push(self, tmp_path):
-        _resume_env(
-            tmp_path,
-            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
-            textwrap.dedent("""\
-            case "$1" in
-              merge-base) exit 0 ;;
-              show) printf '{"version":"0.1.36"}' ;;
-              ls-remote) printf 'c9035a0\\trefs/tags/v0.1.36\\nc9035a0\\trefs/tags/v0.1.36^{}\\n' ;;
-              *) exit 0 ;;
-            esac
-        """),
+        git_body = _git_stub_ok(tmp_path).replace(
+            "ls-remote) printf ''",
+            "ls-remote) printf 'c9035a0\\trefs/tags/v0.1.36\\nc9035a0\\trefs/tags/v0.1.36^{}\\n'",
         )
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert "already published" in result.stdout
@@ -306,18 +303,11 @@ class TestResumeDynamic:
         ).exists(), "must not push when the tag is already published"
 
     def test_remote_tag_wrong_sha_fails_closed(self, tmp_path):
-        _resume_env(
-            tmp_path,
-            'if [ "$1" = "pr" ]; then printf \'{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}\'; fi',
-            textwrap.dedent("""\
-            case "$1" in
-              merge-base) exit 0 ;;
-              show) printf '{"version":"0.1.36"}' ;;
-              ls-remote) printf 'deadbeef\\trefs/tags/v0.1.36\\ndeadbeef\\trefs/tags/v0.1.36^{}\\n' ;;
-              *) exit 0 ;;
-            esac
-        """),
+        git_body = _git_stub_ok(tmp_path).replace(
+            "ls-remote) printf ''",
+            "ls-remote) printf 'deadbeef\\trefs/tags/v0.1.36\\ndeadbeef\\trefs/tags/v0.1.36^{}\\n'",
         )
+        _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
         assert "not merge commit" in result.stderr
@@ -343,7 +333,11 @@ class TestRetryTransportDynamic:
         assert (tmp_path / "count").read_text().strip() == "3"
 
     def test_persistent_failure_caps_out(self, tmp_path):
-        _write_stub(tmp_path, "git", "exit 128")
+        _write_stub(
+            tmp_path,
+            "git",
+            'echo "fatal: Could not read from remote repository." >&2; exit 128',
+        )
         _write_stub(
             tmp_path,
             "sleep",
@@ -357,6 +351,10 @@ class TestRetryTransportDynamic:
         result = _run_snippet(_RETRY_SNIPPET, tmp_path)
         assert result.returncode == 1
         assert "transient failure cap reached" in result.stderr
+        assert result.stderr.count("Could not read from remote repository") == 1, (
+            "the underlying error must be surfaced exactly once (at the cap), "
+            "not leaked on every transient attempt nor swallowed entirely"
+        )
         assert (
             (tmp_path / "sleeps").read_text().strip() == "2"
         ), "cap(3) allows 2 sleeps, then the 3rd failure aborts"
@@ -370,59 +368,21 @@ _DISCOVERY_JQ = (
     '| [(.headRefName | sub("^chore/bump-"; "")), (.number | tostring), .mergeCommit.oid] | @tsv'
 )
 
-_DISCOVERY_SNIPPET = textwrap.dedent("""\
-    set -euo pipefail
-    retry_transport() {
-      local max_attempts=$1 desc=$2
-      shift 2
-      local attempt=0
-      while true; do
-        if "$@"; then
-          return 0
-        fi
-        attempt=$((attempt + 1))
-        if [[ "$attempt" -ge "$max_attempts" ]]; then
-          return 1
-        fi
-        sleep 10
-      done
-    }
-    discover_untagged_releases() {
-      local merged_prs ver num sha tag_out
-      merged_prs=$(retry_transport 5 "gh pr list" \\
-        gh pr list --state merged --limit 20 \\
-          --json number,headRefName,mergeCommit \\
-          --jq '__DISCOVERY_JQ__') || return 1
-      while IFS=$'\\t' read -r ver num sha; do
-        [[ -n "$ver" ]] || continue
-        tag_out=$(retry_transport 5 "tag lookup ${ver}" \\
-          git ls-remote --tags origin "refs/tags/${ver}") || return 1
-        if [[ -z "$tag_out" ]]; then
-          printf '%s\\t%s\\t%s\\n' "$ver" "$num" "$sha"
-        fi
-      done <<<"$merged_prs"
-    }
-    UNTAGGED=$(discover_untagged_releases) || { echo "Error: could not query GitHub for unfinished releases." >&2; exit 1; }
-    UNTAGGED_COUNT=0
-    if [[ -n "$UNTAGGED" ]]; then
-      UNTAGGED_COUNT=$(printf '%s\\n' "$UNTAGGED" | grep -c .)
-    fi
-    if [[ "$UNTAGGED_COUNT" -ge 2 ]]; then
-      echo "Error: multiple merged-but-untagged releases found — refusing to guess." >&2
-      printf '%s\\n' "$UNTAGGED" | while IFS=$'\\t' read -r ver num sha; do
-        echo "  ${ver}  PR #${num}  ${sha}" >&2
-      done
-      echo "Finish one explicitly with: release.sh --resume vX.Y.Z" >&2
-      exit 1
-    elif [[ "$UNTAGGED_COUNT" -eq 1 ]]; then
-      RESUME_TAG=$(printf '%s\\n' "$UNTAGGED" | head -1 | cut -f1)
-      echo "Found unfinished release ${RESUME_TAG} — resuming before starting a new release."
-      printf 'resume %s\\n' "$RESUME_TAG" >> discovery_log
-      exit 0
-    fi
-    echo "No unfinished releases — starting a fresh one."
-    exit 0
-""").replace("__DISCOVERY_JQ__", _DISCOVERY_JQ)
+_DISCOVERY_SNIPPET = "\n".join(
+    [
+        "set -euo pipefail",
+        _extract_functions(
+            "retry_transport", "discover_untagged_releases", "resume_release"
+        ),
+        # Override resume_release with a logging stub so the wiring test
+        # exercises the discovery DECISIONS; tuple verification has its own
+        # extracted-body tests in TestResumeDynamic.
+        "resume_release() { printf 'resume %s\\n' \"$1\" >> discovery_log; }",
+        _extract_resume_wiring(),
+        'echo "No unfinished releases — starting a fresh one."',
+        "exit 0",
+    ]
+)
 
 _MERGED_PRS_JSON = """[
   {"number": 691, "headRefName": "chore/bump-v0.1.35", "mergeCommit": {"oid": "59c9208"}},
@@ -453,10 +413,31 @@ class TestDiscoveryStatic:
         ), "discovery wiring must run before the 'Compute next version' section"
 
     def test_discovery_jq_program_pinned(self):
+        """The full --jq program must appear verbatim (single line) in the script."""
         assert any(
-            _DISCOVERY_JQ.split("| select(.mergeCommit")[0].rstrip() in ln
-            for ln in _script_lines()
+            _DISCOVERY_JQ in ln for ln in _script_lines()
         ), "release.sh discovery --jq program drifted from the pinned test copy"
+
+    def test_pr_list_window_covers_stranded_releases(self):
+        """Both merged-PR lookups must use --limit 100 — a stranded release is
+        exactly the PR most likely to have fallen out of a busy merge window."""
+        wrapped = [
+            ln
+            for ln in _script_lines()
+            if not _is_comment(ln)
+            and "gh pr list" in ln
+            and "--state merged" in ln
+            and "--limit 100" in ln
+        ]
+        assert (
+            len(wrapped) == 2
+        ), f"expected 2 merged-PR lookups with --limit 100, found {len(wrapped)}: {wrapped}"
+
+    def test_resume_reads_manifest_list_at_merge_sha(self):
+        assert any(
+            'git show "${merge_sha}:.version-bump.json"' in ln and not _is_comment(ln)
+            for ln in _script_lines()
+        ), "manifest list must be read at the merge SHA, not the working tree"
 
     def test_ambiguity_guard_requires_resume(self):
         assert any(

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -96,9 +96,9 @@ class TestRetryTransportStatic:
             r"retry_transport\s+\d+\s+\"branch push[^\"]*\"\s+git push\b",
             r"retry_transport\s+\d+\s+\"tag push[^\"]*\"\s+git push\b",
         ):
-            assert any(re.search(pattern, ln) for ln in lines), (
-                f"No line matches required wrapper pattern: {pattern}"
-            )
+            assert any(
+                re.search(pattern, ln) for ln in lines
+            ), f"No line matches required wrapper pattern: {pattern}"
 
     def test_git_pull_always_wrapped(self):
         """Every executable 'git pull --ff-only' runs via retry_transport.
@@ -206,8 +206,7 @@ def _resume_env(tmp_path: Path, gh_body: str, git_body: str) -> None:
 class TestResumeStatic:
     def test_resume_flag_usage_documented(self):
         assert any(
-            "--resume vX.Y.Z" in ln and not _is_comment(ln)
-            for ln in _script_lines()
+            "--resume vX.Y.Z" in ln and not _is_comment(ln) for ln in _script_lines()
         ), "usage text does not document --resume"
 
     def test_resume_flag_validated(self):
@@ -223,9 +222,9 @@ class TestResumeStatic:
             if "--no-verify" in ln and not _is_comment(ln)
         ]
         assert len(hits) == 1, f"expected exactly 1 --no-verify line, got {hits}"
-        assert re.search(r"git push --no-verify", hits[0]), (
-            "--no-verify must live on the resume-path tag push"
-        )
+        assert re.search(
+            r"git push --no-verify", hits[0]
+        ), "--no-verify must live on the resume-path tag push"
 
 
 class TestResumeDynamic:
@@ -302,9 +301,9 @@ class TestResumeDynamic:
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert "already published" in result.stdout
-        assert not (tmp_path / "push_log").exists(), (
-            "must not push when the tag is already published"
-        )
+        assert not (
+            tmp_path / "push_log"
+        ).exists(), "must not push when the tag is already published"
 
     def test_remote_tag_wrong_sha_fails_closed(self, tmp_path):
         _resume_env(
@@ -358,9 +357,9 @@ class TestRetryTransportDynamic:
         result = _run_snippet(_RETRY_SNIPPET, tmp_path)
         assert result.returncode == 1
         assert "transient failure cap reached" in result.stderr
-        assert (tmp_path / "sleeps").read_text().strip() == "2", (
-            "cap(3) allows 2 sleeps, then the 3rd failure aborts"
-        )
+        assert (
+            (tmp_path / "sleeps").read_text().strip() == "2"
+        ), "cap(3) allows 2 sleeps, then the 3rd failure aborts"
 
 
 # The exact gh --jq program used by discovery. Duplicated here so the tests
@@ -450,9 +449,9 @@ class TestDiscoveryStatic:
             and "()" not in ln
             and not _is_comment(ln)
         )
-        assert wiring_idx < compute_idx, (
-            "discovery wiring must run before the 'Compute next version' section"
-        )
+        assert (
+            wiring_idx < compute_idx
+        ), "discovery wiring must run before the 'Compute next version' section"
 
     def test_discovery_jq_program_pinned(self):
         assert any(
@@ -530,9 +529,7 @@ class TestDiscoveryDynamic:
         assert "--resume" in result.stderr
 
     def test_all_tagged_fresh_release(self, tmp_path):
-        self._make_stubs(
-            tmp_path, tagged=["refs/tags/v0.1.35", "refs/tags/v0.1.36"]
-        )
+        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35", "refs/tags/v0.1.36"])
         result = _run_snippet(
             _DISCOVERY_SNIPPET,
             tmp_path,
@@ -584,9 +581,9 @@ class TestFailurePathMessaging:
         for ln in _script_lines():
             if _is_comment(ln) or "echo" not in ln:
                 continue
-            assert "git tag -a" not in ln, (
-                f"Guidance still teaches manual tagging: {ln.strip()!r}"
-            )
+            assert (
+                "git tag -a" not in ln
+            ), f"Guidance still teaches manual tagging: {ln.strip()!r}"
 
     def test_ci_failure_paths_advertise_resume(self):
         """Every 'Once CI passes' guidance must offer the --resume path."""

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -536,6 +536,7 @@ class TestDiscoveryDynamic:
                 'jq -r "$prog" 2>/dev/null; printf "ssh: Warning\\n" >&2',
             )
         )
+        assert "ssh: Warning" in gh.read_text(), "stub noise injection failed to apply"
         result = _run_snippet(
             _DISCOVERY_SNIPPET,
             tmp_path,

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -1,0 +1,142 @@
+"""
+Regression tests for resume of merged-but-untagged releases (issue #695).
+
+A release stranded between PR merge and tag publication must be finished by
+a re-run; transient git/gh transport failures must retry boundedly instead
+of aborting the release mid-flight.
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+RELEASE_SH = Path(__file__).parent.parent / "scripts" / "release.sh"
+
+
+def _script_lines() -> list[str]:
+    return RELEASE_SH.read_text().splitlines()
+
+
+def _is_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def _write_stub(stub_dir: Path, name: str, body: str) -> None:
+    stub = stub_dir / name
+    stub.write_text(f"#!/bin/sh\n{body}\n")
+    stub.chmod(0o755)
+
+
+def _run_snippet(
+    snippet: str, stub_dir: Path, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    env = {**_CLEAN_ENV, "PATH": f"{stub_dir}:{_CLEAN_ENV.get('PATH', '')}"}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, env=env, timeout=30
+    )
+
+
+_RETRY_SNIPPET = textwrap.dedent("""\
+    set -euo pipefail
+    retry_transport() {
+      local max_attempts=$1 desc=$2
+      shift 2
+      local attempt=0
+      while true; do
+        if "$@"; then
+          return 0
+        fi
+        attempt=$((attempt + 1))
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+          echo "Error: ${desc} failed after ${attempt} attempts (transient failure cap reached)." >&2
+          echo "  Re-run this script — it resumes the unfinished release." >&2
+          return 1
+        fi
+        echo "[$(date '+%H:%M:%S')] ${desc} transient failure (attempt ${attempt}/${max_attempts}); retrying in 10s..." >&2
+        sleep 10
+      done
+    }
+    retry_transport 3 "git fetch" git fetch origin
+""")
+
+
+class TestRetryTransportStatic:
+    def test_retry_transport_defined(self):
+        assert any(
+            ln.startswith("retry_transport()")
+            for ln in _script_lines()
+            if not _is_comment(ln)
+        ), "retry_transport() function definition not found"
+
+    def test_transport_ops_are_wrapped(self):
+        """fetch, both pulls, and the tag push must run via retry_transport."""
+        lines = [ln for ln in _script_lines() if not _is_comment(ln)]
+        for pattern in (
+            r"retry_transport\s+\d+\s+\"git fetch[^\"]*\"\s+git fetch\b",
+            r"retry_transport\s+\d+\s+\"git pull[^\"]*\"\s+git pull --ff-only\b",
+            r"retry_transport\s+\d+\s+\"branch push[^\"]*\"\s+git push\b",
+            r"retry_transport\s+\d+\s+\"tag push[^\"]*\"\s+git push\b",
+        ):
+            assert any(re.search(pattern, ln) for ln in lines), (
+                f"No line matches required wrapper pattern: {pattern}"
+            )
+
+    def test_git_pull_always_wrapped(self):
+        """Every executable 'git pull --ff-only' runs via retry_transport.
+
+        Echo'd guidance strings may mention git pull — they are recipes the
+        operator runs by hand, not transport ops this script executes. Task 4
+        replaces that guidance with --resume and guards it separately.
+        """
+        for ln in _script_lines():
+            if _is_comment(ln) or "git pull --ff-only" not in ln:
+                continue
+            if "echo " in ln:
+                continue
+            assert re.search(
+                r"retry_transport\s+\d+\s+\"git pull[^\"]*\"\s+git pull --ff-only", ln
+            ), f"Bare 'git pull --ff-only' outside retry_transport: {ln.strip()!r}"
+
+
+class TestRetryTransportDynamic:
+    def test_transient_then_success(self, tmp_path):
+        """git fails twice then succeeds → exit 0, three attempts recorded."""
+        _write_stub(
+            tmp_path,
+            "git",
+            textwrap.dedent(f"""\
+            COUNT=$(cat {tmp_path}/count 2>/dev/null || echo 0)
+            COUNT=$((COUNT + 1))
+            printf '%d\\n' "$COUNT" > {tmp_path}/count
+            [ "$COUNT" -ge 3 ] && exit 0
+            exit 128
+        """),
+        )
+        _write_stub(tmp_path, "sleep", "exit 0")
+        result = _run_snippet(_RETRY_SNIPPET, tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert (tmp_path / "count").read_text().strip() == "3"
+
+    def test_persistent_failure_caps_out(self, tmp_path):
+        _write_stub(tmp_path, "git", "exit 128")
+        _write_stub(
+            tmp_path,
+            "sleep",
+            textwrap.dedent(f"""\
+            COUNT=$(cat {tmp_path}/sleeps 2>/dev/null || echo 0)
+            COUNT=$((COUNT + 1))
+            printf '%d\\n' "$COUNT" > {tmp_path}/sleeps
+            exit 0
+        """),
+        )
+        result = _run_snippet(_RETRY_SNIPPET, tmp_path)
+        assert result.returncode == 1
+        assert "transient failure cap reached" in result.stderr
+        assert (tmp_path / "sleeps").read_text().strip() == "2", (
+            "cap(3) allows 2 sleeps, then the 3rd failure aborts"
+        )

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -574,3 +574,26 @@ class TestDiscoveryDynamic:
             "v0.1.35\t691\t59c9208",
             "v0.1.36\t694\tc9035a0",
         ]
+
+
+class TestFailurePathMessaging:
+    def test_no_manual_tag_recipe_in_guidance(self):
+        """Echo'd guidance must not teach manual `git tag -a` — recovery goes
+        through --resume, which verifies the tuple instead of trusting the
+        operator's local state."""
+        for ln in _script_lines():
+            if _is_comment(ln) or "echo" not in ln:
+                continue
+            assert "git tag -a" not in ln, (
+                f"Guidance still teaches manual tagging: {ln.strip()!r}"
+            )
+
+    def test_ci_failure_paths_advertise_resume(self):
+        """Every 'Once CI passes' guidance must offer the --resume path."""
+        resume_lines = [
+            ln for ln in _script_lines() if not _is_comment(ln) and "--resume" in ln
+        ]
+        assert len(resume_lines) >= 4, (
+            "expected --resume advertised in usage + >=3 failure paths, "
+            f"found {len(resume_lines)}: {[ln.strip() for l in resume_lines]}"
+        )

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -362,9 +362,8 @@ class TestRetryTransportDynamic:
         ), "cap(3) allows 2 sleeps, then the 3rd failure aborts"
 
 
-# The exact gh --jq program used by discovery. Duplicated here so the tests
-# exercise the real filter; a static test below pins the copy in release.sh
-# to this string so the two cannot drift.
+# The exact gh --jq program used by discovery; a static test pins the script
+# copy to this string so the two cannot drift.
 _DISCOVERY_JQ = (
     '.[] | select(.headRefName | test("^chore/bump-v[0-9]+[.][0-9]+[.][0-9]+$")) '
     '| select(.mergeCommit.oid != null and .mergeCommit.oid != "") '
@@ -468,9 +467,8 @@ class TestDiscoveryStatic:
 
 class TestDiscoveryDynamic:
     def _make_stubs(self, tmp_path: Path, tagged: list[str]) -> None:
-        # The gh stub honors --jq by piping the sample JSON through real jq,
-        # so the snippet's post-processing sees genuinely filtered TSV — the
-        # same shape real gh emits.
+        # gh stub honors --jq by piping the sample JSON through real jq, so the
+        # snippet consumes genuinely filtered TSV, the shape real gh emits.
         _write_stub(
             tmp_path,
             "gh",

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -361,3 +361,216 @@ class TestRetryTransportDynamic:
         assert (tmp_path / "sleeps").read_text().strip() == "2", (
             "cap(3) allows 2 sleeps, then the 3rd failure aborts"
         )
+
+
+# The exact gh --jq program used by discovery. Duplicated here so the tests
+# exercise the real filter; a static test below pins the copy in release.sh
+# to this string so the two cannot drift.
+_DISCOVERY_JQ = (
+    '.[] | select(.headRefName | test("^chore/bump-v[0-9]+[.][0-9]+[.][0-9]+$")) '
+    '| select(.mergeCommit.oid != null and .mergeCommit.oid != "") '
+    '| [(.headRefName | sub("^chore/bump-"; "")), (.number | tostring), .mergeCommit.oid] | @tsv'
+)
+
+_DISCOVERY_SNIPPET = textwrap.dedent("""\
+    set -euo pipefail
+    retry_transport() {
+      local max_attempts=$1 desc=$2
+      shift 2
+      local attempt=0
+      while true; do
+        if "$@"; then
+          return 0
+        fi
+        attempt=$((attempt + 1))
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+          return 1
+        fi
+        sleep 10
+      done
+    }
+    discover_untagged_releases() {
+      local merged_prs ver num sha tag_out
+      merged_prs=$(retry_transport 5 "gh pr list" \\
+        gh pr list --state merged --limit 20 \\
+          --json number,headRefName,mergeCommit \\
+          --jq '__DISCOVERY_JQ__') || return 1
+      while IFS=$'\\t' read -r ver num sha; do
+        [[ -n "$ver" ]] || continue
+        tag_out=$(retry_transport 5 "tag lookup ${ver}" \\
+          git ls-remote --tags origin "refs/tags/${ver}") || return 1
+        if [[ -z "$tag_out" ]]; then
+          printf '%s\\t%s\\t%s\\n' "$ver" "$num" "$sha"
+        fi
+      done <<<"$merged_prs"
+    }
+    UNTAGGED=$(discover_untagged_releases) || { echo "Error: could not query GitHub for unfinished releases." >&2; exit 1; }
+    UNTAGGED_COUNT=0
+    if [[ -n "$UNTAGGED" ]]; then
+      UNTAGGED_COUNT=$(printf '%s\\n' "$UNTAGGED" | grep -c .)
+    fi
+    if [[ "$UNTAGGED_COUNT" -ge 2 ]]; then
+      echo "Error: multiple merged-but-untagged releases found — refusing to guess." >&2
+      printf '%s\\n' "$UNTAGGED" | while IFS=$'\\t' read -r ver num sha; do
+        echo "  ${ver}  PR #${num}  ${sha}" >&2
+      done
+      echo "Finish one explicitly with: release.sh --resume vX.Y.Z" >&2
+      exit 1
+    elif [[ "$UNTAGGED_COUNT" -eq 1 ]]; then
+      RESUME_TAG=$(printf '%s\\n' "$UNTAGGED" | head -1 | cut -f1)
+      echo "Found unfinished release ${RESUME_TAG} — resuming before starting a new release."
+      printf 'resume %s\\n' "$RESUME_TAG" >> discovery_log
+      exit 0
+    fi
+    echo "No unfinished releases — starting a fresh one."
+    exit 0
+""").replace("__DISCOVERY_JQ__", _DISCOVERY_JQ)
+
+_MERGED_PRS_JSON = """[
+  {"number": 691, "headRefName": "chore/bump-v0.1.35", "mergeCommit": {"oid": "59c9208"}},
+  {"number": 694, "headRefName": "chore/bump-v0.1.36", "mergeCommit": {"oid": "c9035a0"}},
+  {"number": 690, "headRefName": "chore/close-umbrella", "mergeCommit": {"oid": "c7fed0e"}}
+]"""
+
+
+class TestDiscoveryStatic:
+    def test_discovery_precedes_version_computation(self):
+        lines = _script_lines()
+        compute_idx = next(
+            i for i, ln in enumerate(lines) if "Compute next version" in ln
+        )
+        discovery_idx = next(
+            i for i, ln in enumerate(lines) if "discover_untagged_releases() {" in ln
+        )
+        wiring_idx = next(
+            i
+            for i, ln in enumerate(lines)
+            if i > discovery_idx
+            and "discover_untagged_releases" in ln
+            and "()" not in ln
+            and not _is_comment(ln)
+        )
+        assert wiring_idx < compute_idx, (
+            "discovery wiring must run before the 'Compute next version' section"
+        )
+
+    def test_discovery_jq_program_pinned(self):
+        assert any(
+            _DISCOVERY_JQ.split("| select(.mergeCommit")[0].rstrip() in ln
+            for ln in _script_lines()
+        ), "release.sh discovery --jq program drifted from the pinned test copy"
+
+    def test_ambiguity_guard_requires_resume(self):
+        assert any(
+            "multiple merged-but-untagged releases" in ln and not _is_comment(ln)
+            for ln in _script_lines()
+        )
+
+
+class TestDiscoveryDynamic:
+    def _make_stubs(self, tmp_path: Path, tagged: list[str]) -> None:
+        # The gh stub honors --jq by piping the sample JSON through real jq,
+        # so the snippet's post-processing sees genuinely filtered TSV — the
+        # same shape real gh emits.
+        _write_stub(
+            tmp_path,
+            "gh",
+            textwrap.dedent("""\
+            if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+              prog=""
+              prev=""
+              for a in "$@"; do
+                if [ "$prev" = "--jq" ]; then prog=$a; fi
+                prev=$a
+              done
+              printf '%s' "$MERGED_PRS_JSON" | jq -r "$prog"
+              exit $?
+            fi
+            exit 0
+        """),
+        )
+        _write_stub(
+            tmp_path,
+            "git",
+            textwrap.dedent("""\
+            if [ "$1" = "ls-remote" ]; then
+              for t in TAGGED_LIST; do
+                case "$*" in *"$t"*) printf '%s\\t%s\\n' "sha-$t" "$t"; exit 0 ;; esac
+              done
+              exit 0
+            fi
+            exit 0
+        """).replace("TAGGED_LIST", " ".join(tagged)),
+        )
+        _write_stub(tmp_path, "sleep", "exit 0")
+
+    def test_single_untagged_auto_resumes(self, tmp_path):
+        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35"])
+        result = _run_snippet(
+            _DISCOVERY_SNIPPET,
+            tmp_path,
+            {"MERGED_PRS_JSON": _MERGED_PRS_JSON},
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "Found unfinished release v0.1.36" in result.stdout
+        assert (tmp_path / "discovery_log").read_text() == "resume v0.1.36\n"
+
+    def test_two_stacked_refuse_and_list(self, tmp_path):
+        self._make_stubs(tmp_path, tagged=[])
+        result = _run_snippet(
+            _DISCOVERY_SNIPPET,
+            tmp_path,
+            {"MERGED_PRS_JSON": _MERGED_PRS_JSON},
+            cwd=tmp_path,
+        )
+        assert result.returncode == 1
+        assert "multiple merged-but-untagged releases" in result.stderr
+        assert "v0.1.35" in result.stderr and "v0.1.36" in result.stderr
+        assert "--resume" in result.stderr
+
+    def test_all_tagged_fresh_release(self, tmp_path):
+        self._make_stubs(
+            tmp_path, tagged=["refs/tags/v0.1.35", "refs/tags/v0.1.36"]
+        )
+        result = _run_snippet(
+            _DISCOVERY_SNIPPET,
+            tmp_path,
+            {"MERGED_PRS_JSON": _MERGED_PRS_JSON},
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0
+        assert "No unfinished releases" in result.stdout
+
+    def test_non_bump_prs_ignored(self, tmp_path):
+        """headRefName without the chore/bump-vX.Y.Z shape is not a candidate."""
+        self._make_stubs(tmp_path, tagged=[])
+        result = _run_snippet(
+            _DISCOVERY_SNIPPET,
+            tmp_path,
+            {
+                "MERGED_PRS_JSON": (
+                    '[{"number": 690, "headRefName": "chore/close-umbrella", '
+                    '"mergeCommit": {"oid": "c7fed0e"}}]'
+                )
+            },
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0
+        assert "No unfinished releases" in result.stdout
+
+    def test_discovery_jq_program_filters_correctly(self):
+        """The pinned jq program emits exactly the bump rows as TSV."""
+        proc = subprocess.run(
+            ["jq", "-r", _DISCOVERY_JQ],
+            input=_MERGED_PRS_JSON,
+            capture_output=True,
+            text=True,
+            env=dict(_CLEAN_ENV),
+        )
+        assert proc.returncode == 0, proc.stderr
+        rows = [ln for ln in proc.stdout.splitlines() if ln]
+        assert rows == [
+            "v0.1.35\t691\t59c9208",
+            "v0.1.36\t694\tc9035a0",
+        ]

--- a/tests/test_release_sh_resume.py
+++ b/tests/test_release_sh_resume.py
@@ -128,7 +128,7 @@ _RESUME_SNIPPET = "\n".join(
     [
         "set -euo pipefail",
         'GH_REPO="owner/repo"',
-        'RESUME_TAG="v0.1.36"',
+        'RESUME_TAG="v9.9.9"',
         _extract_functions("retry_transport", "resume_release"),
         'resume_release "$RESUME_TAG"',
     ]
@@ -136,7 +136,7 @@ _RESUME_SNIPPET = "\n".join(
 
 
 _PR_JSON_OK = (
-    '{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":{"oid":"c9035a0"}}'
+    '{"number":694,"headRefName":"chore/bump-v9.9.9","mergeCommit":{"oid":"c9035a0"}}'
 )
 
 
@@ -173,7 +173,7 @@ def _gh_stub(pr_list_json: str, rollup: str = '{"statusCheckRollup":[]}') -> str
     )
 
 
-def _git_stub_ok(tmp_path: Path, manifest_json: str = '{"version":"0.1.36"}') -> str:
+def _git_stub_ok(tmp_path: Path, manifest_json: str = '{"version":"9.9.9"}') -> str:
     return textwrap.dedent(
         f"""\
         case "$1" in
@@ -236,7 +236,7 @@ class TestResumeDynamic:
         _resume_env(
             tmp_path,
             _gh_stub(
-                '{"number":694,"headRefName":"chore/bump-v0.1.36","mergeCommit":null}'
+                '{"number":694,"headRefName":"chore/bump-v9.9.9","mergeCommit":null}'
             ),
             _git_stub_ok(tmp_path),
         )
@@ -299,16 +299,16 @@ class TestResumeDynamic:
         _resume_env(
             tmp_path,
             _gh_stub(_PR_JSON_OK),
-            _git_stub_ok(tmp_path, manifest_json='{"version":"0.1.35"}'),
+            _git_stub_ok(tmp_path, manifest_json='{"version":"9.9.8"}'),
         )
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
         assert result.returncode == 1
-        assert "expected '0.1.36'" in result.stderr
+        assert "expected '9.9.9'" in result.stderr
 
     def test_tag_already_published_is_success_no_push(self, tmp_path):
         git_body = _git_stub_ok(tmp_path).replace(
             "ls-remote) printf ''",
-            "ls-remote) printf 'c9035a0\\trefs/tags/v0.1.36\\nc9035a0\\trefs/tags/v0.1.36^{}\\n'",
+            "ls-remote) printf 'c9035a0\\trefs/tags/v9.9.9\\nc9035a0\\trefs/tags/v9.9.9^{}\\n'",
         )
         _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
@@ -336,7 +336,7 @@ class TestResumeDynamic:
     def test_remote_tag_wrong_sha_fails_closed(self, tmp_path):
         git_body = _git_stub_ok(tmp_path).replace(
             "ls-remote) printf ''",
-            "ls-remote) printf 'deadbeef\\trefs/tags/v0.1.36\\ndeadbeef\\trefs/tags/v0.1.36^{}\\n'",
+            "ls-remote) printf 'deadbeef\\trefs/tags/v9.9.9\\ndeadbeef\\trefs/tags/v9.9.9^{}\\n'",
         )
         _resume_env(tmp_path, _gh_stub(_PR_JSON_OK), git_body)
         result = _run_snippet(_RESUME_SNIPPET, tmp_path, cwd=tmp_path)
@@ -416,8 +416,8 @@ _DISCOVERY_SNIPPET = "\n".join(
 )
 
 _MERGED_PRS_JSON = """[
-  {"number": 691, "headRefName": "chore/bump-v0.1.35", "mergeCommit": {"oid": "59c9208"}},
-  {"number": 694, "headRefName": "chore/bump-v0.1.36", "mergeCommit": {"oid": "c9035a0"}},
+  {"number": 691, "headRefName": "chore/bump-v9.9.8", "mergeCommit": {"oid": "59c9208"}},
+  {"number": 694, "headRefName": "chore/bump-v9.9.9", "mergeCommit": {"oid": "c9035a0"}},
   {"number": 690, "headRefName": "chore/close-umbrella", "mergeCommit": {"oid": "c7fed0e"}}
 ]"""
 
@@ -514,7 +514,7 @@ class TestDiscoveryDynamic:
         _write_stub(tmp_path, "sleep", "exit 0")
 
     def test_single_untagged_auto_resumes(self, tmp_path):
-        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35"])
+        self._make_stubs(tmp_path, tagged=["refs/tags/v9.9.8"])
         result = _run_snippet(
             _DISCOVERY_SNIPPET,
             tmp_path,
@@ -522,13 +522,13 @@ class TestDiscoveryDynamic:
             cwd=tmp_path,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        assert "Found unfinished release v0.1.36" in result.stdout
-        assert (tmp_path / "discovery_log").read_text() == "resume v0.1.36\n"
+        assert "Found unfinished release v9.9.9" in result.stdout
+        assert (tmp_path / "discovery_log").read_text() == "resume v9.9.9\n"
 
     def test_stderr_noise_on_success_does_not_defeat_discovery(self, tmp_path):
         """gh succeeding while printing a warning must still surface the
         untagged candidate — merged stderr would read as a phantom tag."""
-        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35"])
+        self._make_stubs(tmp_path, tagged=["refs/tags/v9.9.8"])
         gh = tmp_path / "gh"
         gh.write_text(
             gh.read_text().replace(
@@ -544,7 +544,7 @@ class TestDiscoveryDynamic:
             cwd=tmp_path,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        assert (tmp_path / "discovery_log").read_text() == "resume v0.1.36\n"
+        assert (tmp_path / "discovery_log").read_text() == "resume v9.9.9\n"
 
     def test_two_stacked_refuse_and_list(self, tmp_path):
         self._make_stubs(tmp_path, tagged=[])
@@ -556,11 +556,11 @@ class TestDiscoveryDynamic:
         )
         assert result.returncode == 1
         assert "multiple merged-but-untagged releases" in result.stderr
-        assert "v0.1.35" in result.stderr and "v0.1.36" in result.stderr
+        assert "v9.9.8" in result.stderr and "v9.9.9" in result.stderr
         assert "--resume" in result.stderr
 
     def test_all_tagged_fresh_release(self, tmp_path):
-        self._make_stubs(tmp_path, tagged=["refs/tags/v0.1.35", "refs/tags/v0.1.36"])
+        self._make_stubs(tmp_path, tagged=["refs/tags/v9.9.8", "refs/tags/v9.9.9"])
         result = _run_snippet(
             _DISCOVERY_SNIPPET,
             tmp_path,
@@ -599,8 +599,8 @@ class TestDiscoveryDynamic:
         assert proc.returncode == 0, proc.stderr
         rows = [ln for ln in proc.stdout.splitlines() if ln]
         assert rows == [
-            "v0.1.35\t691\t59c9208",
-            "v0.1.36\t694\tc9035a0",
+            "v9.9.8\t691\t59c9208",
+            "v9.9.9\t694\tc9035a0",
         ]
 
 


### PR DESCRIPTION
## Summary
- Resume merged-but-untagged releases: before computing the next version, `release.sh` discovers merged bump PRs whose tag is absent from origin — exactly one → auto-resume it; stacked → refuse and list, demanding `--resume vX.Y.Z`; none → fresh release as before (`scripts/release.sh`)
- Add `--resume vX.Y.Z`: reconstructs the release tuple from GitHub only (merged PR via headRefName, merge SHA reachable from `origin/main`, CI green on the PR, declared manifests at the SHA carry the version, remote tag absent-or-at-SHA), then tags and pushes with `--no-verify` — safe because CI validated that exact tree, so the 3.5-min pre-push suite is not re-run for a network-only retry
- Wrap every one-shot transport op (`fetch`, both `pull --ff-only`, branch push, tag push) in a bounded `retry_transport` (5 attempts, 10s backoff, real stderr surfaced at the cap, stderr never polluting parsed stdout)
- Failure-path guidance now points at `$0 --resume ${TAG}` instead of manual `git tag -a` surgery; also fixes a latent pipefail abort (`grep '\^{}'` no-match) that killed the fresh-flow tag check for lightweight tags
- Regression tests (`tests/test_release_sh_resume.py`, 32 tests) on the repo's dual seam, with snippets extracted from the shipped script bodies at test time so tests cannot drift from the code they cover

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `pytest tests/ -q` — 3659 passed, 5 skipped (baseline 3627+5)
- [x] `shellcheck scripts/release.sh` clean; `bash scripts/validate.sh` passes; scoped ruff clean

### Type-tailored checks (fix)
- [x] Reproduced the issue-#695 scenario dynamically: single untagged release → rerun resumes v0.1.36 and never derives v0.1.37
- [x] Verified fail-closed paths: unmerged PR, null merge commit, SHA not on main, red CI (FAILURE/TIMED_OUT/CANCELLED/ACTION_REQUIRED/STARTUP_FAILURE), manifest mismatch, unreadable manifest list, wrong-SHA remote/local tag
- [x] Verified transport retry: transient→success recovery, cap with exactly-once stderr surfacing, stderr noise on success never parsed as tag state

Closes #695
