### PR TITLE
[fix] Stop pr-review-worktree test from hanging release.sh on a credential prompt

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,10 @@ mistakenly treats the temp test directory as a bare repo too — causing
 hard-to-diagnose test failures.
 
 `_CLEAN_ENV` strips every `GIT_*` environment variable and re-adds
-`GIT_CONFIG_NOSYSTEM=1` for system-gitconfig hermeticity. Use it whenever a
+`GIT_CONFIG_NOSYSTEM=1` for system-gitconfig hermeticity, plus
+`GIT_TERMINAL_PROMPT=0` so a fixture that fakes `HOME` (and therefore has no
+credential helper) fails fast on an unauthenticated remote instead of
+blocking on an interactive username/password prompt. Use it whenever a
 test spawns a subprocess that runs `git` or a shell script that calls `git`:
 
 ```python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,14 @@ import pytest
 # fail unexpectedly on an unrelated ambient value. Tests that want to exercise the kill switch
 # opt in explicitly via env={**_CLEAN_ENV, "SWE_WORKBENCH_PI_TOOLS": "0"}.
 #
+# GIT_TERMINAL_PROMPT=0 is set because fixtures that fake HOME (e.g. _rimba_absent_env)
+# make the real ~/.gitconfig credential helper invisible, so any git operation that
+# reaches a remote requiring auth has no way to authenticate. Without this, git falls
+# back to an interactive username/password prompt on the controlling tty instead of
+# failing fast -- which, when the test runs under the pre-push hook, silently freezes
+# the developer's terminal on `git push` instead of surfacing a test failure. Failing
+# fast is always the correct behaviour for a test subprocess.
+#
 # Snapshot: built once from os.environ at pytest collection time. Session-scoped
 # fixtures that mutate GIT_* vars after import will not be reflected here.
 #
@@ -54,6 +62,7 @@ _CLEAN_ENV: Final[MappingProxyType[str, str]] = MappingProxyType(
     _clean_environment(os.environ)
     | {
         "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
         "GIT_AUTHOR_NAME": "T",
         "GIT_AUTHOR_EMAIL": "t@t.com",
         "GIT_COMMITTER_NAME": "T",

--- a/tests/test_conftest_clean_env.py
+++ b/tests/test_conftest_clean_env.py
@@ -1,0 +1,56 @@
+"""Ratchet tests for _CLEAN_ENV's credential-prompt guard.
+
+See tests/README.md's `_CLEAN_ENV` section for the rationale: fixtures that fake
+HOME have no credential helper, so a git operation reaching an unauthenticated
+remote would otherwise block on an interactive prompt instead of failing fast.
+"""
+
+from __future__ import annotations
+
+import http.server
+import subprocess
+import threading
+
+from conftest import _CLEAN_ENV
+
+
+def test_clean_env_disables_git_credential_prompts():
+    assert _CLEAN_ENV["GIT_TERMINAL_PROMPT"] == "0"
+
+
+class _UnauthorizedHandler(http.server.BaseHTTPRequestHandler):
+    """Answers every request with 401, as a real auth-requiring git remote would."""
+
+    def do_GET(self):
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", 'Basic realm="git"')
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_git_fetch_fails_fast_on_unauthenticated_remote(tmp_path):
+    """Proves GIT_TERMINAL_PROMPT=0 actually changes git's behavior, not just
+    that the key is present: against a real 401-returning remote, with no
+    credential helper visible (HOME faked, same as the fixtures this guards),
+    git must fail immediately instead of blocking on a tty prompt."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _UnauthorizedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    try:
+        port = server.server_address[1]
+        result = subprocess.run(
+            ["git", "ls-remote", f"http://127.0.0.1:{port}/repo.git"],
+            capture_output=True,
+            text=True,
+            env={**_CLEAN_ENV, "HOME": str(fake_home)},
+            timeout=10,
+        )
+        assert result.returncode != 0
+        assert "terminal prompts disabled" in result.stderr
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)

--- a/tests/test_pr_review_worktree_script.py
+++ b/tests/test_pr_review_worktree_script.py
@@ -944,7 +944,6 @@ class TestLegacyFallbackAttribution:
         own origin gates it; our slugged allocation proceeds unaffected."""
         n = _unique_n()
         repo = _build_repo_with_pr_ref(tmp_path, n)
-        _run("git", "remote", "set-url", "origin", "https://github.com/octocat/widgets.git", cwd=repo)
         foreign_base = tmp_path / "foreign"
         foreign_base.mkdir()
         foreign = _build_repo(foreign_base)
@@ -957,13 +956,18 @@ class TestLegacyFallbackAttribution:
         acquired = None
         try:
             acquired = _run_script(
-                repo, ["acquire", "--mode", "first-pass", "--pr", n], env,
+                repo,
+                ["acquire", "--mode", "first-pass", "--pr", n, "--repo", "octocat/widgets"],
+                env,
             )
             assert acquired.returncode == 0, acquired.stderr
             kv = _kv(acquired)
             assert kv["PROVIDER"] == "git"
             assert Path(kv["WT"]).name == f"7-octocat-widgets-{n}"
             assert legacy.exists(), "foreign-origin legacy fallback must survive our acquire"
+            wt = Path(kv["WT"])
+            assert wt.exists(), "acquire reported a worktree path that was never created"
+            assert (wt / f"pr_file_{n}.txt").exists(), "PR ref was not fetched into the worktree"
         finally:
             if acquired is not None:
                 try:


### PR DESCRIPTION
## Summary
- `tests/test_pr_review_worktree_script.py::TestLegacyFallbackAttribution::test_acquire_leaves_foreign_legacy_fallback_alone` repointed a fixture repo's `origin` to a real, routable `https://github.com/octocat/widgets.git` before exercising `acquire`'s real fetch. Combined with the harness's faked `HOME` (no credential helper visible) and `_CLEAN_ENV` never setting `GIT_TERMINAL_PROMPT=0`, the fetch blocked on an interactive `Username for 'https://github.com':` prompt on `/dev/tty` — which silently hung `./scripts/release.sh`'s push under the pre-push hook.
- Fix is entirely in the test harness: `tests/conftest.py` now sets `GIT_TERMINAL_PROMPT=0` suite-wide in `_CLEAN_ENV` so any future fixture that reaches an unauthenticated remote fails fast instead of blocking. The offending test now passes `--repo octocat/widgets` explicitly instead of repointing `origin`, so its `acquire` fetch stays fully local against the fixture's own `origin_src` remote — same attribution-slug behavior (`7-octocat-widgets-<n>`), zero network dependency.
- Strengthened that test to assert the acquired worktree and fetched PR file actually exist (it previously only checked a derived name string, which passed even when the fetch/worktree-add had silently failed).
- Added `tests/test_conftest_clean_env.py`: a config-presence ratchet plus a behavioral test that spins up a local unauthenticated HTTP server and confirms the fetch actually fails fast (`terminal prompts disabled`) instead of just checking the env var is set.
- Documented `GIT_TERMINAL_PROMPT` in `tests/README.md`'s `_CLEAN_ENV` contract section.

## Test Plan
- [x] Changed skills/commands/agents load without errors
- [x] Examples in the diff were exercised manually
- [x] `python3 -m pytest tests/test_pr_review_worktree_script.py -q` — 41/41 pass
- [x] Same test file under a real pty (`script -q /dev/null ...`) — 0 occurrences of "Username for"
- [x] `python3 -m pytest tests/test_pr_review_worktree_script.py tests/test_address_feedback_worktree_script.py -q` — 76/76 pass, confirming the suite needs no network access
- [x] `bash scripts/validate.sh && python3 -m pytest tests/ -q` — full suite 3973 passed, 5 skipped
- [x] End-to-end: pushing this branch completed the pre-push hook's full pytest run with no hang and no prompt

### Type-tailored checks (fix)
- [x] Reproduced the original hang's root cause (a real network fetch against a routable GitHub URL with a faked, helper-less `HOME`) and confirmed the fix addresses it directly, not just symptomatically

Issue: N/A — reported live by the user as an interactive incident (release script stalling), not filed as a tracked issue; root-caused and fixed in this PR.
