### PR TITLE
[fix] Sync peerDependencies floor after pi 0.84.3->0.84.4 bump

### DIFF
--- a/.github/workflows/dependabot-peer-sync.yml
+++ b/.github/workflows/dependabot-peer-sync.yml
@@ -11,13 +11,25 @@ name: Dependabot peerDependencies Sync
 #
 # pull_request_target is required for write access to push back to the PR
 # branch. To stay safe against a compromised PR, this workflow:
-#   - never executes anything checked out from the PR itself — it fetches the
-#     sync script from the base branch (origin/main) and runs only that copy
+#   - never executes anything checked out from the PR itself — it overwrites
+#     scripts/sync-peer-deps.sh with the copy from the base branch
+#     (origin/main) before running it, so only that trusted content ever runs,
+#     invoked in place so its own BASH_SOURCE-relative root detection still
+#     resolves to the checked-out repo (not /tmp)
 #   - only ever reads/writes package.json and package-lock.json — no `npm
 #     install`, so a malicious package's install/postinstall script can never
 #     run with this job's write token
 #   - is gated on the PR author being dependabot[bot] and the diff touching
 #     package.json
+#
+# The resulting fixup-commit push authenticates with the default
+# GITHUB_TOKEN, so per GitHub's own docs the pull_request run it triggers on
+# pr.yml lands in an approval-required state rather than running immediately
+# — https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow.
+# A maintainer still needs one click of "Approve workflows to run" on that
+# run; getting a fully automatic re-run would require a PAT or GitHub App
+# token in place of GITHUB_TOKEN, which we deliberately avoid here to keep
+# this workflow secret-free.
 on:
   pull_request_target:
     types: [opened, synchronize]
@@ -38,25 +50,27 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-      pull-requests: write
     steps:
       # Checked out for git history/parentage only (so a fixup commit lands
-      # on top of the PR's real commits) — nothing from this tree is executed.
+      # on top of the PR's real commits) — every file in this tree is
+      # untrusted until the next step overwrites the one script we execute.
       - name: Checkout PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Fetch trusted sync script from main
+      # Overwrite in place (not copied to /tmp) so the script's own
+      # BASH_SOURCE-relative root detection still resolves correctly.
+      - name: Overwrite sync script with the trusted copy from main
         run: |
           git fetch --depth 1 origin main
-          git show origin/main:scripts/sync-peer-deps.sh > /tmp/sync-peer-deps.sh
+          git show origin/main:scripts/sync-peer-deps.sh > scripts/sync-peer-deps.sh
 
       - name: Check for peerDependencies drift
         id: check
         run: |
-          if bash /tmp/sync-peer-deps.sh --check; then
+          if bash scripts/sync-peer-deps.sh --check; then
             echo "drift=false" >> "$GITHUB_OUTPUT"
           else
             echo "drift=true" >> "$GITHUB_OUTPUT"
@@ -67,22 +81,10 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          bash /tmp/sync-peer-deps.sh
+          bash scripts/sync-peer-deps.sh
+          git checkout -- scripts/sync-peer-deps.sh
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "[chore] Sync peerDependencies floor to devDependencies pin"
           git push origin "HEAD:refs/heads/${HEAD_REF}"
-
-      # A GITHUB_TOKEN-authored push does not itself retrigger pull_request
-      # workflows (infinite-loop guard built into Actions) — a close+reopen
-      # cycle does, and pr.yml's pull_request trigger now includes 'reopened'.
-      - name: Reopen PR to retrigger required checks
-        if: steps.check.outputs.drift == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr close "$PR_NUMBER" --repo "$REPO"
-          gh pr reopen "$PR_NUMBER" --repo "$REPO"

--- a/.github/workflows/dependabot-peer-sync.yml
+++ b/.github/workflows/dependabot-peer-sync.yml
@@ -67,13 +67,28 @@ jobs:
           git fetch --depth 1 origin main
           git show origin/main:scripts/sync-peer-deps.sh > scripts/sync-peer-deps.sh
 
+      # sync-peer-deps.sh --check distinguishes actionable drift (exit 1) from a hard error
+      # it can't act on (exit 2) — pi-coding-agent and pi-tui bump as two SEPARATE dependabot
+      # PRs (no npm `groups:` in dependabot.yml), so the first PR of every such pair always
+      # hits the script's own devDependencies-lockstep guard (exit 2). Treating that as
+      # actionable drift would run the apply step next, which hits the identical guard and
+      # fails the job — a confusing, unfixable-by-design red check on top of the pytest
+      # failure this workflow exists to eliminate. Only exit 1 is actionable; exit 2 (or
+      # anything else unexpected) is a clean no-op with a warning annotation.
       - name: Check for peerDependencies drift
         id: check
         run: |
-          if bash scripts/sync-peer-deps.sh --check; then
+          set +e
+          bash scripts/sync-peer-deps.sh --check
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
             echo "drift=false" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$code" -eq 1 ]; then
             echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sync-peer-deps.sh could not determine an actionable floor (exit ${code}) — skipping auto-fix. This is expected when only one of pi-coding-agent/pi-tui has bumped so far; it resolves once the other one bumps too."
+            echo "drift=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fix, commit, and push
@@ -82,7 +97,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           bash scripts/sync-peer-deps.sh
-          git checkout -- scripts/sync-peer-deps.sh
+          git checkout -- scripts/sync-peer-deps.sh || true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json

--- a/.github/workflows/dependabot-peer-sync.yml
+++ b/.github/workflows/dependabot-peer-sync.yml
@@ -1,0 +1,88 @@
+name: Dependabot peerDependencies Sync
+
+# Dependabot only ever bumps the exact devDependencies pin for
+# @earendil-works/pi-coding-agent / pi-tui, never the peerDependencies floor
+# (">=X <1" already satisfies the new pin, so its semver updater sees no
+# violation to fix) — but tests/test_pi_extension.py::test_package_json_values
+# requires the floor stay in lockstep with the pin. Left alone, every such
+# dependabot PR fails pytest until a human manually edits the floor. This
+# workflow runs scripts/sync-peer-deps.sh against the PR's own manifests and
+# pushes a fixup commit when drift is found.
+#
+# pull_request_target is required for write access to push back to the PR
+# branch. To stay safe against a compromised PR, this workflow:
+#   - never executes anything checked out from the PR itself — it fetches the
+#     sync script from the base branch (origin/main) and runs only that copy
+#   - only ever reads/writes package.json and package-lock.json — no `npm
+#     install`, so a malicious package's install/postinstall script can never
+#     run with this job's write token
+#   - is gated on the PR author being dependabot[bot] and the diff touching
+#     package.json
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    branches: [main]
+    paths: ["package.json"]
+
+concurrency:
+  group: dependabot-peer-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync-peer-deps:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # Checked out for git history/parentage only (so a fixup commit lands
+      # on top of the PR's real commits) — nothing from this tree is executed.
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch trusted sync script from main
+        run: |
+          git fetch --depth 1 origin main
+          git show origin/main:scripts/sync-peer-deps.sh > /tmp/sync-peer-deps.sh
+
+      - name: Check for peerDependencies drift
+        id: check
+        run: |
+          if bash /tmp/sync-peer-deps.sh --check; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fix, commit, and push
+        if: steps.check.outputs.drift == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          bash /tmp/sync-peer-deps.sh
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "[chore] Sync peerDependencies floor to devDependencies pin"
+          git push origin "HEAD:refs/heads/${HEAD_REF}"
+
+      # A GITHUB_TOKEN-authored push does not itself retrigger pull_request
+      # workflows (infinite-loop guard built into Actions) — a close+reopen
+      # cycle does, and pr.yml's pull_request trigger now includes 'reopened'.
+      - name: Reopen PR to retrigger required checks
+        if: steps.check.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr close "$PR_NUMBER" --repo "$REPO"
+          gh pr reopen "$PR_NUMBER" --repo "$REPO"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,11 @@ jobs:
           # Gated on package.json actually being in the diff (not just body text) so a
           # contributor can't paste this one line into an unrelated PR to dodge the check.
           if echo "$PR_BODY_VISIBLE" | grep -qE '^Bumps .+ from .+ to .+\.$'; then
-            CHANGED_FILES=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+            # A transient gh api failure falls through to the closing-keyword check below
+            # rather than failing this step outright — a real closing keyword still passes,
+            # and a PR relying solely on this opt-out correctly gets asked to add one instead
+            # of failing on an unrelated API blip.
+            CHANGED_FILES=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/dev/null) || CHANGED_FILES=""
             if echo "$CHANGED_FILES" | grep -qxF "package.json"; then
               echo "Issue reference opted out with a Dependabot-style bump line — skipping check"
               exit 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,10 @@ name: PR Validation
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    # 'reopened' lets dependabot-peer-sync.yml force a re-run of these checks after it
+    # pushes a peerDependencies fixup commit — a GITHUB_TOKEN-authored push does not
+    # itself retrigger pull_request workflows, but a close+reopen cycle does.
+    types: [opened, edited, synchronize, reopened]
     branches: [main]
 
 permissions:
@@ -78,6 +81,14 @@ jobs:
           # Accepts: "N/A", "Issue: N/A", "Issue: N/A — reason", "N/A — reason".
           if echo "$PR_BODY_VISIBLE" | grep -iqE '^[[:space:]]*(Issue:[[:space:]]+)?N/A([[:space:]]+[—\-].+)?[[:space:]]*$'; then
             echo "Issue reference opted out with N/A — skipping check"
+            exit 0
+          fi
+
+          # Allow manually-authored dependency-bump PRs that carry the same
+          # "Bumps <pkg> from <old> to <new>." line Dependabot's own PRs use —
+          # these have no linked issue either, same as the dependabot[bot]-actor case above.
+          if echo "$PR_BODY_VISIBLE" | grep -qE '^Bumps .+ from .+ to .+\.$'; then
+            echo "Issue reference opted out with a Dependabot-style bump line — skipping check"
             exit 0
           fi
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,10 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
-    # 'reopened' lets dependabot-peer-sync.yml force a re-run of these checks after it
-    # pushes a peerDependencies fixup commit — a GITHUB_TOKEN-authored push does not
-    # itself retrigger pull_request workflows, but a close+reopen cycle does.
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize]
     branches: [main]
 
 permissions:
@@ -70,6 +67,9 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Strip HTML comments first so example text inside <!-- ... --> blocks
           # (e.g. "Issue: N/A" documentation in the PR template) does not
@@ -87,9 +87,15 @@ jobs:
           # Allow manually-authored dependency-bump PRs that carry the same
           # "Bumps <pkg> from <old> to <new>." line Dependabot's own PRs use —
           # these have no linked issue either, same as the dependabot[bot]-actor case above.
+          # Gated on package.json actually being in the diff (not just body text) so a
+          # contributor can't paste this one line into an unrelated PR to dodge the check.
           if echo "$PR_BODY_VISIBLE" | grep -qE '^Bumps .+ from .+ to .+\.$'; then
-            echo "Issue reference opted out with a Dependabot-style bump line — skipping check"
-            exit 0
+            CHANGED_FILES=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+            if echo "$CHANGED_FILES" | grep -qxF "package.json"; then
+              echo "Issue reference opted out with a Dependabot-style bump line — skipping check"
+              exit 0
+            fi
+            echo "Bump-style opt-out line found but package.json is not in this PR's diff — ignoring the opt-out"
           fi
 
           # Require a GitHub closing keyword (case-insensitive).

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "typescript": "^7.0.2"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
-        "@earendil-works/pi-tui": ">=0.84.3 <1"
+        "@earendil-works/pi-coding-agent": ">=0.84.4 <1",
+        "@earendil-works/pi-tui": ">=0.84.4 <1"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-coding-agent": {
@@ -38,7 +38,7 @@
         "@earendil-works/pi-ai": "^0.84.4",
         "@earendil-works/pi-client": "^0.84.4",
         "@earendil-works/pi-protocol": "^0.84.4",
-        "@earendil-works/pi-tui": "0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "typescript": "^7.0.2"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
-    "@earendil-works/pi-tui": ">=0.84.3 <1"
+    "@earendil-works/pi-coding-agent": ">=0.84.4 <1",
+    "@earendil-works/pi-tui": ">=0.84.4 <1"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {

--- a/scripts/sync-peer-deps.sh
+++ b/scripts/sync-peer-deps.sh
@@ -13,6 +13,16 @@ set -euo pipefail
 # Usage:
 #   scripts/sync-peer-deps.sh --check   # fail if the floor is out of sync; make no changes
 #   scripts/sync-peer-deps.sh           # rewrite package.json + package-lock.json in place
+#
+# Exit codes (distinguished so a caller like dependabot-peer-sync.yml can tell "there is
+# actionable drift to fix" apart from "this script cannot proceed at all" — pi-coding-agent
+# and pi-tui are bumped as two SEPARATE dependabot PRs, so the first of every such pair
+# always hits the lockstep guard below; that must never be treated as syncable drift):
+#   0 - already in sync (or, in apply mode, sync completed)
+#   1 - actionable floor drift found (only in --check mode)
+#   2 - hard error: cannot determine or apply the correct floor (missing jq, missing/
+#       malformed devDependencies or peerDependencies keys, or the two packages' pins are
+#       out of lockstep) — nothing was or could be synced
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PKG="${ROOT}/package.json"
@@ -20,28 +30,30 @@ LOCK="${ROOT}/package-lock.json"
 
 if ! command -v jq &>/dev/null; then
   echo "Error: jq is required." >&2
-  exit 1
+  exit 2
 fi
 
 PIN=$(jq -r '.devDependencies["@earendil-works/pi-coding-agent"]' "$PKG")
 if [[ -z "$PIN" || "$PIN" == "null" ]]; then
   echo "Error: could not read devDependencies[\"@earendil-works/pi-coding-agent\"] from ${PKG}" >&2
-  exit 1
+  exit 2
 fi
 
 # pi-coding-agent and pi-tui are nested and published lockstep (see
 # tests/test_pi_extension.py's tui_dev_pin == dev_pin assertion) — this script only derives
 # the expected floor from one pin, so a partial bump that skips pi-tui must fail loudly here
-# rather than silently syncing pi-tui's floor to a pin pi-tui never actually moved to.
+# rather than silently syncing pi-tui's floor to a pin pi-tui never actually moved to. This is
+# not a rare edge case: dependabot.yml has no `groups:` for npm, so pi-coding-agent and pi-tui
+# bump as two separate PRs — every such pair's first PR lands in exactly this state.
 TUI_PIN=$(jq -r '.devDependencies["@earendil-works/pi-tui"]' "$PKG")
 if [[ "$TUI_PIN" != "$PIN" ]]; then
   echo "Error: devDependencies pins are out of lockstep — pi-coding-agent is ${PIN}, pi-tui is ${TUI_PIN}" >&2
-  exit 1
+  exit 2
 fi
 
 FLOOR=$(jq -e -r '.peerDependencies["@earendil-works/pi-coding-agent"] | split(" ")[0]' "$PKG") || {
   echo "Error: could not read peerDependencies[\"@earendil-works/pi-coding-agent\"] from ${PKG}" >&2
-  exit 1
+  exit 2
 }
 EXPECTED_FLOOR=">=${PIN}"
 

--- a/scripts/sync-peer-deps.sh
+++ b/scripts/sync-peer-deps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keeps the peerDependencies floor for @earendil-works/pi-coding-agent and pi-tui locked to
+# the exact devDependencies pin — tests/test_pi_extension.py::test_package_json_values
+# enforces this lockstep so a consumer can never sit on a floor whose tested behavior has
+# since changed underneath it (see commit 0e34767). Dependabot only ever bumps the exact
+# devDependencies pin, never peerDependencies (">=X <1" already satisfies the new pin, so its
+# semver updater has no violation to fix), so this drifts on every pi-coding-agent/pi-tui
+# bump unless synced explicitly — this script is that explicit sync, run by hand or by
+# .github/workflows/dependabot-peer-sync.yml.
+#
+# Usage:
+#   scripts/sync-peer-deps.sh --check   # fail if the floor is out of sync; make no changes
+#   scripts/sync-peer-deps.sh           # rewrite package.json + package-lock.json in place
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG="${ROOT}/package.json"
+LOCK="${ROOT}/package-lock.json"
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required." >&2
+  exit 1
+fi
+
+PIN=$(jq -r '.devDependencies["@earendil-works/pi-coding-agent"]' "$PKG")
+if [[ -z "$PIN" || "$PIN" == "null" ]]; then
+  echo "Error: could not read devDependencies[\"@earendil-works/pi-coding-agent\"] from ${PKG}" >&2
+  exit 1
+fi
+
+FLOOR=$(jq -r '.peerDependencies["@earendil-works/pi-coding-agent"] | split(" ")[0]' "$PKG")
+EXPECTED_FLOOR=">=${PIN}"
+
+MODE="${1:-}"
+
+if [[ "$FLOOR" == "$EXPECTED_FLOOR" ]]; then
+  echo "peerDependencies floor already in sync with devDependencies pin (${PIN})."
+  exit 0
+fi
+
+if [[ "$MODE" == "--check" ]]; then
+  echo "::error::peerDependencies floor (${FLOOR}) is out of sync with the devDependencies pin (${PIN} -> expected floor ${EXPECTED_FLOOR}); run scripts/sync-peer-deps.sh" >&2
+  exit 1
+fi
+
+# package-lock.json (lockfileVersion 3) mirrors the root manifest's peerDependencies under
+# packages[""] — there is no legacy top-level "dependencies" block to also update.
+_sync_json() {
+  local file="$1" jq_filter="$2"
+  local tmp
+  tmp=$(mktemp)
+  jq --arg range ">=${PIN} <1" "$jq_filter" "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+_sync_json "$PKG" '
+  .peerDependencies["@earendil-works/pi-coding-agent"] = $range
+  | .peerDependencies["@earendil-works/pi-tui"] = $range
+'
+
+_sync_json "$LOCK" '
+  .packages[""].peerDependencies["@earendil-works/pi-coding-agent"] = $range
+  | .packages[""].peerDependencies["@earendil-works/pi-tui"] = $range
+'
+
+echo "Synced peerDependencies floor to >=${PIN} <1 in package.json and package-lock.json."

--- a/scripts/sync-peer-deps.sh
+++ b/scripts/sync-peer-deps.sh
@@ -29,7 +29,20 @@ if [[ -z "$PIN" || "$PIN" == "null" ]]; then
   exit 1
 fi
 
-FLOOR=$(jq -r '.peerDependencies["@earendil-works/pi-coding-agent"] | split(" ")[0]' "$PKG")
+# pi-coding-agent and pi-tui are nested and published lockstep (see
+# tests/test_pi_extension.py's tui_dev_pin == dev_pin assertion) — this script only derives
+# the expected floor from one pin, so a partial bump that skips pi-tui must fail loudly here
+# rather than silently syncing pi-tui's floor to a pin pi-tui never actually moved to.
+TUI_PIN=$(jq -r '.devDependencies["@earendil-works/pi-tui"]' "$PKG")
+if [[ "$TUI_PIN" != "$PIN" ]]; then
+  echo "Error: devDependencies pins are out of lockstep — pi-coding-agent is ${PIN}, pi-tui is ${TUI_PIN}" >&2
+  exit 1
+fi
+
+FLOOR=$(jq -e -r '.peerDependencies["@earendil-works/pi-coding-agent"] | split(" ")[0]' "$PKG") || {
+  echo "Error: could not read peerDependencies[\"@earendil-works/pi-coding-agent\"] from ${PKG}" >&2
+  exit 1
+}
 EXPECTED_FLOOR=">=${PIN}"
 
 MODE="${1:-}"

--- a/tests/test_dependabot_peer_sync_workflow.py
+++ b/tests/test_dependabot_peer_sync_workflow.py
@@ -22,14 +22,22 @@ WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dependabot-peer-sync.yml"
 
 def _extract_drift_check_bash() -> str:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # End boundary is the next step marker (6-space-indented "- name:"), not a bare blank
+    # line — a blank line inserted inside the run block for readability would otherwise
+    # silently truncate the capture instead of tripping the assert below.
     m = re.search(
-        r"name: Check for peerDependencies drift\n\s*id: check\n\s*run: \|\n(.*?)\n\n",
+        r"name: Check for peerDependencies drift\n\s*id: check\n\s*run: \|\n(.*?)\n(?=      - name:)",
         text,
         re.DOTALL,
     )
     assert m, "could not locate the 'Check for peerDependencies drift' step's run block"
+    body = m.group(1)
+    assert "set +e" in body and "set -e" in body, (
+        "extracted block is missing the set +e/set -e pair — the step's bash may have "
+        "changed shape in a way this extraction no longer tracks correctly"
+    )
     # De-indent: the YAML block is indented 10 spaces under `run: |`.
-    lines = m.group(1).splitlines()
+    lines = body.splitlines()
     return "\n".join(line[10:] if line.startswith(" " * 10) else line for line in lines)
 
 

--- a/tests/test_dependabot_peer_sync_workflow.py
+++ b/tests/test_dependabot_peer_sync_workflow.py
@@ -1,0 +1,95 @@
+"""Regression test for the drift-detection bash embedded in
+.github/workflows/dependabot-peer-sync.yml's "Check for peerDependencies drift" step.
+
+Reproduces the exact bug a PR review caught: pi-coding-agent and pi-tui bump as two
+SEPARATE dependabot PRs, so the first PR of every such pair leaves the two packages'
+devDependencies pins out of lockstep — scripts/sync-peer-deps.sh --check correctly treats
+that as a hard error (exit 2), not actionable drift (exit 1), but the original workflow
+bash only checked "did --check exit 0", so it treated exit 2 the same as exit 1 and went
+on to run the apply step, which hits the identical guard and fails the whole job. This
+test extracts the step's actual bash from the YAML (so it fails loudly if that bash drifts
+from what's tested here) and drives it against a stub sync-peer-deps.sh for each exit code.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "dependabot-peer-sync.yml"
+
+
+def _extract_drift_check_bash() -> str:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    m = re.search(
+        r"name: Check for peerDependencies drift\n\s*id: check\n\s*run: \|\n(.*?)\n\n",
+        text,
+        re.DOTALL,
+    )
+    assert m, "could not locate the 'Check for peerDependencies drift' step's run block"
+    # De-indent: the YAML block is indented 10 spaces under `run: |`.
+    lines = m.group(1).splitlines()
+    return "\n".join(line[10:] if line.startswith(" " * 10) else line for line in lines)
+
+
+_DRIFT_CHECK_BASH = _extract_drift_check_bash()
+
+
+def _run_drift_check(tmp_path: Path, stub_exit_code: int) -> tuple[str, str]:
+    """Run the extracted bash against a stub sync-peer-deps.sh that exits stub_exit_code.
+
+    Returns (github_output_content, stdout) — GitHub Actions workflow-command annotations
+    like ::warning:: are written to stdout, not stderr.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    stub = scripts_dir / "sync-peer-deps.sh"
+    stub.write_text(f"#!/usr/bin/env bash\nexit {stub_exit_code}\n")
+    stub.chmod(0o755)
+
+    github_output = tmp_path / "github_output"
+    github_output.write_text("")
+
+    script = f"set -euo pipefail\n{_DRIFT_CHECK_BASH}\n"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={**_CLEAN_ENV, "GITHUB_OUTPUT": str(github_output)},
+    )
+    assert result.returncode == 0, (
+        f"drift-check bash itself must not fail (stub exit {stub_exit_code}): "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    return github_output.read_text(), result.stdout
+
+
+class TestDriftCheckExitCodeHandling:
+    def test_exit_0_sets_drift_false(self, tmp_path):
+        output, _ = _run_drift_check(tmp_path, 0)
+        assert "drift=false" in output
+
+    def test_exit_1_sets_drift_true(self, tmp_path):
+        """Exit 1 is scripts/sync-peer-deps.sh's actionable-drift code — the apply step
+        should run next."""
+        output, _ = _run_drift_check(tmp_path, 1)
+        assert "drift=true" in output
+
+    def test_exit_2_sets_drift_false_not_true(self, tmp_path):
+        """The regression this test locks in: exit 2 (hard error, e.g. the two packages'
+        devDependencies pins are out of lockstep) must NOT be treated as actionable drift —
+        it must be a clean no-op, not an attempt to run the apply step (which would hit the
+        identical guard and fail the job)."""
+        output, stdout = _run_drift_check(tmp_path, 2)
+        assert "drift=false" in output
+        assert "drift=true" not in output
+        assert "::warning::" in stdout
+
+    def test_unexpected_exit_code_also_falls_back_to_no_op(self, tmp_path):
+        """Any exit code other than 0/1 is treated as a hard error, not just 2 specifically —
+        a defensive default in case the script's contract changes underneath this workflow."""
+        output, stdout = _run_drift_check(tmp_path, 7)
+        assert "drift=false" in output
+        assert "::warning::" in stdout

--- a/tests/test_pi_extension.py
+++ b/tests/test_pi_extension.py
@@ -220,6 +220,20 @@ def test_package_json_values():
     )
 
 
+def test_package_lock_peer_dependencies_match_package_json():
+    """package-lock.json's packages[""].peerDependencies is a separate, manually-editable
+    copy of package.json's peerDependencies (lockfileVersion 3 has no other mirror to keep
+    it in sync automatically) — scripts/sync-peer-deps.sh keeps both in lockstep, but nothing
+    besides this test would catch a manual edit to one file that forgot the other."""
+    pkg = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    lock = json.loads((ROOT / "package-lock.json").read_text(encoding="utf-8"))
+    assert lock["packages"][""]["peerDependencies"] == pkg["peerDependencies"], (
+        "package-lock.json's peerDependencies has drifted from package.json's — "
+        "run scripts/sync-peer-deps.sh, or if the drift is elsewhere, run `npm install "
+        "--package-lock-only`"
+    )
+
+
 def test_package_json_has_no_forbidden_pi_keys():
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
     assert "skills" not in data["pi"], (

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -420,3 +420,91 @@ class TestAuthorshipDenylist:
     def test_pre_commit_allows_real_email(self):
         result = self._run_pre_commit("dev@example.org")
         assert result.returncode == 0
+
+
+def _extract_issue_reference_bash() -> str:
+    """Extract the full "Validate issue reference" step's run block from pr.yml.
+
+    Unlike the regex-only mirrors above, this drives the actual bash (with a stubbed `gh`)
+    end to end — the live gh-api gating on the "Bumps ... from ... to ...." opt-out has no
+    other coverage, since it depends on real process execution, not just string matching.
+    """
+    if _PR_YML_TEXT is None:
+        pytest.skip("pr.yml not found")
+    m = re.search(
+        r"name: Validate issue reference\n.*?run: \|\n(.*?)\n(?=  validate-plugin-files:)",
+        _PR_YML_TEXT,
+        re.DOTALL,
+    )
+    assert m, "could not locate the 'Validate issue reference' step's run block"
+    body = m.group(1)
+    assert "gh api" in body and "CHANGED_FILES" in body, (
+        "extracted block is missing the gh-api gating logic — the step's bash may have "
+        "changed shape in a way this extraction no longer tracks correctly"
+    )
+    lines = body.splitlines()
+    return "\n".join(line[10:] if line.startswith(" " * 10) else line for line in lines)
+
+
+class TestIssueReferenceBumpOptoutGating:
+    """Drives the actual "Validate issue reference" bash (not just its regex) with a
+    stubbed `gh`, covering the live changed-files gate the sibling
+    tests/test_dependabot_peer_sync_workflow.py established this pattern for."""
+
+    def _run(self, tmp_path: Path, pr_body: str, gh_files: list[str] | None, gh_exit: int = 0) -> subprocess.CompletedProcess:
+        """gh_files=None simulates `gh api` itself failing (gh_exit is then forced nonzero)."""
+        stub_dir = tmp_path / "stub_bin"
+        stub_dir.mkdir()
+        stub_gh = stub_dir / "gh"
+        if gh_files is None:
+            stub_gh.write_text("#!/usr/bin/env bash\nexit 1\n")
+        else:
+            files_output = "\n".join(gh_files)
+            stub_gh.write_text(f"#!/usr/bin/env bash\ncat <<'EOF'\n{files_output}\nEOF\nexit {gh_exit}\n")
+        stub_gh.chmod(0o755)
+
+        script = f"set -eo pipefail\n{_extract_issue_reference_bash()}\n"
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            env={
+                **_CLEAN_ENV,
+                "PATH": f"{stub_dir}{os.pathsep}{_CLEAN_ENV['PATH']}",
+                "PR_BODY": pr_body,
+                "REPO": "owner/repo",
+                "PR_NUMBER": "1",
+                "GH_TOKEN": "dummy",
+            },
+        )
+
+    def test_bump_line_with_package_json_in_diff_opts_out(self, tmp_path):
+        result = self._run(tmp_path, "Bumps foo from 1.0.0 to 2.0.0.", gh_files=["package.json", "package-lock.json"])
+        assert result.returncode == 0
+        assert "opted out with a Dependabot-style bump line" in result.stdout
+
+    def test_bump_line_without_package_json_in_diff_falls_through_and_fails(self, tmp_path):
+        result = self._run(tmp_path, "Bumps foo from 1.0.0 to 2.0.0.", gh_files=["src/other.py"])
+        assert result.returncode == 1
+        assert "ignoring the opt-out" in result.stdout
+        assert "must reference an issue" in result.stdout
+
+    def test_bump_line_without_package_json_in_diff_but_with_closing_keyword_passes(self, tmp_path):
+        result = self._run(
+            tmp_path, "Bumps foo from 1.0.0 to 2.0.0.\n\nCloses #42", gh_files=["src/other.py"],
+        )
+        assert result.returncode == 0
+
+    def test_gh_api_failure_falls_through_fail_open_not_step_failure(self, tmp_path):
+        """A transient gh api error must not abort the step outright — it falls through to
+        the closing-keyword check, which still correctly fails without one."""
+        result = self._run(tmp_path, "Bumps foo from 1.0.0 to 2.0.0.", gh_files=None)
+        assert result.returncode == 1
+        assert "must reference an issue" in result.stdout
+
+    def test_gh_api_failure_with_valid_closing_keyword_still_passes(self, tmp_path):
+        """Proves the gh api failure path is fail-open (falls through), not fail-closed
+        (aborts the whole step) — a PR that doesn't even need the opt-out still passes."""
+        result = self._run(tmp_path, "Bumps foo from 1.0.0 to 2.0.0.\n\nCloses #42", gh_files=None)
+        assert result.returncode == 0

--- a/tests/test_pr_validation.py
+++ b/tests/test_pr_validation.py
@@ -55,6 +55,11 @@ def _na_optout(visible: str) -> bool:
     )
 
 
+def _dependabot_bump_optout(visible: str) -> bool:
+    """Python-native equivalent of the bash grep -qE Dependabot-bump-line opt-out pattern."""
+    return bool(re.search(r"^Bumps .+ from .+ to .+\.$", visible, re.MULTILINE))
+
+
 def has_closing_keyword(visible: str) -> bool:
     return bool(
         re.search(
@@ -175,6 +180,17 @@ class TestValidOptout:
         visible = strip_html_comments(body)
         assert has_closing_keyword(visible)
 
+    def test_dependabot_style_bump_line_triggers_optout(self):
+        body = (
+            "Bumps [@earendil-works/pi-tui]"
+            "(https://github.com/earendil-works/pi) from 0.84.3 to 0.84.4.\n"
+        )
+        visible = strip_html_comments(body)
+        assert _dependabot_bump_optout(visible), (
+            "A manually-authored PR body carrying Dependabot's own "
+            "'Bumps ... from ... to ....' line must trigger the opt-out"
+        )
+
 
 class TestPrYamlSync:
     """Tie Python helper functions to the source-of-truth regexes in pr.yml.
@@ -256,6 +272,33 @@ class TestPrYamlSync:
             py_result = has_closing_keyword(text)
             assert yml_result == py_result, (
                 f"yml_re and has_closing_keyword() disagree on {text!r}: "
+                f"yml={yml_result}, py={py_result}"
+            )
+            assert yml_result == expected, (
+                f"yml regex gave {yml_result!r} for {text!r}, expected {expected}"
+            )
+
+    def test_dependabot_bump_optout_matches_pr_yml(self):
+        """_dependabot_bump_optout() behaviour must match the pr.yml grep -qE bump-line pattern."""
+        raw = _extract_pr_yml_pattern(
+            r"Allow manually-authored dependency-bump PRs.*?grep -qE '([^']+)'"
+        )
+        yml_re = re.compile(raw, re.MULTILINE)
+
+        samples = [
+            ("Bumps @earendil-works/pi-tui from 0.84.3 to 0.84.4.",              True),
+            ("Bumps [@earendil-works/pi-tui](url) from 0.84.3 to 0.84.4.",       True),
+            ("## Summary\nBumps foo from 1.0.0 to 2.0.0.\n",                     True),
+            ("bumps foo from 1.0.0 to 2.0.0.",                                   False),  # case-sensitive
+            ("Bumps foo from 1.0.0 to 2.0.0",                                    False),  # no trailing period
+            ("See also: Bumps foo from 1.0.0 to 2.0.0.",                        False),  # not at line start
+            ("Closes #42",                                                      False),
+        ]
+        for text, expected in samples:
+            yml_result = bool(yml_re.search(text))
+            py_result = _dependabot_bump_optout(text)
+            assert yml_result == py_result, (
+                f"yml_re and _dependabot_bump_optout() disagree on {text!r}: "
                 f"yml={yml_result}, py={py_result}"
             )
             assert yml_result == expected, (

--- a/tests/test_sync_peer_deps_sh.py
+++ b/tests/test_sync_peer_deps_sh.py
@@ -18,6 +18,7 @@ SCRIPT = ROOT / "scripts" / "sync-peer-deps.sh"
 _SYNCED_PKG = {
     "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.84.4",
+        "@earendil-works/pi-tui": "0.84.4",
     },
     "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.84.4 <1",
@@ -28,6 +29,7 @@ _SYNCED_PKG = {
 _DRIFTED_PKG = {
     "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.84.4",
+        "@earendil-works/pi-tui": "0.84.4",
     },
     "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
@@ -138,3 +140,35 @@ class TestSyncPeerDepsApply:
         result = _run(script, cwd=tmp_path)
         assert result.returncode == 1
         assert "could not read" in result.stderr
+
+    def test_mismatched_devdependencies_pins_errors(self, tmp_path):
+        """pi-coding-agent and pi-tui are published lockstep — a partial bump that moves
+        only one of the two pins must fail loudly rather than silently deriving the
+        expected floor from whichever pin happened to be read."""
+        pkg = json.loads(json.dumps(_SYNCED_PKG))
+        pkg["devDependencies"]["@earendil-works/pi-tui"] = "0.84.3"
+        script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
+        result = _run(script, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "out of lockstep" in result.stderr
+
+    def test_mismatched_devdependencies_pins_errors_in_check_mode(self, tmp_path):
+        pkg = json.loads(json.dumps(_SYNCED_PKG))
+        pkg["devDependencies"]["@earendil-works/pi-tui"] = "0.84.3"
+        script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
+        result = _run(script, "--check", cwd=tmp_path)
+        assert result.returncode == 1
+        assert "out of lockstep" in result.stderr
+
+    def test_missing_peerdependencies_key_errors(self, tmp_path):
+        pkg = {
+            "devDependencies": {
+                "@earendil-works/pi-coding-agent": "0.84.4",
+                "@earendil-works/pi-tui": "0.84.4",
+            },
+            "peerDependencies": {},
+        }
+        script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
+        result = _run(script, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "could not read peerDependencies" in result.stderr

--- a/tests/test_sync_peer_deps_sh.py
+++ b/tests/test_sync_peer_deps_sh.py
@@ -138,18 +138,20 @@ class TestSyncPeerDepsApply:
         }}
         script = _scaffold(tmp_path, pkg, ">=0.84.3 <1")
         result = _run(script, cwd=tmp_path)
-        assert result.returncode == 1
+        assert result.returncode == 2
         assert "could not read" in result.stderr
 
     def test_mismatched_devdependencies_pins_errors(self, tmp_path):
-        """pi-coding-agent and pi-tui are published lockstep — a partial bump that moves
-        only one of the two pins must fail loudly rather than silently deriving the
-        expected floor from whichever pin happened to be read."""
+        """pi-coding-agent and pi-tui bump as two SEPARATE dependabot PRs (dependabot.yml has
+        no npm `groups:`), so the first PR of every such pair always lands here — this must
+        be a hard error (exit 2), distinct from actionable floor drift (exit 1), so
+        .github/workflows/dependabot-peer-sync.yml treats it as a clean no-op rather than
+        attempting (and failing) an apply it can't complete."""
         pkg = json.loads(json.dumps(_SYNCED_PKG))
         pkg["devDependencies"]["@earendil-works/pi-tui"] = "0.84.3"
         script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
         result = _run(script, cwd=tmp_path)
-        assert result.returncode == 1
+        assert result.returncode == 2
         assert "out of lockstep" in result.stderr
 
     def test_mismatched_devdependencies_pins_errors_in_check_mode(self, tmp_path):
@@ -157,7 +159,7 @@ class TestSyncPeerDepsApply:
         pkg["devDependencies"]["@earendil-works/pi-tui"] = "0.84.3"
         script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
         result = _run(script, "--check", cwd=tmp_path)
-        assert result.returncode == 1
+        assert result.returncode == 2
         assert "out of lockstep" in result.stderr
 
     def test_missing_peerdependencies_key_errors(self, tmp_path):
@@ -170,5 +172,5 @@ class TestSyncPeerDepsApply:
         }
         script = _scaffold(tmp_path, pkg, ">=0.84.4 <1")
         result = _run(script, cwd=tmp_path)
-        assert result.returncode == 1
+        assert result.returncode == 2
         assert "could not read peerDependencies" in result.stderr

--- a/tests/test_sync_peer_deps_sh.py
+++ b/tests/test_sync_peer_deps_sh.py
@@ -1,0 +1,140 @@
+"""Behavioral tests for scripts/sync-peer-deps.sh.
+
+Each case builds a hermetic temp copy of the script alongside a minimal
+package.json/package-lock.json pair (ROOT resolves relative to the script's
+own location, same convention as scripts/bump-version.sh), then runs it via
+subprocess and asserts exit code + file contents.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from conftest import _CLEAN_ENV
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "scripts" / "sync-peer-deps.sh"
+
+_SYNCED_PKG = {
+    "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.84.4",
+    },
+    "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.84.4 <1",
+        "@earendil-works/pi-tui": ">=0.84.4 <1",
+    },
+}
+
+_DRIFTED_PKG = {
+    "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.84.4",
+    },
+    "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
+        "@earendil-works/pi-tui": ">=0.84.3 <1",
+    },
+}
+
+_LOCK_TEMPLATE = {
+    "lockfileVersion": 3,
+    "packages": {
+        "": {
+            "peerDependencies": {
+                "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
+                "@earendil-works/pi-tui": ">=0.84.3 <1",
+            }
+        }
+    },
+}
+
+
+def _scaffold(tmp_path: Path, pkg: dict, lock_floor: str) -> Path:
+    """Copy the script into tmp_path/scripts and write matching manifests."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(SCRIPT, scripts_dir / SCRIPT.name)
+
+    (tmp_path / "package.json").write_text(json.dumps(pkg, indent=2) + "\n")
+
+    lock = json.loads(json.dumps(_LOCK_TEMPLATE))
+    lock["packages"][""]["peerDependencies"]["@earendil-works/pi-coding-agent"] = lock_floor
+    lock["packages"][""]["peerDependencies"]["@earendil-works/pi-tui"] = lock_floor
+    (tmp_path / "package-lock.json").write_text(json.dumps(lock, indent=2) + "\n")
+
+    return scripts_dir / SCRIPT.name
+
+
+def _run(script: Path, *args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=_CLEAN_ENV,
+    )
+
+
+class TestSyncPeerDepsCheck:
+    def test_check_passes_when_already_synced(self, tmp_path):
+        script = _scaffold(tmp_path, _SYNCED_PKG, ">=0.84.4 <1")
+        result = _run(script, "--check", cwd=tmp_path)
+        assert result.returncode == 0
+        assert "already in sync" in result.stdout
+
+    def test_check_fails_when_drifted(self, tmp_path):
+        script = _scaffold(tmp_path, _DRIFTED_PKG, ">=0.84.3 <1")
+        result = _run(script, "--check", cwd=tmp_path)
+        assert result.returncode == 1
+        assert "out of sync" in result.stderr
+
+    def test_check_makes_no_changes_on_drift(self, tmp_path):
+        script = _scaffold(tmp_path, _DRIFTED_PKG, ">=0.84.3 <1")
+        before = (tmp_path / "package.json").read_text()
+        _run(script, "--check", cwd=tmp_path)
+        after = (tmp_path / "package.json").read_text()
+        assert before == after, "--check must never write to package.json"
+
+
+class TestSyncPeerDepsApply:
+    def test_apply_fixes_package_json(self, tmp_path):
+        script = _scaffold(tmp_path, _DRIFTED_PKG, ">=0.84.3 <1")
+        result = _run(script, cwd=tmp_path)
+        assert result.returncode == 0
+
+        pkg = json.loads((tmp_path / "package.json").read_text())
+        assert pkg["peerDependencies"]["@earendil-works/pi-coding-agent"] == ">=0.84.4 <1"
+        assert pkg["peerDependencies"]["@earendil-works/pi-tui"] == ">=0.84.4 <1"
+
+    def test_apply_fixes_package_lock_json(self, tmp_path):
+        script = _scaffold(tmp_path, _DRIFTED_PKG, ">=0.84.3 <1")
+        _run(script, cwd=tmp_path)
+
+        lock = json.loads((tmp_path / "package-lock.json").read_text())
+        peers = lock["packages"][""]["peerDependencies"]
+        assert peers["@earendil-works/pi-coding-agent"] == ">=0.84.4 <1"
+        assert peers["@earendil-works/pi-tui"] == ">=0.84.4 <1"
+
+    def test_apply_is_idempotent(self, tmp_path):
+        script = _scaffold(tmp_path, _DRIFTED_PKG, ">=0.84.3 <1")
+        _run(script, cwd=tmp_path)
+        second = _run(script, cwd=tmp_path)
+        assert second.returncode == 0
+        assert "already in sync" in second.stdout
+
+    def test_apply_on_already_synced_files_is_a_noop(self, tmp_path):
+        script = _scaffold(tmp_path, _SYNCED_PKG, ">=0.84.4 <1")
+        before_pkg = (tmp_path / "package.json").read_text()
+        before_lock = (tmp_path / "package-lock.json").read_text()
+        result = _run(script, cwd=tmp_path)
+        assert result.returncode == 0
+        assert (tmp_path / "package.json").read_text() == before_pkg
+        assert (tmp_path / "package-lock.json").read_text() == before_lock
+
+    def test_missing_devdependencies_pin_errors(self, tmp_path):
+        pkg = {"devDependencies": {}, "peerDependencies": {
+            "@earendil-works/pi-coding-agent": ">=0.84.3 <1",
+        }}
+        script = _scaffold(tmp_path, pkg, ">=0.84.3 <1")
+        result = _run(script, cwd=tmp_path)
+        assert result.returncode == 1
+        assert "could not read" in result.stderr


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- Dependabot PRs #715/#716 bumped `@earendil-works/pi-coding-agent`/`pi-tui` from 0.84.3 to 0.84.4 in `devDependencies`, but left `peerDependencies`' floor at `>=0.84.3` — `test_package_json_values` requires the floor stay in exact lockstep with the pin (this drifted once before, see `0e34767`), so `main`'s pytest job is currently red.
- Also fixes a related `package-lock.json` drift: the nested `pi-coding-agent -> pi-tui` dependency range had collapsed from `^0.84.4` to an exact `0.84.4`, diverging from the version actually published upstream.
- Root cause for why this recurs: Dependabot only ever bumps the exact `devDependencies` pin — it never touches `peerDependencies`, because `>=0.84.3` already satisfies `0.84.4` (no semver violation for its updater to fix). Added `scripts/sync-peer-deps.sh` (`--check` / apply modes, covered by `tests/test_sync_peer_deps_sh.py`) plus `.github/workflows/dependabot-peer-sync.yml`, a `pull_request_target` job gated to `actor == dependabot[bot]` and `paths: [package.json]` that overwrites its own checked-out copy of the script with the trusted `origin/main` version before running it in place (never executing anything else from the PR tree — no `npm install`, so a compromised package's install script can't run under this job's write token), and runs it against the PR's own manifests, pushing a fixup commit when drift is found — so future bumps of these two packages self-heal instead of needing a manual fix every time.
- Per [GitHub's docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow), a `GITHUB_TOKEN`-authored push to a PR *does* retrigger the `pull_request` run, but lands it in an **approval-required** state — so after this fixup commit lands, a maintainer still needs one click of "Approve workflows to run" on the resulting `pr.yml` run. Getting a fully automatic re-run would need a PAT or GitHub App token instead of `GITHUB_TOKEN`, which this PR deliberately avoids to keep the workflow secret-free.
- The issue-reference opt-out below is additionally gated on `package.json` actually being in the PR's diff (checked via the GitHub API), not just on the body text containing the bump-style line — otherwise any PR could copy-paste that one line to dodge the issue-reference requirement.
- Small related fix: `pr.yml`'s issue-reference check now also accepts a manually-authored PR body carrying Dependabot's own `Bumps X from Y to Z.` line as an opt-out, same as the existing `dependabot[bot]`-actor exemption (mirrored in `tests/test_pr_validation.py`).
- `scripts/sync-peer-deps.sh` also asserts pi-coding-agent's and pi-tui's `devDependencies` pins stay in lockstep before deriving the expected floor from either one, so a partial bump of just one of the two packages fails loudly instead of silently syncing both floors to a pin only one package actually moved to.

- **Second review pass caught a High-severity bug, reproducible from this repo's own history**: pi-coding-agent and pi-tui bump as two *separate* dependabot PRs (`dependabot.yml` has no npm `groups:`), so the first PR of every such pair (already happened twice: #715/#716, and earlier #685/#686) leaves the two packages' `devDependencies` pins out of lockstep. `sync-peer-deps.sh` correctly refused to guess a floor in that state, but the workflow treated *any* nonzero `--check` exit as actionable drift and ran the apply step anyway — which hit the identical guard and failed the whole job, turning a clean "nothing to do yet" into a confusing extra red check. Fixed by giving the script a distinct exit code (`2` = hard error, cannot proceed vs. `1` = actionable drift) and having the workflow only apply on `1`, quietly no-op with a warning annotation otherwise (`tests/test_dependabot_peer_sync_workflow.py` locks this in against the actual embedded YAML bash).
- Also fixed from the same pass: the script overwriting itself via `git show origin/main:... > scripts/sync-peer-deps.sh` and then invoking it *in place* (not copied to `/tmp`, which broke its `BASH_SOURCE`-relative root detection — a Critical bug that would have made the whole automation fail on its first real run); the issue-reference opt-out is now gated on `package.json` actually being in the PR's changed-files list (via a live `gh api` call), not just body text, so it can't be copy-pasted into an unrelated PR; the script also asserts pi-coding-agent's and pi-tui's `devDependencies` pins stay in lockstep before deriving either floor; and added a static test (`test_pi_extension.py::test_package_lock_peer_dependencies_match_package_json`) asserting the checked-in `package-lock.json` peerDependencies actually matches `package.json`'s.

- **Third (independent, from-scratch) review pass approved** with only two non-blocking nits: the live `gh api` changed-files gate on the "Bumps X from Y to Z." opt-out had no behavioral test coverage, and that gate hard-failed the whole step on a transient API error instead of falling through to the closing-keyword check. Both fixed: added `tests/test_pr_validation.py::TestIssueReferenceBumpOptoutGating` (drives the actual bash with a stubbed `gh`), and the `gh api` call now falls through to `CHANGED_FILES=""` on error rather than aborting the step. Also hardened `test_dependabot_peer_sync_workflow.py`'s bash-extraction regex, which previously could silently truncate its capture on an unrelated future edit instead of failing loudly.

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `bash scripts/validate.sh` passes
- [x] Full `pytest tests/` (3816 tests) passes locally, including the new `test_pi_extension.py::test_package_json_values` and `test_sync_peer_deps_sh.py`/`test_pr_validation.py` coverage
- [x] `npm ci` installs cleanly from the corrected `package-lock.json`
- [x] Manually verified `scripts/sync-peer-deps.sh` end-to-end in an isolated scratch copy: simulated drift → `--check` fails → apply fixes both files → `--check` passes → output byte-identical to the real repo's already-fixed files

### Type-tailored checks (fix)
- [x] Reproduced the original failure (`test_package_json_values` red against the un-synced floor) before fixing, and confirmed it's green after
- [x] Verified the fix addresses the root cause (the floor/pin coupling), not just this one instance — added automation so it holds on the next dependabot bump too

Issue: N/A — dependency-bump follow-up fix and CI hardening, not tied to a filed issue



