### PR TITLE
[feat] Add a free-text "Other" row to ask_user_question

### DIFF
--- a/pi/extensions/ask-user.ts
+++ b/pi/extensions/ask-user.ts
@@ -133,6 +133,16 @@ export function registerAskUser(pi: ExtensionAPI): void {
         );
       }
 
+      // An authored option can render identically to OTHER_CHOICE (optionLabel uses the same
+      // " — " join), which would show an indistinguishable duplicate row — reject up front.
+      const collision = questions.find((q) => q.options.map(optionLabel).includes(OTHER_CHOICE));
+      if (collision) {
+        throw new Error(
+          `ask_user_question: an option in "${collision.question}" renders identically to the ` +
+            `tool's automatic free-text "Other" row ("${OTHER_CHOICE}") — rephrase or remove it.`,
+        );
+      }
+
       const answers: Record<string, string> = {};
       for (const q of questions) {
         const choice = await ctx.ui.select(
@@ -148,10 +158,12 @@ export function registerAskUser(pi: ExtensionAPI): void {
         }
         if (choice === OTHER_CHOICE) {
           const typed = await ctx.ui.input(q.question, "Type your answer", { signal });
-          if (typed === undefined) {
+          // The SDK input dialog resolves "" (not undefined) on an empty Enter — treat both
+          // as not-answered so one accidental keypress can't masquerade as a deliberate answer.
+          if (typed === undefined || typed.trim() === "") {
             throw new Error(
-              `ask_user_question: the user dismissed the free-text answer to "${q.question}" ` +
-                "without entering one — stop and check in with the user rather than assuming an answer.",
+              `ask_user_question: the user did not enter a free-text answer to "${q.question}" — ` +
+                "stop and check in with the user rather than assuming an answer.",
             );
           }
           answers[q.question] = typed;

--- a/pi/extensions/ask-user.ts
+++ b/pi/extensions/ask-user.ts
@@ -74,6 +74,9 @@ function optionLabel(option: AskUserOption): string {
   return option.description ? `${option.label} — ${option.description}` : option.label;
 }
 
+/** Rendered as the last row of every question — choosing it opens a free-text input dialog. */
+const OTHER_CHOICE = "Other — type your own answer";
+
 export function registerAskUser(pi: ExtensionAPI): void {
   // Read once per process at registration time — an immutable config read, not a module-state
   // anti-pattern (nothing here mutates after this check). Gates Tier-2 tool registration only;
@@ -88,9 +91,11 @@ export function registerAskUser(pi: ExtensionAPI): void {
       "a decision genuinely belongs to the user — never as a substitute for a reasonable default.",
     promptSnippet:
       "ask_user_question(questions): present the user 1-4 fixed-option questions (2-4 options " +
-      "each) and get their picks back. Use when blocked on a decision only the user can make.",
+      "each, plus an automatic free-text \"Other\" row) and get their picks back. Use when " +
+      "blocked on a decision only the user can make.",
     promptGuidelines: [
-      "Never fabricate a free-text \"Other\" option — ask_user_question only supports fixed choices.",
+      "Never author an \"Other\" option — a free-text \"Other\" row is appended automatically; " +
+        "when the user picks it they type an answer that is returned for that question.",
       "Each question is single-select. To collect more than one choice per question, ask " +
         "separate sequential single-select questions instead of setting multiSelect.",
     ],
@@ -132,7 +137,7 @@ export function registerAskUser(pi: ExtensionAPI): void {
       for (const q of questions) {
         const choice = await ctx.ui.select(
           q.question,
-          q.options.map(optionLabel),
+          [...q.options.map(optionLabel), OTHER_CHOICE],
           { signal },
         );
         if (choice === undefined) {
@@ -140,6 +145,17 @@ export function registerAskUser(pi: ExtensionAPI): void {
             `ask_user_question: the user dismissed "${q.question}" without choosing an option — ` +
               "stop and check in with the user rather than assuming an answer.",
           );
+        }
+        if (choice === OTHER_CHOICE) {
+          const typed = await ctx.ui.input(q.question, "Type your answer", { signal });
+          if (typed === undefined) {
+            throw new Error(
+              `ask_user_question: the user dismissed the free-text answer to "${q.question}" ` +
+                "without entering one — stop and check in with the user rather than assuming an answer.",
+            );
+          }
+          answers[q.question] = typed;
+          continue;
         }
         answers[q.question] = choice;
       }

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -800,6 +800,19 @@ def test_ask_user_ts_has_no_typebox_import():
     )
 
 
+def test_ask_user_prompt_guidelines_offer_free_text_other():
+    """Issue #706: the guideline forbidding a free-text "Other" is retracted alongside the
+    feature — otherwise the model is instructed not to use the row the tool just added."""
+    text = ASK_USER_TS.read_text(encoding="utf-8")
+    assert "Never fabricate" not in text, (
+        'the "Never fabricate a free-text Other option" guideline must be removed once the '
+        "tool appends an Other row itself"
+    )
+    assert "appended automatically" in text, (
+        "the replacement guideline must tell the caller the Other row is automatic"
+    )
+
+
 # ---------------------------------------------------------------------------
 # task-tool dispatcher (agent-spec.ts + subagent.ts). Layering boundary, translation-table
 # exhaustiveness, and a live zero-LLM probe of the --exclude-tools recursion guard.

--- a/tests/test_pi_contract.py
+++ b/tests/test_pi_contract.py
@@ -801,7 +801,7 @@ def test_ask_user_ts_has_no_typebox_import():
 
 
 def test_ask_user_prompt_guidelines_offer_free_text_other():
-    """Issue #706: the guideline forbidding a free-text "Other" is retracted alongside the
+    """The guideline forbidding a free-text "Other" is retracted alongside the
     feature — otherwise the model is instructed not to use the row the tool just added."""
     text = ASK_USER_TS.read_text(encoding="utf-8")
     assert "Never fabricate" not in text, (

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1146,12 +1146,13 @@ if (registered) {
   }
   async function run(hasUI, params, b) {
     behavior = b;
-    const before = inputCalls.length;
+    const beforeInputs = inputCalls.length;
+    const beforeSelects = selectCalls.length;
     try {
       const result = await registered.execute("tc1", params, undefined, undefined, makeCtx(hasUI));
-      return { ok: true, result, inputCalls: inputCalls.slice(before) };
+      return { ok: true, result, inputCalls: inputCalls.slice(beforeInputs), selectCalls: selectCalls.slice(beforeSelects) };
     } catch (err) {
-      return { ok: false, message: String(err && err.message), inputCalls: inputCalls.slice(before) };
+      return { ok: false, message: String(err && err.message), inputCalls: inputCalls.slice(beforeInputs), selectCalls: selectCalls.slice(beforeSelects) };
     } finally {
       behavior = {};
     }
@@ -1162,8 +1163,9 @@ if (registered) {
   out.noUI = await run(false, config.singleParams, {});
   out.otherChosen = await run(true, config.singleParams, { selectReturn: "__LAST__" });
   out.otherDismissInput = await run(true, config.singleParams, { selectReturn: "__LAST__", inputReturn: "__DISMISS__" });
+  out.otherEmptyInput = await run(true, config.singleParams, { selectReturn: "__LAST__", inputReturn: "" });
   out.dismissed = await run(true, config.singleParams, { selectReturn: "__DISMISS__" });
-  out.selectCalls = selectCalls;
+  out.collision = await run(true, config.collisionParams, {});
 }
 console.log(JSON.stringify(out));
 """
@@ -1183,6 +1185,12 @@ def _ask_user_result(env, tmp_path_factory):
             "questions": [
                 {"question": "Same text", "header": "Q1", "multiSelect": False, "options": [{"label": "A"}, {"label": "B"}]},
                 {"question": "Same text", "header": "Q2", "multiSelect": False, "options": [{"label": "C"}, {"label": "D"}]},
+            ]
+        },
+        "collisionParams": {
+            "questions": [
+                {"question": "Trap", "header": "Trap", "multiSelect": False,
+                 "options": [{"label": "A"}, {"label": "Other", "description": "type your own answer"}]},
             ]
         },
     }
@@ -1217,14 +1225,14 @@ def test_ask_user_single_select_returns_the_choice_via_ctx_ui_select(tmp_path_fa
     result = _ask_user_result({}, tmp_path_factory)
     assert result["singleSelect"]["ok"] is True
     assert result["singleSelect"]["result"]["details"] == {"Pick one": "A — desc A"}
-    assert result["selectCalls"][0]["options"] == ["A — desc A", "B", "Other — type your own answer"]
+    assert result["singleSelect"]["selectCalls"][0]["options"] == ["A — desc A", "B", "Other — type your own answer"]
     assert result["singleSelect"]["inputCalls"] == [], "ctx.ui.input must only open after the Other row is chosen"
 
 
 @requires_node
 def test_ask_user_options_always_end_with_free_text_other_row(tmp_path_factory):
     result = _ask_user_result({}, tmp_path_factory)
-    options = result["selectCalls"][0]["options"]
+    options = result["singleSelect"]["selectCalls"][0]["options"]
     assert options[-1] == "Other — type your own answer", (
         "issue #706: an Other row must always be appended so the user is never trapped "
         "in the fixed choices"
@@ -1255,7 +1263,29 @@ def test_ask_user_dismissing_select_still_errors(tmp_path_factory):
 def test_ask_user_dismissing_other_free_text_input_errors(tmp_path_factory):
     result = _ask_user_result({}, tmp_path_factory)
     assert result["otherDismissInput"]["ok"] is False
-    assert "dismissed" in result["otherDismissInput"]["message"]
+    assert "free-text answer" in result["otherDismissInput"]["message"]
+    assert "Pick one" in result["otherDismissInput"]["message"]
+
+
+@requires_node
+def test_ask_user_empty_free_text_submit_is_rejected_not_answered(tmp_path_factory):
+    """The SDK input dialog resolves "" (not undefined) on empty Enter — accepting it would
+    let one accidental keypress masquerade as a deliberate answer (review finding on #706)."""
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["otherEmptyInput"]["ok"] is False
+    assert "free-text answer" in result["otherEmptyInput"]["message"]
+
+
+@requires_node
+def test_ask_user_authored_option_rendering_as_the_other_row_is_rejected(tmp_path_factory):
+    """optionLabel joins label+description with the same separator as OTHER_CHOICE, so an
+    authored option can render identically to the automatic row — reject up front instead of
+    rendering an indistinguishable duplicate (review finding on #706)."""
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["collision"]["ok"] is False
+    assert "free-text" in result["collision"]["message"]
+    assert "Trap" in result["collision"]["message"]
+    assert result["collision"]["selectCalls"] == [], "collision must be rejected before any dialog renders"
 
 
 @requires_node

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1123,29 +1123,47 @@ const out = { registered: registered !== undefined };
 if (registered) {
   const inputCalls = [];
   const selectCalls = [];
+  // Per-scenario steering: "__DISMISS__" -> undefined, "__LAST__" -> last rendered option;
+  // absent -> options[0] (select) / "TYPED-ANSWER" (input).
+  let behavior = {};
   function makeCtx(hasUI) {
     return {
       hasUI,
       ui: {
-        select: async (title, options) => { selectCalls.push({ title, options }); return options[0]; },
-        input: async (...args) => { inputCalls.push(args); return "SHOULD-NEVER-HAPPEN"; },
+        select: async (title, options) => {
+          selectCalls.push({ title, options });
+          if (behavior.selectReturn === "__DISMISS__") return undefined;
+          if (behavior.selectReturn === "__LAST__") return options[options.length - 1];
+          return behavior.selectReturn ?? options[0];
+        },
+        input: async (...args) => {
+          inputCalls.push(args);
+          if (behavior.inputReturn === "__DISMISS__") return undefined;
+          return behavior.inputReturn ?? "TYPED-ANSWER";
+        },
       },
     };
   }
-  async function run(hasUI, params) {
+  async function run(hasUI, params, b) {
+    behavior = b;
+    const before = inputCalls.length;
     try {
       const result = await registered.execute("tc1", params, undefined, undefined, makeCtx(hasUI));
-      return { ok: true, result };
+      return { ok: true, result, inputCalls: inputCalls.slice(before) };
     } catch (err) {
-      return { ok: false, message: String(err && err.message) };
+      return { ok: false, message: String(err && err.message), inputCalls: inputCalls.slice(before) };
+    } finally {
+      behavior = {};
     }
   }
-  out.singleSelect = await run(true, config.singleParams);
-  out.multiSelect = await run(true, config.multiParams);
-  out.duplicate = await run(true, config.duplicateParams);
-  out.noUI = await run(false, config.singleParams);
+  out.singleSelect = await run(true, config.singleParams, {});
+  out.multiSelect = await run(true, config.multiParams, {});
+  out.duplicate = await run(true, config.duplicateParams, {});
+  out.noUI = await run(false, config.singleParams, {});
+  out.otherChosen = await run(true, config.singleParams, { selectReturn: "__LAST__" });
+  out.otherDismissInput = await run(true, config.singleParams, { selectReturn: "__LAST__", inputReturn: "__DISMISS__" });
+  out.dismissed = await run(true, config.singleParams, { selectReturn: "__DISMISS__" });
   out.selectCalls = selectCalls;
-  out.inputCalls = inputCalls;
 }
 console.log(JSON.stringify(out));
 """
@@ -1199,8 +1217,45 @@ def test_ask_user_single_select_returns_the_choice_via_ctx_ui_select(tmp_path_fa
     result = _ask_user_result({}, tmp_path_factory)
     assert result["singleSelect"]["ok"] is True
     assert result["singleSelect"]["result"]["details"] == {"Pick one": "A — desc A"}
-    assert result["selectCalls"][0]["options"] == ["A — desc A", "B"]
-    assert result["inputCalls"] == [], "ask_user_question must never fall back to ctx.ui.input"
+    assert result["selectCalls"][0]["options"] == ["A — desc A", "B", "Other — type your own answer"]
+    assert result["singleSelect"]["inputCalls"] == [], "ctx.ui.input must only open after the Other row is chosen"
+
+
+@requires_node
+def test_ask_user_options_always_end_with_free_text_other_row(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    options = result["selectCalls"][0]["options"]
+    assert options[-1] == "Other — type your own answer", (
+        "issue #706: an Other row must always be appended so the user is never trapped "
+        "in the fixed choices"
+    )
+    assert options[:-1] == ["A — desc A", "B"], "author-supplied options stay in order, untouched"
+
+
+@requires_node
+def test_ask_user_other_row_opens_ctx_ui_input_and_returns_typed_answer(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["otherChosen"]["ok"] is True
+    assert result["otherChosen"]["result"]["details"] == {"Pick one": "TYPED-ANSWER"}
+    assert len(result["otherChosen"]["inputCalls"]) == 1
+    assert result["otherChosen"]["inputCalls"][0][0] == "Pick one", (
+        "input() must be titled with the question text"
+    )
+
+
+@requires_node
+def test_ask_user_dismissing_select_still_errors(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["dismissed"]["ok"] is False
+    assert "dismissed" in result["dismissed"]["message"]
+    assert "Pick one" in result["dismissed"]["message"]
+
+
+@requires_node
+def test_ask_user_dismissing_other_free_text_input_errors(tmp_path_factory):
+    result = _ask_user_result({}, tmp_path_factory)
+    assert result["otherDismissInput"]["ok"] is False
+    assert "dismissed" in result["otherDismissInput"]["message"]
 
 
 @requires_node
@@ -1225,7 +1280,7 @@ def test_ask_user_no_ui_fails_loudly_without_calling_input(tmp_path_factory):
     result = _ask_user_result({}, tmp_path_factory)
     assert result["noUI"]["ok"] is False
     assert "interactive UI" in result["noUI"]["message"]
-    assert result["inputCalls"] == [], "hasUI:false must fail loudly, never silently fall back to ctx.ui.input"
+    assert result["noUI"]["inputCalls"] == [], "hasUI:false must fail loudly, never silently fall back to ctx.ui.input"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -1234,7 +1234,7 @@ def test_ask_user_options_always_end_with_free_text_other_row(tmp_path_factory):
     result = _ask_user_result({}, tmp_path_factory)
     options = result["singleSelect"]["selectCalls"][0]["options"]
     assert options[-1] == "Other — type your own answer", (
-        "issue #706: an Other row must always be appended so the user is never trapped "
+        "an Other row must always be appended so the user is never trapped "
         "in the fixed choices"
     )
     assert options[:-1] == ["A — desc A", "B"], "author-supplied options stay in order, untouched"
@@ -1270,7 +1270,7 @@ def test_ask_user_dismissing_other_free_text_input_errors(tmp_path_factory):
 @requires_node
 def test_ask_user_empty_free_text_submit_is_rejected_not_answered(tmp_path_factory):
     """The SDK input dialog resolves "" (not undefined) on empty Enter — accepting it would
-    let one accidental keypress masquerade as a deliberate answer (review finding on #706)."""
+    let one accidental keypress masquerade as a deliberate answer."""
     result = _ask_user_result({}, tmp_path_factory)
     assert result["otherEmptyInput"]["ok"] is False
     assert "free-text answer" in result["otherEmptyInput"]["message"]
@@ -1280,7 +1280,7 @@ def test_ask_user_empty_free_text_submit_is_rejected_not_answered(tmp_path_facto
 def test_ask_user_authored_option_rendering_as_the_other_row_is_rejected(tmp_path_factory):
     """optionLabel joins label+description with the same separator as OTHER_CHOICE, so an
     authored option can render identically to the automatic row — reject up front instead of
-    rendering an indistinguishable duplicate (review finding on #706)."""
+    rendering an indistinguishable duplicate."""
     result = _ask_user_result({}, tmp_path_factory)
     assert result["collision"]["ok"] is False
     assert "free-text" in result["collision"]["message"]


### PR DESCRIPTION
## Summary
- `ask_user_question` now appends a free-text **"Other" row** to every question's options; choosing it opens `ctx.ui.input()` and returns the typed value as that question's answer (issue #706: the user was previously trapped in the 2–4 fixed choices).
- The stale `promptGuidelines` line ("Never fabricate a free-text Other option…") is retracted and replaced with guidance that the row is automatic; `promptSnippet` mentions it. `QUESTIONS_SCHEMA` is unchanged — "Other" is appended at render time, never authored by the caller.
- Review-hardened guards: an authored option that would render identically to the sentinel row is rejected up front (mirrors the existing multiSelect/duplicate rejection pattern), and an empty/whitespace free-text submit (the SDK input dialog resolves `""`, not `undefined`) is treated as not-answered rather than returned as a valid answer.
- Contrast half (dark-theme legibility of the SDK's built-in `select()` dialog) is SDK-side: filed upstream as earendil-works/pi#8934 and linked from #706. Upstream closed it as `not_planned`, so the remaining path is a repo-side workaround — tracked in #706, deliberately out of scope here.
- Test-harness note (deliberate deviation from the plan): the behavioral driver snapshots `inputCalls`/`selectCalls` **per scenario** instead of globally — the plan's global-list assertions were unsatisfiable once two scenarios legitimately call `ctx.ui.input`. Assertion intent unchanged.
- Contract decision: empty free-text submits are rejected ("did not enter a free-text answer") rather than returned as `""` — an accidental Enter cannot masquerade as a deliberate answer, consistent with the tool's existing "stop and check in with the user" dismissal contract.

## Test Plan
- [x] Changed skills/commands/agents load without errors (no skills/commands/agents changed; the extension registers and loads — pinned by `test_ask_user_registers_by_default` and the schema dump driver)
- [x] Examples in the diff were exercised manually (exercised via the pytest node-driver running the real `ask-user.ts` under `node --experimental-strip-types`: Other row always last, `ctx.ui.input` opens titled with the question, typed answer returned, both dismissal paths error, collision and empty-submit rejected before/without accepting a bogus answer)
- [x] `npm run typecheck` — exit 0

### Type-tailored checks ([feat])
- [x] New behaviour pinned red→green: `test_ask_user_options_always_end_with_free_text_other_row`, `test_ask_user_other_row_opens_ctx_ui_input_and_returns_typed_answer`, `test_ask_user_dismissing_select_still_errors`, `test_ask_user_dismissing_other_free_text_input_errors`, `test_ask_user_empty_free_text_submit_is_rejected_not_answered`, `test_ask_user_authored_option_rendering_as_the_other_row_is_rejected`
- [x] Guideline retraction ratchet: `test_ask_user_prompt_guidelines_offer_free_text_other` (`"Never fabricate"` absent, "appended automatically" present)
- [x] Pre-existing guards untouched and green: multiSelect rejection, duplicate-question rejection, no-UI failure, kill switch, no-typebox ratchet
- [x] Full suite: `python3 -m pytest tests/ -q` — 3710 passed, 3 skipped (re-run independently by the pre-push hook on push)
- [x] Comment scan: `swe-workbench-comment-scan` — 0 must-triage

Closes #706
