### PR TITLE
[chore] Bump version to 0.1.38

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "swe-workbench",
       "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "source": "./",
       "author": {
         "name": "Lugas Septiawan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "swe-workbench",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Senior-engineer toolkit: principled design (Clean Arch, DDD, SOLID, TDD, patterns, observability, concurrency), security review, language expertise (Bash, C#, Dart, Go, Java, Kotlin, Python, Ruby, Rust, SQL, Swift, TypeScript), and pragmatic workflows.",
   "author": {
     "name": "Lugas Septiawan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swe-workbench-pi",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swe-workbench-pi",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.84.4",
         "@earendil-works/pi-tui": "0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swe-workbench-pi",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": true,
   "type": "module",
   "description": "swe-workbench: senior-engineer toolkit for Claude Code and the Pi Coding Agent",


### PR DESCRIPTION
## Summary
- Bump version: `0.1.37` → `0.1.38`
- Tag `v0.1.38` will be pushed automatically once this merges, triggering `.github/workflows/release.yml` to publish a GitHub Release.

## Test Plan
- [x] CI (pr.yml) passes
- [x] Tag-triggered release workflow publishes `v0.1.38`

N/A