### PR TITLE
[fix] Name the leased worktree in handoff guard messages

### DIFF
--- a/bin/swe-workbench-handoff
+++ b/bin/swe-workbench-handoff
@@ -1069,10 +1069,19 @@ def guard_decision(as_harness: str, session_ref: str | None) -> tuple[Envelope, 
         )
     paths = StatePaths.from_environment()
     workspace_directory = paths.workspace_directory(workspace)
+    worktree_root = str(workspace.worktree_root)
     lease = load_lease(workspace_directory)
     if lease is None:
         return (
-            Envelope("ok", {"decision": "allow", "reason": "no handoff lease for this worktree"}, []),
+            Envelope(
+                "ok",
+                {
+                    "decision": "allow",
+                    "reason": "no handoff lease for this worktree",
+                    "worktree_root": worktree_root,
+                },
+                [],
+            ),
             0,
         )
     owner = str(lease["owner_harness"])
@@ -1097,6 +1106,7 @@ def guard_decision(as_harness: str, session_ref: str | None) -> tuple[Envelope, 
                     "checkpoint_id": checkpoint_id,
                     "target_harness": target_harness,
                     "instruction": f"{command_name} resume {checkpoint_id}",
+                    "worktree_root": worktree_root,
                 },
                 [],
             ),
@@ -1110,6 +1120,7 @@ def guard_decision(as_harness: str, session_ref: str | None) -> tuple[Envelope, 
                     "decision": "deny",
                     "reason": f"handoff lease is held by {owner}",
                     "instruction": f"the {owner} harness owns this worktree; stop it or resume its checkpoint",
+                    "worktree_root": worktree_root,
                 },
                 [],
             ),
@@ -1124,12 +1135,20 @@ def guard_decision(as_harness: str, session_ref: str | None) -> tuple[Envelope, 
                     "decision": "deny",
                     "reason": "handoff lease is bound to a different receiver session",
                     "instruction": f"only receiver session {bound_session!r} may mutate this worktree",
+                    "worktree_root": worktree_root,
                 },
                 [],
             ),
             GUARD_DENY_EXIT_CODE,
         )
-    return (Envelope("ok", {"decision": "allow", "reason": f"handoff lease held by {owner}"}, []), 0)
+    return (
+        Envelope(
+            "ok",
+            {"decision": "allow", "reason": f"handoff lease held by {owner}", "worktree_root": worktree_root},
+            [],
+        ),
+        0,
+    )
 
 
 def _safe_lease_for_cleanup(workspace_directory: Path) -> dict[str, object] | None | bool:

--- a/bin/swe-workbench-handoff
+++ b/bin/swe-workbench-handoff
@@ -56,6 +56,7 @@ FORBIDDEN_INPUT_FIELDS = frozenset(
 VERIFICATION_FIELDS = frozenset({"command", "label", "exit_status", "timestamp", "result"})
 VERIFICATION_RESULTS = frozenset({"passed", "failed", "not_run", "skipped"})
 HARNESSES = ("claude", "pi")
+SESSION_ENV_NAMES = {"claude": "CLAUDE_CODE_SESSION_ID", "pi": "PI_SESSION_ID"}
 LEASE_SCHEMA_VERSION = 1
 MANDATORY_REVIEW_ACTION = (
     "Review the salvage manifest, reconcile it with the live worktree, "
@@ -509,6 +510,27 @@ def valid_session_ref(value: object) -> bool:
         and len(value) <= 256
         and all(ord(character) >= 32 and ord(character) != 127 for character in value)
     )
+
+
+def resolve_session_ref(literal: str | None, env_name: str | None, as_harness: str) -> str:
+    """Resolve a --receiver-session/--session-ref value from a literal or an env-var name.
+
+    The env-name form keeps every argument in the lifecycle pipelines literal (inert),
+    which is what lets a harness's static command guard clear them. The allowlist is
+    load-bearing, not a nicety: an arbitrary env name would turn the flag into an
+    env-value exfiltration primitive into persisted lease state.
+    """
+    if env_name is not None:
+        expected = SESSION_ENV_NAMES.get(as_harness)
+        if env_name != expected:
+            raise InputError(f"--*-session-env must be {expected!r} for --as {as_harness}; got {env_name!r}")
+        value = os.environ.get(env_name)
+        if not value:
+            raise InputError(f"missing {env_name}")
+        return value
+    if literal is None:
+        raise InputError("a session reference is required")
+    return literal
 
 
 def load_lease(workspace_directory: Path) -> dict[str, object] | None:
@@ -1254,7 +1276,9 @@ def build_parser() -> argparse.ArgumentParser:
     resume_parser = subcommands.add_parser("resume", help="acquire ownership of a handoff checkpoint")
     resume_parser.add_argument("checkpoint_id")
     resume_parser.add_argument("--as", dest="as_harness", required=True, choices=list(HARNESSES))
-    resume_parser.add_argument("--receiver-session", required=True)
+    resume_session_group = resume_parser.add_mutually_exclusive_group(required=True)
+    resume_session_group.add_argument("--receiver-session")
+    resume_session_group.add_argument("--receiver-session-env")
     resume_parser.add_argument("--acknowledge-degraded", action="store_true")
     recover_parser = subcommands.add_parser("recover", help="rebuild a degraded checkpoint after source failure")
     recover_parser.add_argument("--from", dest="from_harness", required=True, choices=list(HARNESSES))
@@ -1263,7 +1287,9 @@ def build_parser() -> argparse.ArgumentParser:
     close_parser = subcommands.add_parser("close", help="close a handoff checkpoint and release the worktree")
     close_parser.add_argument("checkpoint_id")
     close_parser.add_argument("--as", dest="as_harness", required=True, choices=list(HARNESSES))
-    close_parser.add_argument("--session-ref", required=True)
+    close_session_group = close_parser.add_mutually_exclusive_group(required=True)
+    close_session_group.add_argument("--session-ref")
+    close_session_group.add_argument("--session-ref-env")
     guard_parser = subcommands.add_parser("guard", help="decide whether a harness may mutate this worktree")
     guard_parser.add_argument("--as", dest="as_harness", required=True, choices=list(HARNESSES))
     guard_parser.add_argument("--session-ref")
@@ -1279,18 +1305,22 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "show":
             write_envelope(show_checkpoint(args.checkpoint_id))
         elif args.command == "resume":
+            receiver_session = resolve_session_ref(
+                args.receiver_session, args.receiver_session_env, args.as_harness
+            )
             write_envelope(
                 resume_checkpoint(
                     args.checkpoint_id,
                     args.as_harness,
-                    args.receiver_session,
+                    receiver_session,
                     args.acknowledge_degraded,
                 )
             )
         elif args.command == "recover":
             write_envelope(recover_checkpoint(args.from_harness, args.source_stopped, args.source_session_ref))
         elif args.command == "close":
-            write_envelope(close_checkpoint(args.checkpoint_id, args.as_harness, args.session_ref))
+            session_ref = resolve_session_ref(args.session_ref, args.session_ref_env, args.as_harness)
+            write_envelope(close_checkpoint(args.checkpoint_id, args.as_harness, session_ref))
         elif args.command == "guard":
             envelope, exit_code = guard_decision(args.as_harness, args.session_ref)
             write_envelope(envelope)

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -77,20 +77,20 @@ Never export, copy, summarize from, or persist a native Claude/Pi transcript. Ne
 
 ## Resume
 
-Determine the current harness (`pi` when `PI_SESSION_ID` is set; otherwise `claude`). Bind the lease to the canonical receiver session: Pi uses `PI_SESSION_ID`; Claude uses `CLAUDE_CODE_SESSION_ID`, which matches the Claude hook payload identity. A missing session ID is an error; never acquire an unbound lease.
+Determine the current harness (`pi` when `PI_SESSION_ID` is set; otherwise `claude`). Bind the lease to the canonical receiver session via its environment variable name: Pi uses `PI_SESSION_ID`; Claude uses `CLAUDE_CODE_SESSION_ID`, which matches the Claude hook payload identity. The runtime reads the named variable itself and errors if it is missing or blank; never acquire an unbound lease.
 
-Run exactly one of these single pipelines, inserting `--acknowledge-degraded` only when explicitly requested:
+Run exactly one of these single pipelines, inserting `--acknowledge-degraded` only when explicitly requested. Every argument is a literal value — never a `${VAR}` shell expansion — so the pipeline stays inert enough for the harness's own command-safety checks to verify:
 
 ```bash
 # Claude receiver
 swe-workbench-handoff resume "<checkpoint-id>" --as claude \
-  --receiver-session "${CLAUDE_CODE_SESSION_ID:?missing CLAUDE_CODE_SESSION_ID}" \
+  --receiver-session-env CLAUDE_CODE_SESSION_ID \
   <include --acknowledge-degraded only when requested> \
   | swe-workbench-result-check swb.handoff/1
 
 # Pi receiver
 swe-workbench-handoff resume "<checkpoint-id>" --as pi \
-  --receiver-session "${PI_SESSION_ID:?missing PI_SESSION_ID}" \
+  --receiver-session-env PI_SESSION_ID \
   <include --acknowledge-degraded only when requested> \
   | swe-workbench-result-check swb.handoff/1
 ```
@@ -110,17 +110,17 @@ Print the returned checkpoint id and warning. Recovery is truthful degraded salv
 
 ## Close
 
-Authenticate close with the same harness and canonical receiver session that acquired the lease. Run exactly one pipeline:
+Authenticate close with the same harness and canonical receiver session that acquired the lease. Run exactly one pipeline, again using the literal environment-variable-name form:
 
 ```bash
 # Claude receiver
 swe-workbench-handoff close "<checkpoint-id>" --as claude \
-  --session-ref "${CLAUDE_CODE_SESSION_ID:?missing CLAUDE_CODE_SESSION_ID}" \
+  --session-ref-env CLAUDE_CODE_SESSION_ID \
   | swe-workbench-result-check swb.handoff/1
 
 # Pi receiver
 swe-workbench-handoff close "<checkpoint-id>" --as pi \
-  --session-ref "${PI_SESSION_ID:?missing PI_SESSION_ID}" \
+  --session-ref-env PI_SESSION_ID \
   | swe-workbench-result-check swb.handoff/1
 ```
 

--- a/docs/cross-harness-handoff.md
+++ b/docs/cross-harness-handoff.md
@@ -27,9 +27,12 @@ The **source harness must stop mutating after `create`** — this is enforced, n
 Claude's PreToolUse hook (`hooks/handoff_guard.py`) and Pi's native adapter
 (`pi/extensions/handoff.ts`) block `Bash`/`Edit`/`Write` (Pi: `bash`/`write`/`edit`) while a
 lease they do not own is in flight, allowing only the exact anchored lifecycle pipelines
-(resume/recover with `--receiver-session`/`--source-stopped` and a
-`| swe-workbench-result-check swb.handoff/1` tail). Blocking messages carry the exact
-receiver command, e.g. ``run `/handoff resume <id>` in the receiver``.
+(resume/recover with a literal `--receiver-session-env`/`--source-stopped` and a
+`| swe-workbench-result-check swb.handoff/1` tail — every pipeline argument is a literal
+value, never a runtime `${VAR}` shell expansion). Blocking messages carry the exact receiver
+command and the leased worktree path, e.g. ``run `/handoff resume <id>` in the receiver``
+plus the worktree root the guard resolved the lease against — so a session that finds itself
+blocked can tell which worktree holds the lease even when it differs from its own.
 
 ## Routes
 
@@ -38,7 +41,7 @@ receiver command, e.g. ``run `/handoff resume <id>` in the receiver``.
   `swe-workbench-handoff create < file`, validates the `swb.handoff/1` envelope, prints the
   receiver instruction, and **stops**.
 - **resume** — the receiver acquires ownership:
-  `swe-workbench-handoff resume <id> --as <harness> --receiver-session "${PI_SESSION_ID:?…}"`
+  `swe-workbench-handoff resume <id> --as <harness> --receiver-session-env PI_SESSION_ID`
   (Claude: `CLAUDE_CODE_SESSION_ID`), then `show` to present the checkpoint. Session refs are
   required and bounded; a session-less resume is rejected rather than binding an unbound lease.
 - **recover** — after the source harness has *hard-failed* (quota exhaustion, crash): the
@@ -47,8 +50,31 @@ receiver command, e.g. ``run `/handoff resume <id>` in the receiver``.
   Recovery is **truthful degraded salvage**: it rebuilds from the prior checkpoint (if any)
   plus deterministic git evidence only, marks the checkpoint `degraded`, and requires
   `--acknowledge-degraded` on resume before ownership is granted.
-- **close** — owner-authenticated (`--as` + `--session-ref` matching the lease); closes the
+- **close** — owner-authenticated (`--as` + `--session-ref-env` matching the lease); closes the
   checkpoint and removes the lease.
+
+### Abandoning a checkpoint
+
+The guard mediates the *agent's* tools (`Bash`/`Edit`/`Write` on Claude, `bash`/`write`/`edit`
+on Pi) — it does not, and cannot, stop a human operator from running the runtime directly in a
+plain shell. If a checkpoint needs to be walked back (a lease left `released` with no live
+receiver, an abandoned salvage attempt), an operator can resume and immediately close it:
+
+```bash
+swe-workbench-handoff resume <id> --as <target> --receiver-session <ref>
+swe-workbench-handoff close <id> --as <same-target> --session-ref <same-ref>
+```
+
+Three sharp edges apply, all enforced by the runtime itself:
+
+- `--as` must match the checkpoint's `target_harness` exactly; resuming with the wrong harness
+  is rejected before any lease state changes.
+- A `degraded` (salvage) checkpoint requires `--acknowledge-degraded` on the `resume` call, or
+  it is refused.
+- `resume` refuses if the live worktree has drifted since the checkpoint was written (its
+  dirty fingerprint no longer matches). That is not itself abandonable — the path is
+  `swe-workbench-handoff recover --from <source> --source-stopped`, which rebuilds a fresh,
+  honestly `degraded` checkpoint from the current worktree instead of trusting stale state.
 
 Stale-checkpoint and lease-identity mismatches are rejected on both `resume` and `close`,
 so an old checkpoint id can never rebind or release a newer handoff's lease.

--- a/docs/decisions-cross-harness.md
+++ b/docs/decisions-cross-harness.md
@@ -35,6 +35,42 @@ signal — context-window usage accessors are explicitly NOT quota — so Pi war
 an actual HTTP 429. Pre-limit percentage warnings remain a Claude-only affordance driven
 by Claude's five-hour quota fields (`status-segment`).
 
+**A read-only Bash allowlist for the guard — rejected.** "Read-only" is not a decidable
+property of a command string, and even with perfect tokenization `git` itself is not
+read-only: `git diff --ext-diff` runs a configured external diff driver, `git -c
+core.pager='sh -c …'` injects execution through config, `git -C <path>` retargets outside
+the guarded worktree, `--output=` writes files, and bare `git status` writes `.git/index`.
+A safe allowlist would have to be flag-scoped per verb and maintained against upstream git
+forever, for the sole benefit of typing `cat` instead of using the `Read` tool — which the
+guard never blocked in the first place (only `Bash`/`Edit`/`Write`, Pi:
+`bash`/`write`/`edit`). `tests/test_handoff_guard.py`'s
+`test_still_blocks_arbitrary_read_only_bash_under_a_released_lease` is the standing ruling.
+
+**Auto-releasing a "stale" `released` lease — rejected.** The lease exists *because* the
+source harness is expected to be gone for hours at a time (quota exhaustion); `released` is
+the protocol's normal waiting state, not evidence of abandonment. Nothing observable from
+one harness's session can prove the other harness's session is dead — which is exactly why
+`recover` requires the operator to type `--source-stopped` by hand. Auto-releasing on a
+timeout would silently destroy a real in-flight checkpoint the moment it happened to outlive
+the timeout, converting a diagnostic annoyance into a destructive one. The existing 7-day
+open-checkpoint expiry, 24-hour consumed/closed sweep, and `_recorded_worktree_exists`
+orphan reaping are the correct staleness story; the escape hatch for a checkpoint an
+operator wants to walk back by hand is `resume` immediately followed by `close` (see
+`docs/cross-harness-handoff.md`'s "Abandoning a checkpoint"), not a new `abandon`
+subcommand or an allowlisted `close` — `close` authenticates on `owner_harness` *and*
+`receiver_session_ref`, and allowlisting it would let a non-owner delete a lease, which is
+the exact thing the guard exists to prevent.
+
+**The harness's own worktree-isolation / git-detection guard is out of scope here.** A
+worktree-isolated Claude Code session's Bash tool refuses a compound command it cannot
+statically prove stays confined to git and to the current worktree — that guard is compiled
+into the Claude Code binary, not this plugin (no matches under `hooks/`, `bin/`,
+`commands/`, or `skills/`). It refuses a lifecycle pipeline carrying a `${VAR:?…}` shell
+expansion because that is a runtime-computed, non-inert argument; this plugin can (and
+does, via the `--*-session-env` literal-argument form) remove that condition from its own
+pipelines, but the guard's underlying false-positive rate on an unrecognized binary piped
+into another is upstream Claude Code's to fix.
+
 ## 2. Cross-harness memory — main-checkout anchoring, dual-slug read, own-store-only writes
 
 Each harness owns one per-repo memory store and reads the other's read-only

--- a/docs/decisions-hooks.md
+++ b/docs/decisions-hooks.md
@@ -20,9 +20,11 @@ Applied to every entry in `hooks/hooks.json`, no `if` buys anything:
 | `skill_usage_record.sh` | `PreToolUse` / `Skill` | `Skill(*)` is exactly redundant with `matcher` |
 | `worktree_permission_grant.sh` | `PreToolUse` / `Read\|Edit\|Write` | Worktree root is runtime-resolved, not a static path rule |
 | `secret_guard.py` | `PreToolUse` / `Write\|Edit` | Same as `worktree_permission_grant.sh` — no static pattern captures "contains a credential" |
+| `handoff_guard.py` | `PreToolUse` / `Bash\|Edit\|Write` | Lease ownership is runtime-resolved per worktree, not a static path/pattern rule |
 | `skill_autoload_hint.sh` | `PostToolUse` / `Read\|Edit\|Write` | Would need every extension enumerated; a miss silently loses the hint |
 | `skill_usage_flush.sh` | `SubagentStop` | No tool call to match against — inert at best, disabling at worst |
 | `workflow_resume_hint.sh` ×3 | `SessionStart` | Same — lifecycle events carry no tool call |
+| `memory_hint.sh` ×3 | `SessionStart` | Same — lifecycle events carry no tool call |
 
 **Ruling: no `hooks.json` entry may carry an `if` key**, enforced by
 `scripts/validate.py:check_hooks_json()`. This is strictly stronger than the two security

--- a/hooks/handoff_guard.py
+++ b/hooks/handoff_guard.py
@@ -32,9 +32,8 @@ _CONTROL_COMMANDS = (
         rf'--receiver-session {_CLAUDE_SESSION_ARGUMENT} '
         rf'(?:--acknowledge-degraded )?{_CHECKED_PIPE}$'
     ),
-    # Literal-argument form: no runtime shell expansion, so a harness's static command
-    # guard can prove the pipeline inert. See resolve_session_ref in
-    # bin/swe-workbench-handoff for the allowlist this mirrors.
+    # Literal-argument form: lets a harness's static command guard prove the pipeline inert
+    # (mirrors bin/swe-workbench-handoff's resolve_session_ref allowlist).
     re.compile(
         rf'^swe-workbench-handoff resume "?{_UUID}"? --as "?claude"? '
         rf'--receiver-session-env {_CLAUDE_SESSION_ENV_ARGUMENT} '

--- a/hooks/handoff_guard.py
+++ b/hooks/handoff_guard.py
@@ -25,10 +25,19 @@ _CHECKED_PIPE = r"\| swe-workbench-result-check swb\.handoff/1"
 _CLAUDE_SESSION_ARGUMENT = re.escape(
     '"${CLAUDE_CODE_SESSION_ID:?missing CLAUDE_CODE_SESSION_ID}"'
 )
+_CLAUDE_SESSION_ENV_ARGUMENT = re.escape("CLAUDE_CODE_SESSION_ID")
 _CONTROL_COMMANDS = (
     re.compile(
         rf'^swe-workbench-handoff resume "?{_UUID}"? --as "?claude"? '
         rf'--receiver-session {_CLAUDE_SESSION_ARGUMENT} '
+        rf'(?:--acknowledge-degraded )?{_CHECKED_PIPE}$'
+    ),
+    # Literal-argument form: no runtime shell expansion, so a harness's static command
+    # guard can prove the pipeline inert. See resolve_session_ref in
+    # bin/swe-workbench-handoff for the allowlist this mirrors.
+    re.compile(
+        rf'^swe-workbench-handoff resume "?{_UUID}"? --as "?claude"? '
+        rf'--receiver-session-env {_CLAUDE_SESSION_ENV_ARGUMENT} '
         rf'(?:--acknowledge-degraded )?{_CHECKED_PIPE}$'
     ),
     re.compile(

--- a/hooks/handoff_guard.py
+++ b/hooks/handoff_guard.py
@@ -56,12 +56,35 @@ def _runtime_path() -> Path | None:
 
 
 def _working_directory(payload: dict[str, object]) -> Path:
+    """Resolve the directory the guarded tool call will run in.
+
+    Falls back to ``Path.cwd()`` when the PreToolUse payload carries no ``cwd`` — a
+    Claude-Code-specific payload artifact with no Pi counterpart (Pi reads ``ctx.cwd``
+    directly). Do not "fix" this asymmetry by adding a fallback on the Pi side.
+    """
     cwd = payload.get("cwd")
     if isinstance(cwd, str):
         candidate = Path(cwd)
         if candidate.is_dir():
             return candidate
     return Path.cwd()
+
+
+def _safe_worktree_root(value: object) -> str | None:
+    """Validate an untrusted worktree_root before it reaches stderr.
+
+    The path is decoded with ``surrogateescape`` upstream, so treat it as untrusted text:
+    require a bounded string free of control characters. Validation failure omits the
+    clause; it never raises.
+    """
+    if (
+        isinstance(value, str)
+        and value.startswith("/")
+        and len(value) <= 4096
+        and all(ord(character) >= 32 and ord(character) != 127 for character in value)
+    ):
+        return value
+    return None
 
 
 def _is_control_command(payload: dict[str, object]) -> bool:
@@ -82,7 +105,7 @@ def _block(message: str) -> None:
     raise SystemExit(2)
 
 
-def _decision(output: str) -> tuple[str, str, str | None, str | None] | None:
+def _decision(output: str) -> tuple[str, str, str | None, str | None, str | None] | None:
     try:
         envelope = json.loads(output)
     except json.JSONDecodeError:
@@ -108,7 +131,8 @@ def _decision(output: str) -> tuple[str, str, str | None, str | None] | None:
         if isinstance(target_harness, str) and target_harness in {"claude", "pi"}
         else None
     )
-    return decision, reason, safe_checkpoint_id, safe_target_harness
+    safe_worktree_root = _safe_worktree_root(data.get("worktree_root"))
+    return decision, reason, safe_checkpoint_id, safe_target_harness, safe_worktree_root
 
 
 def main() -> None:
@@ -145,19 +169,20 @@ def main() -> None:
         return
 
     if parsed is not None and parsed[0] == "deny":
-        reason, checkpoint_id, target_harness = parsed[1:]
+        reason, checkpoint_id, target_harness, worktree_root = parsed[1:]
         if "released" in reason:
             if checkpoint_id is None or target_harness is None:
                 _block("handoff ownership is released but its receiver state is invalid")
             command_name = "/handoff" if target_harness == "pi" else "/swe-workbench:handoff"
+            leased_clause = f" this worktree ({worktree_root}) is leased;" if worktree_root else ""
             _block(
-                f"handoff ownership is released to {target_harness}; "
+                f"handoff ownership is released to {target_harness};{leased_clause} "
                 f"run `{command_name} resume {checkpoint_id}` in the receiver"
             )
         if "different receiver session" in reason:
-            _block("this worktree is bound to a different receiver session")
+            _block(f"this worktree ({worktree_root}) is bound to a different receiver session" if worktree_root else reason)
         if "held by" in reason:
-            _block(reason)
+            _block(f"{reason} (worktree: {worktree_root})" if worktree_root else reason)
         _block("the handoff lease denies mutation from this Claude session")
 
     if result.returncode != 0 and "Traceback" in result.stderr:

--- a/hooks/handoff_guard.py
+++ b/hooks/handoff_guard.py
@@ -113,6 +113,10 @@ def _block(message: str) -> None:
     raise SystemExit(2)
 
 
+def _with_worktree_clause(message: str, worktree_root: str | None) -> str:
+    return f"{message} (worktree: {worktree_root})" if worktree_root else message
+
+
 def _decision(output: str) -> tuple[str, str, str | None, str | None, str | None] | None:
     try:
         envelope = json.loads(output)
@@ -182,15 +186,17 @@ def main() -> None:
             if checkpoint_id is None or target_harness is None:
                 _block("handoff ownership is released but its receiver state is invalid")
             command_name = "/handoff" if target_harness == "pi" else "/swe-workbench:handoff"
-            leased_clause = f" this worktree ({worktree_root}) is leased;" if worktree_root else ""
             _block(
-                f"handoff ownership is released to {target_harness};{leased_clause} "
-                f"run `{command_name} resume {checkpoint_id}` in the receiver"
+                _with_worktree_clause(
+                    f"handoff ownership is released to {target_harness}; "
+                    f"run `{command_name} resume {checkpoint_id}` in the receiver",
+                    worktree_root,
+                )
             )
         if "different receiver session" in reason:
-            _block(f"this worktree ({worktree_root}) is bound to a different receiver session" if worktree_root else reason)
+            _block(_with_worktree_clause("this worktree is bound to a different receiver session", worktree_root))
         if "held by" in reason:
-            _block(f"{reason} (worktree: {worktree_root})" if worktree_root else reason)
+            _block(_with_worktree_clause(reason, worktree_root))
         _block("the handoff lease denies mutation from this Claude session")
 
     if result.returncode != 0 and "Traceback" in result.stderr:

--- a/pi/extensions/handoff.ts
+++ b/pi/extensions/handoff.ts
@@ -123,7 +123,7 @@ function safeWorktreeRoot(value: unknown): string | undefined {
   if (
     typeof value === "string" &&
     value.startsWith("/") &&
-    value.length <= 4096 &&
+    Array.from(value).length <= 4096 &&
     Array.from(value).every((character) => {
       const code = character.codePointAt(0) ?? 0;
       return code >= 32 && code !== 127;

--- a/pi/extensions/handoff.ts
+++ b/pi/extensions/handoff.ts
@@ -93,6 +93,7 @@ interface GuardData {
   decision?: unknown;
   reason?: unknown;
   instruction?: unknown;
+  worktree_root?: unknown;
 }
 
 function parseGuardDecision(stdout: string): GuardData | undefined {
@@ -109,12 +110,29 @@ function parseGuardDecision(stdout: string): GuardData | undefined {
   }
 }
 
+/** Validate an untrusted worktree_root before it reaches a block reason string. */
+function safeWorktreeRoot(value: unknown): string | undefined {
+  if (
+    typeof value === "string" &&
+    value.startsWith("/") &&
+    value.length <= 4096 &&
+    Array.from(value).every((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code >= 32 && code !== 127;
+    })
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
 function blockReason(data: GuardData | undefined, fallback: string): string {
   if (data === undefined) return fallback;
   const reason = typeof data.reason === "string" ? data.reason : "";
   const instruction = typeof data.instruction === "string" ? data.instruction : "";
-  if (reason && instruction) return `${reason} — ${instruction}`;
-  return instruction || reason || fallback;
+  const worktreeRoot = safeWorktreeRoot(data.worktree_root);
+  const base = reason && instruction ? `${reason} — ${instruction}` : instruction || reason || fallback;
+  return worktreeRoot ? `${base} (worktree: ${worktreeRoot})` : base;
 }
 
 export function registerHandoff(pi: ExtensionAPI, root: string): void {

--- a/pi/extensions/handoff.ts
+++ b/pi/extensions/handoff.ts
@@ -48,6 +48,7 @@ const INTERPRETER_FAILURE_TEXT =
 const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 const CHECKED_PIPE = String.raw`\| swe-workbench-result-check swb\.handoff/1`;
 const PI_SESSION_ARGUMENT = '"${PI_SESSION_ID:?missing PI_SESSION_ID}"';
+const PI_SESSION_ENV_ARGUMENT = "PI_SESSION_ID";
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -62,6 +63,13 @@ const CONTROL_COMMANDS: readonly RegExp[] = [
   new RegExp(
     `^swe-workbench-handoff resume "?${UUID_PATTERN.source}"? --as "?pi"? ` +
       `--receiver-session ${escapeRegExp(PI_SESSION_ARGUMENT)} ` +
+      `(?:--acknowledge-degraded )?${CHECKED_PIPE}$`,
+  ),
+  // Literal-argument form: no runtime shell expansion, so a harness's static command guard
+  // can prove the pipeline inert. Mirrors bin/swe-workbench-handoff's resolve_session_ref.
+  new RegExp(
+    `^swe-workbench-handoff resume "?${UUID_PATTERN.source}"? --as "?pi"? ` +
+      `--receiver-session-env ${escapeRegExp(PI_SESSION_ENV_ARGUMENT)} ` +
       `(?:--acknowledge-degraded )?${CHECKED_PIPE}$`,
   ),
   new RegExp(

--- a/tests/test_handoff_command.py
+++ b/tests/test_handoff_command.py
@@ -47,9 +47,9 @@ def test_planned_handoff_prints_the_stop_invariant_and_exact_resume_commands():
 
 def test_resume_binds_a_receiver_session_from_the_harness_environment():
     text = _text()
-    assert "--receiver-session" in text
-    assert "${PI_SESSION_ID:?" in text
-    assert "${CLAUDE_CODE_SESSION_ID:?" in text
+    assert "--receiver-session-env" in text
+    assert "PI_SESSION_ID" in text
+    assert "CLAUDE_CODE_SESSION_ID" in text
     assert "CLAUDE_SESSION_ID" not in text
 
 
@@ -83,7 +83,7 @@ def test_close_authenticates_the_current_harness_and_session():
     text = _text()
     close_section = text.split("## Close", 1)[1]
     assert "--as" in close_section
-    assert "--session-ref" in close_section
+    assert "--session-ref-env" in close_section
     assert "CLAUDE_CODE_SESSION_ID" in close_section
     assert "PI_SESSION_ID" in close_section
 

--- a/tests/test_handoff_guard.py
+++ b/tests/test_handoff_guard.py
@@ -208,6 +208,45 @@ def test_allows_exact_resume_pipeline_through_a_released_lease(tmp_path):
     assert result.returncode == 0, result.stderr
 
 
+def test_allows_exact_resume_env_pipeline_through_a_released_lease(tmp_path):
+    repo = tmp_path / "repo"
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create(repo, state_dir, target="claude", source="pi")
+    payload = _payload(repo, "Bash")
+    payload["tool_input"] = {
+        "command": (
+            f'swe-workbench-handoff resume "{checkpoint_id}" --as claude '
+            "--receiver-session-env CLAUDE_CODE_SESSION_ID "
+            "| swe-workbench-result-check swb.handoff/1"
+        )
+    }
+
+    result = _run_hook(payload, state_dir=state_dir)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_blocks_resume_pipeline_with_a_near_miss_session_env_name(tmp_path):
+    repo = tmp_path / "repo"
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create(repo, state_dir, target="claude", source="pi")
+    payload = _payload(repo, "Bash")
+    payload["tool_input"] = {
+        "command": (
+            f'swe-workbench-handoff resume "{checkpoint_id}" --as claude '
+            "--receiver-session-env HOME "
+            "| swe-workbench-result-check swb.handoff/1"
+        )
+    }
+
+    result = _run_hook(payload, state_dir=state_dir)
+
+    assert result.returncode == 2
+    assert "BLOCKED:" in result.stderr
+
+
 def test_allows_exact_pi_source_recovery_pipeline_through_ownership_gate(tmp_path):
     repo = tmp_path / "repo"
     _initialize_repo(repo)

--- a/tests/test_handoff_guard.py
+++ b/tests/test_handoff_guard.py
@@ -112,6 +112,7 @@ def test_blocks_mutating_tools_under_a_released_lease(tmp_path):
         assert result.returncode == 2, f"{tool_name}: {result.stderr}"
         assert "BLOCKED:" in result.stderr
         assert f"/handoff resume {checkpoint_id}" in result.stderr
+        assert str(repo.resolve()) in result.stderr
 
 
 def test_released_lease_names_the_claude_receiver_command(tmp_path):
@@ -160,6 +161,7 @@ def test_allows_the_bound_owner_session_and_blocks_other_sessions(tmp_path):
     assert bound.returncode == 0, bound.stderr
     assert other.returncode == 2
     assert "BLOCKED:" in other.stderr
+    assert str(repo.resolve()) in other.stderr
 
 
 def test_blocks_when_the_other_harness_owns_the_lease(tmp_path):
@@ -184,6 +186,7 @@ def test_blocks_when_the_other_harness_owns_the_lease(tmp_path):
     assert result.returncode == 2
     assert "BLOCKED:" in result.stderr
     assert "pi" in result.stderr
+    assert str(repo.resolve()) in result.stderr
 
 
 def test_allows_exact_resume_pipeline_through_a_released_lease(tmp_path):
@@ -372,6 +375,19 @@ def test_interpreter_startup_failure_names_the_required_runtime(tmp_path):
     assert result.returncode == 2
     assert "Python 3.9" in result.stderr
     assert "pin" in result.stderr
+
+
+def test_a_control_character_worktree_root_is_omitted_not_emitted(tmp_path):
+    repo = tmp_path / "repo\nweird"
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    _create(repo, state_dir, target="pi")
+
+    result = _run_hook(_payload(repo, "Bash"), state_dir=state_dir)
+
+    assert result.returncode == 2
+    assert "BLOCKED:" in result.stderr
+    assert result.stderr.count("\n") == 1, "an unvalidated worktree_root must never split the BLOCKED line"
 
 
 def test_no_secrets_in_blocking_output(tmp_path):

--- a/tests/test_handoff_script.py
+++ b/tests/test_handoff_script.py
@@ -840,7 +840,20 @@ def test_guard_allows_mutation_outside_a_git_workspace(tmp_path):
     result = _run_handoff("guard", "--as", "claude", cwd=plain, env=_env_for(tmp_path / "state"))
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["data"]["decision"] == "allow"
+    envelope = json.loads(result.stdout)
+    assert envelope["data"]["decision"] == "allow"
+    assert "worktree_root" not in envelope["data"]
+
+
+def test_guard_allow_envelope_carries_the_worktree_root_when_no_lease_exists(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+
+    result = _run_handoff("guard", "--as", "claude", cwd=repo, env=_env_for(tmp_path / "state"))
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["data"]["worktree_root"] == str(repo.resolve())
 
 
 def test_guard_denies_a_released_lease_for_both_harnesses(tmp_path):
@@ -858,6 +871,7 @@ def test_guard_denies_a_released_lease_for_both_harnesses(tmp_path):
         assert envelope["data"]["checkpoint_id"] == checkpoint_id
         assert envelope["data"]["target_harness"] == "pi"
         assert envelope["data"]["instruction"] == f"/handoff resume {checkpoint_id}"
+        assert envelope["data"]["worktree_root"] == str(repo.resolve())
 
 
 def test_guard_allows_only_the_bound_owner_session(tmp_path):
@@ -875,13 +889,19 @@ def test_guard_allows_only_the_bound_owner_session(tmp_path):
     foreign = _run_handoff("guard", "--as", "claude", cwd=repo, env=_env_for(state_dir))
 
     assert allowed.returncode == 0, allowed.stderr
-    assert json.loads(allowed.stdout)["data"]["decision"] == "allow"
+    allowed_envelope = json.loads(allowed.stdout)
+    assert allowed_envelope["data"]["decision"] == "allow"
+    assert allowed_envelope["data"]["worktree_root"] == str(repo.resolve())
     assert wrong_session.returncode == 3
-    assert json.loads(wrong_session.stdout)["data"]["decision"] == "deny"
+    wrong_session_envelope = json.loads(wrong_session.stdout)
+    assert wrong_session_envelope["data"]["decision"] == "deny"
+    assert wrong_session_envelope["data"]["worktree_root"] == str(repo.resolve())
     assert missing_session.returncode == 3
     assert json.loads(missing_session.stdout)["data"]["decision"] == "deny"
     assert foreign.returncode == 3
-    assert json.loads(foreign.stdout)["data"]["decision"] == "deny"
+    foreign_envelope = json.loads(foreign.stdout)
+    assert foreign_envelope["data"]["decision"] == "deny"
+    assert foreign_envelope["data"]["worktree_root"] == str(repo.resolve())
 
 
 def test_close_rejects_a_stale_checkpoint_without_releasing_the_current_lease(tmp_path):

--- a/tests/test_handoff_script.py
+++ b/tests/test_handoff_script.py
@@ -1422,6 +1422,183 @@ def _python39() -> str | None:
     return None
 
 
+# ── Task 3: session-env flags (literal-argument-only lifecycle pipelines) ────
+
+
+def _checkpoint_targeting(operation_id: str, target: str) -> dict[str, object]:
+    payload = _create_input(operation_id)
+    payload["source_harness"] = "pi" if target == "claude" else "claude"
+    payload["target_harness"] = target
+    return payload
+
+
+def test_resume_accepts_a_receiver_session_env_name(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(repo, state_dir, _checkpoint_targeting("resume-env-happy", "claude"))[
+        "data"
+    ]["checkpoint_id"]
+
+    result = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session-env",
+        "CLAUDE_CODE_SESSION_ID",
+        cwd=repo,
+        env={**_env_for(state_dir), "CLAUDE_CODE_SESSION_ID": "sess-env-1"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    lease = _lease(state_dir)
+    assert lease["owner_harness"] == "claude"
+    assert lease["receiver_session_ref"] == "sess-env-1"
+
+
+@pytest.mark.parametrize("env_value", [None, ""], ids=["unset", "blank"])
+def test_resume_rejects_an_unset_or_blank_receiver_session_env(tmp_path, env_value):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(repo, state_dir, _checkpoint_targeting("resume-env-unset", "claude"))[
+        "data"
+    ]["checkpoint_id"]
+    env = _env_for(state_dir)
+    if env_value is not None:
+        env["CLAUDE_CODE_SESSION_ID"] = env_value
+
+    result = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session-env",
+        "CLAUDE_CODE_SESSION_ID",
+        cwd=repo,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "CLAUDE_CODE_SESSION_ID" in result.stderr
+    lease = _lease_for_checkpoint(state_dir, checkpoint_id)
+    assert lease["owner_harness"] == "released"
+
+
+def test_resume_rejects_a_non_allowlisted_session_env_name(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(
+        repo, state_dir, _checkpoint_targeting("resume-env-non-allowlisted", "claude")
+    )["data"]["checkpoint_id"]
+
+    result = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session-env",
+        "HOME",
+        cwd=repo,
+        env={**_env_for(state_dir), "HOME": "/tmp/whatever"},
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_resume_rejects_a_session_env_name_for_the_other_harness(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(
+        repo, state_dir, _checkpoint_targeting("resume-env-wrong-harness", "claude")
+    )["data"]["checkpoint_id"]
+
+    result = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session-env",
+        "PI_SESSION_ID",
+        cwd=repo,
+        env={**_env_for(state_dir), "PI_SESSION_ID": "pi-sess-1"},
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_resume_requires_exactly_one_session_source(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(repo, state_dir, _checkpoint_targeting("resume-env-exclusive", "claude"))[
+        "data"
+    ]["checkpoint_id"]
+
+    neither = _run_handoff("resume", checkpoint_id, "--as", "claude", cwd=repo, env=_env_for(state_dir))
+    both = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session",
+        "literal-sess",
+        "--receiver-session-env",
+        "CLAUDE_CODE_SESSION_ID",
+        cwd=repo,
+        env={**_env_for(state_dir), "CLAUDE_CODE_SESSION_ID": "sess-env-1"},
+    )
+
+    assert neither.returncode != 0
+    assert both.returncode != 0
+
+
+def test_close_accepts_a_session_ref_env_name(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _initialize_repo(repo)
+    state_dir = tmp_path / "state"
+    checkpoint_id = _create_checkpoint(repo, state_dir, _checkpoint_targeting("close-env-happy", "claude"))[
+        "data"
+    ]["checkpoint_id"]
+    acquired = _run_handoff(
+        "resume",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--receiver-session-env",
+        "CLAUDE_CODE_SESSION_ID",
+        cwd=repo,
+        env={**_env_for(state_dir), "CLAUDE_CODE_SESSION_ID": "sess-env-1"},
+    )
+    assert acquired.returncode == 0, acquired.stderr
+
+    closed = _run_handoff(
+        "close",
+        checkpoint_id,
+        "--as",
+        "claude",
+        "--session-ref-env",
+        "CLAUDE_CODE_SESSION_ID",
+        cwd=repo,
+        env={**_env_for(state_dir), "CLAUDE_CODE_SESSION_ID": "sess-env-1"},
+    )
+
+    assert closed.returncode == 0, closed.stderr
+    assert not list(state_dir.glob("workspaces/*/*/lease.json"))
+
+
 def test_handoff_script_avoids_post_3_9_datetime_imports():
     source = SCRIPT.read_text(encoding="utf-8")
     assert re.search(r"^from datetime import .*\bUTC\b", source, re.MULTILINE) is None, (

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -3094,13 +3094,15 @@ def _handoff_driver_result(tmp_path_factory, label, mutate=None):
             f'--session-ref {session_arg} | swe-workbench-result-check swb.handoff/1'
         ),
     }
-    return _run_node(
+    result = _run_node(
         _HANDOFF_DRIVER,
         [str(HANDOFF_TS), json.dumps(config)],
         tmp_path_factory,
         label=label,
         env={**_CLEAN_ENV, "SWE_WORKBENCH_HANDOFF_STATE_DIR": str(state_dir)},
     )
+    result["repos"] = {name: str(path) for name, path in repos.items()}
+    return result
 
 
 def test_handoff_module_exists():
@@ -3137,10 +3139,12 @@ def test_handoff_allows_mutation_when_no_state_exists(tmp_path_factory):
 
 @requires_node
 def test_handoff_blocks_mutating_tools_under_a_released_lease(tmp_path_factory):
-    out = _handoff_driver_result(tmp_path_factory, "pi-handoff-released")["out"]
+    result = _handoff_driver_result(tmp_path_factory, "pi-handoff-released")
+    out = result["out"]
     for key in ("releasedBash", "releasedEdit", "releasedWrite"):
         assert out[key]["block"] is True, f"{key}: {out[key]}"
     assert "/handoff resume" in out["releasedBash"]["reason"]
+    assert result["repos"]["released"] in out["releasedBash"]["reason"]
     assert out.get("releasedRead") is None
 
 

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -2908,6 +2908,8 @@ out.releasedRead = await toolCall(config.repos.released, "read", { path: "/tmp/f
 
 out.resumePipeline = await toolCall(config.repos.released, "bash", { command: config.resumePipeline });
 out.resumeDegradedPipeline = await toolCall(config.repos.released, "bash", { command: config.resumeDegradedPipeline });
+out.resumeEnvPipeline = await toolCall(config.repos.released, "bash", { command: config.resumeEnvPipeline });
+out.resumeNearMissEnvPipeline = await toolCall(config.repos.released, "bash", { command: config.resumeNearMissEnvPipeline });
 out.recoverPipeline = await toolCall(config.repos.released, "bash", { command: config.recoverPipeline });
 out.injectedPipeline = await toolCall(config.repos.released, "bash", { command: config.injectedPipeline });
 out.closePipeline = await toolCall(config.repos.released, "bash", { command: config.closePipeline });
@@ -3081,6 +3083,16 @@ def _handoff_driver_result(tmp_path_factory, label, mutate=None):
             f'--receiver-session {session_arg} --acknowledge-degraded '
             f'| swe-workbench-result-check swb.handoff/1'
         ),
+        "resumeEnvPipeline": (
+            f'swe-workbench-handoff resume "{released_id}" --as pi '
+            f'--receiver-session-env PI_SESSION_ID '
+            f'| swe-workbench-result-check swb.handoff/1'
+        ),
+        "resumeNearMissEnvPipeline": (
+            f'swe-workbench-handoff resume "{released_id}" --as pi '
+            f'--receiver-session-env HOME '
+            f'| swe-workbench-result-check swb.handoff/1'
+        ),
         "recoverPipeline": (
             'swe-workbench-handoff recover --from "claude" --source-stopped '
             "| swe-workbench-result-check swb.handoff/1"
@@ -3156,6 +3168,13 @@ def test_handoff_permits_only_the_exact_lifecycle_pipelines(tmp_path_factory):
     assert out.get("recoverPipeline") is None
     assert out["injectedPipeline"]["block"] is True
     assert out["closePipeline"]["block"] is True
+
+
+@requires_node
+def test_handoff_allowlists_the_literal_session_env_resume_pipeline(tmp_path_factory):
+    out = _handoff_driver_result(tmp_path_factory, "pi-handoff-env-pipeline")["out"]
+    assert out.get("resumeEnvPipeline") is None
+    assert out["resumeNearMissEnvPipeline"]["block"] is True
 
 
 @requires_node


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `guard_decision` now includes `worktree_root` in every allow/deny envelope (never on the no-git-workspace path); both the Claude PreToolUse hook and the Pi extension validate it (absolute, bounded, no control characters) and fold it into the block message, so a blocked session can see which worktree holds the lease.
- `resume`/`close` accept a new `--receiver-session-env`/`--session-ref-env` flag (a hard-allowlisted env-var name the runtime reads itself) alongside the existing literal `--receiver-session`/`--session-ref`, via argparse mutually-exclusive groups. This removes the runtime-computed `${VAR:?...}` shell expansion from the documented lifecycle pipelines — one of the conditions a worktree-isolated harness session's own command-safety guard refuses on. Verified empirically in a worktree-isolated session: the reshaped pipeline reaches argparse instead of being refused, while the original `${VAR:?...}` form is reproducibly refused.
- Both hook allowlists (`hooks/handoff_guard.py`, `pi/extensions/handoff.ts`) gain a second anchored pattern for the resume env-form; the original form is kept for backward compatibility. `close` stays deliberately un-allowlisted — it authenticates via the normal owner/session check, not a command-shape bypass.
- Documentation: `docs/cross-harness-handoff.md` gets an "Abandoning a checkpoint" section for the manual operator escape hatch, `docs/decisions-cross-harness.md` records why a read-only Bash allowlist and auto-releasing stale leases were rejected, and `docs/decisions-hooks.md` gets two hook-table rows it had been missing.
- Explicitly **not** implemented (see rejected-alternatives rulings in `docs/decisions-cross-harness.md`): a read-only Bash command allowlist, auto-releasing "stale" released leases, or an `abandon` subcommand / allowlisting `close`. The harness's own git-detection/worktree-isolation guard producing a false positive on an unrecognized binary piped into another is a Claude Code platform issue outside this plugin's control — this change only reduces its own trigger surface.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] Full suite: `pytest tests/ -v` (3791 passed, 3 skipped) and `npm run typecheck` (clean); `bash scripts/validate.sh` (0 issues); `swe-workbench-comment-scan` against the branch diff (0 must-triage)

### Type-tailored checks (fix)
- [x] Reproduced the reported symptom (a block message naming no worktree) before the fix; confirmed it now names the leased worktree
- [x] Empirical gate: reproduced the pre-existing `${VAR:?...}` pipeline being refused by a worktree-isolated session's command guard, then confirmed the reshaped `--receiver-session-env`/`--session-ref-env` pipelines reach argparse instead of being refused, for both `resume` and `close`

<!-- Link to the GitHub issue this PR addresses.
     Use one of:  Closes #<number>  |  Fixes #<number>  |  Resolves #<number>

     If no issue applies, DELETE the "Closes #" line and replace it with
     a standalone line:
         Issue: N/A
     Preferred (more useful for reviewers):
         Issue: N/A — <one-line reason, e.g. "trivial docs typo" or "urgent hotfix">

     The following WILL fail CI:
       - leaving "Closes #" empty with no replacement
       - deleting the line entirely with nothing in its place
       - writing "Closes N/A" or "Closes #N/A" (malformed — use a standalone "Issue: N/A" instead) -->
Closes #711
